### PR TITLE
Add historical supp_fam IM_max param

### DIFF
--- a/openfisca_france/param/param.xml
+++ b/openfisca_france/param/param.xml
@@ -3920,6 +3920,7 @@
       <CODE code="IM_max" description="Indice majoré plafond" format="integer">
         <VALUE deb="2015-01-01" fuzzy="true" valeur="717" />
         <VALUE deb="2006-01-01" fin="2014-12-31" valeur="717" />
+        <VALUE deb="1988-03-01" fin="2005-12-31" valeur="716" />
       </CODE>
       <CODE code="IM_min" description="Indice majoré plancher" format="integer">
         <VALUE deb="2015-01-01" fuzzy="true" valeur="449" />


### PR DESCRIPTION
See https://github.com/openfisca/openfisca-core/issues/368 and the [source](https://github.com/openfisca/openfisca-core/issues/368#issuecomment-168713564) of the param history.
IM_max appears to be the only rate breaking tests after @cbenz 's [fix](https://github.com/openfisca/openfisca-france/commit/7b881be35aebe830eadad64b3af102479ac2141d)

