### PR TITLE
Simplify situation_occupation in al, cmu, rsa

### DIFF
--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -265,9 +265,7 @@ class aide_logement_montant_brut(Variable):
         al_pac = simulation.calculate('al_pac', period)
 
         # Logement
-        statut_occupation_holder = simulation.compute('statut_occupation', period)
-        statut_occupation = self.cast_from_entity_to_roles(statut_occupation_holder)
-        statut_occupation = self.filter_role(statut_occupation, role = CHEF)
+        statut_occupation = simulation.calculate('statut_occupation_famille', period)
         loyer_holder = simulation.compute('loyer', period)
         loyer = self.cast_from_entity_to_roles(loyer_holder)
         loyer = self.filter_role(loyer, role = CHEF)
@@ -467,9 +465,8 @@ class alf(Variable):
         period = period.this_month
         aide_logement_montant = simulation.calculate('aide_logement_montant', period)
         al_pac = simulation.calculate('al_pac', period)
-        statut_occupation_famille = simulation.calculate('statut_occupation_famille', period)
+        statut_occupation = simulation.calculate('statut_occupation_famille', period)
         proprietaire_proche_famille = simulation.calculate('proprietaire_proche_famille', period)
-        statut_occupation = statut_occupation_famille
 
         result = (al_pac >= 1) * (statut_occupation != 3) * not_(proprietaire_proche_famille) * aide_logement_montant
         return period, result
@@ -485,10 +482,8 @@ class als_nonet(Variable):
         aide_logement_montant = simulation.calculate('aide_logement_montant', period)
         al_pac = simulation.calculate('al_pac', period)
         etu_holder = simulation.compute('etu', period)
-        statut_occupation_famille = simulation.calculate('statut_occupation_famille', period)
+        statut_occupation = simulation.calculate('statut_occupation_famille', period)
         proprietaire_proche_famille = simulation.calculate('proprietaire_proche_famille', period)
-
-        statut_occupation = statut_occupation_famille
 
         etu = self.split_by_roles(etu_holder, roles = [CHEF, PART])
         return period, (
@@ -509,11 +504,8 @@ class alset(Variable):
         aide_logement_montant = simulation.calculate('aide_logement_montant', period)
         al_pac = simulation.calculate('al_pac', period)
         etu_holder = simulation.compute('etu', period)
-        statut_occupation_holder = simulation.compute('statut_occupation', period)
+        statut_occupation = simulation.calculate('statut_occupation_famille', period)
         proprietaire_proche_famille = simulation.calculate('proprietaire_proche_famille', period)
-
-        statut_occupation = self.cast_from_entity_to_roles(statut_occupation_holder)
-        statut_occupation = self.filter_role(statut_occupation, role = CHEF)
 
         etu = self.split_by_roles(etu_holder, roles = [CHEF, PART])
         return period, (
@@ -549,10 +541,8 @@ class apl(Variable):
     def function(self, simulation, period):
         period = period.this_month
         aide_logement_montant = simulation.calculate('aide_logement_montant', period)
-        statut_occupation_holder = simulation.compute('statut_occupation', period)
+        statut_occupation = simulation.calculate('statut_occupation_famille', period)
 
-        statut_occupation = self.cast_from_entity_to_roles(statut_occupation_holder)
-        statut_occupation = self.filter_role(statut_occupation, role = CHEF)
         return period, aide_logement_montant * (statut_occupation == 3)
 
 
@@ -570,7 +560,7 @@ class aide_logement_non_calculable(Variable):
 
     def function(self, simulation, period):
         period = period.this_month
-        statut_occupation = simulation.calculate('statut_occupation', period)
+        statut_occupation = simulation.calculate('statut_occupation_famille', period)
 
         return period, (statut_occupation == 1) * 1 + (statut_occupation == 7) * 2
 

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -235,15 +235,12 @@ class cmu_base_ressources(Variable):
         paje_clca = simulation.calculate_add('paje_clca', previous_year)
         paje_prepare = simulation.calculate_add('paje_prepare', previous_year)
         aide_logement = simulation.calculate_add('aide_logement', previous_year)
-        statut_occupation_holder = simulation.compute('statut_occupation', period)
+        statut_occupation = simulation.calculate('statut_occupation_famille', period)
         cmu_forfait_logement_base = simulation.calculate('cmu_forfait_logement_base', period)
         cmu_forfait_logement_al = simulation.calculate('cmu_forfait_logement_al', period)
         age_holder = simulation.compute('age', period)
         cmu_base_ressources_i_holder = simulation.compute('cmu_base_ressources_i', period)
         P = simulation.legislation_at(period.start).cmu
-
-        statut_occupation = self.cast_from_entity_to_roles(statut_occupation_holder)
-        statut_occupation = self.filter_role(statut_occupation, role = CHEF)
 
         cmu_br_i_par = self.split_by_roles(cmu_base_ressources_i_holder, roles = [CHEF, PART])
         cmu_br_i_pac = self.split_by_roles(cmu_base_ressources_i_holder, roles = ENFS)

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -832,9 +832,7 @@ class rsa_forfait_logement(Variable):
         rmi_nbp = simulation.calculate('rmi_nbp', period)
         aide_logement = simulation.calculate('aide_logement', period)
 
-        statut_occupation_holder = simulation.compute('statut_occupation', period)
-        statut_occupation = self.cast_from_entity_to_roles(statut_occupation_holder)
-        statut_occupation = self.filter_role(statut_occupation, role = CHEF)
+        statut_occupation = simulation.calculate('statut_occupation_famille', period)
 
         participation_frais_holder = simulation.compute('participation_frais', period)
         participation_frais = self.cast_from_entity_to_roles(participation_frais_holder)


### PR DESCRIPTION
Use `situation_occupation_famille` instead of heavy entity casting.

Btw, is there any *practical* reason why `statut_occupation` is related to a `Menage` ? It seems like it is always used  in the context of a `Famille`.

(This caused @kinta95 some trouble, as she was trying to declare a `statut_occupation` for a `Familles` in yaml tests, which sounds pretty natural)