### PR TITLE
Introduce extension mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@
 /dist
 /openfisca_france/assets/apl/france2014.txt
 /openfisca_france/assets/apl/france2014.zip
+openfisca_france/model/extensions
 /tags

--- a/openfisca_france/__init__.py
+++ b/openfisca_france/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import os
+import os, itertools
 
 
 COUNTRY_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -73,7 +73,7 @@ def init_country(qt = False):  # drop_survey_only_variables = False, simulate_f6
             #     os.path.join(COUNTRY_DIR, 'assets', 'xxx', 'yyy.xml'),
             #     ('insert', 'into', 'existing', 'element'),
             #     ),
-            ]
+            ] + zip(model.extensions.extensions_parameters, itertools.repeat(None))
 
         preprocess_legislation = staticmethod(preprocessing.preprocess_legislation)
 

--- a/openfisca_france/model/extensions/README.md
+++ b/openfisca_france/model/extensions/README.md
@@ -1,0 +1,34 @@
+Openfisca extensions
+====================
+
+Extensions allow you to add formulas to Openfisca that are not included in this repository (e.g. local prestations).
+
+Extensions folders located in this directory will be **automatically loaded** at the initialization of the tax benefit system.
+They can be brought here manually or by any custom mechanism up to your convenience.
+
+If you need to import an extension located out of the `extensions` folder, you can use the following function:
+
+```py
+openfisca_france.model.extensions.import_extension('/path/to/external/extension/folder')
+```
+
+Extension architecture
+-----------------------
+The architecture of an extension folder is the following:
+
+```sh
+extensions/{extension_name}/ # The folder name is by convention the name of the extension.
+    extensions/{extension_name}/__init__.py # Empty file.
+    extensions/{extension_name}/{extension_name}.xml # Optional parameters file. The name must be the same than the extension.
+    extensions/{extension_name}/{some_formula}.py # File containing formulas
+    extensions/{extension_name}/{other_formula}.py
+    extensions/{extension_name}/{some_formula}.yaml # Optional test files
+    extensions/{extension_name}/{other_formula}.yaml
+```
+All python files located directly in `extensions/{extension_name}/` are imported in the tax benefit system.
+
+Subdirectories are ignored, as well as any other xml file than `{extension_name}.xml`.
+
+The syntax of the formulas within extension python files is the same than in the general openfisca-france formulas, except that imports should not be relative (e.g. `from openfisca_france.model.base import *`).
+
+Variables inside an extension should not have the same name than any existing formula, nor than any formula in another extension being used.

--- a/openfisca_france/model/extensions/README.md
+++ b/openfisca_france/model/extensions/README.md
@@ -1,34 +1,3 @@
-Openfisca extensions
-====================
+Put here the extensions you want to add to Openfisca, they will be automatically loaded.
 
-Extensions allow you to add formulas to Openfisca that are not included in this repository (e.g. local prestations).
-
-Extensions folders located in this directory will be **automatically loaded** at the initialization of the tax benefit system.
-They can be brought here manually or by any custom mechanism up to your convenience.
-
-If you need to import an extension located out of the `extensions` folder, you can use the following function:
-
-```py
-openfisca_france.model.extensions.import_extension('/path/to/external/extension/folder')
-```
-
-Extension architecture
------------------------
-The architecture of an extension folder is the following:
-
-```sh
-extensions/{extension_name}/ # The folder name is by convention the name of the extension.
-    extensions/{extension_name}/__init__.py # Empty file.
-    extensions/{extension_name}/{extension_name}.xml # Optional parameters file. The name must be the same than the extension.
-    extensions/{extension_name}/{some_formula}.py # File containing formulas
-    extensions/{extension_name}/{other_formula}.py
-    extensions/{extension_name}/{some_formula}.yaml # Optional test files
-    extensions/{extension_name}/{other_formula}.yaml
-```
-All python files located directly in `extensions/{extension_name}/` are imported in the tax benefit system.
-
-Subdirectories are ignored, as well as any other xml file than `{extension_name}.xml`.
-
-The syntax of the formulas within extension python files is the same than in the general openfisca-france formulas, except that imports should not be relative (e.g. `from openfisca_france.model.base import *`).
-
-Variables inside an extension should not have the same name than any existing formula, nor than any formula in another extension being used.
+More info on extensions [here](http://doc.openfisca.fr/contribute/extensions.html).

--- a/openfisca_france/model/extensions/__init__.py
+++ b/openfisca_france/model/extensions/__init__.py
@@ -1,5 +1,5 @@
 import os, glob
-from importlib import import_module
+from imp import find_module, load_module
 
 EXTENSIONS_PATH = os.path.dirname(os.path.abspath(__file__))
 EXTENSIONS_DIRECTORIES = glob.glob(os.path.join(EXTENSIONS_PATH, '*/'))
@@ -9,13 +9,14 @@ extensions_parameters = []
 def import_extension(extension_directory):
 	extension_name = os.path.basename(os.path.normpath(extension_directory))
 	py_files = glob.glob(os.path.join(extension_directory, "*.py"))
-	modules = [
+	module_names = [
 		os.path.basename(f)[:-3]
 		for f in py_files
 		if not os.path.basename(f).startswith('_')
 		]
-	for module in modules:
-		import_module('.' + module, __package__ + '.' + extension_name)
+	for module_name in module_names:
+		module = find_module(module_name, [extension_directory])
+		load_module(module_name, *module)
 	extensions_parameters.append(os.path.join(extension_directory, extension_name + '.xml'))
 
 for extension_dir in EXTENSIONS_DIRECTORIES:

--- a/openfisca_france/model/extensions/__init__.py
+++ b/openfisca_france/model/extensions/__init__.py
@@ -17,7 +17,9 @@ def import_extension(extension_directory):
 	for module_name in module_names:
 		module = find_module(module_name, [extension_directory])
 		load_module(module_name, *module)
-	extensions_parameters.append(os.path.join(extension_directory, extension_name + '.xml'))
+	param_file = os.path.join(extension_directory, extension_name + '.xml')
+	if os.path.isfile(param_file):
+		extensions_parameters.append(param_file)
 
 for extension_dir in EXTENSIONS_DIRECTORIES:
 	import_extension(extension_dir)

--- a/openfisca_france/model/extensions/__init__.py
+++ b/openfisca_france/model/extensions/__init__.py
@@ -17,7 +17,7 @@ def import_extension(extension_directory):
 	for module_name in module_names:
 		module = find_module(module_name, [extension_directory])
 		load_module(module_name, *module)
-	param_file = os.path.join(extension_directory, extension_name + '.xml')
+	param_file = os.path.join(extension_directory, 'parameters.xml')
 	if os.path.isfile(param_file):
 		extensions_parameters.append(param_file)
 

--- a/openfisca_france/model/extensions/__init__.py
+++ b/openfisca_france/model/extensions/__init__.py
@@ -1,0 +1,22 @@
+import os, glob
+from importlib import import_module
+
+EXTENSIONS_PATH = os.path.dirname(os.path.abspath(__file__))
+EXTENSIONS_DIRECTORIES = glob.glob(os.path.join(EXTENSIONS_PATH, '*/'))
+
+extensions_parameters = []
+
+def import_extension(extension_directory):
+	extension_name = os.path.basename(os.path.normpath(extension_directory))
+	py_files = glob.glob(os.path.join(extension_directory, "*.py"))
+	modules = [
+		os.path.basename(f)[:-3]
+		for f in py_files
+		if not os.path.basename(f).startswith('_')
+		]
+	for module in modules:
+		import_module('.' + module, __package__ + '.' + extension_name)
+	extensions_parameters.append(os.path.join(extension_directory, extension_name + '.xml'))
+
+for extension_dir in EXTENSIONS_DIRECTORIES:
+	import_extension(extension_dir)

--- a/openfisca_france/model/model.py
+++ b/openfisca_france/model/model.py
@@ -64,6 +64,8 @@ from prestations.prestations_familiales import (  # noqa analysis:ignore
     cf,
     )
 
+from . import extensions
+
 from revenus import autres
 
 from revenus.activite import (  # noqa analysis:ignore


### PR DESCRIPTION
With mes-aides, we had, in several contexts, the need for **formulas that would not be included by default in the general openfisca france model**. The most significant example si local prestations (e.g Paris). The idea is to avoid polluting the country general model with specific formulas that most people don't need.

We first used *reforms* to do this. From my understanding, *reforms* were originally implemented to allow economists to experiment modifying parameters or formulas, in order to compare results between this reformed tax benefit system and the original one.

We were able in the beginning to use reforms as a way to insulate local prestations, but it was not pleasant and definitely not scalable. As it was designed for another purpose that ours, it offered features we did not need, and brought constraints unnecessary in our context. For instance:

- Reforms are written in a single file. Not realistic for 12 Paris prestations.
- Reforms need to be both declared in the `.ini` file, and in the api call. This add complexity to the dependency management between `france`,  `wep-api` and `mes-aides`.
- The syntax is slightly different than regular formulas. (e.g. using `Reform.Variable`)
- Introducing new legal parameters is painful
- There is extra complexity (`build_reform`, etc.)
- Being able to call both the original and the reformed tax benefit system is not needed.
- Replacing an existing variable is not needed (we just want to add new ones)

As we now have to integrate all the Paris prestation into our openfisca instance, we took some time to work on an extension mechanism that would fit our need better. Here is the idea: 

There is in `openfisca_france/model` a directory called `extensions`. To add an extension to Openfisca, let's say paris for instance, we just have to add to this folder a `paris` directory containing python formula files, xml parameters, and yaml tests.

Ex: 
```sh
openfisca_france/model/extensions/paris/__init__.py
openfisca_france/model/extensions/paris/paris.xml
openfisca_france/model/extensions/paris/paris_logement_famille.py
openfisca_france/model/extensions/paris/paris_logement_famille.yaml
openfisca_france/model/extensions/paris/paris_solidarite.py
openfisca_france/model/extensions/paris/paris_solidarite.yaml
```

With this actual implementation, the behaviour is the following : 
- All pythons files located in the `paris` will be imported in the openfisca model. <sub><sup>Subdirectories are ignored.</sup></sub>
- paris.xml (the name must be the same than the directory) will be added as a `paris`node at the root level of the legislation parameters tree. <sub><sup>Other xml files are ignored.</sup></sub>

Thus, the extension code doesn't need to be in the `openfisca-france` repository. This reduces friction and anyone car write extensions. Right now, the extension directory need to be added manually to `extensions`, but we can find a smart way to script it.

@cbenz @MattiSG @benjello, I'm open to all feedback and suggestions. What do you think ?