### PR TITLE
Progression Mes-Aides 03/03/2015

### DIFF
--- a/openfisca_france/model/aides_logement.py
+++ b/openfisca_france/model/aides_logement.py
@@ -234,7 +234,9 @@ class aide_logement_montant(SimpleFormulaColumn):
         zone_apl_famille = simulation.calculate('zone_apl_famille', period)
         nat_imp_holder = simulation.compute('nat_imp', period.start.period(u'year').offset('first-of'))
         al = simulation.legislation_at(period.start).al
-        fam = simulation.legislation_at(period.start).fam
+
+        pfam = simulation.legislation_at(period.start).fam
+        pfam_n_2 = simulation.legislation_at(period.start.offset(-2, 'year')).fam
 
         # le barème "couple" est utilisé pour les femmes enceintes isolées
         couple = or_(concub, enceinte_fam)
@@ -333,7 +335,7 @@ class aide_logement_montant(SimpleFormulaColumn):
             al.R1.taux5 * rmi * (al_pac > 2) * (al_pac - 2)
             )
 
-        bmaf = fam.af.bmaf_n_2
+        bmaf = pfam_n_2.af.bmaf
         R2 = (
             al.R2.taux4 * bmaf * (al_pac >= 2) +
             al.R2.taux5 * bmaf * (al_pac > 2) * (al_pac - 2)
@@ -380,9 +382,8 @@ class aide_logement_montant(SimpleFormulaColumn):
         al_acc = 0 * acce
         # # APL (tous)
 
-        taux_crds = simulation.legislation_at(period.start).fam.af.crds
         al = al_loc + al_acc
-        al = round(al * (1 - taux_crds), 2)
+        al = round(al * (1 - pfam.af.crds), 2)
 
         return period, al
 

--- a/openfisca_france/model/aides_logement.py
+++ b/openfisca_france/model/aides_logement.py
@@ -272,7 +272,8 @@ class aide_logement_montant(SimpleFormulaColumn):
 
         # # aides au logement pour les locataires
         # loyer mensuel;
-        L1 = loyer
+        L1 = round((so == 5) * loyer * 2 / 3 + (so != 5) * loyer, 2)
+
         # loyer plafond;
         lp_taux = (not_(coloc)) * 1 + coloc * al.loyers_plafond.colocation
 

--- a/openfisca_france/model/aides_logement.py
+++ b/openfisca_france/model/aides_logement.py
@@ -142,10 +142,10 @@ class aide_logement_base_ressources_defaut(SimpleFormulaColumn):
     def function(self, simulation, period):
         period = period.start.offset('first-of', 'month').period('month')
         two_years_ago = period.start.offset('first-of', 'year').period('year').offset(-2)
-        br_pf_i_holder = simulation.compute('br_pf_i', two_years_ago)
+        br_pf_i_holder = simulation.compute('br_pf_i', period)
         rev_coll_holder = simulation.compute('rev_coll', two_years_ago)
         rev_coll = self.sum_by_entity(rev_coll_holder)
-        biact = simulation.calculate('biact', period, accept_other_period = True)
+        biact = simulation.calculate('biact', period)
         Pr = simulation.legislation_at(period.start).al.ressources
         br_pf_i = self.split_by_roles(br_pf_i_holder, roles = [CHEF, PART])
         abattement_chomage_indemnise_holder = simulation.compute('aide_logement_abattement_chomage_indemnise', period)

--- a/openfisca_france/model/aides_logement.py
+++ b/openfisca_france/model/aides_logement.py
@@ -228,6 +228,7 @@ class aide_logement_montant(SimpleFormulaColumn):
         so_holder = simulation.compute('so', period)
         loyer_holder = simulation.compute('loyer', period)
         coloc_holder = simulation.compute('coloc', period)
+        logement_chambre_holder = simulation.compute('logement_chambre', period)
         al_pac = simulation.calculate('al_pac', period)
         enceinte_fam = simulation.calculate('enceinte_fam', period)
         zone_apl_famille = simulation.calculate('zone_apl_famille', period)
@@ -247,6 +248,8 @@ class aide_logement_montant(SimpleFormulaColumn):
         zone_apl = zone_apl_famille
         # Variables individuelles
         coloc = self.any_by_roles(coloc_holder)
+        chambre = self.any_by_roles(logement_chambre_holder)
+
         # Variables du foyer fiscal
         nat_imp = self.cast_from_entity_to_roles(nat_imp_holder)
         nat_imp = self.any_by_roles(nat_imp)
@@ -267,40 +270,43 @@ class aide_logement_montant(SimpleFormulaColumn):
 
         loca = (3 <= so) & (5 >= so)
         acce = so == 1
-        rmi = al.rmi
-        bmaf = fam.af.bmaf_n_2
 
         # # aides au logement pour les locataires
-        # loyer mensuel;
+        # loyer mensuel, multiplié par 2/3 pour les meublés
         L1 = round((so == 5) * loyer * 2 / 3 + (so != 5) * loyer, 2)
 
-        # loyer plafond;
-        lp_taux = (not_(coloc)) * 1 + coloc * al.loyers_plafond.colocation
+        # taux à appliquer sur le loyer plafond
+        taux_loyer_plafond = (and_(not_(coloc), not_(chambre)) * 1
+                             + chambre * al.loyers_plafond.chambre
+                             + not_(chambre) * coloc * al.loyers_plafond.colocation)
+
+        loyer_plafond_personne_seule = or_(personne_seule * (al_pac == 0), chambre)
+        loyer_plafond_famille = not_(loyer_plafond_personne_seule) * (al_pac > 0)
+        loyer_plafond_couple = and_(not_(loyer_plafond_famille), not_(loyer_plafond_personne_seule))
 
         z1 = al.loyers_plafond.zone1
         z2 = al.loyers_plafond.zone2
         z3 = al.loyers_plafond.zone3
 
         Lz1 = (
-            personne_seule * (al_pac == 0) * z1.L1 +
-            couple * (al_pac == 0) * z1.L2 +
-            (al_pac > 0) * z1.L3 +
-            (al_pac > 1) * (al_pac - 1) * z1.L4
-            ) * lp_taux
+            loyer_plafond_personne_seule * z1.L1 +
+            loyer_plafond_couple * z1.L2 +
+            loyer_plafond_famille * (z1.L3 + (al_pac > 1) * (al_pac - 1) * z1.L4)
+            )
         Lz2 = (
-            personne_seule * (al_pac == 0) * z2.L1 +
-            couple * (al_pac == 0) * z2.L2 +
-            (al_pac > 0) * z2.L3 +
-            (al_pac > 1) * (al_pac - 1) * z2.L4
-            ) * lp_taux
+            loyer_plafond_personne_seule * z2.L1 +
+            loyer_plafond_couple * z2.L2 +
+            loyer_plafond_famille * (z2.L3 + (al_pac > 1) * (al_pac - 1) * z2.L4)
+            )
         Lz3 = (
-            personne_seule * (al_pac == 0) * z3.L1 +
-            couple * (al_pac == 0) * z3.L2 +
-            (al_pac > 0) * z3.L3 +
-            (al_pac > 1) * (al_pac - 1) * z3.L4
-            ) * lp_taux
+            loyer_plafond_personne_seule * z3.L1 +
+            loyer_plafond_couple * z3.L2 +
+            loyer_plafond_famille * (z3.L3 + (al_pac > 1) * (al_pac - 1) * z3.L4)
+            )
 
         L2 = Lz1 * (zone_apl == 1) + Lz2 * (zone_apl == 2) + Lz3 * (zone_apl == 3)
+        L2 = round(L2 * taux_loyer_plafond, 2)
+
         # loyer retenu
         L = min_(L1, L2)
 
@@ -318,6 +324,7 @@ class aide_logement_montant(SimpleFormulaColumn):
         R = aide_logement_base_ressources
 
         # Plafond RO
+        rmi = al.rmi
         R1 = (
             al.R1.taux1 * rmi * personne_seule * (al_pac == 0) +
             al.R1.taux2 * rmi * couple * (al_pac == 0) +
@@ -326,6 +333,7 @@ class aide_logement_montant(SimpleFormulaColumn):
             al.R1.taux5 * rmi * (al_pac > 2) * (al_pac - 2)
             )
 
+        bmaf = fam.af.bmaf_n_2
         R2 = (
             al.R2.taux4 * bmaf * (al_pac >= 2) +
             al.R2.taux5 * bmaf * (al_pac > 2) * (al_pac - 2)

--- a/openfisca_france/model/cotisations_sociales/travail_fonction_publique.py
+++ b/openfisca_france/model/cotisations_sociales/travail_fonction_publique.py
@@ -382,10 +382,10 @@ class supp_familial_traitement(SimpleFormulaColumn):
         period = period.start.period(u'month').offset('first-of')
         type_sal = simulation.calculate('type_sal', period)
         traitement_indiciaire_brut = simulation.calculate('traitement_indiciaire_brut', period)
-        #af_nbenf_holder = simulation.compute('af_nbenf', period)
+        af_nbenf_holder = simulation.compute('af_nbenf', period)
         _P = simulation.legislation_at(period.start)
 
-        fonc_nbenf = 0 #self.cast_from_entity_to_role(af_nbenf_holder, role = CHEF)
+        fonc_nbenf = self.cast_from_entity_to_role(af_nbenf_holder, role = CHEF)
         P = _P.fonc.supp_fam
         part_fixe_1 = P.fixe.enf1
         part_fixe_2 = P.fixe.enf2

--- a/openfisca_france/model/cotisations_sociales/travail_fonction_publique.py
+++ b/openfisca_france/model/cotisations_sociales/travail_fonction_publique.py
@@ -382,10 +382,10 @@ class supp_familial_traitement(SimpleFormulaColumn):
         period = period.start.period(u'month').offset('first-of')
         type_sal = simulation.calculate('type_sal', period)
         traitement_indiciaire_brut = simulation.calculate('traitement_indiciaire_brut', period)
-        af_nbenf_holder = simulation.compute('af_nbenf', period)
+        #af_nbenf_holder = simulation.compute('af_nbenf', period)
         _P = simulation.legislation_at(period.start)
 
-        fonc_nbenf = self.cast_from_entity_to_role(af_nbenf_holder, role = CHEF)
+        fonc_nbenf = 0 #self.cast_from_entity_to_role(af_nbenf_holder, role = CHEF)
         P = _P.fonc.supp_fam
         part_fixe_1 = P.fixe.enf1
         part_fixe_2 = P.fixe.enf2

--- a/openfisca_france/model/cotisations_sociales/travail_totaux.py
+++ b/openfisca_france/model/cotisations_sociales/travail_totaux.py
@@ -28,6 +28,7 @@ from __future__ import division
 
 import logging
 
+from numpy import zeros
 
 from ..base import *  # noqa analysis:ignore
 from .base import montant_csg_crds
@@ -384,6 +385,11 @@ class salnet(SimpleFormulaColumn):
         net = net de csg et crds
         '''
         period = period
+
+        salaire_de_base = simulation.get_array('salaire_de_base', period)
+        if salaire_de_base is None:
+            return period, zeros(self.holder.entity.count)
+
         sal = simulation.calculate('sal', period)
         crdssal = simulation.calculate_add('crdssal', period)
         csgsali = simulation.calculate_add('csgsali', period)

--- a/openfisca_france/model/input_variables/base.py
+++ b/openfisca_france/model/input_variables/base.py
@@ -78,6 +78,7 @@ build_column('gar_dom', BoolCol(entity = 'fam',
 
 # Autres
 build_column('coloc', BoolCol(label = u"Vie en colocation"))
+build_column('logement_chambre', BoolCol(label = u"Le logement est considéré comme une chambre"))
 build_column(
     'csg_rempl',
     EnumCol(

--- a/openfisca_france/model/minima_sociaux/rsa.py
+++ b/openfisca_france/model/minima_sociaux/rsa.py
@@ -392,30 +392,41 @@ class br_rmi_i(SimpleFormulaColumn):
     def function(self, simulation, period):
         period = period.start.offset('first-of', 'month').period('month')
         three_previous_months = period.start.period('month', 3).offset(-3)
+
         ra_rsa_i = simulation.calculate('ra_rsa_i', period)
-        chonet = simulation.calculate('chonet', three_previous_months)
-        rstnet = simulation.calculate('rstnet', three_previous_months)
-        pensions_alimentaires_percues = simulation.calculate('pensions_alimentaires_percues', three_previous_months)
-        rto_declarant1 = simulation.calculate('rto_declarant1', three_previous_months)
+
+        def calcule_type_ressource(type, neutralisable = False):
+            ressource_trois_derniers_mois = simulation.calculate(type, three_previous_months)
+            if neutralisable:
+                ressource_mois_courant = simulation.calculate(type, period)
+                return (ressource_mois_courant > 0) * ressource_trois_derniers_mois
+            else:
+                return ressource_trois_derniers_mois
+
+        # Ressources neutralisables
+        chonet = calcule_type_ressource('chonet', True)
+        pensions_alimentaires_percues = calcule_type_ressource('pensions_alimentaires_percues', True)
+        allocation_aide_retour_emploi = calcule_type_ressource('allocation_aide_retour_emploi', True)
+        allocation_securisation_professionnelle = calcule_type_ressource('allocation_securisation_professionnelle', True)
+        prestation_compensatoire = calcule_type_ressource('prestation_compensatoire', True)
+
+        # Autres ressources
+        rstnet = calcule_type_ressource('rstnet')
+        rto_declarant1 = calcule_type_ressource('rto_declarant1')
+        rfon_ms = calcule_type_ressource('rfon_ms')
+        div_ms = calcule_type_ressource('div_ms')
+        gains_exceptionnels = calcule_type_ressource('gains_exceptionnels')
+        dedommagement_victime_amiante = calcule_type_ressource('dedommagement_victime_amiante')
+        pensions_invalidite = calcule_type_ressource('pensions_invalidite')
+        bourse_enseignement_sup = calcule_type_ressource('bourse_enseignement_sup')
+        bourse_recherche = calcule_type_ressource('bourse_recherche')
+        rsa_base_ressources_patrimoine_i = calcule_type_ressource('rsa_base_ressources_patrimoine_i')
+
         rev_cap_bar_holder = simulation.compute('rev_cap_bar', three_previous_months)
         rev_cap_lib_holder = simulation.compute('rev_cap_lib', three_previous_months)
-        rfon_ms = simulation.calculate('rfon_ms', three_previous_months)
-        div_ms = simulation.calculate('div_ms', three_previous_months)
-        gains_exceptionnels = simulation.calculate('gains_exceptionnels', three_previous_months)
-        dedommagement_victime_amiante = simulation.calculate('dedommagement_victime_amiante', three_previous_months)
-        pensions_invalidite = simulation.calculate('pensions_invalidite', three_previous_months)
-        allocation_aide_retour_emploi = simulation.calculate('allocation_aide_retour_emploi', three_previous_months)
-
-        allocation_securisation_professionnelle = simulation.calculate(
-            'allocation_securisation_professionnelle', three_previous_months)
-        prestation_compensatoire = simulation.calculate('prestation_compensatoire', three_previous_months)
-        bourse_enseignement_sup = simulation.calculate('bourse_enseignement_sup', three_previous_months)
-        bourse_recherche = simulation.calculate('bourse_recherche', three_previous_months)
-        rsa_base_ressources_patrimoine_i = simulation.calculate(
-            'rsa_base_ressources_patrimoine_i', three_previous_months)
-
         rev_cap_bar = self.cast_from_entity_to_role(rev_cap_bar_holder, role = VOUS)
         rev_cap_lib = self.cast_from_entity_to_role(rev_cap_lib_holder, role = VOUS)
+
         return period, ra_rsa_i + (
             chonet + rstnet + pensions_alimentaires_percues + rto_declarant1 + rev_cap_bar +
             rev_cap_lib + rfon_ms + div_ms +
@@ -515,26 +526,34 @@ class ra_rsa_i(SimpleFormulaColumn):
     def function(self, simulation, period):
         period = period.start.offset('first-of', 'month').period('month')
         three_previous_months = period.start.period('month', 3).offset(-3)
-        salnet = simulation.calculate('salnet', three_previous_months)
-        hsup = simulation.calculate('hsup', three_previous_months)
-        rpns = simulation.calculate_add_divide('rpns', three_previous_months)
-        etr = simulation.calculate('etr', three_previous_months)
-        indemnites_chomage_partiel = simulation.calculate('indemnites_chomage_partiel', three_previous_months)
-        indemnites_journalieres_maternite = simulation.calculate(
-            'indemnites_journalieres_maternite', three_previous_months)
-        indemnites_journalieres_paternite = simulation.calculate(
-            'indemnites_journalieres_paternite', three_previous_months)
-        indemnites_journalieres_adoption = simulation.calculate(
-            'indemnites_journalieres_adoption', three_previous_months)
-        indemnites_journalieres_maladie = simulation.calculate('indemnites_journalieres_maladie', three_previous_months)
-        indemnites_journalieres_accident_travail = simulation.calculate(
-            'indemnites_journalieres_accident_travail', three_previous_months)
-        indemnites_journalieres_maladie_professionnelle = simulation.calculate(
-            'indemnites_journalieres_maladie_professionnelle', three_previous_months)
-        indemnites_volontariat = simulation.calculate('indemnites_volontariat', three_previous_months)
-        revenus_stage_formation_pro = simulation.calculate('revenus_stage_formation_pro', three_previous_months)
-        indemnites_stage = simulation.calculate('indemnites_stage', three_previous_months)
+
+        def calcule_type_ressource(type, neutralisable = False):
+            ressource_trois_derniers_mois = simulation.calculate(type, three_previous_months)
+            if neutralisable:
+                ressource_mois_courant = simulation.calculate(type, period)
+                return (ressource_mois_courant > 0) * ressource_trois_derniers_mois
+            else:
+                return ressource_trois_derniers_mois
+
+        # Ressources neutralisables
+        salnet = calcule_type_ressource('salnet', True)
+        indemnites_chomage_partiel = calcule_type_ressource('indemnites_chomage_partiel', True)
+        indemnites_journalieres_maternite = calcule_type_ressource('indemnites_journalieres_maternite', True)
+        indemnites_journalieres_paternite = calcule_type_ressource('indemnites_journalieres_paternite', True)
+        indemnites_journalieres_adoption = calcule_type_ressource('indemnites_journalieres_adoption', True)
+        indemnites_journalieres_maladie = calcule_type_ressource('indemnites_journalieres_maladie', True)
+        indemnites_journalieres_accident_travail = calcule_type_ressource('indemnites_journalieres_accident_travail', True)
+        indemnites_journalieres_maladie_professionnelle = calcule_type_ressource('indemnites_journalieres_maladie_professionnelle', True)
+        indemnites_volontariat = calcule_type_ressource('indemnites_volontariat', True)
+        revenus_stage_formation_pro = calcule_type_ressource('revenus_stage_formation_pro', True)
+        indemnites_stage = calcule_type_ressource('indemnites_stage', True)
+
+        # Autres ressources
+        hsup = calcule_type_ressource('hsup')
+        etr = calcule_type_ressource('etr')
+
         tns_total_revenus = simulation.calculate_add('tns_total_revenus', three_previous_months)
+        rpns = simulation.calculate_add_divide('rpns', three_previous_months)
 
         return period, (
             salnet + hsup + rpns + etr + indemnites_chomage_partiel + indemnites_journalieres_maternite +

--- a/openfisca_france/model/minima_sociaux/rsa.py
+++ b/openfisca_france/model/minima_sociaux/rsa.py
@@ -446,8 +446,8 @@ class br_rmi(SimpleFormulaColumn):
         br_rmi_ms = simulation.calculate('br_rmi_ms', period)
         br_rmi_i_holder = simulation.compute('br_rmi_i', period)
 
-        br_rmi_i = self.split_by_roles(br_rmi_i_holder, roles = [CHEF, PART])
-        return period, br_rmi_pf + br_rmi_ms + br_rmi_i[CHEF] + br_rmi_i[PART]
+        br_rmi_i_total = self.sum_by_entity(br_rmi_i_holder)
+        return period, br_rmi_pf + br_rmi_ms + br_rmi_i_total
 
 
 @reference_formula
@@ -573,8 +573,8 @@ class ra_rsa(SimpleFormulaColumn):
         period = period.start.offset('first-of', 'month').period('month')
         ra_rsa_i_holder = simulation.compute('ra_rsa_i', period)
 
-        ra_rsa = self.split_by_roles(ra_rsa_i_holder)
-        return period, ra_rsa[CHEF] + ra_rsa[PART]
+        ra_rsa = self.sum_by_entity(ra_rsa_i_holder)
+        return period, ra_rsa
 
 
 @reference_formula

--- a/openfisca_france/model/minima_sociaux/rsa.py
+++ b/openfisca_france/model/minima_sociaux/rsa.py
@@ -418,8 +418,6 @@ class br_rmi_i(SimpleFormulaColumn):
         gains_exceptionnels = calcule_type_ressource('gains_exceptionnels')
         dedommagement_victime_amiante = calcule_type_ressource('dedommagement_victime_amiante')
         pensions_invalidite = calcule_type_ressource('pensions_invalidite')
-        bourse_enseignement_sup = calcule_type_ressource('bourse_enseignement_sup')
-        bourse_recherche = calcule_type_ressource('bourse_recherche')
         rsa_base_ressources_patrimoine_i = calcule_type_ressource('rsa_base_ressources_patrimoine_i')
 
         rev_cap_bar_holder = simulation.compute('rev_cap_bar', three_previous_months)
@@ -432,7 +430,7 @@ class br_rmi_i(SimpleFormulaColumn):
             rev_cap_lib + rfon_ms + div_ms +
             gains_exceptionnels + dedommagement_victime_amiante + pensions_invalidite + allocation_aide_retour_emploi +
             allocation_securisation_professionnelle + prestation_compensatoire +
-            bourse_enseignement_sup + bourse_recherche + rsa_base_ressources_patrimoine_i
+            rsa_base_ressources_patrimoine_i
             ) / 3
 
 
@@ -547,6 +545,7 @@ class ra_rsa_i(SimpleFormulaColumn):
         indemnites_volontariat = calcule_type_ressource('indemnites_volontariat', True)
         revenus_stage_formation_pro = calcule_type_ressource('revenus_stage_formation_pro', True)
         indemnites_stage = calcule_type_ressource('indemnites_stage', True)
+        bourse_recherche = calcule_type_ressource('bourse_recherche', True)
 
         # Autres ressources
         hsup = calcule_type_ressource('hsup')
@@ -559,7 +558,8 @@ class ra_rsa_i(SimpleFormulaColumn):
             salnet + hsup + rpns + etr + indemnites_chomage_partiel + indemnites_journalieres_maternite +
             indemnites_journalieres_paternite + indemnites_journalieres_adoption + indemnites_journalieres_maladie +
             indemnites_journalieres_accident_travail + indemnites_journalieres_maladie_professionnelle +
-            indemnites_volontariat + revenus_stage_formation_pro + indemnites_stage + tns_total_revenus) / 3
+            indemnites_volontariat + revenus_stage_formation_pro + indemnites_stage + tns_total_revenus +
+            bourse_recherche) / 3
 
 
 @reference_formula

--- a/openfisca_france/model/minima_sociaux/rsa.py
+++ b/openfisca_france/model/minima_sociaux/rsa.py
@@ -25,7 +25,7 @@
 
 from __future__ import division
 
-from numpy import (floor, maximum as max_, logical_not as not_, logical_and as and_, logical_or as or_)
+from numpy import (floor, minimum as min_, maximum as max_, logical_not as not_, logical_and as and_, logical_or as or_)
 
 from ..base import *  # noqa
 from ..pfam import nb_enf, age_en_mois_benjamin
@@ -652,13 +652,16 @@ class rsa_forfait_logement(SimpleFormulaColumn):
         avantage_nature = or_(so == 2, so == 6)
         avantage_al = aide_logement > 0
 
-        avantage = or_(avantage_nature, avantage_al)
-
-        return period, rmi * avantage * (
+        montant_forfait = rmi * (
             (rmi_nbp == 1) * forf_logement.taux1 +
             (rmi_nbp == 2) * forf_logement.taux2 +
             (rmi_nbp >= 3) * forf_logement.taux3
             )
+
+        montant_al = avantage_al * min_(aide_logement, montant_forfait)
+        montant_nature = avantage_nature * montant_forfait
+
+        return period, max_(montant_al, montant_nature)
 
 
 @reference_formula

--- a/openfisca_france/model/pfam.py
+++ b/openfisca_france/model/pfam.py
@@ -198,14 +198,14 @@ class smic55(SimpleFormulaColumn):
 
     def function(self, simulation, period):
         period = period.start.offset('first-of', 'month').period('month')
-        salnet = simulation.calculate('salnet', period.start.period('month', 6).offset(-6))
+        salnet = simulation.calculate_add('salnet', period.start.period('month', 6).offset(-6)) / 6
         _P = simulation.legislation_at(period.start)
 
         nbh_travaillees = 169
         smic_mensuel_brut = _P.cotsoc.gen.smic_h_b * nbh_travaillees
 
         # Oui on compare du salaire net avec un bout du SMIC brut ...
-        return period, salnet >= _P.fam.af.seuil_rev_taux * smic_mensuel_brut
+        return period, salnet >= (_P.fam.af.seuil_rev_taux * smic_mensuel_brut)
 
 
 reference_input_variable(

--- a/openfisca_france/model/pfam.py
+++ b/openfisca_france/model/pfam.py
@@ -223,11 +223,11 @@ class biact(SimpleFormulaColumn):
         '''
         period = period.start.offset('first-of', 'month').period('year')
         br_pf_i_holder = simulation.compute('br_pf_i', period)
-        _P = simulation.legislation_at(period.start)
+        pfam = simulation.legislation_at(period.start.offset(-2, 'year')).fam
 
         br_pf_i = self.split_by_roles(br_pf_i_holder, roles = [CHEF, PART])
 
-        seuil_rev = 12 * _P.fam.af.bmaf_n_2
+        seuil_rev = 12 * pfam.af.bmaf
         biact = (br_pf_i[CHEF] >= seuil_rev) & (br_pf_i[PART] >= seuil_rev)
         return period, biact
 

--- a/openfisca_france/model/pfam.py
+++ b/openfisca_france/model/pfam.py
@@ -198,7 +198,7 @@ class smic55(SimpleFormulaColumn):
 
     def function(self, simulation, period):
         period = period.start.offset('first-of', 'month').period('month')
-        salnet = simulation.calculate('salnet', period)
+        salnet = simulation.calculate('salnet', period.start.period('month', 6).offset(-6))
         _P = simulation.legislation_at(period.start)
 
         nbh_travaillees = 169
@@ -224,10 +224,9 @@ class pfam_enfant_a_charge(SimpleFormulaColumn):
 
     def function(self, simulation, period):
         period = period.start.offset('first-of', 'month').period('month')
-        mois_dernier = period.offset(-1)
 
         est_enfant_dans_famille = simulation.calculate('est_enfant_dans_famille', period)
-        smic55 = simulation.calculate('smic55', mois_dernier)
+        smic55 = simulation.calculate('smic55', period)
         age = simulation.calculate('age', period)
         rempli_obligation_scolaire = simulation.calculate('rempli_obligation_scolaire', period)
 

--- a/openfisca_france/model/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations_familiales/af.py
@@ -41,7 +41,7 @@ class af_nbenf(SimpleFormulaColumn):
         # Note : Cette variable est "instantanée" : quelque soit la période demandée, elle retourne la valeur au premier
         # jour, sans changer la période.
         age_holder = simulation.compute('age', period)
-        smic55_holder = simulation.compute('smic55', period.offset(-1), accept_other_period = True)
+        smic55_holder = simulation.compute('smic55', period.start.offset('first-of', 'month').period('month'))
         P = simulation.legislation_at(period.start).fam.af
 
         age = self.split_by_roles(age_holder, roles = ENFS)
@@ -75,7 +75,7 @@ class af_base(DatedFormulaColumn):
 #        period = period.start.offset('first-of', 'month').period('month')
 #
 #        af_nbenf = simulation.calculate('af_nbenf', period)
-#        br_pf = simulation.calculate('br_pf', period.start.offset('first-of', 'year').period('year').offset(-2)) / 12
+#        br_pf = simulation.calculate('br_pf', period) / 12
 #
 #        legislation_af = simulation.legislation_at(period.start).fam.af
 #        bmaf = legislation_af.bmaf

--- a/openfisca_france/model/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations_familiales/ars.py
@@ -47,7 +47,7 @@ class ars(SimpleFormulaColumn):
         age_holder = simulation.compute('age', period)
         af_nbenf = simulation.calculate('af_nbenf', period)
         smic55_holder = simulation.compute('smic55', period)
-        br_pf = simulation.calculate('br_pf', period_br)
+        br_pf = simulation.calculate('br_pf', period_br.start.offset('first-of', 'month').period('month'))
         P = simulation.legislation_at(period.start).fam
         # TODO: convention sur la mensualisation
         # On tient compte du fait qu'en cas de léger dépassement du plafond, une allocation dégressive

--- a/openfisca_france/model/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations_familiales/cf.py
@@ -57,21 +57,23 @@ class cf_temp(SimpleFormulaColumn):
         isol = simulation.calculate('isol', period)
         biact = simulation.calculate('biact', period)
         smic55_holder = simulation.compute('smic55', period, accept_other_period = True)
-        P = simulation.legislation_at(period.start).fam
+
+        pfam = simulation.legislation_at(period.start).fam
+        pfam_n_2 = simulation.legislation_at(period.start.offset(-2, 'year')).fam
 
         age = self.split_by_roles(age_holder, roles = ENFS)
         smic55 = self.split_by_roles(smic55_holder, roles = ENFS)
 
-        bmaf = P.af.bmaf
-        bmaf2 = P.af.bmaf_n_2
-        cf_nbenf = nb_enf(age, smic55, P.cf.age1, P.cf.age2)
+        bmaf = pfam.af.bmaf
+        bmaf2 = pfam_n_2.af.bmaf
+        cf_nbenf = nb_enf(age, smic55, pfam.cf.age1, pfam.cf.age2)
 
-        cf_base_n_2 = P.cf.tx * bmaf2
-        cf_base = P.cf.tx * bmaf
+        cf_base_n_2 = pfam.cf.tx * bmaf2
+        cf_base = pfam.cf.tx * bmaf
 
-        cf_plaf_tx = 1 + P.cf.plaf_tx1 * min_(cf_nbenf, 2) + P.cf.plaf_tx2 * max_(cf_nbenf - 2, 0)
+        cf_plaf_tx = 1 + pfam.cf.plaf_tx1 * min_(cf_nbenf, 2) + pfam.cf.plaf_tx2 * max_(cf_nbenf - 2, 0)
         cf_majo = isol | biact
-        cf_plaf = P.cf.plaf * cf_plaf_tx + P.cf.plaf_maj * cf_majo
+        cf_plaf = pfam.cf.plaf * cf_plaf_tx + pfam.cf.plaf_maj * cf_majo
         cf_plaf2 = cf_plaf + 12 * cf_base_n_2
 
         cf = (cf_nbenf >= 3) * ((br_pf <= cf_plaf) * cf_base +

--- a/openfisca_france/model/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations_familiales/cf.py
@@ -39,10 +39,9 @@ class cf_enfant_a_charge(SimpleFormulaColumn):
 
     def function(self, simulation, period):
         period = period.start.offset('first-of', 'month').period('month')
-        mois_dernier = period.offset(-1)
 
         est_enfant_dans_famille = simulation.calculate('est_enfant_dans_famille', period)
-        smic55 = simulation.calculate('smic55', mois_dernier)
+        smic55 = simulation.calculate('smic55', period)
         age = simulation.calculate('age', period)
         rempli_obligation_scolaire = simulation.calculate('rempli_obligation_scolaire', period)
 

--- a/openfisca_france/model/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations_familiales/paje.py
@@ -184,12 +184,15 @@ class paje_clca(SimpleFormulaColumn):
         http://www.caf.fr/wps/portal/particuliers/catalogue/metropole/paje
         """
         period = period.start.offset('first-of', 'month').period('year')
-        agem_holder = simulation.compute('agem', period)
+        period_new = period.start.period('month')
+
+        agem_holder = simulation.compute('agem', period_new)
         af_nbenf = simulation.calculate('af_nbenf', period)
-        paje_base = simulation.calculate('paje_base', period)
+        paje_base = simulation.calculate('paje_base', period_new)
         inactif = simulation.calculate('inactif', period)
         partiel1 = simulation.calculate('partiel1', period)
         partiel2 = simulation.calculate('partiel2', period)
+
         P = simulation.legislation_at(period.start).fam
 
         agem = self.split_by_roles(agem_holder, roles = ENFS)
@@ -369,14 +372,16 @@ class paje_colca(SimpleFormulaColumn):
         Prestation d'accueil du jeune enfant - Complément optionnel de libre choix du mode de garde
         '''
         period = period.start.offset('first-of', 'month').period('year')
+        period_new = period.start.period('month')
+
         af_nbenf = simulation.calculate('af_nbenf', period)
-        agem_holder = simulation.compute('agem', period)
+        agem_holder = simulation.compute('agem', period_new)
         opt_colca = simulation.calculate('opt_colca', period)
-        paje_base = simulation.calculate('paje_base', period)
+        paje_base = simulation.calculate('paje_base', period_new)
+
         P = simulation.legislation_at(period.start).fam
 
         agem = self.split_by_roles(agem_holder, roles = ENFS)
-
         age_m_benjamin = age_en_mois_benjamin(agem)
         condition = (age_m_benjamin < 12 * P.paje.colca.age) * (age_m_benjamin >= 0)
         nbenf = af_nbenf
@@ -401,15 +406,14 @@ class paje_base(SimpleFormulaColumn):
         '''
         L'allocation de base de la paje n'est pas cumulable avec le complément familial
         '''
-        period = period.start.offset('first-of', 'month').period('year')
-        period_new = period.start.offset('first-of', 'month').period('month')
+        period = period.start.offset('first-of', 'month').period('month')
 
-        paje_base_temp = 12 * simulation.calculate('paje_base_temp', period_new)
-        cf_temp = 12 * simulation.calculate('cf_temp', period_new)
+        paje_base_temp = simulation.calculate('paje_base_temp', period)
+        cf_temp = simulation.calculate('cf_temp', period)
 
         # On regarde ce qui est le plus intéressant pour la famille, chaque mois
         paje_base = (paje_base_temp >= cf_temp) * paje_base_temp
-        return period, round(paje_base, 2)
+        return period, paje_base
 
 
 def _afeama(self, age_holder, smic55_holder, ape, af_nbenf, br_pf, P = law.fam):

--- a/openfisca_france/model/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations_familiales/paje.py
@@ -71,7 +71,9 @@ class paje_base_temp(SimpleFormulaColumn):
         isol = simulation.calculate('isol', period)
         biact = simulation.calculate('biact', period)
         smic55_holder = simulation.compute('smic55', period, accept_other_period = True)
-        P = simulation.legislation_at(period.start).fam
+
+        pfam = simulation.legislation_at(period.start).fam
+        pfam_n_2 = simulation.legislation_at(period.start.offset(-2, 'year')).fam
 
         # TODO cumul des paje si et seulement si naissance multiples
 
@@ -81,20 +83,20 @@ class paje_base_temp(SimpleFormulaColumn):
         age = self.split_by_roles(age_holder, roles = ENFS)
         smic55 = self.split_by_roles(smic55_holder, roles = ENFS)
 
-        bmaf = P.af.bmaf
-        bmaf2 = P.af.bmaf_n_2
+        bmaf = pfam.af.bmaf
+        bmaf2 = pfam_n_2.af.bmaf
 
-        base = round(P.paje.base.taux * bmaf, 2)
-        base2 = round(P.paje.base.taux * bmaf2, 2)
+        base = round(pfam.paje.base.taux * bmaf, 2)
+        base2 = round(pfam.paje.base.taux * bmaf2, 2)
 
         # L'allocation de base est versée jusqu'au dernier jour du mois civil précédant
         # celui au cours duquel l'enfant atteint l'âge de 3 ans.
 
-        nbenf = nb_enf(age, smic55, 0, P.paje.base.age - 1)
+        nbenf = nb_enf(age, smic55, 0, pfam.paje.base.age - 1)
 
-        plaf_tx = (nbenf > 0) + P.paje.base.plaf_tx1 * min_(af_nbenf, 2) + P.paje.base.plaf_tx2 * max_(af_nbenf - 2, 0)
+        plaf_tx = (nbenf > 0) + pfam.paje.base.plaf_tx1 * min_(af_nbenf, 2) + pfam.paje.base.plaf_tx2 * max_(af_nbenf - 2, 0)
         majo = isol | biact
-        plaf = P.paje.base.plaf * plaf_tx + (plaf_tx > 0) * P.paje.base.plaf_maj * majo
+        plaf = pfam.paje.base.plaf * plaf_tx + (plaf_tx > 0) * pfam.paje.base.plaf_maj * majo
         plaf2 = plaf + 12 * base2  # TODO vérifier l'aspect différentielle de la PAJE et le plaf2 de la paje
 
         paje_base = (nbenf > 0) * ((br_pf < plaf) * base +

--- a/openfisca_france/param/param.xml
+++ b/openfisca_france/param/param.xml
@@ -3950,6 +3950,17 @@
     </NODE>
   </NODE>
   <NODE code="fam" description="Prestations familiales">
+    <NODE code="enfants" description="Enfants à charge">
+      <CODE code="age_minimal" description="Âge minimal pour être considéré comme enfant à charge" format="integer" type="age">
+        <VALUE deb="2001-01-01" fin="2015-12-31" valeur="0" />
+      </CODE>
+      <CODE code="age_intermediaire" description="Âge intermédiaire à partir duquel une condition de ressource s'applique pour être considéré comme enfant à charge" format="integer" type="age">
+        <VALUE deb="2001-01-01" fin="2015-12-31" valeur="16" />
+      </CODE>
+      <CODE code="age_limite" description="Âge limite (strict) pour être considéré comme enfant à charge" format="integer" type="age">
+        <VALUE deb="2001-01-01" fin="2015-12-31" valeur="20" />
+      </CODE>
+    </NODE>
     <NODE code="af" description="Allocations familiales">
       <CODE code="bmaf" description="Base mensuelle des allocations familiales" format="float" type="monetary">
         <VALUE deb="2001-01-01" fin="2001-12-31" valeur="334.84" />
@@ -4038,7 +4049,7 @@
       <CODE code="age2" description="Âge limite supérieur" format="integer" type="age">
         <VALUE deb="1986-01-01" fin="1996-12-31" valeur="17" />
         <VALUE deb="1997-01-01" fin="1997-12-31" valeur="18" />
-        <VALUE deb="1998-01-01" fin="2014-03-31" valeur="20" />
+        <VALUE deb="1998-01-01" fin="2014-03-31" valeur="21" />
       </CODE>
       <CODE code="plaf" description="Plafond de ressources" format="integer" type="monetary">
         <VALUE deb="2000-07-01" fin="2001-06-30" valeur="13421" />

--- a/openfisca_france/param/param.xml
+++ b/openfisca_france/param/param.xml
@@ -3967,24 +3967,6 @@
         <VALUE deb="2013-04-01" fin="2014-03-31" valeur="403.79" />
         <VALUE deb="2014-04-01" fin="2015-03-31" valeur="406.21" />
       </CODE>
-      <CODE code="bmaf_n_2" description="Bmaf de l'année n-2" format="float" type="monetary">
-        <VALUE deb="2001-01-01" fin="2001-12-31" valeur="327.27" />
-        <VALUE deb="2002-01-01" fin="2002-12-31" valeur="328.91" />
-        <VALUE deb="2003-01-01" fin="2003-12-31" valeur="334.84" />
-        <VALUE deb="2004-01-01" fin="2004-12-31" valeur="341.87" />
-        <VALUE deb="2005-01-01" fin="2005-12-31" valeur="347.68" />
-        <VALUE deb="2006-01-01" fin="2006-12-31" valeur="353.59" />
-        <VALUE deb="2007-01-01" fin="2007-12-31" valeur="361.37" />
-        <VALUE deb="2008-01-01" fin="2008-12-31" valeur="367.87" />
-        <VALUE deb="2009-01-01" fin="2009-12-31" valeur="374.12" />
-        <VALUE deb="2010-01-01" fin="2010-12-31" valeur="377.86" />
-        <VALUE deb="2011-01-01" fin="2011-12-31" valeur="389.20" />
-        <VALUE deb="2012-01-01" fin="2012-12-31" valeur="389.20" />
-        <VALUE deb="2013-01-01" fin="2013-12-31" valeur="395.04" />
-        <VALUE deb="2014-01-01" fin="2014-12-31" valeur="399" />
-        <VALUE deb="2015-01-01" fin="2015-12-31" valeur="403.79" />
-        <VALUE deb="2016-01-01" fin="2016-12-31" valeur="406.21" />
-      </CODE>
       <CODE code="crds" description="Taux de crds" format="percent">
         <VALUE deb="1996-01-01" fin="2013-12-31" valeur="0.005" />
       </CODE>


### PR DESCRIPTION
Hello,

Voici un package de commit à merger d'urgence (après review) car avec gros potentiel de conflits insolubles si divergence.

En plus d'ajustements sur les AL, il y a l'implémentation de la neutralisation des ressources qui ne sont plus perçues pour le RSA, ainsi qu'une refonte importante des sous-jacents des prestations familiales.

__Neutralisation des ressources pour le RSA__

Désormais le calcul du RSA examine les ressources qui ne sont plus versées, afin d'appliquer le cas échéant de __neutraliser ces ressources__. Cela signifie que pour par exemple calculer un RSA en avril, il faut non seulement les salaires janvier-février-mars, __mais aussi avril__ (en tout cas une valeur non-nulle) !

__Refonte dans les prestations familiales__

Plusieurs formules avec les anciennes périodes ont été réécrites ou migrées (smic55, biact, br_pf ...) mais ce fut surtout l'occasion d'améliorer la structuration des "foyers" au sens des différentes prestations, sans recréer d'entité pour le moment (pas opportun selon moi).
J'ai appliqué ces changements au Complément Familial, qui marche désormais plutôt bien sur Mes-Aides.

Attention ce commit va tout casser, en raison du récursion infinie que vous devez corriger derrière, niveau calcul de la paie. Je vous laisse faire ça __après__ avoir mergé, car c'est le rôle de cette branche !

Enjoy!