### PR TITLE
Include AAH in PPA resources

### DIFF
--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -139,6 +139,7 @@ class ppa_ressources_hors_activite_i(Variable):
         period = period.this_month
 
         ressources = [
+            'aah',
             'chonet',
             'rstnet',
             'retraite_combattant',


### PR DESCRIPTION
"L'AAH est prise en compte à 100%, en tant que prestation sociale, pour le calcul de la prime d'activité : L. 842-4, R. 844-4 et R. 844-5 CSS." — https://mes-aides.gouv.fr/tests/5693d5e8ab1adc4751a7cb46/show