### PR TITLE
Distinction entre loyer et hlm dans statut_occupation

### DIFF
--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -43,15 +43,15 @@ reference_input_variable(
     label = u'Loyer',
     name = 'loyer',
     set_input = set_input_divide_by_period,
-    )
+)
 
 build_column(
     'proprietaire_proche_famille',
     BoolCol(
         entity = "fam",
         label = u"Le propriétaire du logement a un lien de parenté avec la personne de référence ou son conjoint",
-        ),
-    )
+    ),
+)
 
 reference_input_variable(
     column = EnumCol(
@@ -59,16 +59,17 @@ reference_input_variable(
             u"Non renseigné",
             u"Accédant à la propriété",
             u"Propriétaire (non accédant) du logement",
-            u"Locataire d'un logement HLM", #FIXME : Est-ce qu'on parle vraiment d'un HLM et pas d'un foyer ? Incohérence avec mes-aides ? 
+            u"Locataire d'un logement HLM",
             u"Locataire ou sous-locataire d'un logement loué vide non-HLM",
             u"Locataire ou sous-locataire d'un logement loué meublé ou d'une chambre d'hôtel",
-            u"Logé gratuitement par des parents, des amis ou l'employeur"])
-        ),
+            u"Logé gratuitement par des parents, des amis ou l'employeur",
+            u"Locataire d'un foyer (résidence universitaire, maison de retraite, foyer de jeune travailleur, résidence sociale...)"])
+    ),
     entity_class = Menages,
     label = u"Statut d'occupation",
     name = 'statut_occupation',
     set_input = set_input_dispatch_by_period,
-    )
+)
 
 
 @reference_formula

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -279,8 +279,10 @@ class aide_logement_montant_brut(SimpleFormulaColumn):
         #   statut_occupation==5 : Locataire ou statut_occupationus-locataire d'un logement loué meublé
         #                          ou d'une chambre d'hôtel.
         #   statut_occupation==6 : Logé gratuitement par des parents, des amis ou l'employeur
+        #   statut_occupation==7 : Locataire d'un foyer (résidence universitaire, maison de retraite, foyer de
+        #                          jeune travailleur, résidence sociale...)
 
-        loca = (3 <= statut_occupation) & (5 >= statut_occupation)
+        loca = ((3 <= statut_occupation) & (5 >= statut_occupation)) | (statut_occupation == 7)
         acce = statut_occupation == 1
 
         # # aides au logement pour les locataires
@@ -495,7 +497,7 @@ class als(SimpleFormulaColumn):
 
 
 @reference_formula
-class apl(SimpleFormulaColumn):  # FIXME (statut_occupation == 3) correspond un foyer, pas un HLM !
+class apl(SimpleFormulaColumn):
     column = FloatCol
     entity_class = Familles
     label = u" Aide personnalisée au logement"
@@ -529,7 +531,7 @@ class aide_logement_non_calculable(SimpleFormulaColumn):
         period = period.start.offset('first-of', 'month').period('month')
         statut_occupation = simulation.calculate('statut_occupation', period)
 
-        return period, (statut_occupation == 1) * 1 + (statut_occupation == 3) * 2
+        return period, (statut_occupation == 1) * 1 + (statut_occupation == 7) * 2
 
 
 @reference_formula

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -424,10 +424,10 @@ class alf(SimpleFormulaColumn):
         al_pac = simulation.calculate('al_pac', period)
         statut_occupation_famille = simulation.calculate('statut_occupation_famille', period)
         proprietaire_proche_famille = simulation.calculate('proprietaire_proche_famille', period)
-
         statut_occupation = statut_occupation_famille
-        return period, \
-            (al_pac >= 1) * (statut_occupation != 3) * not_(proprietaire_proche_famille) * aide_logement_montant
+
+        result = (al_pac >= 1) * (statut_occupation != 3) * not_(proprietaire_proche_famille) * aide_logement_montant
+        return period, result
 
 
 @reference_formula
@@ -450,7 +450,7 @@ class als_nonet(SimpleFormulaColumn):
         return period, (
             (al_pac == 0) * (statut_occupation != 3) * not_(proprietaire_proche_famille) *
             not_(etu[CHEF] | etu[PART]) * aide_logement_montant
-            )
+        )
 
 
 @reference_formula
@@ -475,7 +475,7 @@ class alset(SimpleFormulaColumn):
         return period, (
             (al_pac == 0) * (statut_occupation != 3) * not_(proprietaire_proche_famille) *
             (etu[CHEF] | etu[PART]) * aide_logement_montant
-            )
+        )
 
 
 @reference_formula
@@ -495,7 +495,7 @@ class als(SimpleFormulaColumn):
 
 
 @reference_formula
-class apl(SimpleFormulaColumn):
+class apl(SimpleFormulaColumn):  # FIXME (statut_occupation == 3) correspond un foyer, pas un HLM !
     column = FloatCol
     entity_class = Familles
     label = u" Aide personnalisée au logement"
@@ -511,14 +511,15 @@ class apl(SimpleFormulaColumn):
         statut_occupation = self.filter_role(statut_occupation, role = CHEF)
         return period, aide_logement_montant * (statut_occupation == 3)
 
+
 @reference_formula
 class aide_logement_non_calculable(SimpleFormulaColumn):
     column = EnumCol(
         enum = Enum([
             u"",
-            u"proprietaire",
+            u"primo_accedant",
             u"locataire_foyer"
-            ]),
+        ]),
         default = 0
     )
     entity_class = Familles
@@ -528,7 +529,8 @@ class aide_logement_non_calculable(SimpleFormulaColumn):
         period = period.start.offset('first-of', 'month').period('month')
         statut_occupation = simulation.calculate('statut_occupation', period)
 
-        return period, ((statut_occupation == 1) + (statut_occupation == 2)) * 1 + (statut_occupation == 3) * 2
+        return period, (statut_occupation == 1) * 1 + (statut_occupation == 3) * 2
+
 
 @reference_formula
 class aide_logement(SimpleFormulaColumn):


### PR DESCRIPTION
Jusqu'à maintenant il y avait incohérence entre openfisca et mes-aides : openfisca considérait que "3" signifiait  HLM, alors que mes-aides considérait qu'il s'agissait d'un foyer. 

=> Création d'une nouvelle valeur pour les foyer (7) 

Depends on #258 
Depends on https://github.com/sgmap/mes-aides-api/pull/21
Connected to https://github.com/sgmap/mes-aides-ui/issues/74