### PR TITLE
Update taux fillon

### DIFF
--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -36,6 +36,7 @@ class allegement_fillon(DatedVariable):
     column = FloatCol
     entity_class = Individus
     label = u"Allègement de charges employeur sur les bas et moyens salaires (dit allègement Fillon)"
+    # Attention : cet allègement a des règles de cumul spécifiques
 
     @dated_function(date(2005, 7, 1))
     def function(self, simulation, period):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -186,7 +186,6 @@ def compute_allegement_fillon_progressif(simulation, period):
         up_to_this_month = period.start.offset('first-of', 'year').period('month', period.start.month)
         up_to_previous_month = period.start.offset('first-of', 'year').period('month', period.start.month - 1)
         cumul = simulation.calculate_add('allegement_fillon', up_to_previous_month, max_nb_cycles = 1)
-        up_to_this_month = period.start.offset('first-of', 'year').period('month', period.start.month)
         return compute_allegement_fillon(simulation, up_to_this_month) - cumul
 
 

--- a/openfisca_france/param/param.xml
+++ b/openfisca_france/param/param.xml
@@ -858,14 +858,14 @@
         <CODE code="tx_max" description="Taux maximum (plus de 20 salariés)" format="percent">
           <VALUE deb="2018-01-01" fuzzy="true" valeur=".2850" />
           <VALUE deb="2017-01-01" fin="2017-12-31" valeur=".2850" />
-          <VALUE deb="2016-01-01" fin="2016-12-31" valeur=".2845" />
+          <VALUE deb="2016-01-01" fin="2016-12-31" valeur=".2842" />
           <VALUE deb="2015-01-01" fin="2015-12-31" valeur=".2835" />
           <VALUE deb="2005-07-01" fin="2014-12-31" valeur=".26" />
         </CODE>
         <CODE code="tx_max2" description="Taux maximum (moins de 20 salariés)" format="percent">
           <VALUE deb="2018-01-01" fuzzy="true" valeur=".2810" />
           <VALUE deb="2017-01-01" fin="2017-12-31" valeur=".2810" />
-          <VALUE deb="2016-01-01" fin="2016-12-31" valeur=".2805" />
+          <VALUE deb="2016-01-01" fin="2016-12-31" valeur=".2802" />
           <VALUE deb="2015-01-01" fin="2015-12-31" valeur=".2795" />
           <VALUE deb="2007-07-01" fin="2014-12-31" valeur=".281" />
           <VALUE deb="2005-07-01" fin="2007-06-30" valeur=".26" />


### PR DESCRIPTION
Le taux du coefficient a changé en 2016.
[source](https://www.urssaf.fr/portail/sites/urssaf/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-reduction-generale.html)