### PR TITLE
No debug=true in CI tests

### DIFF
--- a/openfisca_france/tests/reforms/test_allocations_familliales_imposables.py
+++ b/openfisca_france/tests/reforms/test_allocations_familliales_imposables.py
@@ -32,7 +32,7 @@ def test_allocations_familiales_imposables():
             ],
         )
 
-    reference_simulation = scenario.new_simulation(debug = True, reference = True)
+    reference_simulation = scenario.new_simulation(reference = True)
 
     absolute_error_margin = 0.01
     af = reference_simulation.calculate_add('af')
@@ -40,7 +40,7 @@ def test_allocations_familiales_imposables():
     assert_near(expected_af, af, absolute_error_margin = absolute_error_margin)
     rbg = reference_simulation.calculate('rbg')
 
-    reform_simulation = scenario.new_simulation(debug = True)
+    reform_simulation = scenario.new_simulation()
     reform_af = reform_simulation.calculate_add('af')
 
     assert_near(expected_af, reform_af, absolute_error_margin = absolute_error_margin)

--- a/openfisca_france/tests/reforms/test_cesthra.py
+++ b/openfisca_france/tests/reforms/test_cesthra.py
@@ -32,13 +32,13 @@ def test_cesthra_invalidee():
             ],
         )
 
-    reference_simulation = scenario.new_simulation(debug = True, reference = True)
+    reference_simulation = scenario.new_simulation(reference = True)
     reference_impo = reference_simulation.calculate('impo')
     assert reference_impo is not None
     reference_revdisp = reference_simulation.calculate('revdisp', period = period)
     assert reference_revdisp is not None
 
-    reform_simulation = scenario.new_simulation(debug = True)
+    reform_simulation = scenario.new_simulation()
     reform_impo = reform_simulation.calculate('impo')
     assert reform_impo is not None
     reform_revdisp = reform_simulation.calculate('revdisp', period = period)

--- a/openfisca_france/tests/reforms/test_landais_piketty_saez.py
+++ b/openfisca_france/tests/reforms/test_landais_piketty_saez.py
@@ -31,10 +31,10 @@ def test():
         #     ],
         )
 
-#    reference_simulation = scenario.new_simulation(debug = True, reference = True)
+#    reference_simulation = scenario.new_simulation(reference = True)
 #
 
-    reform_simulation = scenario.new_simulation(debug = True)
+    reform_simulation = scenario.new_simulation()
     reform_assiette_csg = reform_simulation.calculate('assiette_csg')
     reform_impot_revenu_lps = reform_simulation.calculate('impot_revenu_lps')
     assert_near(

--- a/openfisca_france/tests/reforms/test_parametric_reform.py
+++ b/openfisca_france/tests/reforms/test_parametric_reform.py
@@ -42,11 +42,11 @@ def test_parametric_reform():
         parent1 = dict(birth = datetime.date(simulation_year - 40, 1, 1)),
         )
 
-    reference_simulation = scenario.new_simulation(debug = True, reference = True)
+    reference_simulation = scenario.new_simulation(reference = True)
     assert_near(reference_simulation.calculate('impo'), [0, -7889.20019531, -23435.52929688],
         absolute_error_margin = .01)
 
-    reform_simulation = scenario.new_simulation(debug = True)
+    reform_simulation = scenario.new_simulation()
     assert_near(reform_simulation.calculate('impo'), [0, -13900.20019531, -29446.52929688],
         absolute_error_margin = .0001)
 

--- a/openfisca_france/tests/reforms/test_plf2015.py
+++ b/openfisca_france/tests/reforms/test_plf2015.py
@@ -34,8 +34,8 @@ def test(year = 2013):
             ] if people >= 3 else None,
         )
 
-    reference_simulation = scenario.new_simulation(debug = True, reference = True)
-    reform_simulation = scenario.new_simulation(debug = True)
+    reference_simulation = scenario.new_simulation(reference = True)
+    reform_simulation = scenario.new_simulation()
     error_margin = 1
 
     impo = reference_simulation.calculate('impo')

--- a/openfisca_france/tests/reforms/test_trannoy_wasmer.py
+++ b/openfisca_france/tests/reforms/test_trannoy_wasmer.py
@@ -34,7 +34,7 @@ def test_charge_loyer():
             loyer = 1000,
             ),
         )
-    reform_simulation = scenario.new_simulation(debug = True)
+    reform_simulation = scenario.new_simulation()
     absolute_error_margin = 0.01
 
     reform_charge_loyer = reform_simulation.calculate('charge_loyer')

--- a/openfisca_france/tests/test_allegement_fillon.py
+++ b/openfisca_france/tests/test_allegement_fillon.py
@@ -177,7 +177,7 @@ def test_check():
         simulation = reform.new_scenario().init_single_entity(
             period = simulation_period,
             parent1 = parent1,
-            ).new_simulation(debug = True)
+            ).new_simulation()
 
         for variable, amounts in test_parameters['output_variables'].iteritems():
             if isinstance(amounts, dict):

--- a/openfisca_france/tests/test_cotsoc_fonc.py
+++ b/openfisca_france/tests/test_cotsoc_fonc.py
@@ -372,8 +372,7 @@ def test():
         description = scenario_arguments.pop('description')
         error_margin = scenario_arguments.pop('error_margin')
         expected_values = scenario_arguments.pop('expected_values')
-        simulation = base.tax_benefit_system.new_scenario().init_single_entity(**scenario_arguments).new_simulation(
-            debug = True)
+        simulation = base.tax_benefit_system.new_scenario().init_single_entity(**scenario_arguments).new_simulation()
         for variable, expected_value in expected_values.iteritems():
             yield check_simulation_monthly_variable, description, simulation, variable, expected_value, error_margin
 

--- a/openfisca_france/tests/test_cotsoc_sal_cap.py
+++ b/openfisca_france/tests/test_cotsoc_sal_cap.py
@@ -486,7 +486,7 @@ def test_check():
             period = period,
             parent1 = parent1,
             foyer_fiscal = foyer_fiscal,
-            ).new_simulation(debug = True)
+            ).new_simulation()
 
         for variable, monthly_amount in test_parameters['output_variables'].iteritems():
             output = simulation.calculate_add(variable)

--- a/openfisca_france/tests/test_decomposition_fiches_de_paie.py
+++ b/openfisca_france/tests/test_decomposition_fiches_de_paie.py
@@ -24,7 +24,7 @@ def test_decomposition(print_decomposition = False):
         menage = dict(
             zone_apl = 1,
             ),
-        ).new_simulation(debug = True)
+        ).new_simulation()
 
     xml_file_path = os.path.join(
         tax_benefit_system.DECOMP_DIR,

--- a/openfisca_france/tests/test_decompositions.py
+++ b/openfisca_france/tests/test_decompositions.py
@@ -64,6 +64,6 @@ def test_decomposition_calculate():
     simulation = base.tax_benefit_system.new_scenario().init_single_entity(
         period = year,
         parent1 = {},
-        ).new_simulation(debug = True)
+        ).new_simulation()
     decomposition = decompositions.calculate([simulation], decomposition_json)
     assert isinstance(decomposition, dict)

--- a/openfisca_france/tests/test_repairs.py
+++ b/openfisca_france/tests/test_repairs.py
@@ -24,7 +24,7 @@ def test_2_parents_2_enfants():
         )
     scenario.suggest()
     json.dumps(scenario.to_json(), encoding = 'utf-8', ensure_ascii = False, indent = 2)
-    simulation = scenario.new_simulation(debug = True)
+    simulation = scenario.new_simulation()
     assert_equal(
         simulation.calculate('birth').tolist(),
         [
@@ -85,7 +85,7 @@ def test_famille_1_parent_3_enfants():
         )
     scenario.suggest()
     json.dumps(scenario.to_json(), encoding = 'utf-8', ensure_ascii = False, indent = 2)
-    simulation = scenario.new_simulation(debug = True)
+    simulation = scenario.new_simulation()
     assert_equal(
         simulation.calculate('birth').tolist(),
         [
@@ -146,7 +146,7 @@ def test_famille_2_parents_2_enfants():
         )
     scenario.suggest()
     json.dumps(scenario.to_json(), encoding = 'utf-8', ensure_ascii = False, indent = 2)
-    simulation = scenario.new_simulation(debug = True)
+    simulation = scenario.new_simulation()
     assert_equal(
         simulation.calculate('birth').tolist(),
         [
@@ -207,7 +207,7 @@ def test_foyer_fiscal_1_declarant_3_personnes_a_charge():
         )
     scenario.suggest()
     json.dumps(scenario.to_json(), encoding = 'utf-8', ensure_ascii = False, indent = 2)
-    simulation = scenario.new_simulation(debug = True)
+    simulation = scenario.new_simulation()
     assert_equal(
         simulation.calculate('birth').tolist(),
         [
@@ -268,7 +268,7 @@ def test_foyer_fiscal_2_declarants_2_personnes_a_charge():
         )
     scenario.suggest()
     json.dumps(scenario.to_json(), encoding = 'utf-8', ensure_ascii = False, indent = 2)
-    simulation = scenario.new_simulation(debug = True)
+    simulation = scenario.new_simulation()
     assert_equal(
         simulation.calculate('birth').tolist(),
         [
@@ -329,7 +329,7 @@ def test_menage_1_personne_de_reference_3_enfants():
         )
     scenario.suggest()
     json.dumps(scenario.to_json(), encoding = 'utf-8', ensure_ascii = False, indent = 2)
-    simulation = scenario.new_simulation(debug = True)
+    simulation = scenario.new_simulation()
     assert_equal(
         simulation.calculate('birth').tolist(),
         [
@@ -391,7 +391,7 @@ def test_menage_1_personne_de_reference_1_conjoint_2_enfants():
         )
     scenario.suggest()
     json.dumps(scenario.to_json(), encoding = 'utf-8', ensure_ascii = False, indent = 2)
-    simulation = scenario.new_simulation(debug = True)
+    simulation = scenario.new_simulation()
     assert_equal(
         simulation.calculate('birth').tolist(),
         [

--- a/openfisca_france/tests/test_suggestions.py
+++ b/openfisca_france/tests/test_suggestions.py
@@ -21,7 +21,7 @@ def test_birth():
         )
     scenario.suggest()
     json.dumps(scenario.to_json(), encoding = 'utf-8', ensure_ascii = False, indent = 2)
-    simulation = scenario.new_simulation(debug = True)
+    simulation = scenario.new_simulation()
     assert_equal(
         simulation.calculate('birth').tolist(),
         [

--- a/openfisca_france/tests/test_tax_rates.py
+++ b/openfisca_france/tests/test_tax_rates.py
@@ -17,7 +17,7 @@ def test_average_tax_rate():
             ],
         period = year,
         parent1 = dict(age_en_mois = 40 * 12 + 6),
-        ).new_simulation()  # Remove debug = True, because logging is too slow.
+        ).new_simulation()
     assert (average_rate(
         target = simulation.calculate('revdisp'),
         varying = simulation.calculate('revdisp'),
@@ -37,7 +37,7 @@ def test_marginal_tax_rate():
             ],
         period = year,
         parent1 = dict(age_en_mois = 40 * 12 + 6),
-        ).new_simulation()  # Remove debug = True, because logging is too slow.
+        ).new_simulation()
     assert (marginal_rate(
         target = simulation.calculate('revdisp'),
         varying = simulation.calculate('revdisp'),

--- a/openfisca_france/tests/utils.py
+++ b/openfisca_france/tests/utils.py
@@ -42,7 +42,7 @@ def simulation_from_test(test, monthly_amount = False, default_error_margin = 1,
         parent1 = parent1,
         menage = menage,
         foyer_fiscal = foyer_fiscal,
-        ).new_simulation(debug = True)
+        ).new_simulation()
 
     return simulation
 


### PR DESCRIPTION
Please object if you do need the debug mode **by default** for one of these tests.

Nothings prevents a developper from locally activating the debug mode when debugging a failing tests, but this avalanche of logs in CI is a problem we have to address.