### PR TITLE
Stop printing a humongous amount of log in CI

### DIFF
--- a/openfisca_france/tests/test_yaml.py
+++ b/openfisca_france/tests/test_yaml.py
@@ -143,7 +143,7 @@ def assert_near_calculate_output(value, target_value, absolute_error_margin = 0,
 def check(yaml_path, name, period_str, test, force):
     scenario = test['scenario']
     scenario.suggest()
-    simulation = scenario.new_simulation(debug = True)
+    simulation = scenario.new_simulation()
     output_variables = test.get(u'output_variables')
     if output_variables is not None:
         output_variables_name_to_ignore = test.get(u'output_variables_name_to_ignore') or set()
@@ -172,7 +172,7 @@ def check(yaml_path, name, period_str, test, force):
 def check_calculate_output(yaml_path, name, period_str, test, force):
     scenario = test['scenario']
     scenario.suggest()
-    simulation = scenario.new_simulation(debug = True)
+    simulation = scenario.new_simulation()
     output_variables = test.get(u'output_variables')
     if output_variables is not None:
         output_variables_name_to_ignore = test.get(u'output_variables_name_to_ignore') or set()

--- a/openfisca_france/tests/test_yaml.py
+++ b/openfisca_france/tests/test_yaml.py
@@ -140,10 +140,10 @@ def assert_near_calculate_output(value, target_value, absolute_error_margin = 0,
                     abs(target_value - value), abs(relative_error_margin * target_value))
 
 
-def check(yaml_path, name, period_str, test, force):
+def check(yaml_path, name, period_str, test, force, verbose = False):
     scenario = test['scenario']
     scenario.suggest()
-    simulation = scenario.new_simulation()
+    simulation = scenario.new_simulation(debug = verbose)
     output_variables = test.get(u'output_variables')
     if output_variables is not None:
         output_variables_name_to_ignore = test.get(u'output_variables_name_to_ignore') or set()
@@ -169,10 +169,10 @@ def check(yaml_path, name, period_str, test, force):
                     )
 
 
-def check_calculate_output(yaml_path, name, period_str, test, force):
+def check_calculate_output(yaml_path, name, period_str, test, force, verbose = False):
     scenario = test['scenario']
     scenario.suggest()
-    simulation = scenario.new_simulation()
+    simulation = scenario.new_simulation(debug = verbose)
     output_variables = test.get(u'output_variables')
     if output_variables is not None:
         output_variables_name_to_ignore = test.get(u'output_variables_name_to_ignore') or set()
@@ -295,7 +295,7 @@ if __name__ == "__main__":
         options_by_path = None
 
     tests_found = False
-    for test_index, (function, yaml_path, name, period_str, test, force) in enumerate(
+    for test_index, (checker, yaml_path, name, period_str, test, force) in enumerate(
             test(
                 force = args.force,
                 name_filter = args.name,
@@ -313,7 +313,7 @@ if __name__ == "__main__":
         print("=" * len(title))
         print(title)
         print("=" * len(title))
-        function(yaml_path, name, period_str, test, force)
+        checker(yaml_path, name, period_str, test, force, args.verbose)
         tests_found = True
     if not tests_found:
         print("No test found!")


### PR DESCRIPTION
I think we all agree that this is not very useful information to debug when travis doesn't pass: 

![image](https://cloud.githubusercontent.com/assets/11834997/14466401/f69ed698-00d6-11e6-9ba8-85b7a3f95abd.png)

To remove that, I see two easy solutions, and I would like your advice @cbenz @laem @benjello.

- Set `debug` to false in `test_yaml.py`. It is the implementation suggested here. I don't exactly know what activating `debug` means, does it have other effects that were useful to anyone when running tests ?
- Get rid of the `log.info(...)` in [`formulas.py`](https://github.com/openfisca/openfisca-core/blob/master/openfisca_core/formulas.py#L150). Same question: has anyone been using this to debug code recently ?

Thanks for your feedback.