### PR TITLE
Prise en compte des revenus du conjoint pour l'ASS : ARE, Retraite, IJ et ASS abattus 

### DIFF
--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -63,7 +63,7 @@ class ass_base_ressources_i(SimpleFormulaColumn):
         period = period.start.offset('first-of', 'month').period('month')
         previous_year = period.start.period('year').offset(-1)
 
-        salaire_net = simulation.calculate_add('salaire_net', previous_year)
+        sali = simulation.calculate_add('sali', previous_year)
         rstnet = simulation.calculate('rstnet', previous_year)
         pensions_alimentaires_percues = simulation.calculate('pensions_alimentaires_percues', previous_year)
         pensions_alimentaires_versees_individu = simulation.calculate('pensions_alimentaires_versees_individu', previous_year)
@@ -72,7 +72,7 @@ class ass_base_ressources_i(SimpleFormulaColumn):
         indemnites_stage = simulation.calculate('indemnites_stage', previous_year)
         revenus_stage_formation_pro = simulation.calculate('revenus_stage_formation_pro', previous_year)
 
-        return period, salaire_net + rstnet + pensions_alimentaires_percues -abs(pensions_alimentaires_versees_individu) + aah + indemnites_stage + revenus_stage_formation_pro
+        return period, sali + rstnet + pensions_alimentaires_percues -abs(pensions_alimentaires_versees_individu) + aah + indemnites_stage + revenus_stage_formation_pro
 
 
 @reference_formula

--- a/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
+++ b/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
@@ -33,3 +33,21 @@ build_column('indemnites_journalieres_maladie', FloatCol(entity = 'ind', label =
 build_column('indemnites_journalieres_accident_travail', FloatCol(entity = 'ind', label = u"Indemnités journalières d'accident du travail"))
 build_column('indemnites_journalieres_maladie_professionnelle', FloatCol(entity = 'ind', label = u"Indemnités journalières de maladie professionnelle"))
 
+@reference_formula
+class indemnites_journalieres(SimpleFormulaColumn):
+    column = FloatCol
+    label = u"Total des indemnités journalières"
+    entity_class = Individus
+
+    def function(self, simulation, period):
+        period = period.start.offset('first-of', 'month').period('month')
+        indemnites_journalieres_maternite = simulation.calculate('indemnites_journalieres_maternite', period)
+        indemnites_journalieres_paternite = simulation.calculate('indemnites_journalieres_paternite', period)
+        indemnites_journalieres_adoption = simulation.calculate('indemnites_journalieres_adoption', period)
+        indemnites_journalieres_maladie = simulation.calculate('indemnites_journalieres_maladie', period)
+        indemnites_journalieres_accident_travail = simulation.calculate('indemnites_journalieres_accident_travail', period)
+        indemnites_journalieres_maladie_professionnelle = simulation.calculate('indemnites_journalieres_accident_travail', period)
+        result = indemnites_journalieres_maternite + indemnites_journalieres_paternite + indemnites_journalieres_adoption + indemnites_journalieres_maladie + indemnites_journalieres_accident_travail + indemnites_journalieres_maladie_professionnelle
+
+        return period, result
+

--- a/openfisca_france/param/param.xml
+++ b/openfisca_france/param/param.xml
@@ -5211,6 +5211,9 @@
         <VALUE deb="2014-01-01" fin="2014-12-31" valeur="1772.10" />
         <VALUE deb="2015-01-01" fin="2015-12-31" valeur="1787.50" />
       </CODE>
+      <CODE code="abat_rev_subst_conj" description="Abbatement appliqué aux revenus de substitution du conjoint, e.g. ARE, retraite, IJ">
+        <VALUE deb="2014-01-01" fin="2015-12-31" valeur="0.3" />
+      </CODE>
     </NODE>
     <NODE code="aspa" description="Allocation solidarité aux personne agées (ASPA - Minimum vieillesse)">
       <CODE code="montant_seul" description="Montant annuel pour une personne seule" format="float" type="monetary">

--- a/openfisca_france/tests/formulas_mes_aides/ass.yaml
+++ b/openfisca_france/tests/formulas_mes_aides/ass.yaml
@@ -1,0 +1,20 @@
+- name: "Prise en compte des revenus du conjoint ARE, ASS, IJ, retraite"
+  period: "2015-01"
+  familles:
+    parents: ["parent1", "parent2"]
+  individus:
+    - id: "parent1"
+      age: 40
+      sali:
+        2014: 1000
+    - id: "parent2"
+      age: 40
+      chonet:
+        2014: 1000
+      rstnet:
+        2014: 100
+      indemnites_journalieres:
+        2014: 10
+  output_variables:
+    ass_base_ressources:
+      "2015-01": 1777


### PR DESCRIPTION
Depends on https://github.com/openfisca/openfisca-france/pull/241
Connected to https://github.com/sgmap/openfisca-france/issues/6

Warning : No ready to merge yet, as we don't take ASS into account for the partner. I open it for discussion

My main problem : 

We want the calculation of the user's ASS to take into account the ASS perceived by his/her partner. This is tough for two reasons : 

- ASS is, up to date, a formula that apply to Family. We should change this I guess, as it is not the case in law. 
- Even if  the previous point is dealt with :  the ASS of the user will be depending on ASS of his/her partner. But if we try to compute the latter, it will depend on the user's ASS and we are stuck in an infinite recursion. Maybe we need to capture the partner's ASS as an input ? 

So far I ignored ASS, so that should be functional for IJ, Retraite and ARE

@MattiSG what do you think ? 