### PR TITLE
Let CICE be combined with JEI

### DIFF
--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -115,7 +115,8 @@ class credit_impot_competitivite_emploi(DatedVariable):
             taux_cice
             * assiette_allegement
             )
-        non_cumul = (jeune_entreprise_innovante == 0 + stagiaire) > 0
+
+        non_cumul = not_(stagiaire)
 
         return period, credit_impot_competitivite_emploi * non_cumul
 
@@ -205,7 +206,7 @@ class allegement_fillon(DatedVariable):
                 allegement_mode_recouvrement,
                 self.__class__.__name__,
                 )
-                
+
         return period, allegement * not_(stagiaire) * not_(apprenti)
 
 

--- a/openfisca_france/tests/fiches_de_paie/business_develop_2015-02.yaml
+++ b/openfisca_france/tests/fiches_de_paie/business_develop_2015-02.yaml
@@ -50,7 +50,7 @@ output_variables:
   IGNORE_taxe_apprentissage: 0
   versement_transport: 0 # -.027 * 2172.9
   allegement_fillon: 0
-  credit_impot_competitivite_emploi: 0
+  credit_impot_competitivite_emploi: 130.37
   tehr:
     "year:2015": 0
   # assiette_cotisations_sociales


### PR DESCRIPTION
Sur la [page du pacte de résponsabilité](http://www.economie.gouv.fr/pacte-responsabilite/cice/faq/cumul-autres-avantages) :

![selection_050](https://cloud.githubusercontent.com/assets/1177762/13252995/f077b1ae-da39-11e5-855a-477f683b8444.png)
 
Donc peut se cumuler avec l’exonération de charges JEI.

@benjello Ou avais-tu vu que le cumul n'était pas possible ?
