### PR TITLE
Taux formation pro

### DIFF
--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -202,6 +202,7 @@ class formation_professionnelle(SimpleFormulaColumn):
     column = FloatCol
     entity_class = Individus
     label = u"Formation professionnelle"
+    url = u"https://www.service-public.fr/professionnels-entreprises/vosdroits/F22570"
 
     def function(self, simulation, period):
         taille_entreprise = simulation.calculate('taille_entreprise', period)

--- a/openfisca_france/param/param.xml
+++ b/openfisca_france/param/param.xml
@@ -1512,10 +1512,10 @@
           <BAREME code="formprof_09" description="Formation professionnelle (0-9 salaries)" option="main-d-oeuvre">
             <TRANCHE code="tranche0">
               <SEUIL>
-                <VALUE deb="1993-01-01" fin="2013-12-31" valeur="0" />
+                <VALUE deb="1993-01-01" fin="2015-12-31" valeur="0" />
               </SEUIL>
               <TAUX>
-                <VALUE deb="2005-01-01" fin="2013-12-31" valeur="0.0055" />
+                <VALUE deb="2005-01-01" fin="2015-12-31" valeur="0.0055" />
                 <VALUE deb="2004-01-01" fin="2004-12-31" valeur="0.004" />
                 <VALUE deb="1993-01-01" fin="2003-12-31" valeur="0.0015" />
               </TAUX>
@@ -1524,10 +1524,11 @@
           <BAREME code="formprof_1019" description="Formation professionnelle (10-19 salaries)" option="main-d-oeuvre">
             <TRANCHE code="tranche0">
               <SEUIL>
-                <VALUE deb="1992-01-01" fin="2013-12-31" valeur="0" />
+                <VALUE deb="1992-01-01" fin="2015-12-31" valeur="0" />
               </SEUIL>
               <TAUX>
-                <VALUE deb="2005-01-01" fin="2013-12-01" valeur="0.0105" />
+                <VALUE deb="2015-01-01" fin="2015-12-31" valeur="0.01" />
+                <VALUE deb="2005-01-01" fin="2014-12-31" valeur="0.0105" />
                 <VALUE deb="2004-01-01" fin="2004-12-31" valeur="0.016" />
                 <VALUE deb="1993-01-01" fin="2003-12-31" valeur="0.015" />
                 <VALUE deb="1992-01-01" fin="1992-12-31" valeur="0.014" />
@@ -1537,10 +1538,11 @@
           <BAREME code="formprof_20" description="Formation professionnelle (plus de 20 salariés)" option="main-d-oeuvre">
             <TRANCHE code="tranche0">
               <SEUIL>
-                <VALUE deb="1992-01-01" fin="2013-12-31" valeur="0" />
+                <VALUE deb="1992-01-01" fin="2015-12-31" valeur="0" />
               </SEUIL>
               <TAUX>
-                <VALUE deb="2004-01-01" fin="2013-12-31" valeur="0.016" />
+                <VALUE deb="2015-01-01" fin="2015-12-31" valeur="0.01" />
+                <VALUE deb="2004-01-01" fin="2014-12-31" valeur="0.016" />
                 <VALUE deb="1993-01-01" fin="2003-12-31" valeur="0.015" />
                 <VALUE deb="1992-01-01" fin="1992-12-31" valeur="0.014" />
               </TAUX>

--- a/openfisca_france/tests/formulas/formation_professionnelle.yaml
+++ b/openfisca_france/tests/formulas/formation_professionnelle.yaml
@@ -1,0 +1,32 @@
+- period: "month:2015-11"
+  input_variables:
+    effectif_entreprise: 1
+    type_sal: "prive_non_cadre"
+    salaire_de_base: "1457.52"
+    allegement_fillon_mode_recouvrement: "progressif"
+    jeune_entreprise_innovante: "false"
+    contrat_de_travail_debut: "2015-01-01"
+  output_variables:
+    formation_professionnelle: -8.016
+
+- period: "month:2015-11"
+  input_variables:
+    effectif_entreprise: 10
+    type_sal: "prive_non_cadre"
+    salaire_de_base: "1457.52"
+    allegement_fillon_mode_recouvrement: "progressif"
+    jeune_entreprise_innovante: "false"
+    contrat_de_travail_debut: "2015-01-01"
+  output_variables:
+    formation_professionnelle: -14.5752
+
+- period: "month:2015-11"
+  input_variables:
+    effectif_entreprise: 300
+    type_sal: "prive_non_cadre"
+    salaire_de_base: "3000"
+    allegement_fillon_mode_recouvrement: "progressif"
+    jeune_entreprise_innovante: "false"
+    contrat_de_travail_debut: "2015-01-01"
+  output_variables:
+    formation_professionnelle: -30


### PR DESCRIPTION
Mise à jour du taux de la contribution à la formation professionnelle continue. 

> Pour les contributions calculées sur les rémunérations versées en 2015 et recouvrées en 2016, les taux ont été modifiés : la contribution est dorénavant unique de 1 % pour les entreprises à partir de 10 salariés (le seuil de 20 salariés disparaît). 

[Décret](http://www.legifrance.gouv.fr/eli/decret/2014/10/24/ETSD1418587D/jo) (article 9) qui détaille la répartition des cotisations, et donc les taux par taille d'entreprise. 
Et notre cher [service-public.fr](https://www.service-public.fr/professionnels-entreprises/vosdroits/F22570)