### PR TITLE
Taxe apprentissage

### DIFF
--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -251,6 +251,7 @@ class taxe_apprentissage(SimpleFormulaColumn):
     column = FloatCol
     entity_class = Individus
     label = u"Taxe d'apprentissage (employeur, entreprise redevable de la taxe d'apprentissage uniquement)"
+    url = u"https://www.service-public.fr/professionnels-entreprises/vosdroits/F22574"
 
     def function(self, simulation, period):
         period = period.start.period(u'month').offset('first-of')

--- a/openfisca_france/param/param.xml
+++ b/openfisca_france/param/param.xml
@@ -1483,10 +1483,11 @@
           <BAREME code="apprentissage" description="Taxe d'apprentissage (toutes entreprises)" option="main-d-oeuvre">
             <TRANCHE code="tranche0">
               <SEUIL>
-                <VALUE deb="1993-07-01" fin="2014-12-31" valeur="0" />
+                <VALUE deb="1993-07-01" fin="2016-12-31" valeur="0" />
               </SEUIL>
               <TAUX>
-                <VALUE deb="1993-07-01" fin="2014-12-31" valeur="0.005" />
+                <VALUE deb="2014-01-01" fin="2016-12-31" valeur="0.0068" />
+                <VALUE deb="1993-07-01" fin="2013-12-31" valeur="0.005" />
               </TAUX>
             </TRANCHE>
           </BAREME>

--- a/openfisca_france/param/param.xml
+++ b/openfisca_france/param/param.xml
@@ -1497,7 +1497,8 @@
                 <VALUE deb="2004-01-01" fin="2014-12-31" valeur="0" />
               </SEUIL>
               <TAUX>
-                <VALUE deb="2006-01-01" fin="2014-12-31" valeur="0.0018" />
+                <VALUE deb="2014-01-01" fin="2016-12-31" valeur="0" />
+                <VALUE deb="2006-01-01" fin="2013-12-31" valeur="0.0018" />
                 <VALUE deb="2005-01-01" fin="2005-12-31" valeur="0.0012" />
                 <VALUE deb="2004-01-01" fin="2004-12-31" valeur="0.0006" />
               </TAUX>

--- a/openfisca_france/tests/embauche.sgmap.fr/taxe_apprentissage.yaml
+++ b/openfisca_france/tests/embauche.sgmap.fr/taxe_apprentissage.yaml
@@ -1,0 +1,21 @@
+name: Taxe d'apprentissage
+keywords: Taxe d'apprentissage, apprentissage
+description: |
+  Calcul :
+  SMIC mensuel = 1457,52€
+  Taxe d'apprentissage en 2015 : 0.68%
+  Montant mensuel = 1457,52 * 0.0068 = 9,911136
+
+  Contribution au développement de l'apprentissage en 2015 : 0 (obsolète)
+  Montant mensuel = 0
+
+period: "month:2015-1-1"
+relative_error_margin: 0.02
+input_variables:
+  contrat_de_travail_debut: "2015-1-1"
+  effectif_entreprise: 1
+  salaire_de_base: 1457.52
+  type_sal: 0
+output_variables:
+  contribution_developpement_apprentissage: 0
+  taxe_apprentissage: -9.911136

--- a/openfisca_france/tests/fiches_de_paie/coordinatrice_2014-03.yaml
+++ b/openfisca_france/tests/fiches_de_paie/coordinatrice_2014-03.yaml
@@ -55,14 +55,14 @@ output_variables:
 
   # cotisations_employeur_main_d_oeuvre
   conge_individuel_formation_cdd: 0
-  contribution_developpement_apprentissage: -3.24 # avec la taxe d'apprentissage
   contribution_solidarite_autonomie: -5.4
   IGNORE_contribution_supplementaire_apprentissage: 0 #  pas dans la fiche
   IGNORE_fnal: 0  # check
   formation_professionnelle: -28.8
   participation_effort_construction: -8.1
   prevoyance_obligatoire_cadre: 0
-  taxe_apprentissage: -9
+  taxe_apprentissage: -12.24 # taux relevé de 0.5% à 0.68% au 2014-01-01 (aspiration de la contrib. au dév)
+  contribution_developpement_apprentissage: 0
   versement_transport: -36
 
   allegement_fillon: 222.12

--- a/openfisca_france/tests/fiches_de_paie/ingenieur_etude_2014-07.yaml
+++ b/openfisca_france/tests/fiches_de_paie/ingenieur_etude_2014-07.yaml
@@ -46,7 +46,6 @@ output_variables:
   mmid_employeur: -3000 * .128  # est aggrégé avec vieillesse deplaf et csa
   taxe_salaires: 0
   conge_individuel_formation_cdd: 0
-  contribution_developpement_apprentissage: -3000 * 0.0018  # aggrégé avec taxe apprentissage
   contribution_solidarite_autonomie: -3000 * 0.003  #  est aggrégé avec vieillesse deplaf et maladie
   contribution_supplementaire_apprentissage: 0
   fnal: -15
@@ -66,7 +65,7 @@ output_variables:
   formation_professionnelle: -48
   participation_effort_construction: -13.5
   prevoyance_obligatoire_cadre: -59.02
-  taxe_apprentissage: -3000 * 0.005  # aggrégé avec contribution supplémentaire apprentissage
+  taxe_apprentissage: -3000 * 0.0068  # aggrégé avec contribution supplémentaire apprentissage
   taux_versement_transport: .027
   versement_transport: -81
 


### PR DESCRIPTION
Changement du taux de la taxe d'apprentissage (qui passe de `0.005` à `0.0068`).
Suppression de la contribution au développement de l'apprentissage (qui était de `0.0018`, elle a donc été simplement ajoutée à la taxe).

 **Source**

- Augmentation du taux de la taxe : [ LOI n° 2013-1279 du 29 décembre 2013 de finances rectificative pour 2013, article 60](http://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=9B99F4419C389C9F14A3E75337896643.tpdila22v_1?cidTexte=JORFTEXT000028400921&idArticle=LEGIARTI000028428572&dateTexte=20131230)

> 5° A la fin du deuxième alinéa de l'article 1599 ter B, le pourcentage : « 0,50 % » est remplacé par le pourcentage : « 0,68 % » ; 

> Le présent article s'applique pour les contributions et taxe dues au titre des rémunérations versées à compter du 1er janvier 2014.

- Suppression de la contribution au développement :
[Article 1599](http://www.legifrance.gouv.fr/affichCode.do;jsessionid=9B99F4419C389C9F14A3E75337896643.tpdila22v_1?idSectionTA=LEGISCTA000021751374&cidTexte=LEGITEXT000006069577&dateTexte=20130101) quinquies A (abrogé au 1 janvier 2014)