### PR TITLE
Correction seuil effort construction

### DIFF
--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -237,6 +237,8 @@ class participation_effort_construction(Variable):
             variable_name = self.__class__.__name__,
             )
 
+        # TODO : seuil passé de 10 à 20 avec l'Ordonnance n° 2005-895 du 2 août 2005
+
         cotisation = (
             bareme * (effectif_entreprise >= 20) +
             self.zeros() * (effectif_entreprise < 20)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -227,13 +227,21 @@ class participation_effort_construction(Variable):
 
     def function(self, simulation, period):
         period = period.start.period(u'month').offset('first-of')
-        cotisation = apply_bareme(
+        effectif_entreprise = simulation.calculate('effectif_entreprise', period)
+
+        bareme = apply_bareme(
             simulation,
             period,
             cotisation_type = 'employeur',
             bareme_name = 'construction',
             variable_name = self.__class__.__name__,
             )
+
+        cotisation = (
+            bareme * (effectif_entreprise >= 20) +
+            self.zeros() * (effectif_entreprise < 20)
+            )
+
         return period, cotisation
 
 

--- a/openfisca_france/tests/fiches_de_paie/apprenti.yaml
+++ b/openfisca_france/tests/fiches_de_paie/apprenti.yaml
@@ -69,7 +69,7 @@ output_variables:
   financement_organisations_syndicales: -.11  # -35 * 52 * 9.61 * .49 / 12 * 0.00016
   formation_professionnelle: -3.93
   fnal: -.71
-  participation_effort_construction: -3.21
+  participation_effort_construction: 0 # was incorrectly : -3.21
   prevoyance_obligatoire_cadre: 0
   taxe_apprentissage: 0
   versement_transport: 0
@@ -81,8 +81,8 @@ output_variables:
   assiette_cotisations_sociales: 35 * 52 * 9.61 * .49 / 12
 
   cotisations_employeur: -284.96 - 10.71 -.11
-  cotisations_employeur: -2.14 -8.57 -33.21 -28.57 -12.86 -60.71 -10.71 -37.49 -91.42 -2.14 -3.93 -.71 -3.21 -.11
-  exoneration_cotisations_employeur_apprenti: 285.07
+  cotisations_employeur: -2.14 -8.57 -33.21 -28.57 -12.86 -60.71 -10.71 -37.49 -91.42 -2.14 -3.93 -.71 -.11
+  exoneration_cotisations_employeur_apprenti: 281.86
 
   #
   cotisations_salariales: 0  #-5.71 -22.14 -17.14 -2.14 -48.92 -5.36

--- a/openfisca_france/tests/formulas/cout_du_travail.yaml
+++ b/openfisca_france/tests/formulas/cout_du_travail.yaml
@@ -14,11 +14,11 @@
     effectif_entreprise: 1
     contrat_de_travail_debut: 2015-07-01
   output_variables:
-    salaire_super_brut: 1637
-    cout_du_travail: 1383
-    salaire_super_brut_hors_allegements: 2071
+    salaire_super_brut: 1630.4
+    cout_du_travail: 1376.4
+    salaire_super_brut_hors_allegements: 2064.4
     salaire_net: 1136
-    cotisations_employeur: -613.5
+    cotisations_employeur: -606.9
     allegement_fillon: 407
     aide_premier_salarie: 166.7
     credit_impot_competitivite_emploi: 87.5
@@ -33,5 +33,5 @@
     effectif_entreprise: 2
     contrat_de_travail_debut: 2015-07-01
   output_variables:
-    salaire_super_brut: 1637
-    cout_du_travail: 1550
+    salaire_super_brut: 1630.4
+    cout_du_travail: 1543.4

--- a/openfisca_france/tests/formulas/participation_effort_construction.yaml
+++ b/openfisca_france/tests/formulas/participation_effort_construction.yaml
@@ -1,0 +1,17 @@
+- period: "2016-01"
+  name: Participation à l'effort de construction
+  relative_error_margin: 0.01
+  input_variables:
+    salaire_de_base: 1467
+    effectif_entreprise: 20
+  output_variables:
+    participation_effort_construction: -1467 * .0045
+
+- period: "2016-01"
+  name: Participation à l'effort de construction - entreprise en dessous du seuil
+  relative_error_margin: 0.01
+  input_variables:
+    salaire_de_base: 1467
+    effectif_entreprise: 19
+  output_variables:
+    participation_effort_construction: 0

--- a/openfisca_france/tests/formulas/salaire_super_brut.yaml
+++ b/openfisca_france/tests/formulas/salaire_super_brut.yaml
@@ -6,10 +6,10 @@
     effectif_entreprise: 1
     type_sal: 0
   output_variables:
-    cotisations_employeur: -613.55
+    cotisations_employeur: -607
     allegement_fillon: 409.56
-    salaire_super_brut_hors_allegements: 2058
-    salaire_super_brut: 1648 # fillon
+    salaire_super_brut_hors_allegements: 2051.5
+    salaire_super_brut: 1641.5
 
 - period: "2015-04"
   relative_error_margin: 0.01
@@ -20,10 +20,9 @@
     type_sal: 0
     jeune_entreprise_innovante: 1
   output_variables:
-    cotisations_employeur: -613.55
+    cotisations_employeur: -607
     allegement_fillon: 407.4
     exoneration_cotisations_employeur_jei: 413.2
     exonerations_et_allegements: 820.6 # fillon + JEI
-    salaire_super_brut_hors_allegements: 2058
-    salaire_super_brut: 1238
-
+    salaire_super_brut_hors_allegements: 2051.5
+    salaire_super_brut: 1231.5

--- a/openfisca_france/tests/formulas/salaire_super_brut_hors_allegements.yaml
+++ b/openfisca_france/tests/formulas/salaire_super_brut_hors_allegements.yaml
@@ -7,10 +7,10 @@
     effectif_entreprise: 1
     type_sal: 0
   output_variables:
-    cotisations_employeur: -613.55
+    cotisations_employeur: -607
     allegement_fillon: 409.56
     jeune_entreprise_innovante: 0
-    salaire_super_brut_hors_allegements: 2058
+    salaire_super_brut_hors_allegements: 2051.5
 
 - period: "2015-04"
   name: "Salaire super-brut : pas d'allègements et exos."
@@ -26,7 +26,7 @@
     type_sal: 0
     jeune_entreprise_innovante: 1
   output_variables:
-    cotisations_employeur: -613.55
+    cotisations_employeur: -607
     allegement_fillon: 409.56
     exoneration_cotisations_employeur_jei: 413.2
-    salaire_super_brut_hors_allegements: 2058 # le même
+    salaire_super_brut_hors_allegements: 2051.5 # le même


### PR DESCRIPTION
Le seuil de 20 employés n'était pas pris en compte. 
La seule erreur flagrante pour de nombreux utilisateurs du simulateur d'embauche en février 2016 :+1: 

Le `preprocessing.py` (encore lui !) rendait cette erreur moins visible...