### PR TITLE
Refactor ir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 3.0.0 - [diff](https://github.com/openfisca/openfisca-france/compare/3.0.0..2.0.0)
+
+* Make `enfant_a_charge` usable in monthly mode so that we can re-use it in mes-aides, and broaden its definition so that in includes children in `garde_alternee`.
+* Refactor and test nbF, nbG, nbH, nbI.
+* Deprecate:
+	* `nombre_enfants_a_charge_menage`
+	* `enfant_a_charge_invalide`
+	* `enfant_a_charge_garde_alternee`
+	* `enfant_a_charge_garde_alternee_invalide`
+* Rename:
+    * `statmarit` -> `statut_marital`
+    * `marpac` -> `maries_ou_pacses`
+    * `celdiv` -> `celibataire_ou_divorce`
+    * `jveuf` -> `jeune_veuf`
+
 ## 2.0.0 - [diff](https://github.com/openfisca/openfisca-france/compare/2.0.0..1.3.1)
 
 * Deprecate Paris reform

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -89,7 +89,7 @@ class enceinte(Variable):
 
 
 
-class statmarit(Variable):
+class statut_marital(Variable):
     column = EnumCol(
         default = 2,
         enum = Enum([u"Marié",
@@ -243,11 +243,11 @@ class maries(Variable):
         """couple = 1 si couple marié sinon 0 TODO: faire un choix avec couple ?"""
         # Note : Cette variable est "instantanée" : quelque soit la période demandée, elle retourne la valeur au premier
         # jour, sans changer la période.
-        statmarit_holder = simulation.compute('statmarit', period)
+        statut_marital_holder = simulation.compute('statut_marital', period)
 
-        statmarit = self.filter_role(statmarit_holder, role = CHEF)
+        statut_marital = self.filter_role(statut_marital_holder, role = CHEF)
 
-        return period, statmarit == 1
+        return period, statut_marital == 1
 
 
 class en_couple(Variable):

--- a/openfisca_france/model/datatrees.py
+++ b/openfisca_france/model/datatrees.py
@@ -10,7 +10,7 @@ columns_name_tree_by_entity = collections.OrderedDict([
                 ('label', u"""Principal"""),
                 ('children', [
                     'date_naissance',  # Date de naissance
-                    'statmarit',  # Statut marital
+                    'statut_marital',  # Statut marital
                     'salaire_de_base',  # Salaire de base, en général appelé salaire brut, la 1ère ligne sur la fiche de paie
                     'chomage_imposable',  # Autres revenus imposables (chômage, préretraite)
                     'retraite_imposable',  # Pensions, retraites, rentes connues imposables

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
@@ -533,10 +533,10 @@ class cd_percap(DatedVariable):
         '''
         period = period.this_year
         f6cb = simulation.calculate('f6cb', period)
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         percap = simulation.legislation_at(period.start).ir.charges_deductibles.percap
 
-        max_cb = percap.max_cb * (1 + marpac)
+        max_cb = percap.max_cb * (1 + maries_ou_pacses)
         return period, min_(f6cb, max_cb)
 
     @dated_function(start = date(2003, 1, 1), stop = date(2006, 12, 31))
@@ -549,11 +549,11 @@ class cd_percap(DatedVariable):
         period = period.this_year
         f6cb = simulation.calculate('f6cb', period)
         f6da = simulation.calculate('f6da', period)
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         percap = simulation.legislation_at(period.start).ir.charges_deductibles.percap
 
-        max_cb = percap.max_cb * (1 + marpac)
-        max_da = percap.max_da * (1 + marpac)
+        max_cb = percap.max_cb * (1 + maries_ou_pacses)
+        max_da = percap.max_da * (1 + maries_ou_pacses)
         return period, min_(min_(f6cb, max_cb) + min_(f6da, max_da), max_da)
 
 
@@ -645,10 +645,10 @@ class cd_sofipe(Variable):
         period = period.this_year
         f6cc = simulation.calculate('f6cc', period)
         rbg_int = simulation.calculate('rbg_int', period)
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         sofipe = simulation.legislation_at(period.start).ir.charges_deductibles.sofipe
 
-        max1 = min_(sofipe.taux * rbg_int, sofipe.max * (1 + marpac))
+        max1 = min_(sofipe.taux * rbg_int, sofipe.max * (1 + maries_ou_pacses))
         return period, min_(f6cc, max1)
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -346,7 +346,7 @@ class aidper(DatedVariable):
         2002-2003
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         nbH = simulation.calculate('nbH', period)
         f7wi = simulation.calculate('f7wi', period)
@@ -355,7 +355,7 @@ class aidper(DatedVariable):
         P = _P.ir.credits_impot.aidper
 
         n = nb_pac2 - nbH / 2
-        max0 = (P.max * (1 + marpac) +
+        max0 = (P.max * (1 + maries_ou_pacses) +
             P.pac1 * (n >= 1) + P.pac2 * (n >= 2) + P.pac3 * (max_(n - 2, 0)) +
             ((n >= 2) * P.pac3 * nbH +
             (n == 1) * (P.pac2 + (nbH > 1) * P.pac3 * (nbH - 1) ) * (nbH >= 1) +
@@ -371,7 +371,7 @@ class aidper(DatedVariable):
         2004-2005
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         nbH = simulation.calculate('nbH', period)
         f7wi = simulation.calculate('f7wi', period)
@@ -381,7 +381,7 @@ class aidper(DatedVariable):
         P = _P.ir.credits_impot.aidper
 
         n = nb_pac2 - nbH/2
-        max0 = (P.max * (1 + marpac) +
+        max0 = (P.max * (1 + maries_ou_pacses) +
             P.pac1 * (n >= 1) + P.pac2 * (n >= 2) + P.pac3 * (max_(n - 2, 0)) +
             ((n >= 2) * P.pac3 * nbH +
             (n == 1) * (P.pac2 + (nbH > 1) * P.pac3 * (nbH - 1) ) * (nbH >= 1) +
@@ -400,7 +400,7 @@ class aidper(DatedVariable):
         cf. cerfa 50796
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         f7wi = simulation.calculate('f7wi', period)
         f7wj = simulation.calculate('f7wj', period)
@@ -408,7 +408,7 @@ class aidper(DatedVariable):
 
         P = _P.ir.credits_impot.aidper
 
-        max0 = P.max * (1 + marpac) + P.pac1 * nb_pac2
+        max0 = P.max * (1 + maries_ou_pacses) + P.pac1 * nb_pac2
 
         max1 = max_(0, max0 - f7wj)
         return period, (P.taux_wj * min_(f7wj, max0) +
@@ -422,7 +422,7 @@ class aidper(DatedVariable):
         2010-2011
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         f7sf = simulation.calculate('f7sf', period)
         f7wi = simulation.calculate('f7wi', period)
@@ -431,7 +431,7 @@ class aidper(DatedVariable):
         _P = simulation.legislation_at(period.start)
 
         P = _P.ir.credits_impot.aidper
-        max0 = P.max * (1 + marpac) + P.pac1 * nb_pac2
+        max0 = P.max * (1 + maries_ou_pacses) + P.pac1 * nb_pac2
 
         max1 = max_(0, max0 - f7wl - f7sf)
         max2 = max_(0, max1 - f7wj)
@@ -445,7 +445,7 @@ class aidper(DatedVariable):
         2012
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         f7wi = simulation.calculate('f7wi', period)
         f7wj = simulation.calculate('f7wj', period)
@@ -456,7 +456,7 @@ class aidper(DatedVariable):
         P = _P.ir.credits_impot.aidper
         # On ne contrôle pas que 7WR ne dépasse pas le plafond (ça dépend du nombre de logements (7sa) et de la nature des
         #travaux, c'est un peu le bordel)
-        max00 = P.max * (1 + marpac)
+        max00 = P.max * (1 + maries_ou_pacses)
         max0 = max00 + P.pac1 * nb_pac2
         max1 = max_(0, max0 - max_(0,f7wl-max00))
         max2 = max_(0, max1 - f7wj)
@@ -471,7 +471,7 @@ class aidper(DatedVariable):
         2013
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         f7wj = simulation.calculate('f7wj', period)
         f7wl = simulation.calculate('f7wl', period)
@@ -481,7 +481,7 @@ class aidper(DatedVariable):
         P = _P.ir.credits_impot.aidper
         # On ne contrôle pas que 7WR ne dépasse pas le plafond (ça dépend du nombre de logements et de la nature des
         # travaux, c'est un peu le bordel)
-        max00 = P.max * (1 + marpac)
+        max00 = P.max * (1 + maries_ou_pacses)
         max0 = max00 + P.pac1 * nb_pac2
         max1 = max_(0, max0 - max_(0,f7wl-max00))
 
@@ -496,7 +496,7 @@ class aidper(DatedVariable):
         2014 et supérieurs non vérifiée
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         f7wj = simulation.calculate('f7wj', period)
         f7wl = simulation.calculate('f7wl', period)
@@ -506,7 +506,7 @@ class aidper(DatedVariable):
         P = _P.ir.credits_impot.aidper
         # On ne contrôle pas que 7WR ne dépasse pas le plafond (ça dépend du nombre de logements et de la nature des
         # travaux, c'est un peu le bordel)
-        max00 = P.max * (1 + marpac)
+        max00 = P.max * (1 + maries_ou_pacses)
         max0 = max00 + P.pac1 * nb_pac2
         max1 = max_(0, max0 - max_(0,f7wl-max00))
 
@@ -924,14 +924,14 @@ class divide(Variable):
         2005-2009
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f2dc = simulation.calculate('f2dc', period)
         f2gr = simulation.calculate('f2gr', period)
         _P = simulation.legislation_at(period.start)
 
         P = _P.ir.credits_impot.divide
 
-        max1 = P.max * (marpac + 1)
+        max1 = P.max * (maries_ou_pacses + 1)
         return period, min_(P.taux * (f2dc + f2gr), max1)
 
 
@@ -965,7 +965,7 @@ class inthab(DatedVariable):
         2007
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         caseP = simulation.calculate('caseP', period)
         caseF = simulation.calculate('caseF', period)
@@ -975,7 +975,7 @@ class inthab(DatedVariable):
         P = simulation.legislation_at(period.start).ir.credits_impot.inthab
 
         invalide = caseP | caseF | (nbG != 0) | (nbR != 0)
-        max0 = P.max * (marpac + 1) * (1 + invalide) + nb_pac2 * P.add
+        max0 = P.max * (maries_ou_pacses + 1) * (1 + invalide) + nb_pac2 * P.add
         return period, P.taux1 * min_(max0, f7uh)
 
     @dated_function(start = date(2008, 1, 1), stop = date(2008, 12, 31))
@@ -985,7 +985,7 @@ class inthab(DatedVariable):
         2008
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         caseP = simulation.calculate('caseP', period)
         caseF = simulation.calculate('caseF', period)
@@ -998,7 +998,7 @@ class inthab(DatedVariable):
         P = _P.ir.credits_impot.inthab
 
         invalide = caseP | caseF | (nbG != 0) | (nbR != 0)
-        max0 = P.max * (marpac + 1) * (1 + invalide) + nb_pac2 * P.add
+        max0 = P.max * (maries_ou_pacses + 1) * (1 + invalide) + nb_pac2 * P.add
 
         max1 = max_(max0 - f7vy, 0)
         return period, (P.taux1 * min_(f7vy, max0) +
@@ -1011,7 +1011,7 @@ class inthab(DatedVariable):
         2009
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         caseP = simulation.calculate('caseP', period)
         caseF = simulation.calculate('caseF', period)
@@ -1025,7 +1025,7 @@ class inthab(DatedVariable):
         P = _P.ir.credits_impot.inthab
 
         invalide = caseP | caseF | (nbG != 0) | (nbR != 0)
-        max0 = P.max * (marpac + 1) * (1 + invalide) + nb_pac2 * P.add
+        max0 = P.max * (maries_ou_pacses + 1) * (1 + invalide) + nb_pac2 * P.add
 
         max1 = max_(max0 - f7vx, 0)
         max2 = max_(max1 - f7vy, 0)
@@ -1040,7 +1040,7 @@ class inthab(DatedVariable):
         2010
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         caseP = simulation.calculate('caseP', period)
         caseF = simulation.calculate('caseF', period)
@@ -1055,7 +1055,7 @@ class inthab(DatedVariable):
         P = _P.ir.credits_impot.inthab
 
         invalide = caseP | caseF | (nbG != 0) | (nbR != 0)
-        max0 = P.max * (marpac + 1) * (1 + invalide) + nb_pac2 * P.add
+        max0 = P.max * (maries_ou_pacses + 1) * (1 + invalide) + nb_pac2 * P.add
 
         max1 = max_(max0 - f7vx, 0)
         max2 = max_(max1 - f7vy, 0)
@@ -1072,7 +1072,7 @@ class inthab(DatedVariable):
         2011
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         caseP = simulation.calculate('caseP', period)
         caseF = simulation.calculate('caseF', period)
@@ -1089,7 +1089,7 @@ class inthab(DatedVariable):
         P = _P.ir.credits_impot.inthab
 
         invalide = caseP | caseF | (nbG != 0) | (nbR != 0)
-        max0 = P.max * (marpac + 1) * (1 + invalide) + nb_pac2 * P.add
+        max0 = P.max * (maries_ou_pacses + 1) * (1 + invalide) + nb_pac2 * P.add
 
         max1 = max_(max0 - f7vx, 0)
         max2 = max_(max1 - f7vy, 0)
@@ -1110,7 +1110,7 @@ class inthab(DatedVariable):
         2011
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         caseP = simulation.calculate('caseP', period)
         caseF = simulation.calculate('caseF', period)
@@ -1128,7 +1128,7 @@ class inthab(DatedVariable):
         P = _P.ir.credits_impot.inthab
 
         invalide = caseP | caseF | (nbG != 0) | (nbR != 0)
-        max0 = P.max * (marpac + 1) * (1 + invalide) + nb_pac2 * P.add
+        max0 = P.max * (maries_ou_pacses + 1) * (1 + invalide) + nb_pac2 * P.add
 
         max1 = max_(max0 - f7vx, 0)
         max2 = max_(max1 - f7vy, 0)
@@ -1180,7 +1180,7 @@ class jeunes_ind(Variable):
         nbptr_holder = simulation.compute('nbptr', period)
         rfr_holder = simulation.compute('rfr', period)
         salaire_imposable =  simulation.calculate_add('salaire_imposable', period)
-        marpac_holder = simulation.compute('marpac', period)
+        maries_ou_pacses_holder = simulation.compute('maries_ou_pacses', period)
         elig_creimp_jeunes = simulation.calculate('elig_creimp_jeunes', period)
         _P = simulation.legislation_at(period.start)
 
@@ -1189,9 +1189,9 @@ class jeunes_ind(Variable):
         P = _P.ir.credits_impot.jeunes
         rfr = self.cast_from_entity_to_roles(rfr_holder)
         nbptr = self.cast_from_entity_to_roles(nbptr_holder)
-        marpac = self.cast_from_entity_to_roles(marpac_holder)
+        maries_ou_pacses = self.cast_from_entity_to_roles(maries_ou_pacses_holder)
 
-        elig = (age < P.age) * (rfr < P.rfr_plaf * (marpac * P.rfr_mult + not_(marpac)) + max_(0, nbptr - 2) * .5 *
+        elig = (age < P.age) * (rfr < P.rfr_plaf * (maries_ou_pacses * P.rfr_mult + not_(maries_ou_pacses)) + max_(0, nbptr - 2) * .5 *
                 P.rfr_maj + (nbptr == 1.5) * P.rfr_maj)
         montant = (
             (P.min <= salaire_imposable) * (salaire_imposable < P.int) * P.montant +
@@ -1307,10 +1307,10 @@ class prlire(Variable):
         period = period.this_year
         f2dh = simulation.calculate('f2dh', period)
         f2ch = simulation.calculate('f2ch', period)
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         _P = simulation.legislation_at(period.start)
 
-        plaf_resid = max_(_P.ir.rvcm.abat_assvie * (1 + marpac) - f2ch, 0)
+        plaf_resid = max_(_P.ir.rvcm.abat_assvie * (1 + maries_ou_pacses) - f2ch, 0)
         return period, _P.ir.credits_impot.prlire.taux * min_(f2dh, plaf_resid)
 
 
@@ -1327,7 +1327,7 @@ class quaenv(DatedVariable):
         2005
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         f7wf = simulation.calculate('f7wf', period)
         f7wg = simulation.calculate('f7wg', period)
@@ -1337,7 +1337,7 @@ class quaenv(DatedVariable):
         P = _P.ir.credits_impot.quaenv
 
         n = nb_pac2
-        max0 = P.max * (1 + marpac) + P.pac1 * (n >= 1) + P.pac2 * (n >= 2) + P.pac2 * (max_(n - 2, 0))
+        max0 = P.max * (1 + maries_ou_pacses) + P.pac1 * (n >= 1) + P.pac2 * (n >= 2) + P.pac2 * (max_(n - 2, 0))
 
         max1 = max_(0, max0 - f7wf)
         max2 = max_(0, max1 - f7wg)
@@ -1353,7 +1353,7 @@ class quaenv(DatedVariable):
         2006-2008
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         f7wf = simulation.calculate('f7wf', period)
         f7wg = simulation.calculate('f7wg', period)
@@ -1363,7 +1363,7 @@ class quaenv(DatedVariable):
 
         P = _P.ir.credits_impot.quaenv
 
-        max0 = P.max * (1 + marpac) + P.pac1 * nb_pac2
+        max0 = P.max * (1 + maries_ou_pacses) + P.pac1 * nb_pac2
 
         max1 = max_(0, max0 - f7wf)
         max2 = max_(0, max1 - f7wg)
@@ -1381,7 +1381,7 @@ class quaenv(DatedVariable):
         2009
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         f7we = simulation.calculate('f7we', period)
         f7wf = simulation.calculate('f7wf', period)
@@ -1397,7 +1397,7 @@ class quaenv(DatedVariable):
         _P = simulation.legislation_at(period.start)
 
         P = _P.ir.credits_impot.quaenv
-        max0 = P.max * (1 + marpac) + P.pac1 * nb_pac2
+        max0 = P.max * (1 + maries_ou_pacses) + P.pac1 * nb_pac2
 
         max1 = max_(0, max0 - f7wf)
         max2 = max_(0, max1 - f7se)
@@ -1426,7 +1426,7 @@ class quaenv(DatedVariable):
         2010-2011
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         f7we = simulation.calculate('f7we', period)
         f7wf = simulation.calculate('f7wf', period)
@@ -1442,7 +1442,7 @@ class quaenv(DatedVariable):
         _P = simulation.legislation_at(period.start)
 
         P = _P.ir.credits_impot.quaenv
-        max0 = P.max * (1 + marpac) + P.pac1 * nb_pac2
+        max0 = P.max * (1 + maries_ou_pacses) + P.pac1 * nb_pac2
 
         max1 = max_(0, max0 - f7wf)
         max2 = max_(0, max1 - f7se)
@@ -1500,13 +1500,13 @@ class quaenv(DatedVariable):
         f7wg = simulation.calculate('f7wg', period)
         f7wh = simulation.calculate('f7wh', period)
         f7wk = simulation.calculate('f7wk', period)
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         quaenv_bouquet = simulation.calculate('quaenv_bouquet', period)
         rfr = simulation.calculate('rfr', period)
         P = simulation.legislation_at(period.start).ir.credits_impot.quaenv
 
-        max0 = P.max * (1 + marpac) + P.pac1 * nb_pac2
+        max0 = P.max * (1 + maries_ou_pacses) + P.pac1 * nb_pac2
         maxi1 = max_(0, max0 - f7ty)
         maxi2 = max_(0, maxi1 - f7tx)
         maxi3 = max_(0, maxi2 - f7tw)
@@ -1577,13 +1577,13 @@ class quaenv(DatedVariable):
         f7wg = simulation.calculate('f7wg', period)
         f7wh = simulation.calculate('f7wh', period)
         f7wk = simulation.calculate('f7wk', period)
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         nb_pac2 = simulation.calculate('nb_pac2', period)
         quaenv_bouquet = simulation.calculate('quaenv_bouquet', period)
         rfr = simulation.calculate('rfr', period)
         P = simulation.legislation_at(period.start).ir.credits_impot.quaenv
 
-        max0 = P.max * (1 + marpac) + P.pac1 * nb_pac2
+        max0 = P.max * (1 + maries_ou_pacses) + P.pac1 * nb_pac2
         max1 = max_(0, max0 - quaenv_bouquet * (f7ss + f7st) - not_(quaenv_bouquet) * (f7ss + f7st + f7sv))
         max2 = max_(0, max1 - quaenv_bouquet * (f7sn + f7sr + f7sq) - not_(quaenv_bouquet) * (f7sn + f7sq + f7sr))
         max3 = max_(0, max2 - quaenv_bouquet * (f7sv) - not_(quaenv_bouquet) * (f7se))

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 # d'autres - car des cases sont réutilisées pour des variables différentes suivant les années)
 
 # zetrf = zeros(taille)
-# jveuf = zeros(taille, dtype = bool)
+# jeune_veuf = zeros(taille, dtype = bool)
 # Reprise du crédit d'impôt en faveur des jeunes, des accomptes et des versements mensues de prime pour l'emploi
 # reprise = zeros(taille) # TODO : reprise=J80
 # Pcredit = P.credits_impots
@@ -284,13 +284,9 @@ class celibataire_ou_divorce(Variable):
 class veuf(Variable):
     column = BoolCol(default = False)
     entity_class = FoyersFiscaux
-    label = u"veuf"
+    label = u"Déclarant veuf"
 
     def function(self, simulation, period):
-        '''
-        Veuf (4)
-        'foy'
-        '''
         period = period.this_year
         statut_marital_holder = simulation.compute('statut_marital', period)
 
@@ -299,16 +295,12 @@ class veuf(Variable):
         return period, statut_marital == 4
 
 
-class jveuf(Variable):
+class jeune_veuf(Variable):
     column = BoolCol(default = False)
     entity_class = FoyersFiscaux
-    label = u"jveuf"
+    label = u"Déclarant jeune veuf"
 
     def function(self, simulation, period):
-        '''
-        Jeune Veuf
-        'foy'
-        '''
         period = period.this_year
         statut_marital_holder = simulation.compute('statut_marital', period)
 
@@ -1041,7 +1033,7 @@ class ir_plaf_qf(Variable):
         nbptr = simulation.calculate('nbptr', period)
         maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         veuf = simulation.calculate('veuf', period)
-        jveuf = simulation.calculate('jveuf', period)
+        jeune_veuf = simulation.calculate('jeune_veuf', period)
         celibataire_ou_divorce = simulation.calculate('celibataire_ou_divorce', period)
         caseE = simulation.calculate('caseE', period)
         caseF = simulation.calculate('caseF', period)
@@ -1073,10 +1065,10 @@ class ir_plaf_qf(Variable):
         B1 = plafond_qf.celib_enf * aa1 + plafond_qf.maries_ou_pacses * aa2
         # tous les autres
         B2 = plafond_qf.maries_ou_pacses * aa0  # si autre
-        # celibataire_ou_divorce, veufs (non jveuf) vivants seuls et autres conditions
+        # celibataire_ou_divorce, veufs (non jeune_veuf) vivants seuls et autres conditions
 
         # TODO: année en dur... pour caseH
-        condition63 = (celibataire_ou_divorce | (veuf & not_(jveuf))) & not_(caseN) & (nb_pac == 0) & (caseK | caseE) & (caseH < 1981)
+        condition63 = (celibataire_ou_divorce | (veuf & not_(jeune_veuf))) & not_(caseN) & (nb_pac == 0) & (caseK | caseE) & (caseH < 1981)
         B3 = plafond_qf.celib
 
         B = B1 * condition61 + \
@@ -1092,13 +1084,14 @@ class ir_plaf_qf(Variable):
         # réduction complémentaire
         condition62b = (I < C)
         # celibataire_ou_divorce veuf
-        condition62caa0 = (celibataire_ou_divorce | (veuf & not_(jveuf)))
+        condition62caa0 = (celibataire_ou_divorce | (veuf & not_(jeune_veuf)))
         condition62caa1 = (nb_pac == 0) & (caseP | caseG | caseF | caseW)
         condition62caa2 = caseP & ((nbF - nbG > 0) | (nbH - nbI > 0))
         condition62caa3 = not_(caseN) & (caseE | caseK) & (caseH >= 1981)
         condition62caa = condition62caa0 & (condition62caa1 | condition62caa2 | condition62caa3)
         # marié pacs
-        condition62cab = (maries_ou_pacses | jveuf) & caseS & not_(caseP | caseF)
+        condition62cab = (maries_ou_pacses | jeune_veuf) & caseS & not_(caseP | caseF)
+
         condition62ca = (condition62caa | condition62cab)
 
         # plus de 590 euros si on a des plus de
@@ -2618,7 +2611,7 @@ class nbptr(Variable):
         maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         celibataire_ou_divorce = simulation.calculate('celibataire_ou_divorce', period)
         veuf = simulation.calculate('veuf', period)
-        jveuf = simulation.calculate('jveuf', period)
+        jeune_veuf = simulation.calculate('jeune_veuf', period)
         nbF = simulation.calculate('nbF', period)
         nbG = simulation.calculate('nbG', period)
         nbH = simulation.calculate('nbH', period)
@@ -2686,13 +2679,13 @@ class nbptr(Variable):
         # # Régime des mariés ou pacsés
         m = 1 + quotient_familial.conj + enf + n2 + n4
 
-        # # veufs  hors jveuf
+        # # veufs  hors jeune_veuf
         v = 1 + enf + n2 + n3 + n5 + n6
 
         # # celib div
         c = 1 + enf + n2 + n3 + n6 + n7
 
-        return period, (maries_ou_pacses | jveuf) * m + (veuf & not_(jveuf)) * v + celibataire_ou_divorce * c
+        return period, (maries_ou_pacses | jeune_veuf) * m + (veuf & not_(jeune_veuf)) * v + celibataire_ou_divorce * c
 
 
 ###############################################################################

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -271,11 +271,11 @@ class marpac(Variable):
         'foy'
         '''
         period = period.this_year
-        statmarit_holder = simulation.compute('statmarit', period)
+        statut_marital_holder = simulation.compute('statut_marital', period)
 
-        statmarit = self.filter_role(statmarit_holder, role = VOUS)
+        statut_marital = self.filter_role(statut_marital_holder, role = VOUS)
 
-        return period, (statmarit == 1) | (statmarit == 5)
+        return period, (statut_marital == 1) | (statut_marital == 5)
 
 
 class celdiv(Variable):
@@ -289,11 +289,11 @@ class celdiv(Variable):
         'foy'
         '''
         period = period.this_year
-        statmarit_holder = simulation.compute('statmarit', period)
+        statut_marital_holder = simulation.compute('statut_marital', period)
 
-        statmarit = self.filter_role(statmarit_holder, role = VOUS)
+        statut_marital = self.filter_role(statut_marital_holder, role = VOUS)
 
-        return period, (statmarit == 2) | (statmarit == 3)
+        return period, (statut_marital == 2) | (statut_marital == 3)
 
 
 class veuf(Variable):
@@ -307,11 +307,11 @@ class veuf(Variable):
         'foy'
         '''
         period = period.this_year
-        statmarit_holder = simulation.compute('statmarit', period)
+        statut_marital_holder = simulation.compute('statut_marital', period)
 
-        statmarit = self.filter_role(statmarit_holder, role = VOUS)
+        statut_marital = self.filter_role(statut_marital_holder, role = VOUS)
 
-        return period, statmarit == 4
+        return period, statut_marital == 4
 
 
 class jveuf(Variable):
@@ -325,11 +325,11 @@ class jveuf(Variable):
         'foy'
         '''
         period = period.this_year
-        statmarit_holder = simulation.compute('statmarit', period)
+        statut_marital_holder = simulation.compute('statut_marital', period)
 
-        statmarit = self.filter_role(statmarit_holder, role = VOUS)
+        statut_marital = self.filter_role(statut_marital_holder, role = VOUS)
 
-        return period, statmarit == 6
+        return period, statut_marital == 6
 
 
 ###############################################################################

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -181,13 +181,6 @@ class nbF(Variable):
         garde_alternee = simulation.compute('garde_alternee', period)
         return period, self.sum_by_entity(enfant_a_charge.array * not_(garde_alternee.array))
 
-class nombre_enfants_a_charge_menage(PersonToEntityColumn):
-    entity_class = Menages
-    label = u"Nombre d'enfants à charge  non mariés, de moins de 18 ans au 1er janvier de l'année de perception des" \
-        u" revenus, ou nés durant la même année ou handicapés quel que soit leur âge"
-    operation = 'add'
-    variable = enfant_a_charge
-
 
 class nbG(Variable):
     cerfa_field = u'G'

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -133,11 +133,11 @@ class nb_adult(Variable):
 
     def function(self, simulation, period):
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         celdiv = simulation.calculate('celdiv', period)
         veuf = simulation.calculate('veuf', period)
 
-        return period, 2 * marpac + 1 * (celdiv | veuf)
+        return period, 2 * maries_ou_pacses + 1 * (celdiv | veuf)
 
 
 class nb_pac(Variable):
@@ -260,16 +260,12 @@ class nombre_enfants_majeurs_celibataires_sans_enfant(PersonToEntityColumn):
     variable = enfant_majeur_celibataire_sans_enfant
 
 
-class marpac(Variable):
-    column = BoolCol(default = False)
+class maries_ou_pacses(Variable):
+    column = BoolCol
     entity_class = FoyersFiscaux
-    label = u"marpac"
+    label = u"Déclarants mariés ou pacsés"
 
     def function(self, simulation, period):
-        '''
-        Marié (1) ou Pacsé (5)
-        'foy'
-        '''
         period = period.this_year
         statut_marital_holder = simulation.compute('statut_marital', period)
 
@@ -610,7 +606,7 @@ class rev_cat_rvcm(DatedVariable):
         Revenus des valeurs et capitaux mobiliers
         """
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         deficit_rcm = simulation.calculate('deficit_rcm', period)
         f2ch = simulation.calculate('f2ch', period)
         f2dc = simulation.calculate('f2dc', period)
@@ -628,7 +624,7 @@ class rev_cat_rvcm(DatedVariable):
         f2tr_bis = f2tr
         # # Calcul du revenu catégoriel
         # 1.2 Revenus des valeurs et capitaux mobiliers
-        b12 = min_(f2ch, rvcm.abat_assvie * (1 + marpac))
+        b12 = min_(f2ch, rvcm.abat_assvie * (1 + maries_ou_pacses))
         TOT1 = f2ch - b12  # c12
         # Part des frais s'imputant sur les revenus déclarés case DC
         den = ((f2dc_bis + f2ts) != 0) * (f2dc_bis + f2ts) + ((f2dc_bis + f2ts) == 0)
@@ -641,7 +637,7 @@ class rev_cat_rvcm(DatedVariable):
         rev = g12b + f2gr + f2fu * (1 - rvcm.abatmob_taux)
 
         # Abattements, limité au revenu
-        h12 = rvcm.abatmob * (1 + marpac)
+        h12 = rvcm.abatmob * (1 + maries_ou_pacses)
         TOT2 = max_(0, rev - h12)
         # i121= -min_(0,rev - h12)
 
@@ -658,7 +654,7 @@ class rev_cat_rvcm(DatedVariable):
         Revenus des valeurs et capitaux mobiliers
         """
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         deficit_rcm = simulation.calculate('deficit_rcm', period)
         f2ch = simulation.calculate('f2ch', period)
         f2dc = simulation.calculate('f2dc', period)
@@ -676,7 +672,7 @@ class rev_cat_rvcm(DatedVariable):
         f2tr_bis = f2tr
         # # Calcul du revenu catégoriel
         # 1.2 Revenus des valeurs et capitaux mobiliers
-        b12 = min_(f2ch, rvcm.abat_assvie * (1 + marpac))
+        b12 = min_(f2ch, rvcm.abat_assvie * (1 + maries_ou_pacses))
         TOT1 = f2ch - b12  # c12
         # Part des frais s'imputant sur les revenus déclarés case DC
         den = ((f2dc_bis + f2ts) != 0) * (f2dc_bis + f2ts) + ((f2dc_bis + f2ts) == 0)
@@ -689,7 +685,7 @@ class rev_cat_rvcm(DatedVariable):
         rev = g12b + f2gr + f2fu * (1 - rvcm.abatmob_taux)
 
         # Abattements, limité au revenu
-        h12 = rvcm.abatmob * (1 + marpac)
+        h12 = rvcm.abatmob * (1 + maries_ou_pacses)
         TOT2 = max_(0, rev - h12)
         # i121= -min_(0,rev - h12)
 
@@ -706,7 +702,7 @@ class rev_cat_rvcm(DatedVariable):
         Revenus des valeurs et capitaux mobiliers
         """
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         deficit_rcm = simulation.calculate('deficit_rcm', period)
         f2ch = simulation.calculate('f2ch', period)
         f2dc = simulation.calculate('f2dc', period)
@@ -726,7 +722,7 @@ class rev_cat_rvcm(DatedVariable):
 
         # # Calcul du revenu catégoriel
         # 1.2 Revenus des valeurs et capitaux mobiliers
-        b12 = min_(f2ch, rvcm.abat_assvie * (1 + marpac))
+        b12 = min_(f2ch, rvcm.abat_assvie * (1 + maries_ou_pacses))
         TOT1 = f2ch - b12  # c12
         # Part des frais s'imputant sur les revenus déclarés case DC
         den = ((f2dc_bis + f2ts) != 0) * (f2dc_bis + f2ts) + ((f2dc_bis + f2ts) == 0)
@@ -739,7 +735,7 @@ class rev_cat_rvcm(DatedVariable):
         rev = g12b + f2fu * (1 - rvcm.abatmob_taux)
 
         # Abattements, limité au revenu
-        h12 = rvcm.abatmob * (1 + marpac)
+        h12 = rvcm.abatmob * (1 + maries_ou_pacses)
         TOT2 = max_(0, rev - h12)
         # i121= -min_(0,rev - h12)
 
@@ -761,7 +757,7 @@ class rfr_rvcm(Variable):
         Abattements sur rvcm à réintégrer dans le revenu fiscal de référence
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f2dc = simulation.calculate('f2dc', period)
         f2ts = simulation.calculate('f2ts', period)
         f2ca = simulation.calculate('f2ca', period)
@@ -786,7 +782,7 @@ class rfr_rvcm(Variable):
         rev = g12b + f2gr + f2fu * (1 - rvcm.abatmob_taux)
 
         # Abattements, limité au revenu
-        h12 = rvcm.abatmob * (1 + marpac)
+        h12 = rvcm.abatmob * (1 + maries_ou_pacses)
         i121 = - min_(0, rev - h12)
         return period, max_((rvcm.abatmob_taux) * (f2dc_bis + f2fu) - i121, 0)
 
@@ -1054,7 +1050,7 @@ class ir_plaf_qf(Variable):
         nb_adult = simulation.calculate('nb_adult', period)
         nb_pac = simulation.calculate('nb_pac', period)
         nbptr = simulation.calculate('nbptr', period)
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         veuf = simulation.calculate('veuf', period)
         jveuf = simulation.calculate('jveuf', period)
         celdiv = simulation.calculate('celdiv', period)
@@ -1085,9 +1081,9 @@ class ir_plaf_qf(Variable):
         aa2 = max_((nbptr - 2) * 2, 0)  # nombre de demi part restantes
         # celdiv parents isolés
         condition61 = celdiv & caseT
-        B1 = plafond_qf.celib_enf * aa1 + plafond_qf.marpac * aa2
+        B1 = plafond_qf.celib_enf * aa1 + plafond_qf.maries_ou_pacses * aa2
         # tous les autres
-        B2 = plafond_qf.marpac * aa0  # si autre
+        B2 = plafond_qf.maries_ou_pacses * aa0  # si autre
         # celdiv, veufs (non jveuf) vivants seuls et autres conditions
         # TODO: année en dur... pour caseH
         condition63 = (celdiv | (veuf & not_(jveuf))) & not_(caseN) & (nb_pac == 0) & (caseK | caseE) & (caseH < 1981)
@@ -1112,7 +1108,7 @@ class ir_plaf_qf(Variable):
         condition62caa3 = not_(caseN) & (caseE | caseK) & (caseH >= 1981)
         condition62caa = condition62caa0 & (condition62caa1 | condition62caa2 | condition62caa3)
         # marié pacs
-        condition62cab = (marpac | jveuf) & caseS & not_(caseP | caseF)
+        condition62cab = (maries_ou_pacses | jveuf) & caseS & not_(caseP | caseF)
         condition62ca = (condition62caa | condition62cab)
 
         # plus de 590 euros si on a des plus de
@@ -2629,7 +2625,7 @@ class nbptr(Variable):
         '''
         period = period.this_year
         nb_pac = simulation.calculate('nb_pac', period)
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         celdiv = simulation.calculate('celdiv', period)
         veuf = simulation.calculate('veuf', period)
         jveuf = simulation.calculate('jveuf', period)
@@ -2706,7 +2702,7 @@ class nbptr(Variable):
         # # celib div
         c = 1 + enf + n2 + n3 + n6 + n7
 
-        return period, (marpac | jveuf) * m + (veuf & not_(jveuf)) * v + celdiv * c
+        return period, (maries_ou_pacses | jveuf) * m + (veuf & not_(jveuf)) * v + celdiv * c
 
 
 ###############################################################################
@@ -2744,14 +2740,14 @@ class ppe_elig(Variable):
         period = period.this_year
         rfr = simulation.calculate('rfr', period)
         ppe_coef = simulation.calculate('ppe_coef', period)
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         veuf = simulation.calculate('veuf', period)
         celdiv = simulation.calculate('celdiv', period)
         nbptr = simulation.calculate('nbptr', period)
         ppe = simulation.legislation_at(period.start).ir.credits_impot.ppe
 
         seuil = (veuf | celdiv) * (ppe.eligi1 + 2 * max_(nbptr - 1, 0) * ppe.eligi3) \
-                + marpac * (ppe.eligi2 + 2 * max_(nbptr - 2, 0) * ppe.eligi3)
+                + maries_ou_pacses * (ppe.eligi2 + 2 * max_(nbptr - 2, 0) * ppe.eligi3)
         return period, (rfr * ppe_coef) <= seuil
 
 
@@ -2856,7 +2852,7 @@ class ppe_brute(Variable):
         ppe_coef = simulation.calculate('ppe_coef', period)
         ppe_coef_tp_holder = simulation.compute('ppe_coef_tp', period)
         nb_pac = simulation.calculate('nb_pac', period)
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         celdiv = simulation.calculate('celdiv', period)
         veuf = simulation.calculate('veuf', period)
         caseT = simulation.calculate('caseT', period)
@@ -2878,7 +2874,7 @@ class ppe_brute(Variable):
 
         nb_pac_ppe = max_(0, nb_pac - eli1 - eli2 - eli3)
 
-        ligne2 = marpac & xor_(basevi >= ppe.seuil1, baseci >= ppe.seuil1)
+        ligne2 = maries_ou_pacses & xor_(basevi >= ppe.seuil1, baseci >= ppe.seuil1)
         ligne3 = (celdiv | veuf) & caseT & not_(veuf & caseT & caseL)
         ligne1 = not_(ligne2) & not_(ligne3)
 
@@ -2917,7 +2913,7 @@ class ppe_brute(Variable):
 
         # Primes pour enfants à charge
         maj_pac = ppe_elig * (eliv | elic) * (
-            (ligne1 & marpac & ((ppev + ppec) != 0) & (min_(basev, basec) <= ppe.seuil3)) * ppe.pac
+            (ligne1 & maries_ou_pacses & ((ppev + ppec) != 0) & (min_(basev, basec) <= ppe.seuil3)) * ppe.pac
             * (nb_pac_ppe + nbH * 0.5)
             + (ligne1 & (celdiv | veuf) & eliv & (basev <= ppe.seuil3)) * ppe.pac * (nb_pac_ppe + nbH * 0.5)
             + (ligne2 & (base_monacti >= ppe.seuil1) & (base_monact <= ppe.seuil3)) * ppe.pac * (nb_pac_ppe + nbH * 0.5)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -161,7 +161,6 @@ class enfant_a_charge(Variable):
         u" revenus, ou né durant la même année, ou handicapés quel que soit son âge"
 
     def function(self, simulation, period):
-        period = period.this_year
         age = simulation.calculate('age', period)
         garde_alternee = simulation.calculate('garde_alternee', period)
         handicap = simulation.calculate('handicap', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -509,13 +509,13 @@ class cappme(DatedVariable):
         2002
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7cf = simulation.calculate('f7cf', period)
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.cappme
 
         base = f7cf
-        seuil = P.seuil * (marpac + 1)
+        seuil = P.seuil * (maries_ou_pacses + 1)
         return period, P.taux * min_(base, seuil)
 
     @dated_function(start = date(2003, 1, 1), stop = date(2003, 12, 31))
@@ -525,14 +525,14 @@ class cappme(DatedVariable):
         2003
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7cf = simulation.calculate('f7cf', period)
         f7cl = simulation.calculate('f7cl', period)
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.cappme
 
         base = f7cf + f7cl
-        seuil = P.seuil * (marpac + 1)
+        seuil = P.seuil * (maries_ou_pacses + 1)
         return period, P.taux * min_(base, seuil)
 
     @dated_function(start = date(2004, 1, 1), stop = date(2004, 12, 31))
@@ -542,7 +542,7 @@ class cappme(DatedVariable):
         2004
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7cf = simulation.calculate('f7cf', period)
         f7cl = simulation.calculate('f7cl', period)
         f7cm = simulation.calculate('f7cm', period)
@@ -550,7 +550,7 @@ class cappme(DatedVariable):
         P = simulation.legislation_at(period.start).ir.reductions_impots.cappme
 
         base = f7cf + f7cl + f7cm
-        seuil = P.seuil * (marpac + 1)
+        seuil = P.seuil * (maries_ou_pacses + 1)
         return period, P.taux * min_(base, seuil)
 
     @dated_function(start = date(2005, 1, 1), stop = date(2008, 12, 31))
@@ -560,7 +560,7 @@ class cappme(DatedVariable):
         2005-2008
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7cf = simulation.calculate('f7cf', period)
         f7cl = simulation.calculate('f7cl', period)
         f7cm = simulation.calculate('f7cm', period)
@@ -569,7 +569,7 @@ class cappme(DatedVariable):
         P = simulation.legislation_at(period.start).ir.reductions_impots.cappme
 
         base = f7cf + f7cl + f7cm + f7cn
-        seuil = P.seuil * (marpac + 1)
+        seuil = P.seuil * (maries_ou_pacses + 1)
         return period, P.taux * min_(base, seuil)
 
     @dated_function(start = date(2009, 1, 1), stop = date(2010, 12, 31))
@@ -579,7 +579,7 @@ class cappme(DatedVariable):
         2009-2010
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7cf = simulation.calculate('f7cf', period)
         f7cl = simulation.calculate('f7cl', period)
         f7cm = simulation.calculate('f7cm', period)
@@ -589,8 +589,8 @@ class cappme(DatedVariable):
         P = simulation.legislation_at(period.start).ir.reductions_impots.cappme
 
         base = f7cf + f7cl + f7cm + f7cn + f7cu
-        seuil = P.seuil * (marpac + 1)
-        seuil = P.seuil_tpe * (marpac + 1) * (f7cu > 0) + P.seuil * (marpac + 1) * (f7cu <= 0)
+        seuil = P.seuil * (maries_ou_pacses + 1)
+        seuil = P.seuil_tpe * (maries_ou_pacses + 1) * (f7cu > 0) + P.seuil * (maries_ou_pacses + 1) * (f7cu <= 0)
         return period, P.taux * min_(base, seuil)
 
     @dated_function(start = date(2011, 1, 1), stop = date(2011, 12, 31))
@@ -600,7 +600,7 @@ class cappme(DatedVariable):
         2011
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7cf = simulation.calculate('f7cf', period)
         f7cl = simulation.calculate('f7cl', period)
         f7cm = simulation.calculate('f7cm', period)
@@ -611,7 +611,7 @@ class cappme(DatedVariable):
         P = simulation.legislation_at(period.start).ir.reductions_impots.cappme
 
         base = f7cl + f7cm + f7cn + f7cq
-        seuil = P.seuil_tpe * (marpac + 1) * (f7cu > 0) + P.seuil * (marpac + 1) * (f7cu <= 0)
+        seuil = P.seuil_tpe * (maries_ou_pacses + 1) * (f7cu > 0) + P.seuil * (maries_ou_pacses + 1) * (f7cu <= 0)
         max0 = max_(seuil - base, 0)
         return period, max_(P.taux25 * min_(base, seuil), P.taux * min_(max0, f7cf + f7cu))
 
@@ -622,7 +622,7 @@ class cappme(DatedVariable):
         2012 cf. 2041 GR
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7cf = simulation.calculate('f7cf', period)
         f7cl = simulation.calculate('f7cl', period)
         f7cm = simulation.calculate('f7cm', period)
@@ -634,9 +634,9 @@ class cappme(DatedVariable):
 
         #TODO: gérer les changements de situation familiale
         base = f7cl + f7cm + f7cn
-        seuil1 = P.seuil * (marpac + 1)
-        seuil2 = max_(0, P.seuil_tpe * (marpac + 1) - min_(base, seuil1) - min_(f7cq, seuil1) - min_(f7cu, seuil1))
-        seuil3 = min_(P.seuil_tpe * (marpac + 1) - min_(base, seuil1) - min_(f7cq, seuil1), seuil1)
+        seuil1 = P.seuil * (maries_ou_pacses + 1)
+        seuil2 = max_(0, P.seuil_tpe * (maries_ou_pacses + 1) - min_(base, seuil1) - min_(f7cq, seuil1) - min_(f7cu, seuil1))
+        seuil3 = min_(P.seuil_tpe * (maries_ou_pacses + 1) - min_(base, seuil1) - min_(f7cq, seuil1), seuil1)
         return period, P.taux25 * min_(base, seuil1) + P.taux * min_(f7cq, seuil1) + P.taux18 * (min_(f7cf, seuil3) +
                 mini(f7cu, seuil2, seuil1))
 
@@ -647,7 +647,7 @@ class cappme(DatedVariable):
         2013
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7cc = simulation.calculate('f7cc', period)
         f7cf = simulation.calculate('f7cf', period)
         f7cl = simulation.calculate('f7cl', period)
@@ -659,9 +659,9 @@ class cappme(DatedVariable):
         P = simulation.legislation_at(period.start).ir.reductions_impots.cappme
 
         base = f7cl + f7cm
-        seuil1 = P.seuil * (marpac + 1)
-        seuil2 = max_(0, P.seuil_tpe * (marpac + 1) - min_(base, seuil1) - min_(f7cn, seuil1) - min_(f7cu, seuil1))
-        seuil3 = min_(P.seuil_tpe * (marpac + 1) - min_(base, seuil1) - min_(f7cq, seuil1), seuil1)
+        seuil1 = P.seuil * (maries_ou_pacses + 1)
+        seuil2 = max_(0, P.seuil_tpe * (maries_ou_pacses + 1) - min_(base, seuil1) - min_(f7cn, seuil1) - min_(f7cu, seuil1))
+        seuil3 = min_(P.seuil_tpe * (maries_ou_pacses + 1) - min_(base, seuil1) - min_(f7cq, seuil1), seuil1)
         return period, P.taux25 * min_(base, seuil1) + P.taux22 * min_(f7cn, seuil1) + P.taux18 * (min_(f7cf + f7cc, seuil3) +
                 min_(f7cu + f7cq, seuil2))
 
@@ -1741,10 +1741,10 @@ class intagr(Variable):
         '''
         period = period.this_year
         f7um = simulation.calculate('f7um', period)
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         P = simulation.legislation_at(period.start).ir.reductions_impots.intagr
 
-        max1 = P.max * (1 + marpac)
+        max1 = P.max * (1 + maries_ou_pacses)
         return period, P.taux * min_(f7um, max1)
 
 
@@ -1800,12 +1800,12 @@ class invfor(DatedVariable):
         Investissements forestiers pour 2002-2005
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7un = simulation.calculate('f7un', period)
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.invfor
 
-        seuil = P.seuil * (marpac + 1)
+        seuil = P.seuil * (maries_ou_pacses + 1)
         return period, P.taux * min_(f7un, seuil)
 
     @dated_function(start = date(2006, 1, 1), stop = date(2008, 12, 31))
@@ -1826,15 +1826,15 @@ class invfor(DatedVariable):
         Investissements forestiers pour 2009
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7un = simulation.calculate('f7un', period)
         f7up = simulation.calculate('f7up', period)
         f7uq = simulation.calculate('f7uq', period)
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.invfor
 
-        return period, P.taux * (min_(f7un, P.seuil * (marpac + 1)) + min_(f7up, P.ifortra_seuil * (marpac + 1)) +
-                min_(f7uq, P.iforges_seuil * (marpac + 1)))
+        return period, P.taux * (min_(f7un, P.seuil * (maries_ou_pacses + 1)) + min_(f7up, P.ifortra_seuil * (maries_ou_pacses + 1)) +
+                min_(f7uq, P.iforges_seuil * (maries_ou_pacses + 1)))
 
     @dated_function(start = date(2010, 1, 1), stop = date(2010, 12, 31))
     def function_20100101_20101231(self, simulation, period):
@@ -1842,7 +1842,7 @@ class invfor(DatedVariable):
         Investissements forestiers pour 2010
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7te = simulation.calculate('f7te', period)
         f7un = simulation.calculate('f7un', period)
         f7up = simulation.calculate('f7up', period)
@@ -1852,9 +1852,9 @@ class invfor(DatedVariable):
         P = simulation.legislation_at(period.start).ir.reductions_impots.invfor
 
         return period, (P.taux * (
-            min_(f7un, P.seuil * (marpac + 1)) +
-            min_(f7up + f7uu + f7te, P.ifortra_seuil * (marpac + 1)) +
-            min_(f7uq, P.iforges_seuil * (marpac + 1))))
+            min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
+            min_(f7up + f7uu + f7te, P.ifortra_seuil * (maries_ou_pacses + 1)) +
+            min_(f7uq, P.iforges_seuil * (maries_ou_pacses + 1))))
 
     @dated_function(start = date(2011, 1, 1), stop = date(2011, 12, 31))
     def function_20110101_20111231(self, simulation, period):
@@ -1862,7 +1862,7 @@ class invfor(DatedVariable):
         Investissements forestiers pour 2011 cf. 2041 GK
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7te = simulation.calculate('f7te', period)
         f7tf = simulation.calculate('f7tf', period)
         f7ul = simulation.calculate('f7ul', period)
@@ -1874,14 +1874,14 @@ class invfor(DatedVariable):
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.invfor
 
-        max0 = max_(0, P.ifortra_seuil * (marpac + 1) - f7ul)
+        max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
         max1 = max_(0, max0 - f7uu + f7te + f7uv + f7tf)
         return period, (P.taux * (
-            min_(f7un, P.seuil * (marpac + 1)) +
+            min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
             min_(f7up, max1) +
-            min_(f7uq, P.iforges_seuil * (marpac + 1))) +
+            min_(f7uq, P.iforges_seuil * (maries_ou_pacses + 1))) +
             P.report10 * min_(f7uu + f7te + f7uv + f7tf, max0) +
-            P.taux_ass * min_(f7ul, P.ifortra_seuil * (marpac + 1)))
+            P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)))
 
     @dated_function(start = date(2012, 1, 1), stop = date(2012, 12, 31))
     def function_20120101_20121231(self, simulation, period):
@@ -1889,7 +1889,7 @@ class invfor(DatedVariable):
         Investissements forestiers pour 2012 cf. 2041 GK
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7te = simulation.calculate('f7te', period)
         f7tf = simulation.calculate('f7tf', period)
         f7tg = simulation.calculate('f7tg', period)
@@ -1903,16 +1903,16 @@ class invfor(DatedVariable):
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.invfor
 
-        max0 = max_(0, P.ifortra_seuil * (marpac + 1) - f7ul)
+        max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
         max1 = max_(0, max0 - f7uu + f7te + f7uv + f7tf)
         max2 = max_(0, max1 - f7tg - f7uw)
         return period, (P.taux * (
-            min_(f7un, P.seuil * (marpac + 1)) +
+            min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
             min_(f7up, max2) +
-            min_(f7uq, P.iforges_seuil * (marpac + 1))) +
+            min_(f7uq, P.iforges_seuil * (maries_ou_pacses + 1))) +
             P.report10 * min_(f7uu + f7te + f7uv + f7tf, max0) +
             P.report11 * min_(f7tg + f7uw, max1) +
-            P.taux_ass * min_(f7ul, P.ifortra_seuil * (marpac + 1)))
+            P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)))
 
     @dated_function(start = date(2013, 1, 1), stop = date(2013, 12, 31))
     def function_20130101_20131231(self, simulation, period):
@@ -1920,7 +1920,7 @@ class invfor(DatedVariable):
         Investissements forestiers pour 2013 cf. 2041 GK
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7te = simulation.calculate('f7te', period)
         f7tf = simulation.calculate('f7tf', period)
         f7tg = simulation.calculate('f7tg', period)
@@ -1936,18 +1936,18 @@ class invfor(DatedVariable):
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.invfor
 
-        max0 = max_(0, P.ifortra_seuil * (marpac + 1) - f7ul)
+        max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
         max1 = max_(0, max0 - f7uu + f7te + f7uv + f7tf)
         max2 = max_(0, max1 - f7tg - f7uw)
         max3 = max_(0, max2 - f7th - f7ux)
         return period, (P.taux * (
-            min_(f7un, P.seuil * (marpac + 1)) +
+            min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
             min_(f7up, max3) +
-            min_(f7uq, P.iforges_seuil * (marpac + 1))) +
+            min_(f7uq, P.iforges_seuil * (maries_ou_pacses + 1))) +
             P.report10 * min_(f7uu + f7te + f7uv + f7tf, max0) +
             P.report11 * min_(f7tg + f7uw, max1) +
             P.report12 * min_(f7th + f7ux, max2) +
-            P.taux_ass * min_(f7ul, P.ifortra_seuil * (marpac + 1)))
+            P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)))
 
 
 class invlst(DatedVariable):
@@ -1962,7 +1962,7 @@ class invlst(DatedVariable):
         2004
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7xc = simulation.calculate('f7xc', period)
         f7xd = simulation.calculate('f7xd', period)
         f7xe = simulation.calculate('f7xe', period)
@@ -1979,9 +1979,9 @@ class invlst(DatedVariable):
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.invlst
 
-        seuil1 = P.seuil1 * (1 + marpac)
-        seuil2 = P.seuil2 * (1 + marpac)
-        seuil3 = P.seuil3 * (1 + marpac)
+        seuil1 = P.seuil1 * (1 + maries_ou_pacses)
+        seuil2 = P.seuil2 * (1 + maries_ou_pacses)
+        seuil3 = P.seuil3 * (1 + maries_ou_pacses)
 
         xc = P.taux_xc * min_(f7xc, seuil1 / 4)
         xd = P.taux_xd * f7xd
@@ -2006,7 +2006,7 @@ class invlst(DatedVariable):
         2005-2010
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7xc = simulation.calculate('f7xc', period)
         f7xd = simulation.calculate('f7xd', period)
         f7xe = simulation.calculate('f7xe', period)
@@ -2023,9 +2023,9 @@ class invlst(DatedVariable):
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.invlst
 
-        seuil1 = P.seuil1 * (1 + marpac)
-        seuil2 = P.seuil2 * (1 + marpac)
-        seuil3 = P.seuil3 * (1 + marpac)
+        seuil1 = P.seuil1 * (1 + maries_ou_pacses)
+        seuil2 = P.seuil2 * (1 + maries_ou_pacses)
+        seuil3 = P.seuil3 * (1 + maries_ou_pacses)
 
         xc = P.taux_xc * min_(f7xc, seuil1 / 6)
         xd = P.taux_xd * f7xd
@@ -2050,7 +2050,7 @@ class invlst(DatedVariable):
         2011
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7xa = simulation.calculate('f7xa', period)
         f7xb = simulation.calculate('f7xb', period)
         f7xc = simulation.calculate('f7xc', period)
@@ -2072,9 +2072,9 @@ class invlst(DatedVariable):
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.invlst
 
-        seuil1 = P.seuil1 * (1 + marpac)
-        seuil2 = P.seuil2 * (1 + marpac)
-        seuil3 = P.seuil3 * (1 + marpac)
+        seuil1 = P.seuil1 * (1 + maries_ou_pacses)
+        seuil2 = P.seuil2 * (1 + maries_ou_pacses)
+        seuil3 = P.seuil3 * (1 + maries_ou_pacses)
 
         xc = P.taux_xc * min_(f7xc, seuil1 / 6)
         xa = P.taux_xa * min_(f7xa, seuil2)
@@ -2095,7 +2095,7 @@ class invlst(DatedVariable):
         2012
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7xa = simulation.calculate('f7xa', period)
         f7xb = simulation.calculate('f7xb', period)
         f7xc = simulation.calculate('f7xc', period)
@@ -2120,9 +2120,9 @@ class invlst(DatedVariable):
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.invlst
 
-        seuil1 = P.seuil1 * (1 + marpac)
-        seuil2 = P.seuil2 * (1 + marpac)
-        seuil3 = P.seuil3 * (1 + marpac)
+        seuil1 = P.seuil1 * (1 + maries_ou_pacses)
+        seuil2 = P.seuil2 * (1 + maries_ou_pacses)
+        seuil3 = P.seuil3 * (1 + maries_ou_pacses)
 
         xc = P.taux_xc * min_(f7xc, seuil1 / 6)
         xa = P.taux_xa * min_(f7xa, seuil2)
@@ -2145,7 +2145,7 @@ class invlst(DatedVariable):
         2013
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7uy = simulation.calculate('f7uy', period)
         f7uz = simulation.calculate('f7uz', period)
         f7xf = simulation.calculate('f7xf', period)
@@ -2184,7 +2184,7 @@ class invrev(Variable):
         TODO 1/4 codé en dur
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7gs = simulation.calculate('f7gs', period)
         f7gt = simulation.calculate('f7gt', period)
         f7xg = simulation.calculate('f7xg', period)
@@ -2192,9 +2192,9 @@ class invrev(Variable):
         f7gv = simulation.calculate('f7gv', period)
         P = simulation.legislation_at(period.start).ir.reductions_impots.invrev
 
-        return period, (P.taux_gs * min_(f7gs, P.seuil_gs * (1 + marpac)) / 4 +
-                 P.taux_gu * min_(f7gu, P.seuil_gu * (1 + marpac)) / 4 +
-                 P.taux_xg * min_(f7xg, P.seuil_xg * (1 + marpac)) / 4 +
+        return period, (P.taux_gs * min_(f7gs, P.seuil_gs * (1 + maries_ou_pacses)) / 4 +
+                 P.taux_gu * min_(f7gu, P.seuil_gu * (1 + maries_ou_pacses)) / 4 +
+                 P.taux_xg * min_(f7xg, P.seuil_xg * (1 + maries_ou_pacses)) / 4 +
                  P.taux_gt * f7gt + P.taux_gt * f7gv)
 
 
@@ -2497,11 +2497,11 @@ class repsoc(Variable):
         2003-
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7fh = simulation.calculate('f7fh', period)
         P = simulation.legislation_at(period.start).ir.reductions_impots.repsoc
 
-        seuil = P.seuil * (marpac + 1)
+        seuil = P.seuil * (maries_ou_pacses + 1)
         return period, P.taux * min_(f7fh, seuil)
 
 
@@ -3065,13 +3065,13 @@ class sofipe(Variable):
         2009-2011
         """
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         rbg_int = simulation.calculate('rbg_int', period)
         f7gs = simulation.calculate('f7gs', period)
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.sofipe
 
-        max1 = min_(P.max * (marpac + 1), P.base * rbg_int)  # page3 ligne 18
+        max1 = min_(P.max * (maries_ou_pacses + 1), P.base * rbg_int)  # page3 ligne 18
         return period, P.taux * min_(f7gs, max1)
 
 
@@ -3088,12 +3088,12 @@ class spfcpi(DatedVariable):
         2002
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7gq = simulation.calculate('f7gq', period)
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.spfcpi
 
-        max1 = P.max * (marpac + 1)
+        max1 = P.max * (maries_ou_pacses + 1)
         return period, P.taux1 * min_(f7gq, max1)
 
     @dated_function(start = date(2003, 1, 1), stop = date(2006, 12, 31))
@@ -3104,13 +3104,13 @@ class spfcpi(DatedVariable):
         2003-2006
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7gq = simulation.calculate('f7gq', period)
         f7fq = simulation.calculate('f7fq', period)
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.spfcpi
 
-        max1 = P.max * (marpac + 1)
+        max1 = P.max * (maries_ou_pacses + 1)
         return period, (P.taux1 * min_(f7gq, max1) + P.taux1 * min_(f7fq, max1))
 
     @dated_function(start = date(2007, 1, 1), stop = date(2010, 12, 31))
@@ -3121,14 +3121,14 @@ class spfcpi(DatedVariable):
         2007-2010
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7gq = simulation.calculate('f7gq', period)
         f7fq = simulation.calculate('f7fq', period)
         f7fm = simulation.calculate('f7fm', period)
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.spfcpi
 
-        max1 = P.max * (marpac + 1)
+        max1 = P.max * (maries_ou_pacses + 1)
         return period, (P.taux1 * min_(f7gq, max1) +
                     P.taux1 * min_(f7fq, max1) +
                     P.taux2 * min_(f7fm, max1))
@@ -3141,7 +3141,7 @@ class spfcpi(DatedVariable):
         2011-2013
         '''
         period = period.this_year
-        marpac = simulation.calculate('marpac', period)
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
         f7gq = simulation.calculate('f7gq', period)
         f7fq = simulation.calculate('f7fq', period)
         f7fm = simulation.calculate('f7fm', period)
@@ -3149,7 +3149,7 @@ class spfcpi(DatedVariable):
         _P = simulation.legislation_at(period.start)
         P = simulation.legislation_at(period.start).ir.reductions_impots.spfcpi
 
-        max1 = P.max * (marpac + 1)
+        max1 = P.max * (maries_ou_pacses + 1)
         return period, (P.taux1 * min_(f7gq, max1) + P.taux1 * min_(f7fq, max1) + P.taux2 * min_(f7fm, max1) +
                 P.taux3 * min_(f7fl, max1))
 

--- a/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
+++ b/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
@@ -66,7 +66,7 @@ class taxe_habitation(Variable):
     def function(self, simulation, period):
         period = period.start.offset('first-of', 'month').period('year')
         exonere_taxe_habitation = simulation.calculate('exonere_taxe_habitation', period)
-        nombre_enfants_a_charge_menage = simulation.calculate('nombre_enfants_a_charge_menage', period)
+        nombre_enfants_a_charge_menage = self.sum_by_entity(simulation.calculate('enfant_a_charge', period))
         nombre_enfants_majeurs_celibataires_sans_enfant = simulation.calculate('nombre_enfants_majeurs_celibataires_sans_enfant', period)
         rfr_n_1_holder = simulation.compute('rfr_n_1', period)
 

--- a/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
+++ b/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
@@ -33,7 +33,7 @@ class exonere_taxe_habitation(Variable):
         isf_tot_holder = simulation.compute('isf_tot', period)
         nbptr_holder = simulation.compute('nbptr', period)
         rfr_holder = simulation.compute('rfr', period)
-        statmarit_holder = simulation.compute('statmarit', period)
+        statut_marital_holder = simulation.compute('statut_marital', period)
         _P = simulation.legislation_at(period.start)
 
         aah = self.sum_by_entity(aah_holder)
@@ -48,12 +48,12 @@ class exonere_taxe_habitation(Variable):
         nbptr = self.sum_by_entity(nbptr)  # TODO: Beurk
         rfr = self.cast_from_entity_to_role(rfr_holder, role = VOUS)
         rfr = self.sum_by_entity(rfr)
-        statmarit = self.filter_role(statmarit_holder, role = PREF)
+        statut_marital = self.filter_role(statut_marital_holder, role = PREF)
 
         P = _P.cotsoc.gen
 
         seuil_th = P.plaf_th_1 + P.plaf_th_supp * (max_(0, (nbptr - 1) / 2))
-        elig = ((age >= 60) + (statmarit == 4)) * (isf_tot <= 0) * (rfr < seuil_th) + (asi > 0) + (aspa > 0) + (aah > 0)
+        elig = ((age >= 60) + (statut_marital == 4)) * (isf_tot <= 0) * (rfr < seuil_th) + (asi > 0) + (aspa > 0) + (aah > 0)
         return period, not_(elig)
 
 

--- a/openfisca_france/param/param.xml
+++ b/openfisca_france/param/param.xml
@@ -4979,7 +4979,7 @@
         <VALUE deb="2002-01-01" fin="2002-12-31" valeur="3549" />
         <VALUE deb="2001-01-01" fin="2001-12-31" valeur="3490" />
       </CODE>
-      <CODE code="marpac" description="Mariés ou PACS" format="integer" type="monetary">
+      <CODE code="maries_ou_pacses" description="Mariés ou PACS" format="integer" type="monetary">
         <VALUE deb="2015-01-01" fuzzy="true" valeur="1508" />
         <VALUE deb="2014-01-01" fin="2014-12-31" valeur="1508" />
         <VALUE deb="2013-01-01" fin="2013-12-31" valeur="1500" />

--- a/openfisca_france/param/parameters.xml
+++ b/openfisca_france/param/parameters.xml
@@ -7063,7 +7063,7 @@
         <VALUE deb="2002-01-01" fin="2002-12-31" valeur="3549" />
         <VALUE deb="2001-01-01" fin="2001-12-31" valeur="3490" />
       </CODE>
-      <CODE code="marpac" description="Mariés ou PACS" format="integer" type="monetary">
+      <CODE code="maries_ou_pacses" description="Mariés ou PACS" format="integer" type="monetary">
         <VALUE deb="2014-01-01" fin="2014-12-31" valeur="1508" />
         <VALUE deb="2013-01-01" fin="2013-12-31" valeur="1500" />
         <VALUE deb="2012-01-01" fin="2012-12-31" valeur="2000" />

--- a/openfisca_france/reforms/landais_piketty_saez.py
+++ b/openfisca_france/reforms/landais_piketty_saez.py
@@ -54,8 +54,8 @@ def build_reform(base_tax_benefit_system):
             ae = nbEnf * lps.abatt_enfant
             re = nbEnf * lps.reduc_enfant
             ce = nbEnf * lps.credit_enfant
-            statmarit = simulation.calculate('statmarit')
-            couple = (statmarit == 1) | (statmarit == 5)
+            statut_marital = simulation.calculate('statut_marital')
+            couple = (statut_marital == 1) | (statut_marital == 5)
             ac = couple * lps.abatt_conj
             rc = couple * lps.reduc_conj
             assiette_csg = simulation.calculate('assiette_csg')

--- a/openfisca_france/reforms/plf2016_ayrault_muet.py
+++ b/openfisca_france/reforms/plf2016_ayrault_muet.py
@@ -83,11 +83,11 @@ def build_reform(tax_benefit_system):
             ppe_coef = simulation.calculate('ppe_coef', period)
             maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
             veuf = simulation.calculate('veuf', period)
-            celdiv = simulation.calculate('celdiv', period)
+            celibataire_ou_divorce = simulation.calculate('celibataire_ou_divorce', period)
             nbptr = simulation.calculate('nbptr', period)
             variator = simulation.calculate('variator', period)
             ppe = simulation.legislation_at(period.start).ir.credits_impot.ppe
-            seuil = (veuf | celdiv) * (ppe.eligi1 + 2 * max_(nbptr - 1, 0) * ppe.eligi3) \
+            seuil = (veuf | celibataire_ou_divorce) * (ppe.eligi1 + 2 * max_(nbptr - 1, 0) * ppe.eligi3) \
                 + maries_ou_pacses * (ppe.eligi2 + 2 * max_(nbptr - 2, 0) * ppe.eligi3)
             return period, (rfr * ppe_coef) <= (seuil * variator)
 

--- a/openfisca_france/reforms/plf2016_ayrault_muet.py
+++ b/openfisca_france/reforms/plf2016_ayrault_muet.py
@@ -81,14 +81,14 @@ def build_reform(tax_benefit_system):
             period = period.start.offset('first-of', 'year').period('year')
             rfr = simulation.calculate('rfr', period)
             ppe_coef = simulation.calculate('ppe_coef', period)
-            marpac = simulation.calculate('marpac', period)
+            maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
             veuf = simulation.calculate('veuf', period)
             celdiv = simulation.calculate('celdiv', period)
             nbptr = simulation.calculate('nbptr', period)
             variator = simulation.calculate('variator', period)
             ppe = simulation.legislation_at(period.start).ir.credits_impot.ppe
             seuil = (veuf | celdiv) * (ppe.eligi1 + 2 * max_(nbptr - 1, 0) * ppe.eligi3) \
-                + marpac * (ppe.eligi2 + 2 * max_(nbptr - 2, 0) * ppe.eligi3)
+                + maries_ou_pacses * (ppe.eligi2 + 2 * max_(nbptr - 2, 0) * ppe.eligi3)
             return period, (rfr * ppe_coef) <= (seuil * variator)
 
     class ppe_elig_bis_individu(Reform.EntityToPersonColumn):

--- a/openfisca_france/scenarios.py
+++ b/openfisca_france/scenarios.py
@@ -741,18 +741,18 @@ class Scenario(scenarios.AbstractScenario):
                         foyer_fiscal['id'], {})['caseT'] = foyer_fiscal['caseT'] = True
             elif len(foyer_fiscal['declarants']) == 2:
                 # Suggest "PACSé" or "Marié" instead of "Célibataire" when foyer_fiscal contains 2 "declarants" without
-                # "statmarit".
-                statmarit = 5  # PACSé
+                # "statut_marital".
+                statut_marital = 5  # PACSé
                 for individu_id in foyer_fiscal['declarants']:
                     individu = individu_by_id[individu_id]
-                    if individu.get('statmarit') == 1:  # Marié
-                        statmarit = 1
+                    if individu.get('statut_marital') == 1:  # Marié
+                        statut_marital = 1
                 for individu_id in foyer_fiscal['declarants']:
                     individu = individu_by_id[individu_id]
-                    if individu.get('statmarit') is None:
-                        individu['statmarit'] = statmarit
+                    if individu.get('statut_marital') is None:
+                        individu['statut_marital'] = statut_marital
                         suggestions.setdefault('test_case', {}).setdefault('individus', {}).setdefault(individu_id, {})[
-                            'statmarit'] = unicode(statmarit)
+                            'statut_marital'] = unicode(statut_marital)
 
         return suggestions or None
 

--- a/openfisca_france/scripts/calculate_all_columns.py
+++ b/openfisca_france/scripts/calculate_all_columns.py
@@ -47,7 +47,7 @@ def check_1_parent_2_enfants(year):
         parent1 = dict(
             activite = u'Actif occupé',
             date_naissance = 1970,
-            statmarit = u'Célibataire',
+            statut_marital = u'Célibataire',
             ),
         enfants = [
             dict(
@@ -84,7 +84,7 @@ def check_1_parent_2_enfants_1_column(column_name, year):
         parent1 = dict(
             activite = u'Actif occupé',
             date_naissance = 1970,
-            statmarit = u'Célibataire',
+            statut_marital = u'Célibataire',
             ),
         enfants = [
             dict(

--- a/openfisca_france/scripts/calculateur_impots/base.py
+++ b/openfisca_france/scripts/calculateur_impots/base.py
@@ -228,10 +228,10 @@ def transform_scenario_to_tax_calculator_inputs(scenario):
             date_naissance = declarant.pop('date_naissance')
             impots_arguments['0D{}'.format(chr(ord('A') + declarant_index))] = date_naissance.year
 
-            statmarit = declarant.pop('statmarit', None)
-            column = tax_benefit_system.column_by_name['statmarit']
-            if statmarit is None:
-                statmarit = column.enum._vars[column.default]
+            statut_marital = declarant.pop('statut_marital', None)
+            column = tax_benefit_system.column_by_name['statut_marital']
+            if statut_marital is None:
+                statut_marital = column.enum._vars[column.default]
             pre_situation_famille = {
                 u"Marié": 'M',
                 u"Célibataire": 'C',
@@ -239,7 +239,7 @@ def transform_scenario_to_tax_calculator_inputs(scenario):
                 u"Veuf": 'V',
                 u"Pacsé": 'O',
                 # u"Jeune veuf": TODO
-                }[statmarit if isinstance(statmarit, basestring) else column.enum._vars[statmarit]]
+                }[statut_marital if isinstance(statut_marital, basestring) else column.enum._vars[statut_marital]]
             assert 'pre_situation_famille' not in impots_arguments \
                 or impots_arguments['pre_situation_famille'] == pre_situation_famille, str((impots_arguments,
                     pre_situation_famille))
@@ -264,7 +264,7 @@ def transform_scenario_to_tax_calculator_inputs(scenario):
             date_naissance = personne_a_charge.pop('date_naissance')
             impots_arguments['0F{}'.format(personne_a_charge_index)] = date_naissance.year
 
-            personne_a_charge.pop('statmarit', None)
+            personne_a_charge.pop('statut_marital', None)
 
             for column_code, value in personne_a_charge.iteritems():
                 if column_code in (

--- a/openfisca_france/scripts/calculateur_impots/compare_openfisca_impots.py
+++ b/openfisca_france/scripts/calculateur_impots/compare_openfisca_impots.py
@@ -146,7 +146,7 @@ def compare(scenario, tested = False):
         'IPROP': u'Impôt proportionnel',
         'RFOR': u'?',#TODO (f7up)
         'PERPPLAFTP': u'?',
-        'PERPPLAFTC': u'?',#TODO (f2ch, f2dh, marpac)
+        'PERPPLAFTC': u'?',#TODO (f2ch, f2dh, maries_ou_pacses)
         'RHEBE': u'?',#TODO (7ce)
         'RAA': u'?',#TODO (7ud)
         'RAH': u'?',#TODO (7ce)

--- a/openfisca_france/scripts/calculateur_impots/compare_openfisca_impots.py
+++ b/openfisca_france/scripts/calculateur_impots/compare_openfisca_impots.py
@@ -40,12 +40,12 @@ def define_scenario(year):
             activite = u'Actif occupé',
             date_naissance = 1973,
             salaire_imposable = 48000,
-            statmarit = u'Marié',
+            statut_marital = u'Marié',
             ),
         parent2 = dict(
             activite = u'Actif occupé',
             date_naissance = 1973,
-            statmarit = u'Marié',
+            statut_marital = u'Marié',
             ),
         enfants = [
             dict(

--- a/openfisca_france/scripts/calculateur_impots/create_json_then_test.py
+++ b/openfisca_france/scripts/calculateur_impots/create_json_then_test.py
@@ -30,7 +30,7 @@ def define_scenario(year, column_code):
         "activite": u'Actif occupé',
         "date_naissance": 1970,
         "salaire_imposable": 24000,
-        "statmarit": u'Célibataire',
+        "statut_marital": u'Célibataire',
         }
     enfants = [
         # dict(

--- a/openfisca_france/scripts/calculateur_impots/generate_json.py
+++ b/openfisca_france/scripts/calculateur_impots/generate_json.py
@@ -25,7 +25,7 @@ def define_scenario(year = 2013):
             activite = u'Actif occupé',
             date_naissance = 1970,
             salaire_imposable = 24000,
-            statmarit = u'Célibataire',
+            statut_marital = u'Célibataire',
             ),
         enfants = [
             dict(

--- a/openfisca_france/scripts/calculateur_impots/request_impots.py
+++ b/openfisca_france/scripts/calculateur_impots/request_impots.py
@@ -92,7 +92,7 @@ def main():
                 'IAVF2': u'?',#TODO (f8th)
                 'IPROP': u'Impôt proportionnel',
                 'RFOR': u'?',#TODO (f7up)
-                'PERPPLAFTC': u'?',#TODO (f2ch, f2dh, marpac)
+                'PERPPLAFTC': u'?',#TODO (f2ch, f2dh, maries_ou_pacses)
                 'RHEBE': u'?',#TODO (7ce)
                 'RAA': u'?',#TODO (7ud)
                 'RAH': u'?',#TODO (7ce)

--- a/openfisca_france/scripts/rattachement.py
+++ b/openfisca_france/scripts/rattachement.py
@@ -99,7 +99,7 @@ def define_scenario(year):
             date_naissance = 1973,
 #            cadre = True,
             salaire_imposable = 90000,
-            statmarit = u'Célibataire',
+            statut_marital = u'Célibataire',
             ),
         enfants = [
             dict(

--- a/openfisca_france/tests/calculateur_impots/aacc_defn.yaml
+++ b/openfisca_france/tests/calculateur_impots/aacc_defn.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_defn: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_defn: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_defn: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_defn: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_defn: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_defn: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_defn: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_defn: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_defn: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/aacc_defs.yaml
+++ b/openfisca_france/tests/calculateur_impots/aacc_defs.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     aacc_defs: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     aacc_defs: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     aacc_defs: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     aacc_defs: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     aacc_defs: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     aacc_defs: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     aacc_defs: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     aacc_defs: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -235,7 +235,7 @@
     salaire_imposable: 24000
     aacc_defs: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -264,7 +264,7 @@
     salaire_imposable: 24000
     aacc_defs: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/aacc_exon.yaml
+++ b/openfisca_france/tests/calculateur_impots/aacc_exon.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     aacc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     aacc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     aacc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     aacc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     aacc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     aacc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     aacc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     aacc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     aacc_exon: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/aacc_gits.yaml
+++ b/openfisca_france/tests/calculateur_impots/aacc_gits.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     aacc_gits: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
     salaire_imposable: 24000
     aacc_gits: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
     salaire_imposable: 24000
     aacc_gits: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
     salaire_imposable: 24000
     aacc_gits: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -125,7 +125,7 @@
     salaire_imposable: 24000
     aacc_gits: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -153,7 +153,7 @@
     salaire_imposable: 24000
     aacc_gits: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -182,7 +182,7 @@
     salaire_imposable: 24000
     aacc_gits: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/aacc_impn.yaml
+++ b/openfisca_france/tests/calculateur_impots/aacc_impn.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_impn: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_impn: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_impn: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_impn: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_impn: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_impn: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_impn: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_impn: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_impn: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/aacc_imps.yaml
+++ b/openfisca_france/tests/calculateur_impots/aacc_imps.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     aacc_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
     salaire_imposable: 24000
     aacc_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
     salaire_imposable: 24000
     aacc_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
     salaire_imposable: 24000
     aacc_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -125,7 +125,7 @@
     salaire_imposable: 24000
     aacc_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -153,7 +153,7 @@
     salaire_imposable: 24000
     aacc_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -182,7 +182,7 @@
     salaire_imposable: 24000
     aacc_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/aacc_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/aacc_pvce.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_pvce: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_pvce: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_pvce: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_pvce: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_pvce: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_pvce: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_pvce: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_pvce: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     aacc_pvce: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/abic_defn.yaml
+++ b/openfisca_france/tests/calculateur_impots/abic_defn.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_defn: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_defn: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_defn: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_defn: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_defn: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_defn: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_defn: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_defn: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_defn: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/abic_defs.yaml
+++ b/openfisca_france/tests/calculateur_impots/abic_defs.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     abic_defs: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     abic_defs: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     abic_defs: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     abic_defs: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     abic_defs: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     abic_defs: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     abic_defs: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     abic_defs: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -235,7 +235,7 @@
     salaire_imposable: 24000
     abic_defs: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -264,7 +264,7 @@
     salaire_imposable: 24000
     abic_defs: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/abic_exon.yaml
+++ b/openfisca_france/tests/calculateur_impots/abic_exon.yaml
@@ -13,7 +13,7 @@
     abic_exon: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     abic_exon: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     abic_exon: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     abic_exon: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     abic_exon: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     abic_exon: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     abic_exon: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     abic_exon: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     abic_exon: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/abic_impn.yaml
+++ b/openfisca_france/tests/calculateur_impots/abic_impn.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_impn: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_impn: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_impn: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_impn: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_impn: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_impn: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_impn: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_impn: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_impn: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/abic_imps.yaml
+++ b/openfisca_france/tests/calculateur_impots/abic_imps.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     abic_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     abic_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -68,7 +68,7 @@
     salaire_imposable: 24000
     abic_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -96,7 +96,7 @@
     salaire_imposable: 24000
     abic_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -124,7 +124,7 @@
     salaire_imposable: 24000
     abic_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
     salaire_imposable: 24000
     abic_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
     salaire_imposable: 24000
     abic_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
     salaire_imposable: 24000
     abic_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     abic_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -265,7 +265,7 @@
     salaire_imposable: 24000
     abic_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/abic_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/abic_pvce.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_pvce: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_pvce: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_pvce: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_pvce: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_pvce: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_pvce: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_pvce: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_pvce: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     abic_pvce: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/abnc_defi.yaml
+++ b/openfisca_france/tests/calculateur_impots/abnc_defi.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_defi: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_defi: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_defi: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_defi: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_defi: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_defi: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_defi: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_defi: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_defi: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/abnc_exon.yaml
+++ b/openfisca_france/tests/calculateur_impots/abnc_exon.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     abnc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     abnc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     abnc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     abnc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     abnc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     abnc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     abnc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     abnc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     abnc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/abnc_impo.yaml
+++ b/openfisca_france/tests/calculateur_impots/abnc_impo.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     abnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/abnc_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/abnc_pvce.yaml
@@ -13,7 +13,7 @@
     abnc_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     abnc_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     abnc_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     abnc_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     abnc_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     abnc_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     abnc_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     abnc_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     abnc_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/arag_defi.yaml
+++ b/openfisca_france/tests/calculateur_impots/arag_defi.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_defi: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_defi: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_defi: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_defi: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_defi: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_defi: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_defi: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_defi: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_defi: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/arag_exon.yaml
+++ b/openfisca_france/tests/calculateur_impots/arag_exon.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_exon: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_exon: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_exon: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_exon: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_exon: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_exon: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_exon: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_exon: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_exon: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/arag_impg.yaml
+++ b/openfisca_france/tests/calculateur_impots/arag_impg.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     arag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     arag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     arag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     arag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     arag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     arag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     arag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     arag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     arag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/arag_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/arag_pvce.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_pvce: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_pvce: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_pvce: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_pvce: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_pvce: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_pvce: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_pvce: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_pvce: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     arag_pvce: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/cncn_bene.yaml
+++ b/openfisca_france/tests/calculateur_impots/cncn_bene.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     cncn_bene: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     cncn_bene: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     cncn_bene: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     cncn_bene: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     cncn_bene: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     cncn_bene: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     cncn_bene: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     cncn_bene: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     cncn_bene: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/cncn_defi.yaml
+++ b/openfisca_france/tests/calculateur_impots/cncn_defi.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_defi: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_defi: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_defi: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_defi: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_defi: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_defi: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_defi: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_defi: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_defi: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/cncn_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/cncn_pvce.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_pvce: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_pvce: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_pvce: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_pvce: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_pvce: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_pvce: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_pvce: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_pvce: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     cncn_pvce: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/ebic_imps.yaml
+++ b/openfisca_france/tests/calculateur_impots/ebic_imps.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_imps: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_imps: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_imps: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_imps: 0
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_imps: 0
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_imps: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_imps: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_imps: 1500
   menages:
@@ -234,7 +234,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_imps: 1500
   menages:
@@ -262,7 +262,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_imps: 1500
   menages:
@@ -291,7 +291,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_imps: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/ebic_impv.yaml
+++ b/openfisca_france/tests/calculateur_impots/ebic_impv.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_impv: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_impv: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_impv: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_impv: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_impv: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_impv: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_impv: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_impv: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ebic_impv: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/ebnc_impo.yaml
+++ b/openfisca_france/tests/calculateur_impots/ebnc_impo.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     ebnc_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     ebnc_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     ebnc_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     ebnc_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     ebnc_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     ebnc_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     ebnc_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     ebnc_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     ebnc_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f2ch.yaml
+++ b/openfisca_france/tests/calculateur_impots/f2ch.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f2ck.yaml
+++ b/openfisca_france/tests/calculateur_impots/f2ck.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f2dc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f2dc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f2dh.yaml
+++ b/openfisca_france/tests/calculateur_impots/f2dh.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f2gr.yaml
+++ b/openfisca_france/tests/calculateur_impots/f2gr.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f3vv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f3vv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f3vv_end_2010.yaml
+++ b/openfisca_france/tests/calculateur_impots/f3vv_end_2010.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f4tq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f4tq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f5it.yaml
+++ b/openfisca_france/tests/calculateur_impots/f5it.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -125,7 +125,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -153,7 +153,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -182,7 +182,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f5qn.yaml
+++ b/openfisca_france/tests/calculateur_impots/f5qn.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -125,7 +125,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -153,7 +153,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -182,7 +182,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f5qq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f5qq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -125,7 +125,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -153,7 +153,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -182,7 +182,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7cc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7cc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7cd.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7cd.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ce.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ce.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7cf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7cf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7cl.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7cl.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7cm.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7cm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7cn.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7cn.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7cq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7cq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7cu.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7cu.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -240,7 +240,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7db.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7db.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7df.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7df.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7dq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7dq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7fa.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7fa.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7fb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7fb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7fc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7fc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7fd.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7fd.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7fh.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7fh.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7fl.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7fl.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7fm.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7fm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -96,7 +96,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -125,7 +125,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -154,7 +154,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -183,7 +183,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -212,7 +212,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -242,7 +242,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7fn.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7fn.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -68,7 +68,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -126,7 +126,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -155,7 +155,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -184,7 +184,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -213,7 +213,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -243,7 +243,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7fq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7fq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7fy.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7fy.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ga.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ga.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ge.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ge.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gg.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gg.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gh.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gh.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -121,7 +121,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -149,7 +149,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -177,7 +177,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -205,7 +205,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -233,7 +233,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -261,7 +261,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -289,7 +289,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -317,7 +317,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -345,7 +345,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -373,7 +373,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -401,7 +401,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -430,7 +430,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -459,7 +459,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -489,7 +489,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gi.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gi.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gj.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gj.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gk.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gk.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gl.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gl.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gn.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gn.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -68,7 +68,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -126,7 +126,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -155,7 +155,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -184,7 +184,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -213,7 +213,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -243,7 +243,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gp.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gp.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gs.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gs.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gt.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gt.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gu.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gu.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gx.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gx.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gy.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gy.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7gz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7gz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ha.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ha.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hd.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hd.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7he.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7he.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hg.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hg.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hh.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hh.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hj.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hj.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -240,7 +240,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hk.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hk.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -240,7 +240,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hl.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hl.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hm.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hn.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hn.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ho.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ho.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hr.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hr.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hs.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hs.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ht.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ht.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hu.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hu.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hx.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hx.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hy.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hy.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7hz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7hz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ia.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ia.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ib.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ib.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ic.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ic.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7id.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7id.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ie.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ie.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7if.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7if.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ig.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ig.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ih.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ih.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ij.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ij.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -240,7 +240,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ik.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ik.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7il.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7il.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7im.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7im.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7in.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7in.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7io.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7io.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ip.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ip.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7iq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7iq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ir.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ir.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7is.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7is.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7it.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7it.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7iu.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7iu.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7iv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7iv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7iw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7iw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ix.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ix.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7iy.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7iy.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7iz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7iz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ja.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ja.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jd.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jd.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7je.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7je.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jg.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jg.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jh.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jh.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ji.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ji.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jj.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jj.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jk.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jk.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jl.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jl.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jm.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jn.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jn.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jo.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jo.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jp.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jp.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jr.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jr.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7js.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7js.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jt.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jt.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ju.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ju.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jx.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jx.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7jy.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7jy.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ka.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ka.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7kb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7kb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7kc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7kc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7kd.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7kd.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ks.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ks.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7kt.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7kt.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ku.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ku.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ky.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ky.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7la.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7la.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7lb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7lb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7lc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7lc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ld.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ld.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7le.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7le.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7lf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7lf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7lg.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7lg.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7lh.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7lh.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7li.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7li.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7lm.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7lm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ls.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ls.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ly.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ly.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7lz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7lz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ma.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ma.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7mb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7mb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7mc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7mc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7mg.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7mg.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7mm.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7mm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7mn.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7mn.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7my.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7my.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7na.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7na.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nd.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nd.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ne.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ne.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ng.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ng.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nh.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nh.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ni.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ni.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nj.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nj.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nk.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nk.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nl.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nl.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nm.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nn.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nn.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7no.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7no.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7np.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7np.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nr.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nr.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ns.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ns.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nt.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nt.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nu.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nu.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nx.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nx.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ny.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ny.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7nz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7nz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -124,7 +124,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -153,7 +153,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -182,7 +182,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -211,7 +211,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -241,7 +241,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7oz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7oz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pa.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pa.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pd.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pd.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pe.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pe.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pg.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pg.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ph.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ph.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pi.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pi.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pj.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pj.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pk.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pk.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pl.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pl.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pm.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pn.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pn.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7po.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7po.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pp.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pp.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pr.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pr.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ps.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ps.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pt.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pt.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pu.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pu.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7px.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7px.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7py.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7py.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7pz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7pz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qd.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qd.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qe.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qe.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -240,7 +240,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -240,7 +240,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qg.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qg.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -240,7 +240,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qi.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qi.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ql.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ql.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qm.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qo.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qo.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qp.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qp.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qr.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qr.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qt.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qt.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7qz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7qz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ra.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ra.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -240,7 +240,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -240,7 +240,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rd.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rd.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7re.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7re.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rg.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rg.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rh.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rh.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ri.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ri.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rj.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rj.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rk.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rk.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rl.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rl.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rm.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rn.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rn.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ro.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ro.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rp.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rp.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rr.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rr.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rs.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rs.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rt.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rt.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ru.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ru.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rx.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rx.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ry.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ry.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7rz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7rz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -213,7 +213,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -242,7 +242,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sh.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sh.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7si.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7si.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sj.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sj.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sk.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sk.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sl.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sl.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sm.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7so.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7so.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sp.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sp.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sr.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sr.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ss.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ss.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7st.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7st.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7su.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7su.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sx.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sx.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sy.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sy.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7sz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7sz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -68,7 +68,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -126,7 +126,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -155,7 +155,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -183,7 +183,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -211,7 +211,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -240,7 +240,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7td.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7td.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7te.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7te.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7tf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7tf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7tg.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7tg.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7th.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7th.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7tt.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7tt.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7tu.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7tu.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7tv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7tv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7tw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7tw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7tx.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7tx.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ty.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ty.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ua.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ua.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -126,7 +126,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -154,7 +154,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -182,7 +182,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ub.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ub.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -126,7 +126,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -154,7 +154,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -182,7 +182,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7uc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7uc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -68,7 +68,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -126,7 +126,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -155,7 +155,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -184,7 +184,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -213,7 +213,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -243,7 +243,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ud.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ud.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7uf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7uf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7uh.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7uh.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -68,7 +68,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -96,7 +96,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -124,7 +124,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -153,7 +153,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ui.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ui.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -155,7 +155,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -183,7 +183,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -211,7 +211,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -240,7 +240,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7uj.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7uj.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -126,7 +126,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -154,7 +154,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -182,7 +182,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -210,7 +210,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7uk.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7uk.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ul.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ul.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -42,7 +42,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -70,7 +70,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -99,7 +99,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -129,7 +129,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7um.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7um.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7un.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7un.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ur.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ur.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -155,7 +155,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -183,7 +183,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -211,7 +211,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -240,7 +240,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7uu.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7uu.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7uv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7uv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7uw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7uw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7ux.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7ux.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7uy.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7uy.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7uz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7uz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7vc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7vc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7vo.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7vo.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7vt.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7vt.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7vu.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7vu.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7vw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7vw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7vx.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7vx.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7vy.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7vy.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7vz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7vz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7wc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7wc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7wf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7wf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7wg.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7wg.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7wi.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7wi.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7wj.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7wj.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7wl.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7wl.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7wp.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7wp.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7wr.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7wr.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xa.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xa.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xb.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xc.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xd.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xd.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xe.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xe.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xg.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xg.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xh.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xh.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xi.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xi.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -180,7 +180,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -239,7 +239,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xj.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xj.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -126,7 +126,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -154,7 +154,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -183,7 +183,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -212,7 +212,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -242,7 +242,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xk.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xk.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -126,7 +126,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -154,7 +154,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -183,7 +183,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -212,7 +212,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -242,7 +242,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xl.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xl.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xm.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xn.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xn.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -96,7 +96,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -125,7 +125,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -154,7 +154,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -183,7 +183,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -211,7 +211,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -241,7 +241,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xo.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xo.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -124,7 +124,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -153,7 +153,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -182,7 +182,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -211,7 +211,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -241,7 +241,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xp.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xp.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xq.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xr.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xr.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -208,7 +208,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -238,7 +238,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xs.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xs.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xt.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xt.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -98,7 +98,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -127,7 +127,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -156,7 +156,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -185,7 +185,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -214,7 +214,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -244,7 +244,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xu.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xu.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -68,7 +68,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -126,7 +126,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -155,7 +155,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -184,7 +184,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -213,7 +213,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -243,7 +243,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -96,7 +96,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -125,7 +125,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -154,7 +154,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -183,7 +183,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -212,7 +212,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -242,7 +242,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xx.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xx.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f7xz.yaml
+++ b/openfisca_france/tests/calculateur_impots/f7xz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8ta.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8ta.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8tf.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8tf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8th.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8th.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8to.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8to.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8tp.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8tp.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8ts.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8ts.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8uw.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8uw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8uy.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8uy.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8wd.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8wd.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8ws.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8ws.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8wt.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8wt.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8wu.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8wu.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8wv.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8wv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/f8wx.yaml
+++ b/openfisca_france/tests/calculateur_impots/f8wx.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhoz.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhoz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsa.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsa.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsb.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsc.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsd.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsd.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsf.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsf.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsg.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsg.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsh.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsh.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsi.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsi.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsk.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsk.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsl.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsl.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsm.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsm.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsn.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsn.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsp.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsp.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsq.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsq.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsr.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsr.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhss.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhss.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsu.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsu.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsv.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsv.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsw.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsw.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsx.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsx.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsy.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsy.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhsz.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhsz.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhta.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhta.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhtb.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhtb.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/fhtc.yaml
+++ b/openfisca_france/tests/calculateur_impots/fhtc.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/frag_exon.yaml
+++ b/openfisca_france/tests/calculateur_impots/frag_exon.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     frag_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     frag_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     frag_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     frag_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     frag_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     frag_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     frag_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     frag_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     frag_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/frag_impo.yaml
+++ b/openfisca_france/tests/calculateur_impots/frag_impo.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_impo: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/frag_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/frag_pvce.yaml
@@ -13,7 +13,7 @@
     frag_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     frag_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     frag_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     frag_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     frag_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     frag_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     frag_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     frag_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     frag_pvce: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/frag_pvct.yaml
+++ b/openfisca_france/tests/calculateur_impots/frag_pvct.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     frag_pvct: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/macc_exon.yaml
+++ b/openfisca_france/tests/calculateur_impots/macc_exon.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     macc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     macc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     macc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     macc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     macc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     macc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     macc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     macc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     macc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/macc_imps.yaml
+++ b/openfisca_france/tests/calculateur_impots/macc_imps.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     macc_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     macc_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     macc_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     macc_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     macc_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     macc_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     macc_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     macc_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     macc_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/macc_impv.yaml
+++ b/openfisca_france/tests/calculateur_impots/macc_impv.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     macc_impv: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     macc_impv: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     macc_impv: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     macc_impv: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     macc_impv: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     macc_impv: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     macc_impv: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     macc_impv: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     macc_impv: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/macc_mvct.yaml
+++ b/openfisca_france/tests/calculateur_impots/macc_mvct.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/macc_mvlt.yaml
+++ b/openfisca_france/tests/calculateur_impots/macc_mvlt.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_mvlt: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_mvlt: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_mvlt: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_mvlt: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_mvlt: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_mvlt: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_mvlt: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_mvlt: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_mvlt: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/macc_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/macc_pvce.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     macc_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     macc_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     macc_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     macc_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     macc_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     macc_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     macc_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     macc_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     macc_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/macc_pvct.yaml
+++ b/openfisca_france/tests/calculateur_impots/macc_pvct.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_pvct: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_pvct: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_pvct: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_pvct: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_pvct: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_pvct: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_pvct: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_pvct: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     macc_pvct: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/mbic_exon.yaml
+++ b/openfisca_france/tests/calculateur_impots/mbic_exon.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_exon: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/mbic_imps.yaml
+++ b/openfisca_france/tests/calculateur_impots/mbic_imps.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_imps: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_imps: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_imps: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_imps: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_imps: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_imps: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_imps: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_imps: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_imps: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/mbic_impv.yaml
+++ b/openfisca_france/tests/calculateur_impots/mbic_impv.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_impv: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_impv: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_impv: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_impv: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_impv: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_impv: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_impv: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_impv: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbic_impv: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/mbic_mvct.yaml
+++ b/openfisca_france/tests/calculateur_impots/mbic_mvct.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/mbic_mvlt.yaml
+++ b/openfisca_france/tests/calculateur_impots/mbic_mvlt.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_mvlt: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_mvlt: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_mvlt: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_mvlt: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_mvlt: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_mvlt: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_mvlt: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_mvlt: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_mvlt: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/mbic_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/mbic_pvce.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_pvce: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_pvce: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_pvce: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_pvce: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_pvce: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_pvce: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_pvce: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_pvce: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbic_pvce: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/mbic_pvct.yaml
+++ b/openfisca_france/tests/calculateur_impots/mbic_pvct.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     mbic_pvct: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     mbic_pvct: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     mbic_pvct: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     mbic_pvct: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     mbic_pvct: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     mbic_pvct: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     mbic_pvct: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     mbic_pvct: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     mbic_pvct: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/mbnc_exon.yaml
+++ b/openfisca_france/tests/calculateur_impots/mbnc_exon.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_exon: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_exon: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_exon: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_exon: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_exon: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_exon: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_exon: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_exon: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_exon: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/mbnc_impo.yaml
+++ b/openfisca_france/tests/calculateur_impots/mbnc_impo.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_impo: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/mbnc_mvlt.yaml
+++ b/openfisca_france/tests/calculateur_impots/mbnc_mvlt.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     mbnc_mvlt: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     mbnc_mvlt: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     mbnc_mvlt: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     mbnc_mvlt: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     mbnc_mvlt: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     mbnc_mvlt: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     mbnc_mvlt: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     mbnc_mvlt: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     mbnc_mvlt: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/mbnc_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/mbnc_pvce.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_pvce: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_pvce: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_pvce: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_pvce: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_pvce: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_pvce: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_pvce: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_pvce: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     mbnc_pvce: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/mbnc_pvct.yaml
+++ b/openfisca_france/tests/calculateur_impots/mbnc_pvct.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mbnc_pvct: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/mncn_impo.yaml
+++ b/openfisca_france/tests/calculateur_impots/mncn_impo.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     mncn_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     mncn_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     mncn_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     mncn_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     mncn_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     mncn_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     mncn_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     mncn_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     mncn_impo: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/mncn_mvct.yaml
+++ b/openfisca_france/tests/calculateur_impots/mncn_mvct.yaml
@@ -13,7 +13,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/mncn_mvlt.yaml
+++ b/openfisca_france/tests/calculateur_impots/mncn_mvlt.yaml
@@ -13,7 +13,7 @@
     mncn_mvlt: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     mncn_mvlt: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     mncn_mvlt: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     mncn_mvlt: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     mncn_mvlt: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     mncn_mvlt: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     mncn_mvlt: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     mncn_mvlt: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     mncn_mvlt: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/mncn_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/mncn_pvce.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     mncn_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     mncn_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     mncn_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     mncn_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     mncn_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     mncn_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     mncn_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     mncn_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     mncn_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/mncn_pvct.yaml
+++ b/openfisca_france/tests/calculateur_impots/mncn_pvct.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mncn_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mncn_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mncn_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mncn_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mncn_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mncn_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mncn_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mncn_pvct: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     mncn_pvct: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/nacc_defn.yaml
+++ b/openfisca_france/tests/calculateur_impots/nacc_defn.yaml
@@ -13,7 +13,7 @@
     nacc_defn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     nacc_defn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     nacc_defn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     nacc_defn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     nacc_defn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     nacc_defn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     nacc_defn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     nacc_defn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     nacc_defn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/nacc_defs.yaml
+++ b/openfisca_france/tests/calculateur_impots/nacc_defs.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -93,7 +93,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -120,7 +120,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -147,7 +147,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -175,7 +175,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -203,7 +203,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -231,7 +231,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -259,7 +259,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -287,7 +287,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -315,7 +315,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -343,7 +343,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -371,7 +371,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -399,7 +399,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -427,7 +427,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -455,7 +455,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -483,7 +483,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 0
     date_naissance: '1970-01-01'
   menages:
@@ -511,7 +511,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -540,7 +540,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -569,7 +569,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -598,7 +598,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_defs: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/nacc_exon.yaml
+++ b/openfisca_france/tests/calculateur_impots/nacc_exon.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     nacc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     nacc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     nacc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     nacc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     nacc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     nacc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     nacc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     nacc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     nacc_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/nacc_impn.yaml
+++ b/openfisca_france/tests/calculateur_impots/nacc_impn.yaml
@@ -13,7 +13,7 @@
     nacc_impn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     nacc_impn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     nacc_impn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     nacc_impn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     nacc_impn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     nacc_impn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     nacc_impn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     nacc_impn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     nacc_impn: 1500
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/nacc_meup.yaml
+++ b/openfisca_france/tests/calculateur_impots/nacc_meup.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_meup: 0
     date_naissance: '1970-01-01'
   menages:
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_meup: 0
     date_naissance: '1970-01-01'
   menages:
@@ -68,7 +68,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_meup: 0
     date_naissance: '1970-01-01'
   menages:
@@ -96,7 +96,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_meup: 0
     date_naissance: '1970-01-01'
   menages:
@@ -124,7 +124,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_meup: 0
     date_naissance: '1970-01-01'
   menages:
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_meup: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_meup: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/nacc_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/nacc_pvce.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_pvce: 0
     date_naissance: '1970-01-01'
   menages:
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_pvce: 0
     date_naissance: '1970-01-01'
   menages:
@@ -68,7 +68,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_pvce: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -96,7 +96,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_pvce: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -124,7 +124,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_pvce: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_pvce: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nacc_pvce: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/nbic_apch.yaml
+++ b/openfisca_france/tests/calculateur_impots/nbic_apch.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_apch: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_apch: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_apch: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_apch: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_apch: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_apch: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_apch: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_apch: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_apch: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/nbic_defn.yaml
+++ b/openfisca_france/tests/calculateur_impots/nbic_defn.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defn: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defn: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defn: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defn: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defn: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defn: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defn: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defn: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defn: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/nbic_defs.yaml
+++ b/openfisca_france/tests/calculateur_impots/nbic_defs.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defs: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbic_defs: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/nbic_exon.yaml
+++ b/openfisca_france/tests/calculateur_impots/nbic_exon.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     nbic_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     nbic_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     nbic_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     nbic_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     nbic_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     nbic_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     nbic_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     nbic_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     nbic_exon: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/nbic_impn.yaml
+++ b/openfisca_france/tests/calculateur_impots/nbic_impn.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_impn: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_impn: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_impn: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_impn: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_impn: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_impn: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_impn: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_impn: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_impn: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/nbic_imps.yaml
+++ b/openfisca_france/tests/calculateur_impots/nbic_imps.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     nbic_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     nbic_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     nbic_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     nbic_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     nbic_imps: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     nbic_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     nbic_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     nbic_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -235,7 +235,7 @@
     salaire_imposable: 24000
     nbic_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -263,7 +263,7 @@
     salaire_imposable: 24000
     nbic_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -292,7 +292,7 @@
     salaire_imposable: 24000
     nbic_imps: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/nbic_mvct.yaml
+++ b/openfisca_france/tests/calculateur_impots/nbic_mvct.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_mvct: 0
   menages:
@@ -40,7 +40,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_mvct: 0
   menages:
@@ -68,7 +68,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_mvct: 0
   menages:
@@ -96,7 +96,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_mvct: 0
   menages:
@@ -124,7 +124,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_mvct: 0
   menages:
@@ -152,7 +152,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_mvct: 1500
   menages:
@@ -181,7 +181,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbic_mvct: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/nbic_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/nbic_pvce.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     nbic_pvce: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
     salaire_imposable: 24000
     nbic_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
     salaire_imposable: 24000
     nbic_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
     salaire_imposable: 24000
     nbic_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -125,7 +125,7 @@
     salaire_imposable: 24000
     nbic_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -153,7 +153,7 @@
     salaire_imposable: 24000
     nbic_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -182,7 +182,7 @@
     salaire_imposable: 24000
     nbic_pvce: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/nbnc_defi.yaml
+++ b/openfisca_france/tests/calculateur_impots/nbnc_defi.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     nbnc_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     nbnc_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     nbnc_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     nbnc_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     nbnc_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     nbnc_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     nbnc_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     nbnc_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     nbnc_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/nbnc_exon.yaml
+++ b/openfisca_france/tests/calculateur_impots/nbnc_exon.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbnc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbnc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbnc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbnc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbnc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbnc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbnc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbnc_exon: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nbnc_exon: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/nbnc_impo.yaml
+++ b/openfisca_france/tests/calculateur_impots/nbnc_impo.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbnc_impo: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbnc_impo: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbnc_impo: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbnc_impo: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbnc_impo: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbnc_impo: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbnc_impo: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbnc_impo: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nbnc_impo: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/nbnc_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/nbnc_pvce.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     activite: 0
     nbnc_pvce: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
     salaire_imposable: 24000
     activite: 0
     nbnc_pvce: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
     salaire_imposable: 24000
     activite: 0
     nbnc_pvce: 1500
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
     salaire_imposable: 24000
     activite: 0
     nbnc_pvce: 1500
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -125,7 +125,7 @@
     salaire_imposable: 24000
     activite: 0
     nbnc_pvce: 1500
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -153,7 +153,7 @@
     salaire_imposable: 24000
     activite: 0
     nbnc_pvce: 1500
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -182,7 +182,7 @@
     salaire_imposable: 24000
     activite: 0
     nbnc_pvce: 1500
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/nrag_ajag.yaml
+++ b/openfisca_france/tests/calculateur_impots/nrag_ajag.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nrag_ajag: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nrag_ajag: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nrag_ajag: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nrag_ajag: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nrag_ajag: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nrag_ajag: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nrag_ajag: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nrag_ajag: 1500
     date_naissance: '1970-01-01'
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     nrag_ajag: 1500
     date_naissance: '1970-01-01'
   menages:

--- a/openfisca_france/tests/calculateur_impots/nrag_defi.yaml
+++ b/openfisca_france/tests/calculateur_impots/nrag_defi.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     nrag_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     nrag_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     nrag_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     nrag_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     nrag_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     nrag_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     nrag_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     nrag_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     nrag_defi: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/nrag_exon.yaml
+++ b/openfisca_france/tests/calculateur_impots/nrag_exon.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nrag_exon: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nrag_exon: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nrag_exon: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nrag_exon: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nrag_exon: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nrag_exon: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nrag_exon: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nrag_exon: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     nrag_exon: 1500
   menages:

--- a/openfisca_france/tests/calculateur_impots/nrag_impg.yaml
+++ b/openfisca_france/tests/calculateur_impots/nrag_impg.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     nrag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -40,7 +40,7 @@
     salaire_imposable: 24000
     nrag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -67,7 +67,7 @@
     salaire_imposable: 24000
     nrag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -95,7 +95,7 @@
     salaire_imposable: 24000
     nrag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -123,7 +123,7 @@
     salaire_imposable: 24000
     nrag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -151,7 +151,7 @@
     salaire_imposable: 24000
     nrag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -179,7 +179,7 @@
     salaire_imposable: 24000
     nrag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -207,7 +207,7 @@
     salaire_imposable: 24000
     nrag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -236,7 +236,7 @@
     salaire_imposable: 24000
     nrag_impg: 1500
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/nrag_pvce.yaml
+++ b/openfisca_france/tests/calculateur_impots/nrag_pvce.yaml
@@ -13,7 +13,7 @@
     salaire_imposable: 24000
     nrag_pvce: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -41,7 +41,7 @@
     salaire_imposable: 24000
     nrag_pvce: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -69,7 +69,7 @@
     salaire_imposable: 24000
     nrag_pvce: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -97,7 +97,7 @@
     salaire_imposable: 24000
     nrag_pvce: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -125,7 +125,7 @@
     salaire_imposable: 24000
     nrag_pvce: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -153,7 +153,7 @@
     salaire_imposable: 24000
     nrag_pvce: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -181,7 +181,7 @@
     salaire_imposable: 24000
     nrag_pvce: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -209,7 +209,7 @@
     salaire_imposable: 24000
     nrag_pvce: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -237,7 +237,7 @@
     salaire_imposable: 24000
     nrag_pvce: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'
@@ -266,7 +266,7 @@
     salaire_imposable: 24000
     nrag_pvce: 0
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
   menages:
   - id: '0'

--- a/openfisca_france/tests/calculateur_impots/ppe_du_ns.yaml
+++ b/openfisca_france/tests/calculateur_impots/ppe_du_ns.yaml
@@ -12,7 +12,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ppe_du_ns: 1500
   menages:
@@ -39,7 +39,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ppe_du_ns: 1500
   menages:
@@ -66,7 +66,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ppe_du_ns: 1500
   menages:
@@ -94,7 +94,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ppe_du_ns: 1500
   menages:
@@ -122,7 +122,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ppe_du_ns: 1500
   menages:
@@ -150,7 +150,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ppe_du_ns: 1500
   menages:
@@ -178,7 +178,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ppe_du_ns: 1500
   menages:
@@ -206,7 +206,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ppe_du_ns: 1500
   menages:
@@ -235,7 +235,7 @@
   - id: ind0
     salaire_imposable: 24000
     activite: 0
-    statmarit: 2
+    statut_marital: 2
     date_naissance: '1970-01-01'
     ppe_du_ns: 1500
   menages:

--- a/openfisca_france/tests/formulas/irpp.yaml
+++ b/openfisca_france/tests/formulas/irpp.yaml
@@ -1001,7 +1001,7 @@
     quifoy: [VOUS, CONJ]
     salaire_imposable:
       2014: [30000, 0]
-    statmarit: [5,5] #pacsés
+    statut_marital: [5,5] #pacsés
   output_variables:
     decote_gain_fiscal: 803
     irpp: -264

--- a/openfisca_france/tests/formulas/personnes_a_charge.yaml
+++ b/openfisca_france/tests/formulas/personnes_a_charge.yaml
@@ -1,0 +1,71 @@
+
+- name: "enfant_a_charge fonctionne en mode mensuel"
+  period: 2015-01
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 12
+      garde_alternee: True
+  output_variables:
+    enfant_a_charge: [False, True]
+
+- name: "Un enfant de moins de 18 ans"
+  period: 2015
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 12
+  output_variables:
+    enfant_a_charge: [False, True]
+    nbF: 1
+    nbG: 0
+    nbH: 0
+    nbI: 0
+
+- name: "Un enfant de moins de 18 ans titulaire d'une carte d'invalidité"
+  period: 2015
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 12
+      invalidite: True
+  output_variables:
+    enfant_a_charge: [False, True]
+    nbF: 1
+    nbG: 1
+    nbH: 0
+    nbI: 0
+
+- name: "Un enfant de moins de 18 ans en garde alternée"
+  period: 2015
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 12
+      garde_alternee: True
+  output_variables:
+    enfant_a_charge: [False, True]
+    nbF: 0
+    nbG: 0
+    nbH: 1
+    nbI: 0
+
+- name: "Un enfant de moins de 18 ans en garde alternée titulaire d'une carte d'invalidité"
+  period: 2015
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 12
+      garde_alternee: True
+      invalidite: True
+  output_variables:
+    enfant_a_charge: [False, True]
+    nbF: 0
+    nbG: 0
+    nbH: 1
+    nbI: 1

--- a/openfisca_france/tests/formulas/personnes_a_charge.yaml
+++ b/openfisca_france/tests/formulas/personnes_a_charge.yaml
@@ -1,4 +1,3 @@
-
 - name: "enfant_a_charge fonctionne en mode mensuel"
   period: 2015-01
   individus:
@@ -69,3 +68,43 @@
     nbG: 0
     nbH: 1
     nbI: 1
+
+- name: "Une famille avec deux foyers fiscaux"
+  period: 2015
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "parent2"
+      age: 40
+    - id: "enfant1"
+      age: 12
+      invalidite: True
+    - id: "enfant2"
+      age: 14
+    - id: "enfant3"
+      age: 15
+    - id: "enfant4"
+      age: 16
+      garde_alternee: True
+    - id: "enfant5"
+      age: 16
+      invalidite: True
+      garde_alternee: True
+  foyers_fiscaux:
+  - declarants:
+    - parent1
+    personnes_a_charge:
+    - enfant1
+  - declarants:
+    - parent2
+    personnes_a_charge:
+    - enfant2
+    - enfant3
+    - enfant4
+    - enfant5
+  output_variables:
+    enfant_a_charge: [False, False, True, True, True, True, True]
+    nbF: [1, 2] # 1 enfant dans le 1er foyer, 2 qui ne sont pas en garde alternée dans le 2e
+    nbG: [1, 0] # 1 enfant invalide dans le 1er foyer
+    nbH: [0, 2] # 2 enfants en garde alternée dans le 2e foyer
+    nbI: [0, 1] # 1 enfant en garde alternée invalide dans le 2e foyer

--- a/openfisca_france/tests/json/aacc_defn-07c20371c9d6b25d5bb196451c5057dca94553545fd9de9ed9102fe761d5dd8a.json
+++ b/openfisca_france/tests/json/aacc_defn-07c20371c9d6b25d5bb196451c5057dca94553545fd9de9ed9102fe761d5dd8a.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defn-27582fb40a4f628d588cfb2d7a957b7c53af56b7325a6d8e6eeba8b3c6e96fa0.json
+++ b/openfisca_france/tests/json/aacc_defn-27582fb40a4f628d588cfb2d7a957b7c53af56b7325a6d8e6eeba8b3c6e96fa0.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defn-504034bc5e8199d0ec41c185d574a41ad1d0d082d750ab498f78a5e597c477ed.json
+++ b/openfisca_france/tests/json/aacc_defn-504034bc5e8199d0ec41c185d574a41ad1d0d082d750ab498f78a5e597c477ed.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defn-7b7d0a15abe0b1da84a1cfacd6eec77bd15f97d03d5caf6ab13d35035bb0d07c.json
+++ b/openfisca_france/tests/json/aacc_defn-7b7d0a15abe0b1da84a1cfacd6eec77bd15f97d03d5caf6ab13d35035bb0d07c.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defn-8da6828fe5ffb44113c44f91ad6dc4d21ee8e8d95e1dbe9fba833ef8e808960e.json
+++ b/openfisca_france/tests/json/aacc_defn-8da6828fe5ffb44113c44f91ad6dc4d21ee8e8d95e1dbe9fba833ef8e808960e.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defn-a1252552c34d70dc0077446b2655a2760085d7c784b5fabec274d9742ec539fd.json
+++ b/openfisca_france/tests/json/aacc_defn-a1252552c34d70dc0077446b2655a2760085d7c784b5fabec274d9742ec539fd.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defn-be63b8c40ca087862d79adaa437e1056341b0052ffedd4e3f13de07e45395de6.json
+++ b/openfisca_france/tests/json/aacc_defn-be63b8c40ca087862d79adaa437e1056341b0052ffedd4e3f13de07e45395de6.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defn-d5a64d1b8f730b9cfed28b5d4e14f72d82b28caf7d184a215edaa80ccf65a4cb.json
+++ b/openfisca_france/tests/json/aacc_defn-d5a64d1b8f730b9cfed28b5d4e14f72d82b28caf7d184a215edaa80ccf65a4cb.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defn-e1da7c78028baac3db650b3171f50b60727f8a952f74153bccb420ecf3b5c22c.json
+++ b/openfisca_france/tests/json/aacc_defn-e1da7c78028baac3db650b3171f50b60727f8a952f74153bccb420ecf3b5c22c.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defs-1180ace9fe150431b2483a5d2f661ab2af3b9a3fd61365774c788d6838704f38.json
+++ b/openfisca_france/tests/json/aacc_defs-1180ace9fe150431b2483a5d2f661ab2af3b9a3fd61365774c788d6838704f38.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defs-307e8974c9756c74dbca76099cb7164d8a9ae4f8bc2bca72be0422858011527b.json
+++ b/openfisca_france/tests/json/aacc_defs-307e8974c9756c74dbca76099cb7164d8a9ae4f8bc2bca72be0422858011527b.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defs-359fa53e98017137046abbc8f5a1a3b1ced8c28f716156ca88f72795aba66aaa.json
+++ b/openfisca_france/tests/json/aacc_defs-359fa53e98017137046abbc8f5a1a3b1ced8c28f716156ca88f72795aba66aaa.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defs-67b09a3c22c369ddbb9fc5c8edff6ca7b52f205e99f1ca5d35f54a58eb2e5016.json
+++ b/openfisca_france/tests/json/aacc_defs-67b09a3c22c369ddbb9fc5c8edff6ca7b52f205e99f1ca5d35f54a58eb2e5016.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defs-72c66746ef69f0fe4de8e8bab4f52c363cab9fa23eafc092dca89033b0c4f2bd.json
+++ b/openfisca_france/tests/json/aacc_defs-72c66746ef69f0fe4de8e8bab4f52c363cab9fa23eafc092dca89033b0c4f2bd.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defs-7e46da0e74c37a40dc1d6ddff732666d05d25bed0b396423d189c8841f3bad10.json
+++ b/openfisca_france/tests/json/aacc_defs-7e46da0e74c37a40dc1d6ddff732666d05d25bed0b396423d189c8841f3bad10.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defs-8362deba3ce18516796b4479ac37b96f0d67bafb25ec9cda95b14827f7c36e4a.json
+++ b/openfisca_france/tests/json/aacc_defs-8362deba3ce18516796b4479ac37b96f0d67bafb25ec9cda95b14827f7c36e4a.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defs-9afaa36ffa8d3627d5b84dac0f446ac7e1a5ca64dde9ad82657a3ae92d48a1be.json
+++ b/openfisca_france/tests/json/aacc_defs-9afaa36ffa8d3627d5b84dac0f446ac7e1a5ca64dde9ad82657a3ae92d48a1be.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defs-a965a95196557183b4dfd765e447d05a611bf5b8fec56cf33032ff402102dd5f.json
+++ b/openfisca_france/tests/json/aacc_defs-a965a95196557183b4dfd765e447d05a611bf5b8fec56cf33032ff402102dd5f.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_defs-df7f9fd35da33b6bad98c0f3095c92912c2d5e0b25208c8abaccd9df51decacc.json
+++ b/openfisca_france/tests/json/aacc_defs-df7f9fd35da33b6bad98c0f3095c92912c2d5e0b25208c8abaccd9df51decacc.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_exon-3fe8c3ef2c0cd2db9641da5aeca315ce8e38b928bc2b7aad59a6fa7f4298528e.json
+++ b/openfisca_france/tests/json/aacc_exon-3fe8c3ef2c0cd2db9641da5aeca315ce8e38b928bc2b7aad59a6fa7f4298528e.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_exon-43455ad994b82885fab20cbe80dd7f6cfe3c0198d0d37e6339ea407c25e305d9.json
+++ b/openfisca_france/tests/json/aacc_exon-43455ad994b82885fab20cbe80dd7f6cfe3c0198d0d37e6339ea407c25e305d9.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_exon-47f29b5340bc2d3bd9e25b745234fe918fa33fa8db8fa9ffc16a005e3c1b89b1.json
+++ b/openfisca_france/tests/json/aacc_exon-47f29b5340bc2d3bd9e25b745234fe918fa33fa8db8fa9ffc16a005e3c1b89b1.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_exon-7722bed425bd494bcd88560c376d246cdc51b49dad9f0ff65763c806825bc61e.json
+++ b/openfisca_france/tests/json/aacc_exon-7722bed425bd494bcd88560c376d246cdc51b49dad9f0ff65763c806825bc61e.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_exon-98ed9936d5a7732de70e4d6f5363861ba263d1d565303ad480501dec09737515.json
+++ b/openfisca_france/tests/json/aacc_exon-98ed9936d5a7732de70e4d6f5363861ba263d1d565303ad480501dec09737515.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_exon-c5654e3d86fb6c90efc57f2105721053c71387c3b1f57cea33308db6481d278d.json
+++ b/openfisca_france/tests/json/aacc_exon-c5654e3d86fb6c90efc57f2105721053c71387c3b1f57cea33308db6481d278d.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_exon-ce0d2e0287ad4542596d434d6e228239464e81b8266ca37ea1f8e1e51b0806d5.json
+++ b/openfisca_france/tests/json/aacc_exon-ce0d2e0287ad4542596d434d6e228239464e81b8266ca37ea1f8e1e51b0806d5.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_exon-cf19fa461ca709e0c7291f8911b51929187ea28dbb1c8b33867a4633e3da9d7d.json
+++ b/openfisca_france/tests/json/aacc_exon-cf19fa461ca709e0c7291f8911b51929187ea28dbb1c8b33867a4633e3da9d7d.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_exon-d2bd74a9923c04f14a150a936992c407b515baf2fb14fb62fba76032fcb5043b.json
+++ b/openfisca_france/tests/json/aacc_exon-d2bd74a9923c04f14a150a936992c407b515baf2fb14fb62fba76032fcb5043b.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_gits-2007-f16bc611ed7465026d4f3a815e90ed8e89ea3c80c7a9cbff62a9a5fd470b62d9.json
+++ b/openfisca_france/tests/json/aacc_gits-2007-f16bc611ed7465026d4f3a815e90ed8e89ea3c80c7a9cbff62a9a5fd470b62d9.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_gits-2008-2c561bb98ff84760bcf38ecdbddfff87b4ff4c2e2dfdc44d9ab27dba8cd946b9.json
+++ b/openfisca_france/tests/json/aacc_gits-2008-2c561bb98ff84760bcf38ecdbddfff87b4ff4c2e2dfdc44d9ab27dba8cd946b9.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_gits-2009-835414d9190d92262de6d0d61f83f45eb55c9edfc9e7a80e99365c6977086d0b.json
+++ b/openfisca_france/tests/json/aacc_gits-2009-835414d9190d92262de6d0d61f83f45eb55c9edfc9e7a80e99365c6977086d0b.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_gits-2010-6b999806499afa30d512dded17d987270aeb419ede1db9340157ff0b403f02b0.json
+++ b/openfisca_france/tests/json/aacc_gits-2010-6b999806499afa30d512dded17d987270aeb419ede1db9340157ff0b403f02b0.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_gits-2011-0212347ace0e2dcdb9ed5ae30564fdaa120222a850de8c8a7c8699d291c8b316.json
+++ b/openfisca_france/tests/json/aacc_gits-2011-0212347ace0e2dcdb9ed5ae30564fdaa120222a850de8c8a7c8699d291c8b316.json
@@ -118,7 +118,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_gits-2012-fdf215858927c267de0f60c102594dc68f80d539f8b7f74e5651fad64ab58a13.json
+++ b/openfisca_france/tests/json/aacc_gits-2012-fdf215858927c267de0f60c102594dc68f80d539f8b7f74e5651fad64ab58a13.json
@@ -113,7 +113,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_gits-2013-7ac950af4109c9ea6b021717b56ae3fee1875402eb91993404c39f59f74ecbce.json
+++ b/openfisca_france/tests/json/aacc_gits-2013-7ac950af4109c9ea6b021717b56ae3fee1875402eb91993404c39f59f74ecbce.json
@@ -123,7 +123,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_impn-1158f5fc49b8d4806a5dc3a4677e163ef2e4684a7aa9c6600678723290b7af25.json
+++ b/openfisca_france/tests/json/aacc_impn-1158f5fc49b8d4806a5dc3a4677e163ef2e4684a7aa9c6600678723290b7af25.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_impn-2c96f95ce224c9972d23b7c59ce8e6ab60dec9d6426bafc2fecc76a966280dee.json
+++ b/openfisca_france/tests/json/aacc_impn-2c96f95ce224c9972d23b7c59ce8e6ab60dec9d6426bafc2fecc76a966280dee.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_impn-3b05c7aedae97d9f209e25be5ff3e0a8ae38ca52be40da8f74db2bc4662cbab7.json
+++ b/openfisca_france/tests/json/aacc_impn-3b05c7aedae97d9f209e25be5ff3e0a8ae38ca52be40da8f74db2bc4662cbab7.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_impn-46aca31e032d0273279ee22c92106fb892cd10d843a3950805b1ea09b63ed66d.json
+++ b/openfisca_france/tests/json/aacc_impn-46aca31e032d0273279ee22c92106fb892cd10d843a3950805b1ea09b63ed66d.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_impn-892a38b7944a43f3fdc1fc66ed76869530ac9d74f843add364072c58ac6aa700.json
+++ b/openfisca_france/tests/json/aacc_impn-892a38b7944a43f3fdc1fc66ed76869530ac9d74f843add364072c58ac6aa700.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_impn-afa4975700a805875ee04df8ac002ed0f1b96f1b01a6c4ca6d436580b9cb30f2.json
+++ b/openfisca_france/tests/json/aacc_impn-afa4975700a805875ee04df8ac002ed0f1b96f1b01a6c4ca6d436580b9cb30f2.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_impn-b9114081fc971724907e3f6b9a5994b5c218dd756ff5db96e0e3f4ebc90ddef3.json
+++ b/openfisca_france/tests/json/aacc_impn-b9114081fc971724907e3f6b9a5994b5c218dd756ff5db96e0e3f4ebc90ddef3.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_impn-bf0a0c56bc5eafc066212c0c321cc4863c1cd78ba33fc043a1e0767e62fac9f4.json
+++ b/openfisca_france/tests/json/aacc_impn-bf0a0c56bc5eafc066212c0c321cc4863c1cd78ba33fc043a1e0767e62fac9f4.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_impn-c82ed8cf01c52c990e86db1a50cb8b102d3aec5e9bb636c52efcb607f06fba51.json
+++ b/openfisca_france/tests/json/aacc_impn-c82ed8cf01c52c990e86db1a50cb8b102d3aec5e9bb636c52efcb607f06fba51.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_imps-2007-68638b61b3dcd6bfa5235ef3a01f9538710b52e5ad85f3e3d2f7d702403caf99.json
+++ b/openfisca_france/tests/json/aacc_imps-2007-68638b61b3dcd6bfa5235ef3a01f9538710b52e5ad85f3e3d2f7d702403caf99.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_imps-2008-69e4a6a5c911c17506edb0e7ca1f77532ff0fc9de5394802a56f0274a0423f49.json
+++ b/openfisca_france/tests/json/aacc_imps-2008-69e4a6a5c911c17506edb0e7ca1f77532ff0fc9de5394802a56f0274a0423f49.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_imps-2009-269da00297c55ef52913b3dba19d40938cd415dad0047512886c00e646e06846.json
+++ b/openfisca_france/tests/json/aacc_imps-2009-269da00297c55ef52913b3dba19d40938cd415dad0047512886c00e646e06846.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_imps-2010-6844035892c952a89ddc781e34b09640ca843c4ad0eeffe85982958846df8b58.json
+++ b/openfisca_france/tests/json/aacc_imps-2010-6844035892c952a89ddc781e34b09640ca843c4ad0eeffe85982958846df8b58.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_imps-2011-0e0f9eed0f502f2da968bb506af6a6de007eb936a20a4fa4bf6aedb9304544bb.json
+++ b/openfisca_france/tests/json/aacc_imps-2011-0e0f9eed0f502f2da968bb506af6a6de007eb936a20a4fa4bf6aedb9304544bb.json
@@ -118,7 +118,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_imps-2012-8b8e609ac35c757886f3d72c1ba86dad74d63a3ed4ff7bb0b9a3ac688bb47fe0.json
+++ b/openfisca_france/tests/json/aacc_imps-2012-8b8e609ac35c757886f3d72c1ba86dad74d63a3ed4ff7bb0b9a3ac688bb47fe0.json
@@ -113,7 +113,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_imps-2013-b9ffcd66d50c4fd7324fd456bdcbb23aefcab4b5d5c4b0a619003cf2e071c338.json
+++ b/openfisca_france/tests/json/aacc_imps-2013-b9ffcd66d50c4fd7324fd456bdcbb23aefcab4b5d5c4b0a619003cf2e071c338.json
@@ -123,7 +123,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_pvce-02690b166e05cd983b939b619d466a3d2c30ce20e1bfcb423d6a8091864e81fd.json
+++ b/openfisca_france/tests/json/aacc_pvce-02690b166e05cd983b939b619d466a3d2c30ce20e1bfcb423d6a8091864e81fd.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_pvce-51235f9696d57923d3a38ffdf03befae4878564e225b3aab87732b67272aec51.json
+++ b/openfisca_france/tests/json/aacc_pvce-51235f9696d57923d3a38ffdf03befae4878564e225b3aab87732b67272aec51.json
@@ -123,7 +123,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_pvce-707fc647312bebefd143fcb27d43aec7f3e8c2d9b46a89c60904120dcd15f606.json
+++ b/openfisca_france/tests/json/aacc_pvce-707fc647312bebefd143fcb27d43aec7f3e8c2d9b46a89c60904120dcd15f606.json
@@ -128,7 +128,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_pvce-a07e537c2135f747afcb9d941bb52d9046d70d6f840e39a6d26c9786238d4d8c.json
+++ b/openfisca_france/tests/json/aacc_pvce-a07e537c2135f747afcb9d941bb52d9046d70d6f840e39a6d26c9786238d4d8c.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_pvce-c588a961b3f445940f760fb30d02eb37c464dc885daa7a28c237023cdba282a5.json
+++ b/openfisca_france/tests/json/aacc_pvce-c588a961b3f445940f760fb30d02eb37c464dc885daa7a28c237023cdba282a5.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_pvce-ce3379a5878696302d06de1652a3437c784b3d104df076f822f391951aa0dc0b.json
+++ b/openfisca_france/tests/json/aacc_pvce-ce3379a5878696302d06de1652a3437c784b3d104df076f822f391951aa0dc0b.json
@@ -118,7 +118,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_pvce-d23e0d2a6c149a1d78da498d1707453ecb70cd826ad2625f0eca2665f07012da.json
+++ b/openfisca_france/tests/json/aacc_pvce-d23e0d2a6c149a1d78da498d1707453ecb70cd826ad2625f0eca2665f07012da.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_pvce-d2bc3504a0091ca0a74ccac7544f461fda6264fdc006c954b3c6b06ef588c720.json
+++ b/openfisca_france/tests/json/aacc_pvce-d2bc3504a0091ca0a74ccac7544f461fda6264fdc006c954b3c6b06ef588c720.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/aacc_pvce-e033ca26af1413bf8da7b640974f5740a40c244f8630378f9b6640adbdeb5f48.json
+++ b/openfisca_france/tests/json/aacc_pvce-e033ca26af1413bf8da7b640974f5740a40c244f8630378f9b6640adbdeb5f48.json
@@ -128,7 +128,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defn-1073fa83092539cafe8ab076be350c8e47b3326471c5bf8f9d3393f06f5a773c.json
+++ b/openfisca_france/tests/json/abic_defn-1073fa83092539cafe8ab076be350c8e47b3326471c5bf8f9d3393f06f5a773c.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defn-33017a6bcb77e2eb2535a163a5661203ccff7b5beb2ff0f5e9656e0338c7057a.json
+++ b/openfisca_france/tests/json/abic_defn-33017a6bcb77e2eb2535a163a5661203ccff7b5beb2ff0f5e9656e0338c7057a.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defn-3b32eb17f71076adc6f4df042e4e33ef07c6014441fd5c896f515aef0a5ad88f.json
+++ b/openfisca_france/tests/json/abic_defn-3b32eb17f71076adc6f4df042e4e33ef07c6014441fd5c896f515aef0a5ad88f.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defn-4149d5650192f772310413847914fc7e1f74dd2cdfaa066c661494d026f04d0a.json
+++ b/openfisca_france/tests/json/abic_defn-4149d5650192f772310413847914fc7e1f74dd2cdfaa066c661494d026f04d0a.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defn-48e6afd2527b4f3f277c78c2495188067764242ffb13905e0b4e74893e993e7b.json
+++ b/openfisca_france/tests/json/abic_defn-48e6afd2527b4f3f277c78c2495188067764242ffb13905e0b4e74893e993e7b.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defn-7a07fa11916a7d466e269f9844afca286838b3f9e74591e2614204e357a2e564.json
+++ b/openfisca_france/tests/json/abic_defn-7a07fa11916a7d466e269f9844afca286838b3f9e74591e2614204e357a2e564.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defn-997070f71d09ccec0b68906eb6295e493b47ebb11158dfd32a482b50754e4550.json
+++ b/openfisca_france/tests/json/abic_defn-997070f71d09ccec0b68906eb6295e493b47ebb11158dfd32a482b50754e4550.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defn-d2f64bb78d194a31227081c1ccd5bd81d114312ee8518c4a65d07f1f2cd949ef.json
+++ b/openfisca_france/tests/json/abic_defn-d2f64bb78d194a31227081c1ccd5bd81d114312ee8518c4a65d07f1f2cd949ef.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defn-dcde23f220f31af308aa98465915c37cd0a52f6868f7648ba73a3157ed3f854b.json
+++ b/openfisca_france/tests/json/abic_defn-dcde23f220f31af308aa98465915c37cd0a52f6868f7648ba73a3157ed3f854b.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defs-072ed2be9caf3046d6327e1b049a1e9219e036869ff96e7f7ec8e6719ea274f5.json
+++ b/openfisca_france/tests/json/abic_defs-072ed2be9caf3046d6327e1b049a1e9219e036869ff96e7f7ec8e6719ea274f5.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defs-2fab849cf6f133ce7833a5d761988f7a4216df9083dbbb637dd3b1fb079b7116.json
+++ b/openfisca_france/tests/json/abic_defs-2fab849cf6f133ce7833a5d761988f7a4216df9083dbbb637dd3b1fb079b7116.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defs-303cdfa3aae97f337eab76b23ee5aa5f3c279739e09ef59375b55d3bb0dbc2a9.json
+++ b/openfisca_france/tests/json/abic_defs-303cdfa3aae97f337eab76b23ee5aa5f3c279739e09ef59375b55d3bb0dbc2a9.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defs-3d77b239b605e17d7109e2d4fb75431cde7fe3529e75d23101f340fcabfcffad.json
+++ b/openfisca_france/tests/json/abic_defs-3d77b239b605e17d7109e2d4fb75431cde7fe3529e75d23101f340fcabfcffad.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defs-48e700bfab20f1b9a1636165fb3ac1b937a13b9729c644d45efd18a2a40e9e0d.json
+++ b/openfisca_france/tests/json/abic_defs-48e700bfab20f1b9a1636165fb3ac1b937a13b9729c644d45efd18a2a40e9e0d.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defs-60700472bbe97b0d9fa9a6aaa57c6ee213e6d37425df82965c337ef39d78952e.json
+++ b/openfisca_france/tests/json/abic_defs-60700472bbe97b0d9fa9a6aaa57c6ee213e6d37425df82965c337ef39d78952e.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defs-6487de6806cb406ffa37d14c8ace5f4753155bbe1839ff2b57c74e07ea2d0870.json
+++ b/openfisca_france/tests/json/abic_defs-6487de6806cb406ffa37d14c8ace5f4753155bbe1839ff2b57c74e07ea2d0870.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defs-72776228130eabe98a9c56a73cc90e63472f260eb711453788bae1221ff83f16.json
+++ b/openfisca_france/tests/json/abic_defs-72776228130eabe98a9c56a73cc90e63472f260eb711453788bae1221ff83f16.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defs-b5b1851dd6d7f73ad7138c57934cb96fdd1aed0d20ee99d8c5bb37f1a8b21dea.json
+++ b/openfisca_france/tests/json/abic_defs-b5b1851dd6d7f73ad7138c57934cb96fdd1aed0d20ee99d8c5bb37f1a8b21dea.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_defs-dd3d02546afca3b2e17ba95b885d7f9183d867ebb126935b078a44be0a31bbd7.json
+++ b/openfisca_france/tests/json/abic_defs-dd3d02546afca3b2e17ba95b885d7f9183d867ebb126935b078a44be0a31bbd7.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_exon-058f6f4ff45e66bd9fb7cdd22b22fa9d1287c7a2efbbf45818004e7f0fd45215.json
+++ b/openfisca_france/tests/json/abic_exon-058f6f4ff45e66bd9fb7cdd22b22fa9d1287c7a2efbbf45818004e7f0fd45215.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_exon-65db27e474a258f7ebfa415f652c887ac6d4e74ac508b429eee46a2822953dd3.json
+++ b/openfisca_france/tests/json/abic_exon-65db27e474a258f7ebfa415f652c887ac6d4e74ac508b429eee46a2822953dd3.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_exon-8baf6e03f4c3c5a7e953c3c0a35f3e836cf14bdc4364829df8ab19119e69e615.json
+++ b/openfisca_france/tests/json/abic_exon-8baf6e03f4c3c5a7e953c3c0a35f3e836cf14bdc4364829df8ab19119e69e615.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_exon-9aa668ea8dcadfd889af89582ea25aa7ed1f0274275b4f358bcbfc7039d36b11.json
+++ b/openfisca_france/tests/json/abic_exon-9aa668ea8dcadfd889af89582ea25aa7ed1f0274275b4f358bcbfc7039d36b11.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_exon-9e0a887b5be0909e60078d22c9afc73a51b58ac44774539d97a4d0dd0f8fce15.json
+++ b/openfisca_france/tests/json/abic_exon-9e0a887b5be0909e60078d22c9afc73a51b58ac44774539d97a4d0dd0f8fce15.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_exon-ad020130d33c275329c4cd7e4d6c82c90a7ea0637997941f29949fbd4da04cc8.json
+++ b/openfisca_france/tests/json/abic_exon-ad020130d33c275329c4cd7e4d6c82c90a7ea0637997941f29949fbd4da04cc8.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_exon-bea0eb5d7010ddf7006511c477a1928dd2189dc793d240d55d796e8fa2762aa0.json
+++ b/openfisca_france/tests/json/abic_exon-bea0eb5d7010ddf7006511c477a1928dd2189dc793d240d55d796e8fa2762aa0.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_exon-ded969a461aa669be105e95bf2eeae3202e6f99ee4638002ac02c338d47f2a14.json
+++ b/openfisca_france/tests/json/abic_exon-ded969a461aa669be105e95bf2eeae3202e6f99ee4638002ac02c338d47f2a14.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_exon-e16d89ccc55eb6112cb3c21b0f94fb6a9d5baf32e7fe8dcd5229cbbd222a464d.json
+++ b/openfisca_france/tests/json/abic_exon-e16d89ccc55eb6112cb3c21b0f94fb6a9d5baf32e7fe8dcd5229cbbd222a464d.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_impn-1fff5d3c888da1150860848c639f904e92680afba2e899d1964591b6ee8997df.json
+++ b/openfisca_france/tests/json/abic_impn-1fff5d3c888da1150860848c639f904e92680afba2e899d1964591b6ee8997df.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_impn-23b515fa2ba897194c601bdcad4347eaba5e0e6c376cd75582ef0bcdd0d224b7.json
+++ b/openfisca_france/tests/json/abic_impn-23b515fa2ba897194c601bdcad4347eaba5e0e6c376cd75582ef0bcdd0d224b7.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_impn-45d1f88478df8ec8a27f38004f1a91c512431f1610fec58465f05de4433d8e5a.json
+++ b/openfisca_france/tests/json/abic_impn-45d1f88478df8ec8a27f38004f1a91c512431f1610fec58465f05de4433d8e5a.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_impn-6d3fc614818756800991e70f950ebfb8e723d68d23bcd3cbfd0f4832f2eab67c.json
+++ b/openfisca_france/tests/json/abic_impn-6d3fc614818756800991e70f950ebfb8e723d68d23bcd3cbfd0f4832f2eab67c.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_impn-89c61d3fbf8413e6c025fc0ec593f135a2ecb856d8c23290fa9b8c080e2531b4.json
+++ b/openfisca_france/tests/json/abic_impn-89c61d3fbf8413e6c025fc0ec593f135a2ecb856d8c23290fa9b8c080e2531b4.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_impn-cadc5779e19e2877dbdd3895d38317d2993d2505de270c5670f6885957391e71.json
+++ b/openfisca_france/tests/json/abic_impn-cadc5779e19e2877dbdd3895d38317d2993d2505de270c5670f6885957391e71.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_impn-e9582873761b7313ae9e1a0afc665f7920846416fce835229cf24d48adcf0ff8.json
+++ b/openfisca_france/tests/json/abic_impn-e9582873761b7313ae9e1a0afc665f7920846416fce835229cf24d48adcf0ff8.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_impn-f384718bfa0d48ffb7883f1227b2d7bfd8f59cd74c6469b72376e7dc74e04d97.json
+++ b/openfisca_france/tests/json/abic_impn-f384718bfa0d48ffb7883f1227b2d7bfd8f59cd74c6469b72376e7dc74e04d97.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_impn-f953d12a26d7f51fe408b6d3362cb609b3bc9e9ca8a10842569421de58a5f165.json
+++ b/openfisca_france/tests/json/abic_impn-f953d12a26d7f51fe408b6d3362cb609b3bc9e9ca8a10842569421de58a5f165.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_imps-0deabd39df1b87f7c2602aa0dadb7dc4e88d1dd04c156d1b3e6f7c285893d564.json
+++ b/openfisca_france/tests/json/abic_imps-0deabd39df1b87f7c2602aa0dadb7dc4e88d1dd04c156d1b3e6f7c285893d564.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_imps-0e1cf7c21b445936fbadf2caa0342cae24ffec9e15c271cbf589934590a2b5a7.json
+++ b/openfisca_france/tests/json/abic_imps-0e1cf7c21b445936fbadf2caa0342cae24ffec9e15c271cbf589934590a2b5a7.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_imps-1066b26a1bc2686c53202a930d3e373997ed6e6fdc97b21221aa7fb1d2e0048a.json
+++ b/openfisca_france/tests/json/abic_imps-1066b26a1bc2686c53202a930d3e373997ed6e6fdc97b21221aa7fb1d2e0048a.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_imps-14faf9e21f588a7fb67eb97ca18bb5c8664ef6cd79dd706af9b9134c5533c470.json
+++ b/openfisca_france/tests/json/abic_imps-14faf9e21f588a7fb67eb97ca18bb5c8664ef6cd79dd706af9b9134c5533c470.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_imps-22a3f42c5b4afcf85c9944376ded3ca81c47737bf8d7a049f06a40062773363d.json
+++ b/openfisca_france/tests/json/abic_imps-22a3f42c5b4afcf85c9944376ded3ca81c47737bf8d7a049f06a40062773363d.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_imps-45b49fd92113b7dd5422dd8e8c08b0436a6e75ee5cbdb34fbd240501fc883afa.json
+++ b/openfisca_france/tests/json/abic_imps-45b49fd92113b7dd5422dd8e8c08b0436a6e75ee5cbdb34fbd240501fc883afa.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_imps-62392eb9322a079f980e72480b3746752f028e529136215db06ca2e63ce30ee0.json
+++ b/openfisca_france/tests/json/abic_imps-62392eb9322a079f980e72480b3746752f028e529136215db06ca2e63ce30ee0.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_imps-664ddefb1ba09e0615d289492af37bc4a9e9a5d71381db88c71cb802e4107174.json
+++ b/openfisca_france/tests/json/abic_imps-664ddefb1ba09e0615d289492af37bc4a9e9a5d71381db88c71cb802e4107174.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_imps-86c1f18c15b46c8c1c1814d4441b5aec82d5510f82a51598b55d647b9c168dcb.json
+++ b/openfisca_france/tests/json/abic_imps-86c1f18c15b46c8c1c1814d4441b5aec82d5510f82a51598b55d647b9c168dcb.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_imps-e0cae1319c9c5acfd1f6bd69b776194611188145d7aa4e1c368e2997c1f4f3c4.json
+++ b/openfisca_france/tests/json/abic_imps-e0cae1319c9c5acfd1f6bd69b776194611188145d7aa4e1c368e2997c1f4f3c4.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_pvce-22ca13991f740452ed93e750fd93c3a6315771f5064321c16d03a45f1b97497a.json
+++ b/openfisca_france/tests/json/abic_pvce-22ca13991f740452ed93e750fd93c3a6315771f5064321c16d03a45f1b97497a.json
@@ -128,7 +128,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_pvce-31171b91bddfa64c3406ed28249356336033805273aecf46a5c99a69fee4abf9.json
+++ b/openfisca_france/tests/json/abic_pvce-31171b91bddfa64c3406ed28249356336033805273aecf46a5c99a69fee4abf9.json
@@ -128,7 +128,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_pvce-7027771433d2153acdd6b63c927b287a6555688353428b6024678d928f192865.json
+++ b/openfisca_france/tests/json/abic_pvce-7027771433d2153acdd6b63c927b287a6555688353428b6024678d928f192865.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_pvce-72bc72e012774d724009948773c61fccd867758817095377fa7634ccd9ae40f6.json
+++ b/openfisca_france/tests/json/abic_pvce-72bc72e012774d724009948773c61fccd867758817095377fa7634ccd9ae40f6.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_pvce-98f8300117a280e66d910cd489f6cdbb615f2343479af7a2a6402988e851916c.json
+++ b/openfisca_france/tests/json/abic_pvce-98f8300117a280e66d910cd489f6cdbb615f2343479af7a2a6402988e851916c.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_pvce-bbf1c1bfe566188039f7c8b9e05a47f082cde8a46c61f0c9363e6c729a3b479f.json
+++ b/openfisca_france/tests/json/abic_pvce-bbf1c1bfe566188039f7c8b9e05a47f082cde8a46c61f0c9363e6c729a3b479f.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_pvce-bd32d77a7886350ac88809f8632c57ccfe55bd10c24a74381b60440d652d25c1.json
+++ b/openfisca_france/tests/json/abic_pvce-bd32d77a7886350ac88809f8632c57ccfe55bd10c24a74381b60440d652d25c1.json
@@ -123,7 +123,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_pvce-c5b9c8ae31a00141cd8f7a34411be38a74ba640d77f9a6c86cb6f86d84b202a2.json
+++ b/openfisca_france/tests/json/abic_pvce-c5b9c8ae31a00141cd8f7a34411be38a74ba640d77f9a6c86cb6f86d84b202a2.json
@@ -118,7 +118,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abic_pvce-d3fefd45d383da2c9b4d2874d12706aaad6f5378610f607e2606c786e474f393.json
+++ b/openfisca_france/tests/json/abic_pvce-d3fefd45d383da2c9b4d2874d12706aaad6f5378610f607e2606c786e474f393.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_defi-021a306477b63e88fbfeb02c2af8e551fe9c4bb2c2f5f16b7646ad64a4dcef3d.json
+++ b/openfisca_france/tests/json/abnc_defi-021a306477b63e88fbfeb02c2af8e551fe9c4bb2c2f5f16b7646ad64a4dcef3d.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_defi-2cba7daaed0e9a10f1bf77342166eec8fb9f99f325de95fa00332581bac4aacc.json
+++ b/openfisca_france/tests/json/abnc_defi-2cba7daaed0e9a10f1bf77342166eec8fb9f99f325de95fa00332581bac4aacc.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_defi-300723a701e15c7ba1a55017692f6ad243df7d9e10036c09702f3c562a7322e7.json
+++ b/openfisca_france/tests/json/abnc_defi-300723a701e15c7ba1a55017692f6ad243df7d9e10036c09702f3c562a7322e7.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_defi-31e22f0670afa330813edfd3522566ed8fed8193a96a64386a8bebe7ad480fc0.json
+++ b/openfisca_france/tests/json/abnc_defi-31e22f0670afa330813edfd3522566ed8fed8193a96a64386a8bebe7ad480fc0.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_defi-45c95d21a1aa83c98d66be0a5fc078fc3b4a706d51c4dd531de3752b6719e5c9.json
+++ b/openfisca_france/tests/json/abnc_defi-45c95d21a1aa83c98d66be0a5fc078fc3b4a706d51c4dd531de3752b6719e5c9.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_defi-92e065b8ae8315b231c73b703221a6eb1a56fabbf3525eaf1f4ca6822319dda8.json
+++ b/openfisca_france/tests/json/abnc_defi-92e065b8ae8315b231c73b703221a6eb1a56fabbf3525eaf1f4ca6822319dda8.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_defi-b6b9a747a8f20724b167911d9a32f473c912b4fe0b5ca87365a364a2e18173d2.json
+++ b/openfisca_france/tests/json/abnc_defi-b6b9a747a8f20724b167911d9a32f473c912b4fe0b5ca87365a364a2e18173d2.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_defi-d7ac8d38da9ffda040df9be1ebbe331f845fa2e30486bef1553f46540503619d.json
+++ b/openfisca_france/tests/json/abnc_defi-d7ac8d38da9ffda040df9be1ebbe331f845fa2e30486bef1553f46540503619d.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_defi-f6fe70be9e37ae695525e55df95e039bca5af6aa218d8b30218618d2af5cc8c6.json
+++ b/openfisca_france/tests/json/abnc_defi-f6fe70be9e37ae695525e55df95e039bca5af6aa218d8b30218618d2af5cc8c6.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_exon-010e013806352ea45303e8a109fbfca975e980b40ab9d5ed90fa3fb0c1496477.json
+++ b/openfisca_france/tests/json/abnc_exon-010e013806352ea45303e8a109fbfca975e980b40ab9d5ed90fa3fb0c1496477.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_exon-06e82627535c30223a43325810b1dcb598b5876d61718c11a94611625873f5bd.json
+++ b/openfisca_france/tests/json/abnc_exon-06e82627535c30223a43325810b1dcb598b5876d61718c11a94611625873f5bd.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_exon-0baf5e6911bb810fda258d122a6a1bcf0e15046a6572cd079d67aab96250b95e.json
+++ b/openfisca_france/tests/json/abnc_exon-0baf5e6911bb810fda258d122a6a1bcf0e15046a6572cd079d67aab96250b95e.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_exon-2bc6e169b351472d4c776ac8086458d35f247a467be8da02703a8b8981f0d80d.json
+++ b/openfisca_france/tests/json/abnc_exon-2bc6e169b351472d4c776ac8086458d35f247a467be8da02703a8b8981f0d80d.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_exon-4797167e3c181c7a9802899bde59ff436303bb558ea37283512543d30c372c79.json
+++ b/openfisca_france/tests/json/abnc_exon-4797167e3c181c7a9802899bde59ff436303bb558ea37283512543d30c372c79.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_exon-52f8b3e338c413fd0c17131e5a957d35441da8a520aac5ef7bbe40182eba7289.json
+++ b/openfisca_france/tests/json/abnc_exon-52f8b3e338c413fd0c17131e5a957d35441da8a520aac5ef7bbe40182eba7289.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_exon-68ce7886fa382760b5c8d17117c3d2ebd83073f95e983380dd48e1bb8c8b69fb.json
+++ b/openfisca_france/tests/json/abnc_exon-68ce7886fa382760b5c8d17117c3d2ebd83073f95e983380dd48e1bb8c8b69fb.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_exon-6942082f9150c27842e9de88ccc787669ad62234261fa562b4fe5f055bcd0cbe.json
+++ b/openfisca_france/tests/json/abnc_exon-6942082f9150c27842e9de88ccc787669ad62234261fa562b4fe5f055bcd0cbe.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_exon-a8a119e0734f37844203262d4ac25aab79fb7f42d52b3fb105471dedd24b2644.json
+++ b/openfisca_france/tests/json/abnc_exon-a8a119e0734f37844203262d4ac25aab79fb7f42d52b3fb105471dedd24b2644.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_impo-076c9e6f984b78d6eefab7243d6bb180861f25e6e4fef2d25069e5a1505eb0f4.json
+++ b/openfisca_france/tests/json/abnc_impo-076c9e6f984b78d6eefab7243d6bb180861f25e6e4fef2d25069e5a1505eb0f4.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_impo-14d1abb06329552521a94844f75ea721a967165a206e2988c3212592604548f0.json
+++ b/openfisca_france/tests/json/abnc_impo-14d1abb06329552521a94844f75ea721a967165a206e2988c3212592604548f0.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_impo-1d3fcf7407e3afaf8da902cafe7cced5452597042f53180c222ea533f69ae5e5.json
+++ b/openfisca_france/tests/json/abnc_impo-1d3fcf7407e3afaf8da902cafe7cced5452597042f53180c222ea533f69ae5e5.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_impo-20d17eccd07c7f5899d8ad02f0efaca7bebcdc14230d856e8c6c290eaf7755c6.json
+++ b/openfisca_france/tests/json/abnc_impo-20d17eccd07c7f5899d8ad02f0efaca7bebcdc14230d856e8c6c290eaf7755c6.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_impo-2bee27d450e5dd595334c970a0a6952a6b0b7affd06f840685f5d7ce9b058a4d.json
+++ b/openfisca_france/tests/json/abnc_impo-2bee27d450e5dd595334c970a0a6952a6b0b7affd06f840685f5d7ce9b058a4d.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_impo-3437bc3853081fc6c131284267d2ff2f63aa7b60417768d3fddd1fb57f0cf0d2.json
+++ b/openfisca_france/tests/json/abnc_impo-3437bc3853081fc6c131284267d2ff2f63aa7b60417768d3fddd1fb57f0cf0d2.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_impo-578759b9cc8f9c89956a56aa89b918a93813d06a950ffc084e86968a8442d8d4.json
+++ b/openfisca_france/tests/json/abnc_impo-578759b9cc8f9c89956a56aa89b918a93813d06a950ffc084e86968a8442d8d4.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_impo-876ff770513e17d741a7da1ca9b90248b7b4668287aa4f4385e7df3fdaf49760.json
+++ b/openfisca_france/tests/json/abnc_impo-876ff770513e17d741a7da1ca9b90248b7b4668287aa4f4385e7df3fdaf49760.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_impo-f57174f75a7910473155877834b2ceb621217eeaebc1c8d25ca34bd585996123.json
+++ b/openfisca_france/tests/json/abnc_impo-f57174f75a7910473155877834b2ceb621217eeaebc1c8d25ca34bd585996123.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_pvce-3986bd0ce12d3313f012bbe91f5b99216d65021d1ebc90539e827cc590294dde.json
+++ b/openfisca_france/tests/json/abnc_pvce-3986bd0ce12d3313f012bbe91f5b99216d65021d1ebc90539e827cc590294dde.json
@@ -123,7 +123,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_pvce-5960df925c77b8bc04c0f898ee223e2afbdb2a8001c5b88905c0074660146097.json
+++ b/openfisca_france/tests/json/abnc_pvce-5960df925c77b8bc04c0f898ee223e2afbdb2a8001c5b88905c0074660146097.json
@@ -118,7 +118,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_pvce-5961e8038c70e4852d7c91496c7723946622a18d52b3c9fba537317bea9b4632.json
+++ b/openfisca_france/tests/json/abnc_pvce-5961e8038c70e4852d7c91496c7723946622a18d52b3c9fba537317bea9b4632.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_pvce-5fee7a818dfc04159c702fa5d4b290bad2c007efdbfaa3e1877ed7bcfc542c63.json
+++ b/openfisca_france/tests/json/abnc_pvce-5fee7a818dfc04159c702fa5d4b290bad2c007efdbfaa3e1877ed7bcfc542c63.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_pvce-7286f1fd016bbe60ae78775e5fc2f3c200c910b323735d7594b04d97d85de53c.json
+++ b/openfisca_france/tests/json/abnc_pvce-7286f1fd016bbe60ae78775e5fc2f3c200c910b323735d7594b04d97d85de53c.json
@@ -128,7 +128,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_pvce-7cbd8641c2abb88d71e52cad4465beb31389971b27c7c1b738170bfef362c092.json
+++ b/openfisca_france/tests/json/abnc_pvce-7cbd8641c2abb88d71e52cad4465beb31389971b27c7c1b738170bfef362c092.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_pvce-82d754d0ecc8f4efd8385bcca648aa28d36dbf3b2f4fa1ac138ab9561a4ed38a.json
+++ b/openfisca_france/tests/json/abnc_pvce-82d754d0ecc8f4efd8385bcca648aa28d36dbf3b2f4fa1ac138ab9561a4ed38a.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_pvce-e8391c052ad0127914be25d9ef073f6c8cb46a3d98d3ff8efedcaca50aa854e7.json
+++ b/openfisca_france/tests/json/abnc_pvce-e8391c052ad0127914be25d9ef073f6c8cb46a3d98d3ff8efedcaca50aa854e7.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/abnc_pvce-fa80571f24c36e80465c92ff3a7a5a2a94be58481ab6f5b0631e847d4e700b53.json
+++ b/openfisca_france/tests/json/abnc_pvce-fa80571f24c36e80465c92ff3a7a5a2a94be58481ab6f5b0631e847d4e700b53.json
@@ -128,7 +128,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_defi-1dc2bdb1bb6e6b6c1739ca2417f644a9f020bd2093c98f0756f13a05379835b5.json
+++ b/openfisca_france/tests/json/arag_defi-1dc2bdb1bb6e6b6c1739ca2417f644a9f020bd2093c98f0756f13a05379835b5.json
@@ -88,7 +88,7 @@
           "arag_defi": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_defi-414e10fe5996a53ac7fc6d06b88d511838ba8f1cd8a9a34bc03f59adbc47639a.json
+++ b/openfisca_france/tests/json/arag_defi-414e10fe5996a53ac7fc6d06b88d511838ba8f1cd8a9a34bc03f59adbc47639a.json
@@ -88,7 +88,7 @@
           "arag_defi": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_defi-5145150ddb1108eda27a3da72069a9b949958df8af926a7341d0bfec501d044a.json
+++ b/openfisca_france/tests/json/arag_defi-5145150ddb1108eda27a3da72069a9b949958df8af926a7341d0bfec501d044a.json
@@ -88,7 +88,7 @@
           "arag_defi": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_defi-6820220bc32e0629c10164d6c35a1879ead476d11f90a2ef25b071b420d5e40e.json
+++ b/openfisca_france/tests/json/arag_defi-6820220bc32e0629c10164d6c35a1879ead476d11f90a2ef25b071b420d5e40e.json
@@ -83,7 +83,7 @@
           "arag_defi": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_defi-9a555f3d833db6616dcdb6632934e8c4ffc42b5bda4743184cb142b66981f3d3.json
+++ b/openfisca_france/tests/json/arag_defi-9a555f3d833db6616dcdb6632934e8c4ffc42b5bda4743184cb142b66981f3d3.json
@@ -88,7 +88,7 @@
           "arag_defi": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_defi-9b9bdf13692986a3c938867b702840507f256a7d7b69d00ca4c43fe052b1433e.json
+++ b/openfisca_france/tests/json/arag_defi-9b9bdf13692986a3c938867b702840507f256a7d7b69d00ca4c43fe052b1433e.json
@@ -88,7 +88,7 @@
           "arag_defi": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_defi-a2f7029cf73de427570e4e0900b742354a8cf75a242ecd61b42cbd97c456a4b7.json
+++ b/openfisca_france/tests/json/arag_defi-a2f7029cf73de427570e4e0900b742354a8cf75a242ecd61b42cbd97c456a4b7.json
@@ -88,7 +88,7 @@
           "arag_defi": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_defi-b813a21ee4bf9e860e61b383134aef470e0137ac7f46483ffaa92a1837a855c3.json
+++ b/openfisca_france/tests/json/arag_defi-b813a21ee4bf9e860e61b383134aef470e0137ac7f46483ffaa92a1837a855c3.json
@@ -88,7 +88,7 @@
           "arag_defi": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_defi-d30942334697ebb22e09691aee9a4ab659482319511e701699135f645723c78a.json
+++ b/openfisca_france/tests/json/arag_defi-d30942334697ebb22e09691aee9a4ab659482319511e701699135f645723c78a.json
@@ -93,7 +93,7 @@
           "arag_defi": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_exon-23022b596b4d8d60b72dcd5cef02a32ac9689d3f268abe2d172ea4b643c9b6b1.json
+++ b/openfisca_france/tests/json/arag_exon-23022b596b4d8d60b72dcd5cef02a32ac9689d3f268abe2d172ea4b643c9b6b1.json
@@ -88,7 +88,7 @@
           "arag_exon": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_exon-43916b918e4708aefa6e92425ecaf54b1515b30a56595ba94ffddb58275001ac.json
+++ b/openfisca_france/tests/json/arag_exon-43916b918e4708aefa6e92425ecaf54b1515b30a56595ba94ffddb58275001ac.json
@@ -88,7 +88,7 @@
           "arag_exon": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_exon-6029e6e2adbbfe26bcd5d34c4978f6dc6dccac52ad39b1c92ed65470adc37b7b.json
+++ b/openfisca_france/tests/json/arag_exon-6029e6e2adbbfe26bcd5d34c4978f6dc6dccac52ad39b1c92ed65470adc37b7b.json
@@ -83,7 +83,7 @@
           "arag_exon": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_exon-6ad97d9610d9bcd2f9265fcb58c0fb1417c0f048a8c53d514decaf73887aff3f.json
+++ b/openfisca_france/tests/json/arag_exon-6ad97d9610d9bcd2f9265fcb58c0fb1417c0f048a8c53d514decaf73887aff3f.json
@@ -88,7 +88,7 @@
           "arag_exon": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_exon-6dcab65e3153ab9b587524c93a81a4a3b08efdc0e7c90d71b25ba4a03d8d0182.json
+++ b/openfisca_france/tests/json/arag_exon-6dcab65e3153ab9b587524c93a81a4a3b08efdc0e7c90d71b25ba4a03d8d0182.json
@@ -88,7 +88,7 @@
           "arag_exon": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_exon-750c49e36d9011cf0da6e62b9fa6d3b6d3842f6b292a5f6af667e49ed416c651.json
+++ b/openfisca_france/tests/json/arag_exon-750c49e36d9011cf0da6e62b9fa6d3b6d3842f6b292a5f6af667e49ed416c651.json
@@ -88,7 +88,7 @@
           "arag_exon": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_exon-83b0614a4949f7081802708c0950c417ffa8a84ca274acdc761031532f584fe4.json
+++ b/openfisca_france/tests/json/arag_exon-83b0614a4949f7081802708c0950c417ffa8a84ca274acdc761031532f584fe4.json
@@ -88,7 +88,7 @@
           "arag_exon": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_exon-cc8de8adf37f8960252e143ec62431230e0633fb8e441327c756e86c0357f8c1.json
+++ b/openfisca_france/tests/json/arag_exon-cc8de8adf37f8960252e143ec62431230e0633fb8e441327c756e86c0357f8c1.json
@@ -88,7 +88,7 @@
           "arag_exon": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_exon-ffe12602b9333e5e0aaf9e92f99625484927e78afc2b9adb36f2e1cdf9872481.json
+++ b/openfisca_france/tests/json/arag_exon-ffe12602b9333e5e0aaf9e92f99625484927e78afc2b9adb36f2e1cdf9872481.json
@@ -93,7 +93,7 @@
           "arag_exon": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_impg-094d90f8f3b4c73401e8e87306a51906e41da8fbe3dc2538c8dae3ddc31641ac.json
+++ b/openfisca_france/tests/json/arag_impg-094d90f8f3b4c73401e8e87306a51906e41da8fbe3dc2538c8dae3ddc31641ac.json
@@ -88,7 +88,7 @@
           "arag_impg": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_impg-21e01a1ddf2ca54d4fdc12a632e64b827721fc660d0840102513a03159d65963.json
+++ b/openfisca_france/tests/json/arag_impg-21e01a1ddf2ca54d4fdc12a632e64b827721fc660d0840102513a03159d65963.json
@@ -88,7 +88,7 @@
           "arag_impg": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_impg-453d4809cdf53255bfc19d1a705a10ce123037d09fc00d333a625cfdaa4523d1.json
+++ b/openfisca_france/tests/json/arag_impg-453d4809cdf53255bfc19d1a705a10ce123037d09fc00d333a625cfdaa4523d1.json
@@ -88,7 +88,7 @@
           "arag_impg": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_impg-58e4ec54ceda268b20774ad9c96d4a47e0d3fc580e7aa7efeb5ba8c91e733dc0.json
+++ b/openfisca_france/tests/json/arag_impg-58e4ec54ceda268b20774ad9c96d4a47e0d3fc580e7aa7efeb5ba8c91e733dc0.json
@@ -88,7 +88,7 @@
           "arag_impg": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_impg-66328bcc7ced9441f01f231ce75a30fc2b8043c4adec2bbed9ef72ca1ecc2f5e.json
+++ b/openfisca_france/tests/json/arag_impg-66328bcc7ced9441f01f231ce75a30fc2b8043c4adec2bbed9ef72ca1ecc2f5e.json
@@ -88,7 +88,7 @@
           "arag_impg": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_impg-8cc2d770561eb768be3621413ebe7fa40d0a539c64aa895e8eb8f93bf783941b.json
+++ b/openfisca_france/tests/json/arag_impg-8cc2d770561eb768be3621413ebe7fa40d0a539c64aa895e8eb8f93bf783941b.json
@@ -83,7 +83,7 @@
           "arag_impg": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_impg-95bbca0a1fafb41488c4a660631338c597c24f47e71edcdc3ce93459a3542d55.json
+++ b/openfisca_france/tests/json/arag_impg-95bbca0a1fafb41488c4a660631338c597c24f47e71edcdc3ce93459a3542d55.json
@@ -88,7 +88,7 @@
           "arag_impg": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_impg-96320219465d6d1abb5ebd1b11229ecf2dcf8d2dedfe873da17f984e2b3a654e.json
+++ b/openfisca_france/tests/json/arag_impg-96320219465d6d1abb5ebd1b11229ecf2dcf8d2dedfe873da17f984e2b3a654e.json
@@ -88,7 +88,7 @@
           "arag_impg": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_impg-a7e8c8efdc5237a7861a3f9bbbf78ea036613f87da51efd5a5daa5330c5ba0a3.json
+++ b/openfisca_france/tests/json/arag_impg-a7e8c8efdc5237a7861a3f9bbbf78ea036613f87da51efd5a5daa5330c5ba0a3.json
@@ -93,7 +93,7 @@
           "arag_impg": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_pvce-070e3b2045cb08539aa089eda3d133509ceb4905d4b91b50cd6b15a2c88d34dd.json
+++ b/openfisca_france/tests/json/arag_pvce-070e3b2045cb08539aa089eda3d133509ceb4905d4b91b50cd6b15a2c88d34dd.json
@@ -93,7 +93,7 @@
           "arag_pvce": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_pvce-0f6bba4024b21cd8294d96d9a71ec600ddaa310e5a6dbf1bb36c4a4759973ebb.json
+++ b/openfisca_france/tests/json/arag_pvce-0f6bba4024b21cd8294d96d9a71ec600ddaa310e5a6dbf1bb36c4a4759973ebb.json
@@ -93,7 +93,7 @@
           "arag_pvce": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_pvce-2036b897faba99b0612f17f53817fc46929bfa0a2a60dec53e7d4b82f9a718cf.json
+++ b/openfisca_france/tests/json/arag_pvce-2036b897faba99b0612f17f53817fc46929bfa0a2a60dec53e7d4b82f9a718cf.json
@@ -93,7 +93,7 @@
           "arag_pvce": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_pvce-3d4998d9c222e19c9f4069b76569b47320078077884c5d4e84f6493ca20b62ad.json
+++ b/openfisca_france/tests/json/arag_pvce-3d4998d9c222e19c9f4069b76569b47320078077884c5d4e84f6493ca20b62ad.json
@@ -128,7 +128,7 @@
           "arag_pvce": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_pvce-abff42e7354e888a09e6fe36d87a73f2e164f818201d46d9f32abb4f1e39c977.json
+++ b/openfisca_france/tests/json/arag_pvce-abff42e7354e888a09e6fe36d87a73f2e164f818201d46d9f32abb4f1e39c977.json
@@ -118,7 +118,7 @@
           "arag_pvce": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_pvce-b104953562ee42886c7bdb8e94a32fe9bb9ae3829dd3282a94a200e0dd9dafab.json
+++ b/openfisca_france/tests/json/arag_pvce-b104953562ee42886c7bdb8e94a32fe9bb9ae3829dd3282a94a200e0dd9dafab.json
@@ -93,7 +93,7 @@
           "arag_pvce": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_pvce-bcc6d2b884576fb11f03c4c003bd4d1fa087a2377870e3629f9bc0893bfccadc.json
+++ b/openfisca_france/tests/json/arag_pvce-bcc6d2b884576fb11f03c4c003bd4d1fa087a2377870e3629f9bc0893bfccadc.json
@@ -128,7 +128,7 @@
           "arag_pvce": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_pvce-d2f52eb89a6f015b47bea8e81402d89ef300f84b55fc0db101dd02d1b5fa0514.json
+++ b/openfisca_france/tests/json/arag_pvce-d2f52eb89a6f015b47bea8e81402d89ef300f84b55fc0db101dd02d1b5fa0514.json
@@ -93,7 +93,7 @@
           "arag_pvce": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/arag_pvce-e2bbf86ec352a0048810e1368088103dd079a29b615ae111210504b326049c71.json
+++ b/openfisca_france/tests/json/arag_pvce-e2bbf86ec352a0048810e1368088103dd079a29b615ae111210504b326049c71.json
@@ -123,7 +123,7 @@
           "arag_pvce": 1500,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_bene-25d506ff799befd1e03eadc4518624ac26649f3fd2abb5e88b49a6574c9b7367.json
+++ b/openfisca_france/tests/json/cncn_bene-25d506ff799befd1e03eadc4518624ac26649f3fd2abb5e88b49a6574c9b7367.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_bene": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_bene-2ea975ae35e77b8d8d212ec4ece1169b06d9f04ac64db664485510aa983d5aa8.json
+++ b/openfisca_france/tests/json/cncn_bene-2ea975ae35e77b8d8d212ec4ece1169b06d9f04ac64db664485510aa983d5aa8.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_bene": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_bene-47570c25fd96aa25aac42dae797482b61c7dd9f495a3ca2c8d84ace76f2ad111.json
+++ b/openfisca_france/tests/json/cncn_bene-47570c25fd96aa25aac42dae797482b61c7dd9f495a3ca2c8d84ace76f2ad111.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_bene": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_bene-50c49273c7e71b4bbd00ab44c03eade0676af68e68e822e7c70d61e6f5446406.json
+++ b/openfisca_france/tests/json/cncn_bene-50c49273c7e71b4bbd00ab44c03eade0676af68e68e822e7c70d61e6f5446406.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "cncn_bene": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_bene-5125acebb20d6d243e0167603fd46e9d17f2232e9142496bb598db1e7dc3c926.json
+++ b/openfisca_france/tests/json/cncn_bene-5125acebb20d6d243e0167603fd46e9d17f2232e9142496bb598db1e7dc3c926.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_bene": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_bene-955f6fd817f3f6ebe58265ef8e8714d12a08d0717f0e77ff33f70c17798ca11e.json
+++ b/openfisca_france/tests/json/cncn_bene-955f6fd817f3f6ebe58265ef8e8714d12a08d0717f0e77ff33f70c17798ca11e.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "cncn_bene": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_bene-a63de5ca1f570df0bf11f79bf3e65db6a10b6a8d1f7619e6a6b870fbb5f865de.json
+++ b/openfisca_france/tests/json/cncn_bene-a63de5ca1f570df0bf11f79bf3e65db6a10b6a8d1f7619e6a6b870fbb5f865de.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_bene": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_bene-afdf163f18045a21fef4b370d1bfe1f4afa5a9866c3244165f906a9dbc8a4d94.json
+++ b/openfisca_france/tests/json/cncn_bene-afdf163f18045a21fef4b370d1bfe1f4afa5a9866c3244165f906a9dbc8a4d94.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_bene": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_bene-ce31ad5be2b57e532fe9db4c9c7726d1d48dbb568ff150351b8765218b74c674.json
+++ b/openfisca_france/tests/json/cncn_bene-ce31ad5be2b57e532fe9db4c9c7726d1d48dbb568ff150351b8765218b74c674.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_bene": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_defi-177b935f7af65d76fd5c52eb7bde9ff724252c64c12f0d614a91450e1b120637.json
+++ b/openfisca_france/tests/json/cncn_defi-177b935f7af65d76fd5c52eb7bde9ff724252c64c12f0d614a91450e1b120637.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_defi-22ef987b9c1069b4eb72fa35dab5d07fa90d42394d5fc5685e68dbc6dc58e992.json
+++ b/openfisca_france/tests/json/cncn_defi-22ef987b9c1069b4eb72fa35dab5d07fa90d42394d5fc5685e68dbc6dc58e992.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_defi-3bea1a2dbc616ed99fabff47008c529d46a5f8c5112a991eb0514f71b706e78c.json
+++ b/openfisca_france/tests/json/cncn_defi-3bea1a2dbc616ed99fabff47008c529d46a5f8c5112a991eb0514f71b706e78c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_defi-42dcc5cf808176463b4029c562ec8f85729348eec3a8bac2fbf861cd472f8e46.json
+++ b/openfisca_france/tests/json/cncn_defi-42dcc5cf808176463b4029c562ec8f85729348eec3a8bac2fbf861cd472f8e46.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "cncn_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_defi-6fc2ce5596d3414864a543ecea5dc3795d3318c671eccf0c653eccfe47559ceb.json
+++ b/openfisca_france/tests/json/cncn_defi-6fc2ce5596d3414864a543ecea5dc3795d3318c671eccf0c653eccfe47559ceb.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_defi-92f679f330a431020345845cc73a5fdf5de3535927e08883b57739d355ac2fde.json
+++ b/openfisca_france/tests/json/cncn_defi-92f679f330a431020345845cc73a5fdf5de3535927e08883b57739d355ac2fde.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_defi-c52dc26ec853acefede55e997248225dfda18f1e638190beda5c402b4c68a5d8.json
+++ b/openfisca_france/tests/json/cncn_defi-c52dc26ec853acefede55e997248225dfda18f1e638190beda5c402b4c68a5d8.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_defi-d6a0e4d143ae9ec116b7e5204577115851ea19c425398e3eb681db6c352bbaa5.json
+++ b/openfisca_france/tests/json/cncn_defi-d6a0e4d143ae9ec116b7e5204577115851ea19c425398e3eb681db6c352bbaa5.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "cncn_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_defi-fd7a9ff564b581ca3edbd0e2ad1aea835e115bc369716e40d31d594643fe10cf.json
+++ b/openfisca_france/tests/json/cncn_defi-fd7a9ff564b581ca3edbd0e2ad1aea835e115bc369716e40d31d594643fe10cf.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "cncn_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_pvce-1c50089970b03423e015eb4866122fabc64a9b0a4e896eb7ebfbd154c80ba5bd.json
+++ b/openfisca_france/tests/json/cncn_pvce-1c50089970b03423e015eb4866122fabc64a9b0a4e896eb7ebfbd154c80ba5bd.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "cncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_pvce-266288748a55ebc91c9df8b62f9e086e446265c8ed8639ccc265066c33beeaa3.json
+++ b/openfisca_france/tests/json/cncn_pvce-266288748a55ebc91c9df8b62f9e086e446265c8ed8639ccc265066c33beeaa3.json
@@ -123,7 +123,7 @@
           "date_naissance": "1970-01-01",
           "cncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_pvce-2774237ae82717ee44111126e85fdda11669f67cb13fcab0a8f7c8d63e8fb284.json
+++ b/openfisca_france/tests/json/cncn_pvce-2774237ae82717ee44111126e85fdda11669f67cb13fcab0a8f7c8d63e8fb284.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "cncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_pvce-89ee9a68fd0e514de235ac08c6082ade2e787ecd5e180dfa8efcda8fcf670c45.json
+++ b/openfisca_france/tests/json/cncn_pvce-89ee9a68fd0e514de235ac08c6082ade2e787ecd5e180dfa8efcda8fcf670c45.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "cncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_pvce-8b0f1b042ccd8177365fddb1e73682cfdbee6a681560e390abd4473a6df91360.json
+++ b/openfisca_france/tests/json/cncn_pvce-8b0f1b042ccd8177365fddb1e73682cfdbee6a681560e390abd4473a6df91360.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "cncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_pvce-a2b28144820c40889c016047ed0e032f77b82249f1b231d999fdffbd8ad7c933.json
+++ b/openfisca_france/tests/json/cncn_pvce-a2b28144820c40889c016047ed0e032f77b82249f1b231d999fdffbd8ad7c933.json
@@ -128,7 +128,7 @@
           "date_naissance": "1970-01-01",
           "cncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_pvce-a6c769bb7ea280fd2dfb2c7504adb9780933748b52abf38a8ccdaa6f356bf3b9.json
+++ b/openfisca_france/tests/json/cncn_pvce-a6c769bb7ea280fd2dfb2c7504adb9780933748b52abf38a8ccdaa6f356bf3b9.json
@@ -128,7 +128,7 @@
           "date_naissance": "1970-01-01",
           "cncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_pvce-b3a7522658bdab5489df59abda83792c428023a327f5e3a883e87350ba917bb8.json
+++ b/openfisca_france/tests/json/cncn_pvce-b3a7522658bdab5489df59abda83792c428023a327f5e3a883e87350ba917bb8.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "cncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/cncn_pvce-cb661a780b401168d9660ef5aecade3c3d05e84d4d260a1088163196369c2d45.json
+++ b/openfisca_france/tests/json/cncn_pvce-cb661a780b401168d9660ef5aecade3c3d05e84d4d260a1088163196369c2d45.json
@@ -118,7 +118,7 @@
           "date_naissance": "1970-01-01",
           "cncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_imps-037d1b4de02b64c20557ca03e8a167bf55900ff048d2a3177b8f9ff999f64b7f.json
+++ b/openfisca_france/tests/json/ebic_imps-037d1b4de02b64c20557ca03e8a167bf55900ff048d2a3177b8f9ff999f64b7f.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ebic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_imps-21a1e3ecc2547c4591c04bb07b242da5c3494672e6f9255dc288839a51d8444c.json
+++ b/openfisca_france/tests/json/ebic_imps-21a1e3ecc2547c4591c04bb07b242da5c3494672e6f9255dc288839a51d8444c.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "ebic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_imps-417178887ce4d68c490ec2dac9783a5955099c83e7f79121fe26545c38bbd772.json
+++ b/openfisca_france/tests/json/ebic_imps-417178887ce4d68c490ec2dac9783a5955099c83e7f79121fe26545c38bbd772.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebic_imps": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_imps-4b336501162c14eb9ca4d90f9c7f7713d0968c583cf82d6575a18aa2bc4c13eb.json
+++ b/openfisca_france/tests/json/ebic_imps-4b336501162c14eb9ca4d90f9c7f7713d0968c583cf82d6575a18aa2bc4c13eb.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_imps-7d940aa49d7d43b62626a8a585231e597e2009ff8b0b1a8f3c4fa877d569d59d.json
+++ b/openfisca_france/tests/json/ebic_imps-7d940aa49d7d43b62626a8a585231e597e2009ff8b0b1a8f3c4fa877d569d59d.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_imps-94e3f2aea4226c5dccd4968f9f62da23d07c082f00948807e3e0c352dd803262.json
+++ b/openfisca_france/tests/json/ebic_imps-94e3f2aea4226c5dccd4968f9f62da23d07c082f00948807e3e0c352dd803262.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ebic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_imps-afd1e27d3f869ee5937f1884632369698ae3a4c8543d0cee47c17483bc156143.json
+++ b/openfisca_france/tests/json/ebic_imps-afd1e27d3f869ee5937f1884632369698ae3a4c8543d0cee47c17483bc156143.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_imps-b35d38264592e26a63def213308b801afe53c3a42b479f32b511e1320c737a26.json
+++ b/openfisca_france/tests/json/ebic_imps-b35d38264592e26a63def213308b801afe53c3a42b479f32b511e1320c737a26.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebic_imps": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_imps-beb1329ad200dc7656a30316a2b06e0ff99fe97689e6cb0280872631b0fd69ee.json
+++ b/openfisca_france/tests/json/ebic_imps-beb1329ad200dc7656a30316a2b06e0ff99fe97689e6cb0280872631b0fd69ee.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_imps-d1fda952b57b17b74707fc4b28b9262243bc2ac3949d46c58de2e4e2b7ea81f9.json
+++ b/openfisca_france/tests/json/ebic_imps-d1fda952b57b17b74707fc4b28b9262243bc2ac3949d46c58de2e4e2b7ea81f9.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ebic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_imps-fa2db3ec1970f88920570179fa85c86e5c77c471f3a362cd3cc8ddf6d2bb9f81.json
+++ b/openfisca_france/tests/json/ebic_imps-fa2db3ec1970f88920570179fa85c86e5c77c471f3a362cd3cc8ddf6d2bb9f81.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ebic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_impv-2736e90c687a70f259fbcdf5d9d9f1c41f44e66aa077bfcb56cea8c8259fff23.json
+++ b/openfisca_france/tests/json/ebic_impv-2736e90c687a70f259fbcdf5d9d9f1c41f44e66aa077bfcb56cea8c8259fff23.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ebic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_impv-456601f601b197c99968adbf048ee38d5026fc2e0cbd3bddb965904ee6ff5217.json
+++ b/openfisca_france/tests/json/ebic_impv-456601f601b197c99968adbf048ee38d5026fc2e0cbd3bddb965904ee6ff5217.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_impv-467a19d32983745b2451b3ca4f6e001f81d3f08d8c435d53ee6764e1a20ab4de.json
+++ b/openfisca_france/tests/json/ebic_impv-467a19d32983745b2451b3ca4f6e001f81d3f08d8c435d53ee6764e1a20ab4de.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_impv-4b8e0bee6719fd3eabcb5e99f90a9b7c53ef8ee19d4193909e8c7d84be891384.json
+++ b/openfisca_france/tests/json/ebic_impv-4b8e0bee6719fd3eabcb5e99f90a9b7c53ef8ee19d4193909e8c7d84be891384.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_impv-702048d6c2a6250b1673637194aaeda7362315a87949daa7ad877776da7413c1.json
+++ b/openfisca_france/tests/json/ebic_impv-702048d6c2a6250b1673637194aaeda7362315a87949daa7ad877776da7413c1.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_impv-723fc859782930945d803cc47bcc2e2ccaf814efd0737713efb372db60ecc03b.json
+++ b/openfisca_france/tests/json/ebic_impv-723fc859782930945d803cc47bcc2e2ccaf814efd0737713efb372db60ecc03b.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ebic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_impv-b011a6dfa1a605132f79efc2cf77432b35787abc0b48ac849c7e144c367a9bbb.json
+++ b/openfisca_france/tests/json/ebic_impv-b011a6dfa1a605132f79efc2cf77432b35787abc0b48ac849c7e144c367a9bbb.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ebic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_impv-b7cf101bc33d70289c65b66f19e6b4d1a7b618e93d6a309967606d0b0a825074.json
+++ b/openfisca_france/tests/json/ebic_impv-b7cf101bc33d70289c65b66f19e6b4d1a7b618e93d6a309967606d0b0a825074.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "ebic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebic_impv-ee6e9e6e95e702a1ded4f50e25d687aead09cadd9b64d1cfbe37cab2bce1c581.json
+++ b/openfisca_france/tests/json/ebic_impv-ee6e9e6e95e702a1ded4f50e25d687aead09cadd9b64d1cfbe37cab2bce1c581.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ebic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebnc_impo-1225e45e25e157fa93d171b2bc64d7132ac8fdb20f10d50a9a60f229a98b60e2.json
+++ b/openfisca_france/tests/json/ebnc_impo-1225e45e25e157fa93d171b2bc64d7132ac8fdb20f10d50a9a60f229a98b60e2.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebnc_impo-32d4ad93212ee2f51b2408d706990a586e10cdd3d5cb05412c8d656f13d2c1f0.json
+++ b/openfisca_france/tests/json/ebnc_impo-32d4ad93212ee2f51b2408d706990a586e10cdd3d5cb05412c8d656f13d2c1f0.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ebnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebnc_impo-8049855dd923e50198d661405a45e7d03fa2c7c69f60f1e81def11d95bbede98.json
+++ b/openfisca_france/tests/json/ebnc_impo-8049855dd923e50198d661405a45e7d03fa2c7c69f60f1e81def11d95bbede98.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ebnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebnc_impo-806882355872b179f06e6029154b287fedc341dbfbda615020514fd7db26e421.json
+++ b/openfisca_france/tests/json/ebnc_impo-806882355872b179f06e6029154b287fedc341dbfbda615020514fd7db26e421.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "ebnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebnc_impo-80b2e150a23c7834ec484daa89e885c2e68445d26dd35ff59a37a35f426e2698.json
+++ b/openfisca_france/tests/json/ebnc_impo-80b2e150a23c7834ec484daa89e885c2e68445d26dd35ff59a37a35f426e2698.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebnc_impo-a5eb8c5d323391f5ffb549c22f2c0535559e0495447595c58a64f5dbcaa80180.json
+++ b/openfisca_france/tests/json/ebnc_impo-a5eb8c5d323391f5ffb549c22f2c0535559e0495447595c58a64f5dbcaa80180.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ebnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebnc_impo-ac6119afc33a6e81fcdf6457417ee4cf4873926161e143c372a23065c8fc1a69.json
+++ b/openfisca_france/tests/json/ebnc_impo-ac6119afc33a6e81fcdf6457417ee4cf4873926161e143c372a23065c8fc1a69.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ebnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebnc_impo-d523bd4dba23888f95117df0b0ac456e4806ff4f26f21ef0fd2668745894de3a.json
+++ b/openfisca_france/tests/json/ebnc_impo-d523bd4dba23888f95117df0b0ac456e4806ff4f26f21ef0fd2668745894de3a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ebnc_impo-de6099f0a790654a09faf3ac60460977b6acf9762f18056a4643668db98aee8e.json
+++ b/openfisca_france/tests/json/ebnc_impo-de6099f0a790654a09faf3ac60460977b6acf9762f18056a4643668db98aee8e.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ebnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ch-0c2acf2df59c165a8047b185b38c3100785283383b05b1742c82a048ee65e9d6.json
+++ b/openfisca_france/tests/json/f2ch-0c2acf2df59c165a8047b185b38c3100785283383b05b1742c82a048ee65e9d6.json
@@ -119,7 +119,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ch-1e03045359180e87cb550ecc938c8df317c0f3d31d66e2bdaf9def4628c7dbbf.json
+++ b/openfisca_france/tests/json/f2ch-1e03045359180e87cb550ecc938c8df317c0f3d31d66e2bdaf9def4628c7dbbf.json
@@ -124,7 +124,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ch-2874fc198e09f0be0193b07d5fbae9c9dbda38a47edf4cea09f4736d2ae42e62.json
+++ b/openfisca_france/tests/json/f2ch-2874fc198e09f0be0193b07d5fbae9c9dbda38a47edf4cea09f4736d2ae42e62.json
@@ -119,7 +119,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ch-743a0cf6e5c41d49fd6f39b643da3fcf8eb00a1b159b2bd715ffffbcb4011181.json
+++ b/openfisca_france/tests/json/f2ch-743a0cf6e5c41d49fd6f39b643da3fcf8eb00a1b159b2bd715ffffbcb4011181.json
@@ -119,7 +119,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ch-76364ec7f37f9f30b84fd68f2115599da71123073b2c240205073312633c7244.json
+++ b/openfisca_france/tests/json/f2ch-76364ec7f37f9f30b84fd68f2115599da71123073b2c240205073312633c7244.json
@@ -119,7 +119,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ch-a85cc9a21fbccea452b6c33fcd7708f6642843af05f4469b2c51cd9761ca55f3.json
+++ b/openfisca_france/tests/json/f2ch-a85cc9a21fbccea452b6c33fcd7708f6642843af05f4469b2c51cd9761ca55f3.json
@@ -114,7 +114,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ch-c29004f7fd8d52e6dfbfb4cf150b06b88f57431e150ffb1ab21369bdfcada919.json
+++ b/openfisca_france/tests/json/f2ch-c29004f7fd8d52e6dfbfb4cf150b06b88f57431e150ffb1ab21369bdfcada919.json
@@ -119,7 +119,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ch-e242cd3699154bec1a072aa435ef75464dc94d2a213d6a87243c844ebe1869b7.json
+++ b/openfisca_france/tests/json/f2ch-e242cd3699154bec1a072aa435ef75464dc94d2a213d6a87243c844ebe1869b7.json
@@ -119,7 +119,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ch-fc51188b7cebf676a488124ae8533e06fa1f5c22a6bec9db05f788da8a8d5c5f.json
+++ b/openfisca_france/tests/json/f2ch-fc51188b7cebf676a488124ae8533e06fa1f5c22a6bec9db05f788da8a8d5c5f.json
@@ -119,7 +119,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ck-2778665333f13bb87f5b0bbcab8222d5c38cd573ccbb668e8a0ec7d346943443.json
+++ b/openfisca_france/tests/json/f2ck-2778665333f13bb87f5b0bbcab8222d5c38cd573ccbb668e8a0ec7d346943443.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ck-29f7330fbe0162fcc8b794bba616c30091e176e0727676811dc11a8faf62657a.json
+++ b/openfisca_france/tests/json/f2ck-29f7330fbe0162fcc8b794bba616c30091e176e0727676811dc11a8faf62657a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ck-4bb2c05013ad6786377180c238ffeb8d09ceb5d993a67f0e6a49b8509fa3ef70.json
+++ b/openfisca_france/tests/json/f2ck-4bb2c05013ad6786377180c238ffeb8d09ceb5d993a67f0e6a49b8509fa3ef70.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ck-58d2795f90297ad1d4e5acf1198a64b5c34ea558754a9972cef86a880c4b6c65.json
+++ b/openfisca_france/tests/json/f2ck-58d2795f90297ad1d4e5acf1198a64b5c34ea558754a9972cef86a880c4b6c65.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ck-a85bc4588f13e7da75d41ed8f69a3f086f3410c9dd2c31fd04073aa439ab3441.json
+++ b/openfisca_france/tests/json/f2ck-a85bc4588f13e7da75d41ed8f69a3f086f3410c9dd2c31fd04073aa439ab3441.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ck-b5206bc4bb8c9f64b41b6cd5db31a27ad16f1f39db717267596e90796fdc51ca.json
+++ b/openfisca_france/tests/json/f2ck-b5206bc4bb8c9f64b41b6cd5db31a27ad16f1f39db717267596e90796fdc51ca.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ck-b9f29208c30ad52b78f3f98902c4b346dae52ac77b2dfb34f8510484f9fc238b.json
+++ b/openfisca_france/tests/json/f2ck-b9f29208c30ad52b78f3f98902c4b346dae52ac77b2dfb34f8510484f9fc238b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2ck-e44b199a81009c5354a94f2e3b448c7fdf041b3fe8dbd1d0c5cdd40e2b56dc68.json
+++ b/openfisca_france/tests/json/f2ck-e44b199a81009c5354a94f2e3b448c7fdf041b3fe8dbd1d0c5cdd40e2b56dc68.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dc-0b23ab2ce48ba1c2450ca60f111de727824702e929ecd1a8db9dd9c908b8d547.json
+++ b/openfisca_france/tests/json/f2dc-0b23ab2ce48ba1c2450ca60f111de727824702e929ecd1a8db9dd9c908b8d547.json
@@ -124,7 +124,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dc-0deb4dd1b9567a2e50e3f13f8d325b1357670a07362f98e0a1c4f5200c82507b.json
+++ b/openfisca_france/tests/json/f2dc-0deb4dd1b9567a2e50e3f13f8d325b1357670a07362f98e0a1c4f5200c82507b.json
@@ -124,7 +124,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dc-43df9a42e1b4d887a51fb2a2dfb9d1d7a561d2ad8df852655bcd5945e0134ec9.json
+++ b/openfisca_france/tests/json/f2dc-43df9a42e1b4d887a51fb2a2dfb9d1d7a561d2ad8df852655bcd5945e0134ec9.json
@@ -124,7 +124,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dc-4ac2caf0906115573d5bc65d8d5b3cbd399dceb87029893e36452cbeee3ef6d4.json
+++ b/openfisca_france/tests/json/f2dc-4ac2caf0906115573d5bc65d8d5b3cbd399dceb87029893e36452cbeee3ef6d4.json
@@ -124,7 +124,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dc-87cf241444db829de1c256a31c5aef2fbdd8e63edc652b0800a0d3c24a98985d.json
+++ b/openfisca_france/tests/json/f2dc-87cf241444db829de1c256a31c5aef2fbdd8e63edc652b0800a0d3c24a98985d.json
@@ -124,7 +124,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dc-9c30ebbd2f86a2f4170403919e2a605eed3ddb03011c0e63dd7b001881319e05.json
+++ b/openfisca_france/tests/json/f2dc-9c30ebbd2f86a2f4170403919e2a605eed3ddb03011c0e63dd7b001881319e05.json
@@ -114,7 +114,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dc-e6d924af1e43e928c9ede73737f332d04b2724bf91d8eb782d22fbf1323ee8eb.json
+++ b/openfisca_france/tests/json/f2dc-e6d924af1e43e928c9ede73737f332d04b2724bf91d8eb782d22fbf1323ee8eb.json
@@ -119,7 +119,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dc-ecda57631cd2ac79ba6a9e236a856bd54cf0a91dcf28c3c4d9f22acc76892975.json
+++ b/openfisca_france/tests/json/f2dc-ecda57631cd2ac79ba6a9e236a856bd54cf0a91dcf28c3c4d9f22acc76892975.json
@@ -119,7 +119,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dc-f352dd43bdd444b18f5857ea42ad5240fdcaf283b9e6d0e37a1b5367ca79a044.json
+++ b/openfisca_france/tests/json/f2dc-f352dd43bdd444b18f5857ea42ad5240fdcaf283b9e6d0e37a1b5367ca79a044.json
@@ -124,7 +124,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dh-067ac8ac03d5d6596ac2e6a99071871e4f94222ce46596de15c79fba697a1837.json
+++ b/openfisca_france/tests/json/f2dh-067ac8ac03d5d6596ac2e6a99071871e4f94222ce46596de15c79fba697a1837.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dh-15e42c3169d59ab20870b36d8d077ebfd96de1ae56e8823587431e9252afd84d.json
+++ b/openfisca_france/tests/json/f2dh-15e42c3169d59ab20870b36d8d077ebfd96de1ae56e8823587431e9252afd84d.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dh-2b54dd6e1e003224cda3722447a20550ae2cd5f03a10622fc8dbac7fc0afd516.json
+++ b/openfisca_france/tests/json/f2dh-2b54dd6e1e003224cda3722447a20550ae2cd5f03a10622fc8dbac7fc0afd516.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dh-3bc736321318bc4374f8fa784b80d773dbdc3409335daf1c21582ea9effb8203.json
+++ b/openfisca_france/tests/json/f2dh-3bc736321318bc4374f8fa784b80d773dbdc3409335daf1c21582ea9effb8203.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dh-5c7716ca735cc4a05c67aad747ff476c3c02edb50ca60464fe1ccf4f9fbe0cdc.json
+++ b/openfisca_france/tests/json/f2dh-5c7716ca735cc4a05c67aad747ff476c3c02edb50ca60464fe1ccf4f9fbe0cdc.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dh-61cb19e6618bda47a94a117a5c137b273230ffff52b9727fa78b662e8d2eb5cc.json
+++ b/openfisca_france/tests/json/f2dh-61cb19e6618bda47a94a117a5c137b273230ffff52b9727fa78b662e8d2eb5cc.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dh-b2fa57d28186772bd6d0504786da40bce27410b11066d9d308eb62b54b2b1953.json
+++ b/openfisca_france/tests/json/f2dh-b2fa57d28186772bd6d0504786da40bce27410b11066d9d308eb62b54b2b1953.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dh-f37612cce5030620b084a4c185995299ce927cc24437b43e19095fbf3d8283fa.json
+++ b/openfisca_france/tests/json/f2dh-f37612cce5030620b084a4c185995299ce927cc24437b43e19095fbf3d8283fa.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2dh-f6c834d53f30199b2c6606f211b44833284a88415892aaa313783c079e6dbc98.json
+++ b/openfisca_france/tests/json/f2dh-f6c834d53f30199b2c6606f211b44833284a88415892aaa313783c079e6dbc98.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2gr-064404b63aa4540bdaf4daf22425af77df39946b3e3803f1418b3fb824f329fc.json
+++ b/openfisca_france/tests/json/f2gr-064404b63aa4540bdaf4daf22425af77df39946b3e3803f1418b3fb824f329fc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2gr-280b46bbf7b2bc7456b1a6b8cb7831d6395dee205cd643282bd387b04020b4cd.json
+++ b/openfisca_france/tests/json/f2gr-280b46bbf7b2bc7456b1a6b8cb7831d6395dee205cd643282bd387b04020b4cd.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2gr-3a31a2e4c3e72c612fb257923811ce72d6177114467e463b4415ca19c14214aa.json
+++ b/openfisca_france/tests/json/f2gr-3a31a2e4c3e72c612fb257923811ce72d6177114467e463b4415ca19c14214aa.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2gr-6149efe0fd624f18d9a9e7d18bf553babc61eecd6cb66845df53a324415a7a7e.json
+++ b/openfisca_france/tests/json/f2gr-6149efe0fd624f18d9a9e7d18bf553babc61eecd6cb66845df53a324415a7a7e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2gr-7fe69b5a0beab230b8da1c375cc4665ecacbe2c55a87f2d7a1a6570836703ab8.json
+++ b/openfisca_france/tests/json/f2gr-7fe69b5a0beab230b8da1c375cc4665ecacbe2c55a87f2d7a1a6570836703ab8.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2gr-d684f9ebb11f89b6ce39ff0de51ac1fe5b6e5186e5a67c706832b728ff614c9f.json
+++ b/openfisca_france/tests/json/f2gr-d684f9ebb11f89b6ce39ff0de51ac1fe5b6e5186e5a67c706832b728ff614c9f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f2gr-e34eca80cb549a33a8de35e7c7a1c8beb265970bda0644b7f03e4d91c34c3e05.json
+++ b/openfisca_france/tests/json/f2gr-e34eca80cb549a33a8de35e7c7a1c8beb265970bda0644b7f03e4d91c34c3e05.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv-0f91994471914fc5c5e0f72ccc17bfe2370c4fa5001c2c9b5b02e40964d348ca.json
+++ b/openfisca_france/tests/json/f3vv-0f91994471914fc5c5e0f72ccc17bfe2370c4fa5001c2c9b5b02e40964d348ca.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv-0ff1ac83df70272617c95e15078142e6be054566c9d857c0b0c880cbfec27f4f.json
+++ b/openfisca_france/tests/json/f3vv-0ff1ac83df70272617c95e15078142e6be054566c9d857c0b0c880cbfec27f4f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv-3254999a04ff0e3b38a1deec6cf2f0a6889c56f489a00c328ebbfdaa032fd90c.json
+++ b/openfisca_france/tests/json/f3vv-3254999a04ff0e3b38a1deec6cf2f0a6889c56f489a00c328ebbfdaa032fd90c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv-4eb782b21a8a7092d32fb2dde45c308c018339f8d7f444417ab93bba1b1d83e3.json
+++ b/openfisca_france/tests/json/f3vv-4eb782b21a8a7092d32fb2dde45c308c018339f8d7f444417ab93bba1b1d83e3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv-9539caacf5363d4971bd5302c3f8d1a4af55d7c410a9e26171b802d4fd02de7b.json
+++ b/openfisca_france/tests/json/f3vv-9539caacf5363d4971bd5302c3f8d1a4af55d7c410a9e26171b802d4fd02de7b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv-ac0e3e3c3a924982454dc4a03fa7a69ddbd6b546217b9ec9378cd9fb942d727f.json
+++ b/openfisca_france/tests/json/f3vv-ac0e3e3c3a924982454dc4a03fa7a69ddbd6b546217b9ec9378cd9fb942d727f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv-d36fa83b5c872a54440ffd8bb0512d3c85e00e30dd1493c254c3aaf8ad4416ee.json
+++ b/openfisca_france/tests/json/f3vv-d36fa83b5c872a54440ffd8bb0512d3c85e00e30dd1493c254c3aaf8ad4416ee.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv-e6d2fb854920ae0dabca0145b6584b1b2fc002210c614b789ec8754d287f04c7.json
+++ b/openfisca_france/tests/json/f3vv-e6d2fb854920ae0dabca0145b6584b1b2fc002210c614b789ec8754d287f04c7.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv_end_2010-0f3c30518a296c17950f13701e4f9da6c6cbb784e7674eb79ffdbac3ae90cf54.json
+++ b/openfisca_france/tests/json/f3vv_end_2010-0f3c30518a296c17950f13701e4f9da6c6cbb784e7674eb79ffdbac3ae90cf54.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv_end_2010-4bbdbd0547746ec97e27ea6d3b2951ff06f2bafb66bce7ba7b62147ba2486b53.json
+++ b/openfisca_france/tests/json/f3vv_end_2010-4bbdbd0547746ec97e27ea6d3b2951ff06f2bafb66bce7ba7b62147ba2486b53.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv_end_2010-505530b26a0451d7e3971b3601d3484160404239339499ac6bd0384df3c5f1a1.json
+++ b/openfisca_france/tests/json/f3vv_end_2010-505530b26a0451d7e3971b3601d3484160404239339499ac6bd0384df3c5f1a1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv_end_2010-51e420f89eed794556b0284e47820ae42f82c74bd36b08b6629cc02136343d3f.json
+++ b/openfisca_france/tests/json/f3vv_end_2010-51e420f89eed794556b0284e47820ae42f82c74bd36b08b6629cc02136343d3f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv_end_2010-5cb72ab265bbd2b1669bd781e4b39b4a86fc43be4f9cb50bdb47ed959047ec44.json
+++ b/openfisca_france/tests/json/f3vv_end_2010-5cb72ab265bbd2b1669bd781e4b39b4a86fc43be4f9cb50bdb47ed959047ec44.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv_end_2010-963bc96ebee7a329ea802df164c22f8c47df2ca0b182854aa4de69d72bb450de.json
+++ b/openfisca_france/tests/json/f3vv_end_2010-963bc96ebee7a329ea802df164c22f8c47df2ca0b182854aa4de69d72bb450de.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv_end_2010-a42621710e74673c1781e418c6971c58330bad34b6babaeb5ceffecb8484b816.json
+++ b/openfisca_france/tests/json/f3vv_end_2010-a42621710e74673c1781e418c6971c58330bad34b6babaeb5ceffecb8484b816.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f3vv_end_2010-be2a17b0fcc577d6f9295463eb1d8772dba94fc17cf3fa080c8b07fd96255cda.json
+++ b/openfisca_france/tests/json/f3vv_end_2010-be2a17b0fcc577d6f9295463eb1d8772dba94fc17cf3fa080c8b07fd96255cda.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f4tq-111996336712c8e6ca6689d9c8aada98d02d0dd98fbb227e4f7af863d8d48773.json
+++ b/openfisca_france/tests/json/f4tq-111996336712c8e6ca6689d9c8aada98d02d0dd98fbb227e4f7af863d8d48773.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f4tq-16a5327780f0d291273def0d69784726e750d8ef7c9c156e16ac1d1984cc3148.json
+++ b/openfisca_france/tests/json/f4tq-16a5327780f0d291273def0d69784726e750d8ef7c9c156e16ac1d1984cc3148.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f4tq-1abcfeea95a6c38bdac754d43616cc19799440d5f2ec20a522f62f175d81c100.json
+++ b/openfisca_france/tests/json/f4tq-1abcfeea95a6c38bdac754d43616cc19799440d5f2ec20a522f62f175d81c100.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f4tq-32b2722e9892f0d634c68f6b7aed557ae75f467de12daa32f43ec5fcc24b311f.json
+++ b/openfisca_france/tests/json/f4tq-32b2722e9892f0d634c68f6b7aed557ae75f467de12daa32f43ec5fcc24b311f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f4tq-4cb2bbbe1931806d6ef3380e238b1a470d8e0840a2aff1781d46038e345052f1.json
+++ b/openfisca_france/tests/json/f4tq-4cb2bbbe1931806d6ef3380e238b1a470d8e0840a2aff1781d46038e345052f1.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f4tq-7880bbd9ec2ca8c11a1e5b0d5b967b1c09ea0f84586561e7eb179834fd1877e0.json
+++ b/openfisca_france/tests/json/f4tq-7880bbd9ec2ca8c11a1e5b0d5b967b1c09ea0f84586561e7eb179834fd1877e0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f4tq-ae50b45454155d088f4e0fd92d9a373bd8a611599bd8d36cdd11b45ad89399cb.json
+++ b/openfisca_france/tests/json/f4tq-ae50b45454155d088f4e0fd92d9a373bd8a611599bd8d36cdd11b45ad89399cb.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f4tq-c2aa6ebd4d0b1bd0acb9244c85a39ae9647f320fa9b3871f91feea330243c44b.json
+++ b/openfisca_france/tests/json/f4tq-c2aa6ebd4d0b1bd0acb9244c85a39ae9647f320fa9b3871f91feea330243c44b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f4tq-c5d87b9eaacb309ce7a8b277e8d67c6463f13ddc610c29476f43f6c2f748fb73.json
+++ b/openfisca_france/tests/json/f4tq-c5d87b9eaacb309ce7a8b277e8d67c6463f13ddc610c29476f43f6c2f748fb73.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5it-2007-d5afabab81d5604c8912aafec8dff39942cf764a769017a6ca7dbe24df9af83c.json
+++ b/openfisca_france/tests/json/f5it-2007-d5afabab81d5604c8912aafec8dff39942cf764a769017a6ca7dbe24df9af83c.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5it-2008-819c866207594419032517366fc8b2fdfc3d77dc44a455171c47b336d80f3a69.json
+++ b/openfisca_france/tests/json/f5it-2008-819c866207594419032517366fc8b2fdfc3d77dc44a455171c47b336d80f3a69.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5it-2009-57f405db826a383758ffc5cf2a34d99cc7ee4c2ab8714b2e2d821b021f817dc6.json
+++ b/openfisca_france/tests/json/f5it-2009-57f405db826a383758ffc5cf2a34d99cc7ee4c2ab8714b2e2d821b021f817dc6.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5it-2010-53c3be9da4ef4a93824f2127ea02e7e360a158541f7fb0a3bdcd39bbc7f4262c.json
+++ b/openfisca_france/tests/json/f5it-2010-53c3be9da4ef4a93824f2127ea02e7e360a158541f7fb0a3bdcd39bbc7f4262c.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5it-2011-14a9309707130a4a0e2b2df6688b1fcce4e7561a6d562e3074117df3d49e66e4.json
+++ b/openfisca_france/tests/json/f5it-2011-14a9309707130a4a0e2b2df6688b1fcce4e7561a6d562e3074117df3d49e66e4.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5it-2012-992b88733dc4d0bbf0f1802dee2eaaf9cead3c646ad4d0d0d858c720c089f1d8.json
+++ b/openfisca_france/tests/json/f5it-2012-992b88733dc4d0bbf0f1802dee2eaaf9cead3c646ad4d0d0d858c720c089f1d8.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5it-2013-1dec0bcee911e502b7b6c6b57009356b88818538924ea223ceb5e9a62ca561be.json
+++ b/openfisca_france/tests/json/f5it-2013-1dec0bcee911e502b7b6c6b57009356b88818538924ea223ceb5e9a62ca561be.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qn-2007-ff5493f3e48af7a4265dae264145c31a34823ef4f091a837d95ce523fb46bddd.json
+++ b/openfisca_france/tests/json/f5qn-2007-ff5493f3e48af7a4265dae264145c31a34823ef4f091a837d95ce523fb46bddd.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qn-2008-d72d10d18c095f38bcd1982885fb54b375e0e71c63b3f5db20464e7f917dbccb.json
+++ b/openfisca_france/tests/json/f5qn-2008-d72d10d18c095f38bcd1982885fb54b375e0e71c63b3f5db20464e7f917dbccb.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qn-2009-1fe21981895bda68dacd4cefbe962e4230fd994eb75ec07aeb4f483cbb7b7470.json
+++ b/openfisca_france/tests/json/f5qn-2009-1fe21981895bda68dacd4cefbe962e4230fd994eb75ec07aeb4f483cbb7b7470.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qn-2010-6ed99577c07d981086a224fcdacb7a252bcd162201360d3192b95ce159281109.json
+++ b/openfisca_france/tests/json/f5qn-2010-6ed99577c07d981086a224fcdacb7a252bcd162201360d3192b95ce159281109.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qn-2011-953197bf88bc4393861d9a7dead534e75231c3c4f0c585cc2315ece623f0224b.json
+++ b/openfisca_france/tests/json/f5qn-2011-953197bf88bc4393861d9a7dead534e75231c3c4f0c585cc2315ece623f0224b.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qn-2012-ef19fc8b4c202499aeef863011bd9cb7fe504479170f130d99a81a2044076cd6.json
+++ b/openfisca_france/tests/json/f5qn-2012-ef19fc8b4c202499aeef863011bd9cb7fe504479170f130d99a81a2044076cd6.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qn-2013-01a12706f098b203f88538cd55a58bf8797bdc8d8325991b4c5a5bc5538b8f49.json
+++ b/openfisca_france/tests/json/f5qn-2013-01a12706f098b203f88538cd55a58bf8797bdc8d8325991b4c5a5bc5538b8f49.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qq-2007-bd40eda57b861c4d81b8e93fc6f81ca79c9623918fb300abd0d718ecedc38a94.json
+++ b/openfisca_france/tests/json/f5qq-2007-bd40eda57b861c4d81b8e93fc6f81ca79c9623918fb300abd0d718ecedc38a94.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qq-2008-519e691db84c9a098f67bc7069e3f1ad5476edecfdce832f7b7fc235c0d9103d.json
+++ b/openfisca_france/tests/json/f5qq-2008-519e691db84c9a098f67bc7069e3f1ad5476edecfdce832f7b7fc235c0d9103d.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qq-2009-64daf0caf570033b5b6d2681542bafc1b4b00dcccae2df9c9f4ea1adb2b3adbe.json
+++ b/openfisca_france/tests/json/f5qq-2009-64daf0caf570033b5b6d2681542bafc1b4b00dcccae2df9c9f4ea1adb2b3adbe.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qq-2010-970e326c52671c2db08dfe0d91704362b56a1d9d76c1f2b5d488b4a7e9bfafeb.json
+++ b/openfisca_france/tests/json/f5qq-2010-970e326c52671c2db08dfe0d91704362b56a1d9d76c1f2b5d488b4a7e9bfafeb.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qq-2011-45e9d159dc830d07eeb93dd13bff3fbd1d8411496bfc766b0648291a8be1e86c.json
+++ b/openfisca_france/tests/json/f5qq-2011-45e9d159dc830d07eeb93dd13bff3fbd1d8411496bfc766b0648291a8be1e86c.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qq-2012-b1d13b5acefa057d8731c1f48a03191ec9642c755aad903a8e3d60f350af6110.json
+++ b/openfisca_france/tests/json/f5qq-2012-b1d13b5acefa057d8731c1f48a03191ec9642c755aad903a8e3d60f350af6110.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f5qq-2013-e6ef8406d70edb2125d49c4b3b306abe6b20aca10d462decaa1a2a6e8733f519.json
+++ b/openfisca_france/tests/json/f5qq-2013-e6ef8406d70edb2125d49c4b3b306abe6b20aca10d462decaa1a2a6e8733f519.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cc-27ec8aa8b9a363b61b6bbaced09d9ea57b955b99de94982e421055945a21d5a9.json
+++ b/openfisca_france/tests/json/f7cc-27ec8aa8b9a363b61b6bbaced09d9ea57b955b99de94982e421055945a21d5a9.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cc-37535632a401c0828b2bfa4d5c6570d591a8d6d9bdcded473cfb3ba389f0768d.json
+++ b/openfisca_france/tests/json/f7cc-37535632a401c0828b2bfa4d5c6570d591a8d6d9bdcded473cfb3ba389f0768d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cc-5e4d4278103ef3518a805e15b25ebe4883957b893eede0e27f87f3cdb8d159ac.json
+++ b/openfisca_france/tests/json/f7cc-5e4d4278103ef3518a805e15b25ebe4883957b893eede0e27f87f3cdb8d159ac.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cc-5f7823c2b7aeedefdbac07931fa38161ee5963dab18be5f24d84dd45ad0193c0.json
+++ b/openfisca_france/tests/json/f7cc-5f7823c2b7aeedefdbac07931fa38161ee5963dab18be5f24d84dd45ad0193c0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cc-83101406d41eb2342c711c90059468a5928460094a90cafdb35670ff1d6a25ed.json
+++ b/openfisca_france/tests/json/f7cc-83101406d41eb2342c711c90059468a5928460094a90cafdb35670ff1d6a25ed.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cc-879a76a49caf16109ba5e59e6fdcc3de2574d54dc06eaac36561c9c8c1de0cc7.json
+++ b/openfisca_france/tests/json/f7cc-879a76a49caf16109ba5e59e6fdcc3de2574d54dc06eaac36561c9c8c1de0cc7.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cc-8fba6e81c1ff2497c9dce736cb4d4f27bb462b6be8494cad3a5754b3698a1daa.json
+++ b/openfisca_france/tests/json/f7cc-8fba6e81c1ff2497c9dce736cb4d4f27bb462b6be8494cad3a5754b3698a1daa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cc-967efa78119ec2b5be0144933ec0dedea457c275f62f2e5ccb13dacbe8d4aea8.json
+++ b/openfisca_france/tests/json/f7cc-967efa78119ec2b5be0144933ec0dedea457c275f62f2e5ccb13dacbe8d4aea8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cc-e5640a708126ad38e0b876a0726d8451e508ca6da5895ae3209b4bce6f44260e.json
+++ b/openfisca_france/tests/json/f7cc-e5640a708126ad38e0b876a0726d8451e508ca6da5895ae3209b4bce6f44260e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cd-0c77995bebf1ef963207b9fae9bb164af074e7c51702da37f8009042dffa459d.json
+++ b/openfisca_france/tests/json/f7cd-0c77995bebf1ef963207b9fae9bb164af074e7c51702da37f8009042dffa459d.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cd-125f3adffcd4205f97a57ff4517365bac06aec782543d593172cf30e73bcd5a7.json
+++ b/openfisca_france/tests/json/f7cd-125f3adffcd4205f97a57ff4517365bac06aec782543d593172cf30e73bcd5a7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cd-3c4a1461b4569a4c76da178ca2297a145ddede7caa4a7a32189946aa8510649d.json
+++ b/openfisca_france/tests/json/f7cd-3c4a1461b4569a4c76da178ca2297a145ddede7caa4a7a32189946aa8510649d.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cd-4faad59474d5d64c73b92739a788ff6a3547fd01be6ce665cf102c0fa91300ae.json
+++ b/openfisca_france/tests/json/f7cd-4faad59474d5d64c73b92739a788ff6a3547fd01be6ce665cf102c0fa91300ae.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cd-6d7f868bc852697e872639c20fca30b48f2e88a3aebea1e34d38dfc145c9d12e.json
+++ b/openfisca_france/tests/json/f7cd-6d7f868bc852697e872639c20fca30b48f2e88a3aebea1e34d38dfc145c9d12e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cd-7035f58c282c7c3fbec7a26a7fd0315661c4265a62160ec3d94316bc771567b2.json
+++ b/openfisca_france/tests/json/f7cd-7035f58c282c7c3fbec7a26a7fd0315661c4265a62160ec3d94316bc771567b2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cd-98825ab86d4a44bd0690c3099ad0a83a84fed7b73bb3708de2ff904097d52323.json
+++ b/openfisca_france/tests/json/f7cd-98825ab86d4a44bd0690c3099ad0a83a84fed7b73bb3708de2ff904097d52323.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cd-dba4daaefaa87622d6eeae61e69f1e02b20af45dcafac357d230d1e2ea0dd17a.json
+++ b/openfisca_france/tests/json/f7cd-dba4daaefaa87622d6eeae61e69f1e02b20af45dcafac357d230d1e2ea0dd17a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cd-dde280d973e053b1a128c336ec73cb6a3ab26bfaf2f706c2e3f7a5c3427894b6.json
+++ b/openfisca_france/tests/json/f7cd-dde280d973e053b1a128c336ec73cb6a3ab26bfaf2f706c2e3f7a5c3427894b6.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ce-1005b5d23d1677bd17e53c8a248392cd781c987aa7e735a69ac51401f6c6c358.json
+++ b/openfisca_france/tests/json/f7ce-1005b5d23d1677bd17e53c8a248392cd781c987aa7e735a69ac51401f6c6c358.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ce-57a500ef293cf349ca2e3c3932d2d2a6bd7e544b4af23d51ac4e23c21c464311.json
+++ b/openfisca_france/tests/json/f7ce-57a500ef293cf349ca2e3c3932d2d2a6bd7e544b4af23d51ac4e23c21c464311.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ce-6f9a8f66661fdcb8c0efffe6102af98cca32da065a66fe370550ffa613ee46ce.json
+++ b/openfisca_france/tests/json/f7ce-6f9a8f66661fdcb8c0efffe6102af98cca32da065a66fe370550ffa613ee46ce.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ce-8ee14ea429c00571ea162ace375e3c4e4980f2a571f1cb9c4f4dcfa88ddd6071.json
+++ b/openfisca_france/tests/json/f7ce-8ee14ea429c00571ea162ace375e3c4e4980f2a571f1cb9c4f4dcfa88ddd6071.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ce-9d2ce60ce5b0d1dff5d24a15a738d518226cc545043dc38a8e6a7a3127ffcaad.json
+++ b/openfisca_france/tests/json/f7ce-9d2ce60ce5b0d1dff5d24a15a738d518226cc545043dc38a8e6a7a3127ffcaad.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ce-ac93673d82e99a0ed87868ef93bc164639514ef36e95056372e4d9a256917212.json
+++ b/openfisca_france/tests/json/f7ce-ac93673d82e99a0ed87868ef93bc164639514ef36e95056372e4d9a256917212.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ce-cd7878aa767034490bb7bcc487976bea332a2b6c043b422209e9fae580007ace.json
+++ b/openfisca_france/tests/json/f7ce-cd7878aa767034490bb7bcc487976bea332a2b6c043b422209e9fae580007ace.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ce-dc7f359da5152d27d7facb91e389367a44507770701837fd8cee35f68189c82a.json
+++ b/openfisca_france/tests/json/f7ce-dc7f359da5152d27d7facb91e389367a44507770701837fd8cee35f68189c82a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ce-df7fca57c04da0f72434621462ff6fbca5a37d4f4fc52efe93bf0d94ab06cace.json
+++ b/openfisca_france/tests/json/f7ce-df7fca57c04da0f72434621462ff6fbca5a37d4f4fc52efe93bf0d94ab06cace.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cf-1f407f77ac694519300a6fbff6c778a700b531f26d5b6f511ce91b26fb48ea22.json
+++ b/openfisca_france/tests/json/f7cf-1f407f77ac694519300a6fbff6c778a700b531f26d5b6f511ce91b26fb48ea22.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cf-30b69b687d9207418b1a73f322ea14120ed3801011ed9b6b2519490bd389561b.json
+++ b/openfisca_france/tests/json/f7cf-30b69b687d9207418b1a73f322ea14120ed3801011ed9b6b2519490bd389561b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cf-402d75e1ffce57b9f0712633e205bfdd4d6836ffe4c5e35e6539d140ae43f997.json
+++ b/openfisca_france/tests/json/f7cf-402d75e1ffce57b9f0712633e205bfdd4d6836ffe4c5e35e6539d140ae43f997.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cf-5f28cd33e7f8f8e468086f0c124144cb7873ef7bfdd821cbf5f337447338fd4d.json
+++ b/openfisca_france/tests/json/f7cf-5f28cd33e7f8f8e468086f0c124144cb7873ef7bfdd821cbf5f337447338fd4d.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cf-73df4f3510dfc3ed62947962f4005c87710a2858e5970c0ce4f12a1f4afce864.json
+++ b/openfisca_france/tests/json/f7cf-73df4f3510dfc3ed62947962f4005c87710a2858e5970c0ce4f12a1f4afce864.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cf-cfc1b2bfc49567c75656fb1278f34265a2099085a4fc035bb4fb24fdb97d58fe.json
+++ b/openfisca_france/tests/json/f7cf-cfc1b2bfc49567c75656fb1278f34265a2099085a4fc035bb4fb24fdb97d58fe.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cf-eed8f63e003fee72a067af87fd44f75df59df28351e4fff03cb345c45f315025.json
+++ b/openfisca_france/tests/json/f7cf-eed8f63e003fee72a067af87fd44f75df59df28351e4fff03cb345c45f315025.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cf-f14e36030076b461036e8a892d79de250671d53c8307e3f9eb1793bfca4c440c.json
+++ b/openfisca_france/tests/json/f7cf-f14e36030076b461036e8a892d79de250671d53c8307e3f9eb1793bfca4c440c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cf-f5689b93afce022072529b607b6baf0baedf421e4431fce3acadd3a70aa1038c.json
+++ b/openfisca_france/tests/json/f7cf-f5689b93afce022072529b607b6baf0baedf421e4431fce3acadd3a70aa1038c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cl-08b4994fc1fbd2af876ed3bb8a5d8762553bbb866e9143635ce32fdf78cf6459.json
+++ b/openfisca_france/tests/json/f7cl-08b4994fc1fbd2af876ed3bb8a5d8762553bbb866e9143635ce32fdf78cf6459.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cl-27a8f95e13021e7b70c059ca38ad7c0828c41fcb2cd8dd242a8454e1d7160678.json
+++ b/openfisca_france/tests/json/f7cl-27a8f95e13021e7b70c059ca38ad7c0828c41fcb2cd8dd242a8454e1d7160678.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cl-3fbca8d163a2a34e320472ffa8fc38e08df58735d3aab9e2ed2a63b671eff27c.json
+++ b/openfisca_france/tests/json/f7cl-3fbca8d163a2a34e320472ffa8fc38e08df58735d3aab9e2ed2a63b671eff27c.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cl-868436719ecf1cc9bd3ff6f658726068dfb56d058ad33fa36a19c33fd995af6a.json
+++ b/openfisca_france/tests/json/f7cl-868436719ecf1cc9bd3ff6f658726068dfb56d058ad33fa36a19c33fd995af6a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cl-9c152303408c146350b4fa6fece5e5046ad0ba76c5e5593b1c13ca01def89698.json
+++ b/openfisca_france/tests/json/f7cl-9c152303408c146350b4fa6fece5e5046ad0ba76c5e5593b1c13ca01def89698.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cl-b527c895afd9b6e2002086954271018f5f53f26fca55b629e12553d9bbe4ee54.json
+++ b/openfisca_france/tests/json/f7cl-b527c895afd9b6e2002086954271018f5f53f26fca55b629e12553d9bbe4ee54.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cl-bf023ebfec25e108d735879c5994b76d8ef24eef49117505f072566cb0ee54b5.json
+++ b/openfisca_france/tests/json/f7cl-bf023ebfec25e108d735879c5994b76d8ef24eef49117505f072566cb0ee54b5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cl-c3acc0e6674f06d39d77c1d8f45fad025bd097e164cb177d3e3be4d5ddedbe9b.json
+++ b/openfisca_france/tests/json/f7cl-c3acc0e6674f06d39d77c1d8f45fad025bd097e164cb177d3e3be4d5ddedbe9b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cl-d07777bb8081626130a6f4cefc5820d2e9673f14dd891149a9ef068e692fae2c.json
+++ b/openfisca_france/tests/json/f7cl-d07777bb8081626130a6f4cefc5820d2e9673f14dd891149a9ef068e692fae2c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cm-16a38f2b41b39d6de6f4dda83bab4460cdeb39987b996264db9ec3f828ee634a.json
+++ b/openfisca_france/tests/json/f7cm-16a38f2b41b39d6de6f4dda83bab4460cdeb39987b996264db9ec3f828ee634a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cm-2d2a0a0a45c98ba86623d3ab192254790e392dbc4828d750d2889932bc5c958e.json
+++ b/openfisca_france/tests/json/f7cm-2d2a0a0a45c98ba86623d3ab192254790e392dbc4828d750d2889932bc5c958e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cm-3100460c1eb7ed06d4e0694e32bb903708b7e794de378d0b5c81d61867b7f0e8.json
+++ b/openfisca_france/tests/json/f7cm-3100460c1eb7ed06d4e0694e32bb903708b7e794de378d0b5c81d61867b7f0e8.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cm-378f306b698b39078c80258b74a6ed905234ade431343aa41fd6fba7a0659f0f.json
+++ b/openfisca_france/tests/json/f7cm-378f306b698b39078c80258b74a6ed905234ade431343aa41fd6fba7a0659f0f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cm-4025c98412391625aaba16d894624f8492d15c080b8a5584217ab032528111f8.json
+++ b/openfisca_france/tests/json/f7cm-4025c98412391625aaba16d894624f8492d15c080b8a5584217ab032528111f8.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cm-4e291f7955904b1ccd584db7845a22a2818c083c98ee1f820fcb25b4f475a208.json
+++ b/openfisca_france/tests/json/f7cm-4e291f7955904b1ccd584db7845a22a2818c083c98ee1f820fcb25b4f475a208.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cm-76068f9a47fd4419a4f6280098b38f6a152dbe06ccb91fc3bf9bcde96009f42c.json
+++ b/openfisca_france/tests/json/f7cm-76068f9a47fd4419a4f6280098b38f6a152dbe06ccb91fc3bf9bcde96009f42c.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cm-7c5a24286f3f36823ca3774bf954f42a6dd1303cdfc3828bbc933e1aee5e8470.json
+++ b/openfisca_france/tests/json/f7cm-7c5a24286f3f36823ca3774bf954f42a6dd1303cdfc3828bbc933e1aee5e8470.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cm-a1f32861e0e351379a08ad8cf5aff57f3faeab854b8e802dbf91c8392c50c41f.json
+++ b/openfisca_france/tests/json/f7cm-a1f32861e0e351379a08ad8cf5aff57f3faeab854b8e802dbf91c8392c50c41f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cn-049bfade235510aa3b3730b9898b99df510c5f61ce38a7d82ca1fa0f7eb3af64.json
+++ b/openfisca_france/tests/json/f7cn-049bfade235510aa3b3730b9898b99df510c5f61ce38a7d82ca1fa0f7eb3af64.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cn-40f741a1cca785253f8a0c60f0a9e982ae79c4cf9c4e145ff6f788ecbf1260e5.json
+++ b/openfisca_france/tests/json/f7cn-40f741a1cca785253f8a0c60f0a9e982ae79c4cf9c4e145ff6f788ecbf1260e5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cn-66378aeef328acd32796609eaa26a3f95d6e735e4de00d97ffcf3f8dd1a99efc.json
+++ b/openfisca_france/tests/json/f7cn-66378aeef328acd32796609eaa26a3f95d6e735e4de00d97ffcf3f8dd1a99efc.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cn-73175e2b4562567202a19dc85323600c62e120eb9c1fb5a35c2a0abe07d2b655.json
+++ b/openfisca_france/tests/json/f7cn-73175e2b4562567202a19dc85323600c62e120eb9c1fb5a35c2a0abe07d2b655.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cn-74d2f5efcd41cbec33f2db9887c271663c294a8af39abd169fd070b6f02385c9.json
+++ b/openfisca_france/tests/json/f7cn-74d2f5efcd41cbec33f2db9887c271663c294a8af39abd169fd070b6f02385c9.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cn-763d9df8456961de70c64eeacaeb5530e141173f3464be920b9e782a0c840459.json
+++ b/openfisca_france/tests/json/f7cn-763d9df8456961de70c64eeacaeb5530e141173f3464be920b9e782a0c840459.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cn-93dab7c555cc9f5612bee0d9261566d05ef7ae68b7c6437d3beb8253aa4cdd40.json
+++ b/openfisca_france/tests/json/f7cn-93dab7c555cc9f5612bee0d9261566d05ef7ae68b7c6437d3beb8253aa4cdd40.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cn-978b157130b616c29b902494829f86cd5922e4426401fc87fd809a757bb32ea6.json
+++ b/openfisca_france/tests/json/f7cn-978b157130b616c29b902494829f86cd5922e4426401fc87fd809a757bb32ea6.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cn-dc2584abd0e80264fc56d16c4bf3b1cd5d3b021892a60dcf05796eb0804bbc16.json
+++ b/openfisca_france/tests/json/f7cn-dc2584abd0e80264fc56d16c4bf3b1cd5d3b021892a60dcf05796eb0804bbc16.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cq-42d2eb8e1d94c4e931ba3c056b62e7aa1954c1d04da59ca72e66df09e063b028.json
+++ b/openfisca_france/tests/json/f7cq-42d2eb8e1d94c4e931ba3c056b62e7aa1954c1d04da59ca72e66df09e063b028.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cq-a11b3a334843c6f789a342551a747ba6bf361a6a35cd151d69cd99afebac4dcd.json
+++ b/openfisca_france/tests/json/f7cq-a11b3a334843c6f789a342551a747ba6bf361a6a35cd151d69cd99afebac4dcd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cq-a4307f27462fc0a0b86f6366b17be1b64b17700438e04c8579bbe31771996e48.json
+++ b/openfisca_france/tests/json/f7cq-a4307f27462fc0a0b86f6366b17be1b64b17700438e04c8579bbe31771996e48.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cq-ad4f96fa12bb020c614cd07c7dc084685ac0b6d1be895beb1a5739baf33a90cd.json
+++ b/openfisca_france/tests/json/f7cq-ad4f96fa12bb020c614cd07c7dc084685ac0b6d1be895beb1a5739baf33a90cd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cq-be6e3a4bd4e2d80ce7cacb651e9b698e4a9ef2dd444abaea79be89cf79b4a355.json
+++ b/openfisca_france/tests/json/f7cq-be6e3a4bd4e2d80ce7cacb651e9b698e4a9ef2dd444abaea79be89cf79b4a355.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cq-d7bfb0da7e7e9ce5299d970c67bee3cd5aec6bb07872f8f479d4d833ddc9f5bd.json
+++ b/openfisca_france/tests/json/f7cq-d7bfb0da7e7e9ce5299d970c67bee3cd5aec6bb07872f8f479d4d833ddc9f5bd.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cq-dad2b606fb32610fc290cfcefd68882a07ae987d75d6c2c9a4e47cd6656e00a2.json
+++ b/openfisca_france/tests/json/f7cq-dad2b606fb32610fc290cfcefd68882a07ae987d75d6c2c9a4e47cd6656e00a2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cq-ea21692bb5f51a9ef23db94478d478e867a9a1e10d8263dcf3b34c637f6389a2.json
+++ b/openfisca_france/tests/json/f7cq-ea21692bb5f51a9ef23db94478d478e867a9a1e10d8263dcf3b34c637f6389a2.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cu-3ecf74227fe9ff30b83c01e1c8e72ad2b61530f17b934acd7e4a97d5dd55b9b2.json
+++ b/openfisca_france/tests/json/f7cu-3ecf74227fe9ff30b83c01e1c8e72ad2b61530f17b934acd7e4a97d5dd55b9b2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cu-425e90d70657cc632cb259ac64e71aa1383edda0d7e581615fa6774549c05189.json
+++ b/openfisca_france/tests/json/f7cu-425e90d70657cc632cb259ac64e71aa1383edda0d7e581615fa6774549c05189.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cu-773b0a37aa5004aa4348259e1e86be57844f8a0350d1198873db09a097f9075c.json
+++ b/openfisca_france/tests/json/f7cu-773b0a37aa5004aa4348259e1e86be57844f8a0350d1198873db09a097f9075c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cu-899e1bf54f67074252bb4346b150071c31a4fcc098e362a4b3c2fe192b75fb5a.json
+++ b/openfisca_france/tests/json/f7cu-899e1bf54f67074252bb4346b150071c31a4fcc098e362a4b3c2fe192b75fb5a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cu-8f0cac37fdbedc939c8a65c904b7ad7b6308f43ccb346af741db82b1bc573ed1.json
+++ b/openfisca_france/tests/json/f7cu-8f0cac37fdbedc939c8a65c904b7ad7b6308f43ccb346af741db82b1bc573ed1.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cu-a72087406590d743c13b3710fa160b7dc0ca43f44f84f418f0e2f89575f73e88.json
+++ b/openfisca_france/tests/json/f7cu-a72087406590d743c13b3710fa160b7dc0ca43f44f84f418f0e2f89575f73e88.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cu-d4c50394eb16cba97e27b9fcb285dd33f84b2d911d986be34d871fc0209f9ae2.json
+++ b/openfisca_france/tests/json/f7cu-d4c50394eb16cba97e27b9fcb285dd33f84b2d911d986be34d871fc0209f9ae2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cu-e34d9f68a7a7435681cf9cf08dd71af71bfab91d38756077f819d71403d18d50.json
+++ b/openfisca_france/tests/json/f7cu-e34d9f68a7a7435681cf9cf08dd71af71bfab91d38756077f819d71403d18d50.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7cu-e3a8cc022a1e5805fe9c1f56a3cdbc9fe71122adcc0821cf7b73be92e39c5f7d.json
+++ b/openfisca_france/tests/json/f7cu-e3a8cc022a1e5805fe9c1f56a3cdbc9fe71122adcc0821cf7b73be92e39c5f7d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7db-160fefe87f6cb0e500f47351fe72e1ec6ce7eab57803a24727c67ba72a992546.json
+++ b/openfisca_france/tests/json/f7db-160fefe87f6cb0e500f47351fe72e1ec6ce7eab57803a24727c67ba72a992546.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7db-190d5ea08a9c774d44c8689fa87eaea1d5a653bd0ff76394ccf28d71588f3114.json
+++ b/openfisca_france/tests/json/f7db-190d5ea08a9c774d44c8689fa87eaea1d5a653bd0ff76394ccf28d71588f3114.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7db-221e101e31d567ce9b8c9007ac2b683aea05a264185947ae5c79b212b94dcef0.json
+++ b/openfisca_france/tests/json/f7db-221e101e31d567ce9b8c9007ac2b683aea05a264185947ae5c79b212b94dcef0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7db-38244ce0fab1daeae2a1485a3c77f91c6659f4b2dac3ca7b248573851cf8eb99.json
+++ b/openfisca_france/tests/json/f7db-38244ce0fab1daeae2a1485a3c77f91c6659f4b2dac3ca7b248573851cf8eb99.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7db-38c9eea866ee3dfd783a07d1a9421db958abeaa68d6ad6dbb4625acc3a6f0405.json
+++ b/openfisca_france/tests/json/f7db-38c9eea866ee3dfd783a07d1a9421db958abeaa68d6ad6dbb4625acc3a6f0405.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7db-5c89eb8c4e8cf7e052551f366245ffd0f1bb85591613561623950684c00a6858.json
+++ b/openfisca_france/tests/json/f7db-5c89eb8c4e8cf7e052551f366245ffd0f1bb85591613561623950684c00a6858.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7db-ad30c57d3f2ef5b3418e196e0e58dd6a9c0a3464fba8ae7e316b623fe468bec4.json
+++ b/openfisca_france/tests/json/f7db-ad30c57d3f2ef5b3418e196e0e58dd6a9c0a3464fba8ae7e316b623fe468bec4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7db-afd432816ed8d92571d80478d858b9b868c2d4584ebf35573d280f2316d81552.json
+++ b/openfisca_france/tests/json/f7db-afd432816ed8d92571d80478d858b9b868c2d4584ebf35573d280f2316d81552.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7db-c0a84e0e66fcfc3da4d23fdd8ffc75185ea6158b5a04da31b18fbd420bde6221.json
+++ b/openfisca_france/tests/json/f7db-c0a84e0e66fcfc3da4d23fdd8ffc75185ea6158b5a04da31b18fbd420bde6221.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7df-08349e2acaa089d92ca3291ae56034e7cff7bfe107dcbb7c8befc0fb14e9cc95.json
+++ b/openfisca_france/tests/json/f7df-08349e2acaa089d92ca3291ae56034e7cff7bfe107dcbb7c8befc0fb14e9cc95.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7df-088b5fe12f4b1ddd19b20984dd47609ca9c0187c4e28a758b0d107133293946d.json
+++ b/openfisca_france/tests/json/f7df-088b5fe12f4b1ddd19b20984dd47609ca9c0187c4e28a758b0d107133293946d.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7df-11e03fb37b6927e24512a61811ecffe0386fd645dce5ae584fe609d46a0d34e7.json
+++ b/openfisca_france/tests/json/f7df-11e03fb37b6927e24512a61811ecffe0386fd645dce5ae584fe609d46a0d34e7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7df-273cf27ee05286692840116423bf58417eda48afd6ed818c02aaca1b0e4a8c30.json
+++ b/openfisca_france/tests/json/f7df-273cf27ee05286692840116423bf58417eda48afd6ed818c02aaca1b0e4a8c30.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7df-86b205d8e65feb9ba1102d901b14eb2a72ba7a87bf8753849ae155fa1b1356f8.json
+++ b/openfisca_france/tests/json/f7df-86b205d8e65feb9ba1102d901b14eb2a72ba7a87bf8753849ae155fa1b1356f8.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7df-8fd64cd4669efc7b2d4853ea070dbdbdb7f7fee650a8c2495a7831423fe17e6c.json
+++ b/openfisca_france/tests/json/f7df-8fd64cd4669efc7b2d4853ea070dbdbdb7f7fee650a8c2495a7831423fe17e6c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7df-e8912c671f49656cd9f2d18a7bf76faf648bdda3cf7bc334217f2b9fd0261ffc.json
+++ b/openfisca_france/tests/json/f7df-e8912c671f49656cd9f2d18a7bf76faf648bdda3cf7bc334217f2b9fd0261ffc.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7df-eb2c769fb679aa489998cf8b2b2371324859f5c9b82f1a134b6d070970f853ff.json
+++ b/openfisca_france/tests/json/f7df-eb2c769fb679aa489998cf8b2b2371324859f5c9b82f1a134b6d070970f853ff.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7df-fc99889687de9a81742c9b73bf8bd8a0865e5a014eb7f1cf755ca24cd1724976.json
+++ b/openfisca_france/tests/json/f7df-fc99889687de9a81742c9b73bf8bd8a0865e5a014eb7f1cf755ca24cd1724976.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7dq-00cfb95b6f2a8aad39eb9750c1070597176c9bd09336d13ea0ea2c5459a596c4.json
+++ b/openfisca_france/tests/json/f7dq-00cfb95b6f2a8aad39eb9750c1070597176c9bd09336d13ea0ea2c5459a596c4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7dq-401658967fd7b032a3487ded2cf0eeab57b2cf5a378561470a3c04baef81cc05.json
+++ b/openfisca_france/tests/json/f7dq-401658967fd7b032a3487ded2cf0eeab57b2cf5a378561470a3c04baef81cc05.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7dq-e42462efc5ae3559ed3038d550a3a3346f0222a6359b1147f2c93417fc7f5f09.json
+++ b/openfisca_france/tests/json/f7dq-e42462efc5ae3559ed3038d550a3a3346f0222a6359b1147f2c93417fc7f5f09.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7dq-efdc607c9f5a373a14b25dedaca8aa752ed51280d3fc0cbb8e26268892000279.json
+++ b/openfisca_france/tests/json/f7dq-efdc607c9f5a373a14b25dedaca8aa752ed51280d3fc0cbb8e26268892000279.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fa-5dbcbecefeb0723fe5c41bdea62c3fb6559c925b4498a0f96f86aa4917dc1a29.json
+++ b/openfisca_france/tests/json/f7fa-5dbcbecefeb0723fe5c41bdea62c3fb6559c925b4498a0f96f86aa4917dc1a29.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fa-9b2999f0a2d3b3532a2b2695305ac2495c6e1b6e682e1cd938ac584703d2ed48.json
+++ b/openfisca_france/tests/json/f7fa-9b2999f0a2d3b3532a2b2695305ac2495c6e1b6e682e1cd938ac584703d2ed48.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fa-a1346104b76d778af9767300c5c83014a1f33882b73640ba90f264ece374d2da.json
+++ b/openfisca_france/tests/json/f7fa-a1346104b76d778af9767300c5c83014a1f33882b73640ba90f264ece374d2da.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fa-b7f5dc1856305c3908077f448dceca8dfb4c384a2bbb8010c25d3c8dd026b2ef.json
+++ b/openfisca_france/tests/json/f7fa-b7f5dc1856305c3908077f448dceca8dfb4c384a2bbb8010c25d3c8dd026b2ef.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fa-bb04e4782a9e1b486823bf8947b812e0ab99d86d2b01d08b4d9a290eaff87fda.json
+++ b/openfisca_france/tests/json/f7fa-bb04e4782a9e1b486823bf8947b812e0ab99d86d2b01d08b4d9a290eaff87fda.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fa-c378ce27129e90d46411a882eeff7dd50ed182471da5e0eb7ea55af10b703801.json
+++ b/openfisca_france/tests/json/f7fa-c378ce27129e90d46411a882eeff7dd50ed182471da5e0eb7ea55af10b703801.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fa-cd46abbb19118b13ba2cdf738aa9edc65b1aa6ea4b1e68d3fe80ba6e7a53698d.json
+++ b/openfisca_france/tests/json/f7fa-cd46abbb19118b13ba2cdf738aa9edc65b1aa6ea4b1e68d3fe80ba6e7a53698d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fa-d1967449355105620eb85cfff83be23ef0ab2ad7960a7a0b33f161be3ff7ae97.json
+++ b/openfisca_france/tests/json/f7fa-d1967449355105620eb85cfff83be23ef0ab2ad7960a7a0b33f161be3ff7ae97.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fa-f9a976e287e40adff83482328162a7d6d546a80f687145a58cc2b2d770975019.json
+++ b/openfisca_france/tests/json/f7fa-f9a976e287e40adff83482328162a7d6d546a80f687145a58cc2b2d770975019.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fb-1df2f3198e3a0a280b20ce1f86bb1f9bcbd416763a1947e47069d6b106c9de63.json
+++ b/openfisca_france/tests/json/f7fb-1df2f3198e3a0a280b20ce1f86bb1f9bcbd416763a1947e47069d6b106c9de63.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fb-4e1ff63488a5ff5405e53912aa89b821173ce24d30e30c061c5d929cab93e85c.json
+++ b/openfisca_france/tests/json/f7fb-4e1ff63488a5ff5405e53912aa89b821173ce24d30e30c061c5d929cab93e85c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fb-653320c290792d3362630a70a5ad009b621c5497d02e51651b3683dff5678d3f.json
+++ b/openfisca_france/tests/json/f7fb-653320c290792d3362630a70a5ad009b621c5497d02e51651b3683dff5678d3f.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fb-82c91898e66be9c9a762c0f292e153710a54c06de347c272b6c00def53465e31.json
+++ b/openfisca_france/tests/json/f7fb-82c91898e66be9c9a762c0f292e153710a54c06de347c272b6c00def53465e31.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fb-bab8dfa6c1ca420d40a49a43b73276fe9b9348c98f81b3f992a086595d9f4bfa.json
+++ b/openfisca_france/tests/json/f7fb-bab8dfa6c1ca420d40a49a43b73276fe9b9348c98f81b3f992a086595d9f4bfa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fb-d9507ecd5bb27741f5d2f9636b4a17de28bac540ffe93945e731bf9c4e74a932.json
+++ b/openfisca_france/tests/json/f7fb-d9507ecd5bb27741f5d2f9636b4a17de28bac540ffe93945e731bf9c4e74a932.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fb-f2bd0ece55f68aecae32b6bfb36898919542dc924962c980319a89995e944f07.json
+++ b/openfisca_france/tests/json/f7fb-f2bd0ece55f68aecae32b6bfb36898919542dc924962c980319a89995e944f07.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fb-f4c6fd28eb752d60115f7daa10cea1ea000c61af2ffc874d7176aef2b9808510.json
+++ b/openfisca_france/tests/json/f7fb-f4c6fd28eb752d60115f7daa10cea1ea000c61af2ffc874d7176aef2b9808510.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fb-faeb86e60c8a8fc96c8b9b5aa5a7fbbb39a8d1fa2485620f136329009b779553.json
+++ b/openfisca_france/tests/json/f7fb-faeb86e60c8a8fc96c8b9b5aa5a7fbbb39a8d1fa2485620f136329009b779553.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fc-1f82ef36167bb32971b5ba93fd446639c88244f416fa618c1f6b4d9b27b54bd3.json
+++ b/openfisca_france/tests/json/f7fc-1f82ef36167bb32971b5ba93fd446639c88244f416fa618c1f6b4d9b27b54bd3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fc-30c716b6f24f0819cf5fd1f8d98625db3b61f545e0ceb4ee18d6ed4056434827.json
+++ b/openfisca_france/tests/json/f7fc-30c716b6f24f0819cf5fd1f8d98625db3b61f545e0ceb4ee18d6ed4056434827.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fc-3c472aa68171980cc47b2231bca6ea17a0901a99f3f7d9edb0d547f3311a0ddc.json
+++ b/openfisca_france/tests/json/f7fc-3c472aa68171980cc47b2231bca6ea17a0901a99f3f7d9edb0d547f3311a0ddc.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fc-4739ae5b312708705bc3f4d3361329c6eb1d5c3d6a2be29465fa592f9240f448.json
+++ b/openfisca_france/tests/json/f7fc-4739ae5b312708705bc3f4d3361329c6eb1d5c3d6a2be29465fa592f9240f448.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fc-58c7b0e2ff2065b4a5fb30909fe38ce2b1ee19ede01166c8e6245c15360adf92.json
+++ b/openfisca_france/tests/json/f7fc-58c7b0e2ff2065b4a5fb30909fe38ce2b1ee19ede01166c8e6245c15360adf92.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fc-8a8b789e5e41020f95236bf88c765e996fbb93f590283ce679f8a9134cb6731f.json
+++ b/openfisca_france/tests/json/f7fc-8a8b789e5e41020f95236bf88c765e996fbb93f590283ce679f8a9134cb6731f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fc-ba369505e7460f29635646eadce0dd40ad3aac45e0e30822a477fb24e84854a7.json
+++ b/openfisca_france/tests/json/f7fc-ba369505e7460f29635646eadce0dd40ad3aac45e0e30822a477fb24e84854a7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fc-d8fedafed62253b38df0a694f76e57e79154dc129e9fd97f972512e7dc77eda5.json
+++ b/openfisca_france/tests/json/f7fc-d8fedafed62253b38df0a694f76e57e79154dc129e9fd97f972512e7dc77eda5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fc-e1df2516b5f9a45cb19c42c94ad894ba0daa5d67bcdd1ead39835862390db4e4.json
+++ b/openfisca_france/tests/json/f7fc-e1df2516b5f9a45cb19c42c94ad894ba0daa5d67bcdd1ead39835862390db4e4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fd-1be505748258952d7df8ed69bc1d42cc34ca87952bfa3c48bbdcb7ddb693d8bc.json
+++ b/openfisca_france/tests/json/f7fd-1be505748258952d7df8ed69bc1d42cc34ca87952bfa3c48bbdcb7ddb693d8bc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fd-471216d2475f1e1b5c365d14793f3ddb2c187cac486e7f2ced9786b8aac7be38.json
+++ b/openfisca_france/tests/json/f7fd-471216d2475f1e1b5c365d14793f3ddb2c187cac486e7f2ced9786b8aac7be38.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fd-7d40faf944d2c4d2593991e8f1b7dc4492f6d577b324fd4bce80c1a5e4bbbd76.json
+++ b/openfisca_france/tests/json/f7fd-7d40faf944d2c4d2593991e8f1b7dc4492f6d577b324fd4bce80c1a5e4bbbd76.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fd-98fc154af8262c3facd437e8bf713b4f59b6c9a155fdb7d2699e704e4a2edb73.json
+++ b/openfisca_france/tests/json/f7fd-98fc154af8262c3facd437e8bf713b4f59b6c9a155fdb7d2699e704e4a2edb73.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fd-993a50676d1d79569ecb918b58accbf9cba6a315cdf9c580baf25f234c13fdfc.json
+++ b/openfisca_france/tests/json/f7fd-993a50676d1d79569ecb918b58accbf9cba6a315cdf9c580baf25f234c13fdfc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fd-9dcd97995e9a521801bd494c9b835cabfb94c59061eed4da54ff94057534970a.json
+++ b/openfisca_france/tests/json/f7fd-9dcd97995e9a521801bd494c9b835cabfb94c59061eed4da54ff94057534970a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fd-ac0dee51fd6376c270799f726e52b3193642cea80344d92450790b8ba51838dc.json
+++ b/openfisca_france/tests/json/f7fd-ac0dee51fd6376c270799f726e52b3193642cea80344d92450790b8ba51838dc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fd-cf503e06d50f400b357c3889467cc7cfa5afdf231ade13fdf946e8a5b864386f.json
+++ b/openfisca_france/tests/json/f7fd-cf503e06d50f400b357c3889467cc7cfa5afdf231ade13fdf946e8a5b864386f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fd-f425ab9782b2a30271eb72b5523de4d5c4be4e38c405648a8b3b7f0a30ca4380.json
+++ b/openfisca_france/tests/json/f7fd-f425ab9782b2a30271eb72b5523de4d5c4be4e38c405648a8b3b7f0a30ca4380.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fh-0d6745625d67df25de63d8de45ce45dffbb12ac431d2f8ffcb104055cd27a6e7.json
+++ b/openfisca_france/tests/json/f7fh-0d6745625d67df25de63d8de45ce45dffbb12ac431d2f8ffcb104055cd27a6e7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fh-177f88d56ac24f5a547e1c7cc18bb73dfaf149a3d03c9008fda6e1de26086298.json
+++ b/openfisca_france/tests/json/f7fh-177f88d56ac24f5a547e1c7cc18bb73dfaf149a3d03c9008fda6e1de26086298.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fh-38449dedf0912f30828a7d29285d9ccd34c3604cc9111c8b6e0067f63f70eb08.json
+++ b/openfisca_france/tests/json/f7fh-38449dedf0912f30828a7d29285d9ccd34c3604cc9111c8b6e0067f63f70eb08.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fh-3f179da8aacce7f1b278e7c869c92459846e90c1c39cb75000ea33d636b00428.json
+++ b/openfisca_france/tests/json/f7fh-3f179da8aacce7f1b278e7c869c92459846e90c1c39cb75000ea33d636b00428.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fh-69231376f9b65b46c3297dade4291149265ccc22df57c4489845318de8a44689.json
+++ b/openfisca_france/tests/json/f7fh-69231376f9b65b46c3297dade4291149265ccc22df57c4489845318de8a44689.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fh-826f1bba26dfd84d33af3ad843489eeedaa0ce36ceaaaa7c6fb5d5848f71638e.json
+++ b/openfisca_france/tests/json/f7fh-826f1bba26dfd84d33af3ad843489eeedaa0ce36ceaaaa7c6fb5d5848f71638e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fh-910d043680f6e9d6028163f16238901c2da7200f42fb4fb5ed5db464fe7bb5bb.json
+++ b/openfisca_france/tests/json/f7fh-910d043680f6e9d6028163f16238901c2da7200f42fb4fb5ed5db464fe7bb5bb.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fh-defc06d71fcdc7964c09892c4632ae630ffbd536fde404c68feb33680b1cb972.json
+++ b/openfisca_france/tests/json/f7fh-defc06d71fcdc7964c09892c4632ae630ffbd536fde404c68feb33680b1cb972.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fh-f1217104a8024621c8764d15006038222901365792c636456e6e1d05797b97e7.json
+++ b/openfisca_france/tests/json/f7fh-f1217104a8024621c8764d15006038222901365792c636456e6e1d05797b97e7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fl-4fd4db4f5ee96d4d91e9d252569030bf6a97d41da773f5c3fd67f3bd601460df.json
+++ b/openfisca_france/tests/json/f7fl-4fd4db4f5ee96d4d91e9d252569030bf6a97d41da773f5c3fd67f3bd601460df.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fl-64a352386a88bb5e5002f3e32b57123341d8664a7cefc59d31f69017a0c9b4ca.json
+++ b/openfisca_france/tests/json/f7fl-64a352386a88bb5e5002f3e32b57123341d8664a7cefc59d31f69017a0c9b4ca.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fl-66b481972932616807bf706695f4db71c5b5bf922abfacc30bf126d29f2d9e96.json
+++ b/openfisca_france/tests/json/f7fl-66b481972932616807bf706695f4db71c5b5bf922abfacc30bf126d29f2d9e96.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fl-7566e3a3ed12672e339d6575156668f5234f48f73fe363bb488031f82ec2099d.json
+++ b/openfisca_france/tests/json/f7fl-7566e3a3ed12672e339d6575156668f5234f48f73fe363bb488031f82ec2099d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fl-9b8953d42299315488c548d2f569ed418b70cc8119b64c318e5f7e659cae7615.json
+++ b/openfisca_france/tests/json/f7fl-9b8953d42299315488c548d2f569ed418b70cc8119b64c318e5f7e659cae7615.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fl-c97c1129544771628bfdcfaee2366a547b577d5ac5ba286a55752c7acb36f576.json
+++ b/openfisca_france/tests/json/f7fl-c97c1129544771628bfdcfaee2366a547b577d5ac5ba286a55752c7acb36f576.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fm-102228c5d2bd9dc66c33b9d28f7cf4b6a18af213b4e9ea4ed20eac1533f20f60.json
+++ b/openfisca_france/tests/json/f7fm-102228c5d2bd9dc66c33b9d28f7cf4b6a18af213b4e9ea4ed20eac1533f20f60.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fm-2c28e9df513d846de17c64b8eb426843bb0e1f384526604ce9aef604aaf17e5e.json
+++ b/openfisca_france/tests/json/f7fm-2c28e9df513d846de17c64b8eb426843bb0e1f384526604ce9aef604aaf17e5e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fm-39b7c3ccc8f0af757239c713dfbb0cb0c357fb74b346e98487a5580ee626a09a.json
+++ b/openfisca_france/tests/json/f7fm-39b7c3ccc8f0af757239c713dfbb0cb0c357fb74b346e98487a5580ee626a09a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fm-8998fd70b92284b8f2470bc67eced981f6142d5fb3a5dd8089924583d75c25e2.json
+++ b/openfisca_france/tests/json/f7fm-8998fd70b92284b8f2470bc67eced981f6142d5fb3a5dd8089924583d75c25e2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fm-8ed4e1bfcfff12f42882c6ce68bf9f4195278a0853412817959028be0656fe8a.json
+++ b/openfisca_france/tests/json/f7fm-8ed4e1bfcfff12f42882c6ce68bf9f4195278a0853412817959028be0656fe8a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fm-a469aa2df2999d307e746f315a03c75cf442d9636ce0d28768c3773ad968da8e.json
+++ b/openfisca_france/tests/json/f7fm-a469aa2df2999d307e746f315a03c75cf442d9636ce0d28768c3773ad968da8e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fm-e8516c7afd4f3a09c99da913b036d3a7b905e32ebfb5bc5483147b4938e0d797.json
+++ b/openfisca_france/tests/json/f7fm-e8516c7afd4f3a09c99da913b036d3a7b905e32ebfb5bc5483147b4938e0d797.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fm-f7819e1f13d92154ccb70e1871c63686574410c40bcd3aba08cdc00397929fd5.json
+++ b/openfisca_france/tests/json/f7fm-f7819e1f13d92154ccb70e1871c63686574410c40bcd3aba08cdc00397929fd5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fm-fbb1e375390d5fbe84cc6912ea2fdd02de7d2f6fc54859f26d5c5bbea17a685f.json
+++ b/openfisca_france/tests/json/f7fm-fbb1e375390d5fbe84cc6912ea2fdd02de7d2f6fc54859f26d5c5bbea17a685f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fn-3553b7342b1e158a307bcb742517587616420c0f1dd92156d7396cb9c17f35f5.json
+++ b/openfisca_france/tests/json/f7fn-3553b7342b1e158a307bcb742517587616420c0f1dd92156d7396cb9c17f35f5.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fn-40b976ad651b88388da58db2a8f96a802cff9ede494df7e419650124d5c59ca2.json
+++ b/openfisca_france/tests/json/f7fn-40b976ad651b88388da58db2a8f96a802cff9ede494df7e419650124d5c59ca2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fn-51078adf6fe51a0ae7d0bc841cf9274634eda1167e3865ab21434d2fcc914a4a.json
+++ b/openfisca_france/tests/json/f7fn-51078adf6fe51a0ae7d0bc841cf9274634eda1167e3865ab21434d2fcc914a4a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fn-6f383218a770e4c688368c2d88848fd73f94ef5e316694b6c1776c50c38f97d2.json
+++ b/openfisca_france/tests/json/f7fn-6f383218a770e4c688368c2d88848fd73f94ef5e316694b6c1776c50c38f97d2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fn-8bcef43eb4601509cd0ed7c2eeaf1271da5dbcdd84598b4cf380088f7e95e080.json
+++ b/openfisca_france/tests/json/f7fn-8bcef43eb4601509cd0ed7c2eeaf1271da5dbcdd84598b4cf380088f7e95e080.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fn-8ea665836aceb30a001002a305476175641090d1d5edaaee3486b12b5fc501fb.json
+++ b/openfisca_france/tests/json/f7fn-8ea665836aceb30a001002a305476175641090d1d5edaaee3486b12b5fc501fb.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fn-98701d08f0c335d1a61ef403385bbfeb95b781f6e2ba65aa5820b3340b33e98b.json
+++ b/openfisca_france/tests/json/f7fn-98701d08f0c335d1a61ef403385bbfeb95b781f6e2ba65aa5820b3340b33e98b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fn-c5b3828be18c08c3b8b508f6332c09d64fe7e78e56b076b2cfd175a6232553b3.json
+++ b/openfisca_france/tests/json/f7fn-c5b3828be18c08c3b8b508f6332c09d64fe7e78e56b076b2cfd175a6232553b3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fn-eca6e734bd4a12314a3dc230315b87f113083f42e9c5e732dcfb1f96fe01f996.json
+++ b/openfisca_france/tests/json/f7fn-eca6e734bd4a12314a3dc230315b87f113083f42e9c5e732dcfb1f96fe01f996.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fq-093e588d5d59c878dbbd8381211910b3997c6c675f55c2a1156ab49555fc39bb.json
+++ b/openfisca_france/tests/json/f7fq-093e588d5d59c878dbbd8381211910b3997c6c675f55c2a1156ab49555fc39bb.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fq-0e557cc4601b91b2f4a135945ea0fc5ef238a7a327ad9b8a8457612888a7310f.json
+++ b/openfisca_france/tests/json/f7fq-0e557cc4601b91b2f4a135945ea0fc5ef238a7a327ad9b8a8457612888a7310f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fq-171fd84a27fa12263e2ac45a5f8e912c77e1264ed4a4610add93fea8221809dc.json
+++ b/openfisca_france/tests/json/f7fq-171fd84a27fa12263e2ac45a5f8e912c77e1264ed4a4610add93fea8221809dc.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fq-18f90f1a24686eebbef3902c5085013173d425afaa03415c5250689fdff9f556.json
+++ b/openfisca_france/tests/json/f7fq-18f90f1a24686eebbef3902c5085013173d425afaa03415c5250689fdff9f556.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fq-30e0e751ba875907d1b87f2c9d974083e17eb2db1c656744f8ba895e327a1e64.json
+++ b/openfisca_france/tests/json/f7fq-30e0e751ba875907d1b87f2c9d974083e17eb2db1c656744f8ba895e327a1e64.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fq-55729ab58a54539212f6e94b0e289a6b0e4cd9477f89796f9aae6203326907d9.json
+++ b/openfisca_france/tests/json/f7fq-55729ab58a54539212f6e94b0e289a6b0e4cd9477f89796f9aae6203326907d9.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fq-5b64f62a9c3587f02e52e5375f2ddffdef3bd49bd1ad87ae24a2ddb4bbe419f4.json
+++ b/openfisca_france/tests/json/f7fq-5b64f62a9c3587f02e52e5375f2ddffdef3bd49bd1ad87ae24a2ddb4bbe419f4.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fq-820aca06c6925b137179be88550c26ae9048430c9ad3046e2e0bb5a039b37feb.json
+++ b/openfisca_france/tests/json/f7fq-820aca06c6925b137179be88550c26ae9048430c9ad3046e2e0bb5a039b37feb.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fq-f68106357ff54448580af2f8e3a88b530f21ef7a81b8fa83b86f441c78025ea2.json
+++ b/openfisca_france/tests/json/f7fq-f68106357ff54448580af2f8e3a88b530f21ef7a81b8fa83b86f441c78025ea2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7fy-77161e1981752eb995da4ac0808e1d560cbe47c4f8846132bf6d1f9306cf3ee9.json
+++ b/openfisca_france/tests/json/f7fy-77161e1981752eb995da4ac0808e1d560cbe47c4f8846132bf6d1f9306cf3ee9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ga-05635cf7e97cead3fc03a2ac247f6554f8a8972457f2c6b917637808819c0761.json
+++ b/openfisca_france/tests/json/f7ga-05635cf7e97cead3fc03a2ac247f6554f8a8972457f2c6b917637808819c0761.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ga-57b0cc2b2f85d49eff7cc41fca73a3d7d9571ee7ee3d6ba83ef5678429d66732.json
+++ b/openfisca_france/tests/json/f7ga-57b0cc2b2f85d49eff7cc41fca73a3d7d9571ee7ee3d6ba83ef5678429d66732.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ga-59bd3d5b8434924cde180807b734a88c78fc68def657f160c8c33b2522e2b4d7.json
+++ b/openfisca_france/tests/json/f7ga-59bd3d5b8434924cde180807b734a88c78fc68def657f160c8c33b2522e2b4d7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ga-5e9240e2ceab1d2a6305058a800938defb6b6ce02ac528bd3265a40b3730bbde.json
+++ b/openfisca_france/tests/json/f7ga-5e9240e2ceab1d2a6305058a800938defb6b6ce02ac528bd3265a40b3730bbde.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ga-850fc58264ac8348fda9c7f8b1feb000c0267b442812c339f75209fea7ebfe0e.json
+++ b/openfisca_france/tests/json/f7ga-850fc58264ac8348fda9c7f8b1feb000c0267b442812c339f75209fea7ebfe0e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ga-9f0e05607f9c2fb8ad474c38d65be64df6df18a58f2d1640c13e3d884d96cfa2.json
+++ b/openfisca_france/tests/json/f7ga-9f0e05607f9c2fb8ad474c38d65be64df6df18a58f2d1640c13e3d884d96cfa2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ga-a9ea0e9669edccd482001ffe5a424704ed4726674c2be2ea1f7f22b775539809.json
+++ b/openfisca_france/tests/json/f7ga-a9ea0e9669edccd482001ffe5a424704ed4726674c2be2ea1f7f22b775539809.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ga-de087fab1412d47b65db73f16d0bc29310379685b151db8f1e80dc671be1d492.json
+++ b/openfisca_france/tests/json/f7ga-de087fab1412d47b65db73f16d0bc29310379685b151db8f1e80dc671be1d492.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ga-e112c163e5ed2a9cc6676badcfccb9ba3db49e6dcb48fa34d8f8d09dc27410f2.json
+++ b/openfisca_france/tests/json/f7ga-e112c163e5ed2a9cc6676badcfccb9ba3db49e6dcb48fa34d8f8d09dc27410f2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gb-0f4ecb9565d07158a528f8f48edc8b9a8ada8f362511787447b81bd95b58842f.json
+++ b/openfisca_france/tests/json/f7gb-0f4ecb9565d07158a528f8f48edc8b9a8ada8f362511787447b81bd95b58842f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gb-2b26ada78a2f8e2b3238544a170ad107be17e8ea464dba66804729a3ea43959c.json
+++ b/openfisca_france/tests/json/f7gb-2b26ada78a2f8e2b3238544a170ad107be17e8ea464dba66804729a3ea43959c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gb-7f3f80f78c2cd0670e8cc2264f666b05d0c67bc6160a0ce2e0a034b4680df0d0.json
+++ b/openfisca_france/tests/json/f7gb-7f3f80f78c2cd0670e8cc2264f666b05d0c67bc6160a0ce2e0a034b4680df0d0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gb-8990fced9bd253dabf43bfec4a48cb67c9152f215852c4d320a334b081f37bf8.json
+++ b/openfisca_france/tests/json/f7gb-8990fced9bd253dabf43bfec4a48cb67c9152f215852c4d320a334b081f37bf8.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gb-89a1a9466e0a5b4698c05a3cd0b9cca4eff18ebec9e0b98bfcf8327196aa5e2a.json
+++ b/openfisca_france/tests/json/f7gb-89a1a9466e0a5b4698c05a3cd0b9cca4eff18ebec9e0b98bfcf8327196aa5e2a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gb-a0c8fd54a8ac19deceff33beb1db930198db68b88266743340609f41efa84086.json
+++ b/openfisca_france/tests/json/f7gb-a0c8fd54a8ac19deceff33beb1db930198db68b88266743340609f41efa84086.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gb-b9f8b6f955c89ebdc56461f94fb6f0082749813bf15aa76a89663d611e1e2f19.json
+++ b/openfisca_france/tests/json/f7gb-b9f8b6f955c89ebdc56461f94fb6f0082749813bf15aa76a89663d611e1e2f19.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gb-e6cc358e15337f3e5c6899ec610f6b8feae773eda1c3f354263440a1d940b9c6.json
+++ b/openfisca_france/tests/json/f7gb-e6cc358e15337f3e5c6899ec610f6b8feae773eda1c3f354263440a1d940b9c6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gb-fab73416fa51d4357a92c3c7f2706b1811693cb8f56724602b7665e3c2bd8685.json
+++ b/openfisca_france/tests/json/f7gb-fab73416fa51d4357a92c3c7f2706b1811693cb8f56724602b7665e3c2bd8685.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gc-3078321e7480f1c06f6b0eb61bd55b513aa975b9fa4d434b93bc70eb320cf6f4.json
+++ b/openfisca_france/tests/json/f7gc-3078321e7480f1c06f6b0eb61bd55b513aa975b9fa4d434b93bc70eb320cf6f4.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gc-3f31ae5d9c3ceebc509c86f7d8250aad52a9549c15ff2bae50f7a1689a8ad230.json
+++ b/openfisca_france/tests/json/f7gc-3f31ae5d9c3ceebc509c86f7d8250aad52a9549c15ff2bae50f7a1689a8ad230.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gc-5e402a69590a1f740550199765b99825dd8ac7e6dea80c799e0d803bdc620e3b.json
+++ b/openfisca_france/tests/json/f7gc-5e402a69590a1f740550199765b99825dd8ac7e6dea80c799e0d803bdc620e3b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gc-8605f95564a258ce6062ea1b40fc63a1917abe84f770c734bb94d54dbfe93517.json
+++ b/openfisca_france/tests/json/f7gc-8605f95564a258ce6062ea1b40fc63a1917abe84f770c734bb94d54dbfe93517.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gc-86d91276d6499c27d5443a087700b213289c3a7b63a8fea90cec6ef2a4dc15d8.json
+++ b/openfisca_france/tests/json/f7gc-86d91276d6499c27d5443a087700b213289c3a7b63a8fea90cec6ef2a4dc15d8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gc-8efda31a4fceb82c013d9f71bda7bb60f457e39acf14ab24f556316e41197dd5.json
+++ b/openfisca_france/tests/json/f7gc-8efda31a4fceb82c013d9f71bda7bb60f457e39acf14ab24f556316e41197dd5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gc-b97bd75a5b746c6f872244da3e11653df51002c376ee670760a8a5a5847e79b4.json
+++ b/openfisca_france/tests/json/f7gc-b97bd75a5b746c6f872244da3e11653df51002c376ee670760a8a5a5847e79b4.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gc-d3a522619c1fbc85e87580dcb4b155c9743133e61514247b2502faf1350721ed.json
+++ b/openfisca_france/tests/json/f7gc-d3a522619c1fbc85e87580dcb4b155c9743133e61514247b2502faf1350721ed.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gc-fe39a175c8eebd1ac7c6c1808b1d2b9ca1ca7cd999e08b4aaa03ca3ba14f3fc3.json
+++ b/openfisca_france/tests/json/f7gc-fe39a175c8eebd1ac7c6c1808b1d2b9ca1ca7cd999e08b4aaa03ca3ba14f3fc3.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ge-09ecd44f1ae05f73ad48125ee16fe3efa5588fb65472acbb50c4f278e6888910.json
+++ b/openfisca_france/tests/json/f7ge-09ecd44f1ae05f73ad48125ee16fe3efa5588fb65472acbb50c4f278e6888910.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ge-2981a0b39a79c93d682498f086f1f97ecfe6d50e6d212780ba42fa384520e6fa.json
+++ b/openfisca_france/tests/json/f7ge-2981a0b39a79c93d682498f086f1f97ecfe6d50e6d212780ba42fa384520e6fa.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ge-46374c3dbb0da3a6a4417ae254b9c504d7b8775e60af4509b5bd9879eb0ebed9.json
+++ b/openfisca_france/tests/json/f7ge-46374c3dbb0da3a6a4417ae254b9c504d7b8775e60af4509b5bd9879eb0ebed9.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ge-6a3351b74531a4d1f0be10bb5189640e7acf6fbd42b39de9ab39cca0578b19c0.json
+++ b/openfisca_france/tests/json/f7ge-6a3351b74531a4d1f0be10bb5189640e7acf6fbd42b39de9ab39cca0578b19c0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ge-7f268a9d341ba9546196acca09282123249a4b4c04db1d1166bc963bd0ad8c44.json
+++ b/openfisca_france/tests/json/f7ge-7f268a9d341ba9546196acca09282123249a4b4c04db1d1166bc963bd0ad8c44.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ge-aab46ae03a5a5c322d2d8b49618768ad17616fe64a38c743801a62f5d627647b.json
+++ b/openfisca_france/tests/json/f7ge-aab46ae03a5a5c322d2d8b49618768ad17616fe64a38c743801a62f5d627647b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ge-b12eea81c3131efcb8294e02cc2e4da1645cc706629f38e03381eeb45fa1408b.json
+++ b/openfisca_france/tests/json/f7ge-b12eea81c3131efcb8294e02cc2e4da1645cc706629f38e03381eeb45fa1408b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ge-b9753d32f49a351467cd7166b4668ead8439b7551d9d8a1ff9b1e4ffb0abd784.json
+++ b/openfisca_france/tests/json/f7ge-b9753d32f49a351467cd7166b4668ead8439b7551d9d8a1ff9b1e4ffb0abd784.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ge-f3bd2ac54fbc98154c017b3b7bc1d128b3a2c1ff13683428f229402ffac7d806.json
+++ b/openfisca_france/tests/json/f7ge-f3bd2ac54fbc98154c017b3b7bc1d128b3a2c1ff13683428f229402ffac7d806.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gf-17fdc59ece3ef089eb3025b72c4b971315dca03afd00b644ef2bed1c888c0531.json
+++ b/openfisca_france/tests/json/f7gf-17fdc59ece3ef089eb3025b72c4b971315dca03afd00b644ef2bed1c888c0531.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gf-2f91a687f10f88bbf479ab3c6198f1204aec3cd6fc58a5f1ec2c00d323e294a6.json
+++ b/openfisca_france/tests/json/f7gf-2f91a687f10f88bbf479ab3c6198f1204aec3cd6fc58a5f1ec2c00d323e294a6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gf-376d1b47992b4e63b623e33ab7f4e990829a6fcb729156dcb2fc2a7c50710b17.json
+++ b/openfisca_france/tests/json/f7gf-376d1b47992b4e63b623e33ab7f4e990829a6fcb729156dcb2fc2a7c50710b17.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gf-6e35a1206ae7189e1f0e9b687b54e1c7b465fc698e77c124e6ed1d33cbce8599.json
+++ b/openfisca_france/tests/json/f7gf-6e35a1206ae7189e1f0e9b687b54e1c7b465fc698e77c124e6ed1d33cbce8599.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gf-6fcfbecfcb2a22101338d63a113360b6fdfb9ab186acf121f52b76c6056ae14c.json
+++ b/openfisca_france/tests/json/f7gf-6fcfbecfcb2a22101338d63a113360b6fdfb9ab186acf121f52b76c6056ae14c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gf-7e74129826d415d7d9c68d160d66f12315e4842ef51335e53897a5abeb2da0a6.json
+++ b/openfisca_france/tests/json/f7gf-7e74129826d415d7d9c68d160d66f12315e4842ef51335e53897a5abeb2da0a6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gf-c74c550c08343335c5b2b0f68b1b6fa05c047e4688b3bbbe6e4924a7d8428b03.json
+++ b/openfisca_france/tests/json/f7gf-c74c550c08343335c5b2b0f68b1b6fa05c047e4688b3bbbe6e4924a7d8428b03.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gf-d746f528a447abb4607d911ecdf44805c59c21dfdefe1909c4e911a569a08ec0.json
+++ b/openfisca_france/tests/json/f7gf-d746f528a447abb4607d911ecdf44805c59c21dfdefe1909c4e911a569a08ec0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gf-e3501800951f245bf1325cdd6af8f645fe53334e72a5ab921d113c01de40b3a3.json
+++ b/openfisca_france/tests/json/f7gf-e3501800951f245bf1325cdd6af8f645fe53334e72a5ab921d113c01de40b3a3.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gg-0fcfa13bded108cab2c9d809dec917f15fa66b95bfae3a5e627913734b4e0a9c.json
+++ b/openfisca_france/tests/json/f7gg-0fcfa13bded108cab2c9d809dec917f15fa66b95bfae3a5e627913734b4e0a9c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gg-1130af962e56348e43aa26c1bb7af0ea7ab95db94a0d46b442392b4af5bb7b1e.json
+++ b/openfisca_france/tests/json/f7gg-1130af962e56348e43aa26c1bb7af0ea7ab95db94a0d46b442392b4af5bb7b1e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gg-19f25d2da58b6d668cafc4dfa2d1bf400df6ca3fee39e8ff0fd32700bb6dd80c.json
+++ b/openfisca_france/tests/json/f7gg-19f25d2da58b6d668cafc4dfa2d1bf400df6ca3fee39e8ff0fd32700bb6dd80c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gg-3c304979cd20cf07aebf04147ce1550ed20a416052dd5d6fa9d81c183bef317b.json
+++ b/openfisca_france/tests/json/f7gg-3c304979cd20cf07aebf04147ce1550ed20a416052dd5d6fa9d81c183bef317b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gg-4bb76e1bb9c6cf760ca3744a958e38150b970e25f177891880bf156533f16809.json
+++ b/openfisca_france/tests/json/f7gg-4bb76e1bb9c6cf760ca3744a958e38150b970e25f177891880bf156533f16809.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gg-63e794649b1d59df614d247c908f2deea2ba47c36b5763b6d8c93fa341330595.json
+++ b/openfisca_france/tests/json/f7gg-63e794649b1d59df614d247c908f2deea2ba47c36b5763b6d8c93fa341330595.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gg-85f92497a40fd44ec5f3c47c709da9a877ea8ab3b066ebcf384cace11af20a67.json
+++ b/openfisca_france/tests/json/f7gg-85f92497a40fd44ec5f3c47c709da9a877ea8ab3b066ebcf384cace11af20a67.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gg-93b053c90b0629897ec136321e0200425230d9971d4b7e903e75fb04672479c7.json
+++ b/openfisca_france/tests/json/f7gg-93b053c90b0629897ec136321e0200425230d9971d4b7e903e75fb04672479c7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gg-d0eb59f922145bbaebd542a8836050010761905d9ae381a6eb39c72b8846302f.json
+++ b/openfisca_france/tests/json/f7gg-d0eb59f922145bbaebd542a8836050010761905d9ae381a6eb39c72b8846302f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-091be39c5faf858cee10de1a41ebb780aaf6833ece0ff7ea3b01bc9db66d07cf.json
+++ b/openfisca_france/tests/json/f7gh-091be39c5faf858cee10de1a41ebb780aaf6833ece0ff7ea3b01bc9db66d07cf.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-1a94493c47dcb75963f20b88e5afef6792932ed1e75c33dcae7e6ceb37a59af7.json
+++ b/openfisca_france/tests/json/f7gh-1a94493c47dcb75963f20b88e5afef6792932ed1e75c33dcae7e6ceb37a59af7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-1b870cff2f085c4b2e2fa1822c9edce9e1364e7cf57d3cf89c3bf9d9daf3a274.json
+++ b/openfisca_france/tests/json/f7gh-1b870cff2f085c4b2e2fa1822c9edce9e1364e7cf57d3cf89c3bf9d9daf3a274.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-1c1ee0b1d8fd204bac43e9e893a960e047f376ad8cea92e21014db21855b470f.json
+++ b/openfisca_france/tests/json/f7gh-1c1ee0b1d8fd204bac43e9e893a960e047f376ad8cea92e21014db21855b470f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-20561da090d5bca019fb616b363d9186651d54b55a4863a5e27f464f9d09754a.json
+++ b/openfisca_france/tests/json/f7gh-20561da090d5bca019fb616b363d9186651d54b55a4863a5e27f464f9d09754a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-63d7f42949412a2c0f5e2367f0d2a1fd9a57d4e3ddcacc4b0635232eb93055a4.json
+++ b/openfisca_france/tests/json/f7gh-63d7f42949412a2c0f5e2367f0d2a1fd9a57d4e3ddcacc4b0635232eb93055a4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-7ff5bcfbb3c9b78cf96257663e8b0c0046e3df6348b5016387d959bf3016954e.json
+++ b/openfisca_france/tests/json/f7gh-7ff5bcfbb3c9b78cf96257663e8b0c0046e3df6348b5016387d959bf3016954e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-86578f37143d659a001fbeea03944a373e80d1d293037084b8bfdd027e6e0e11.json
+++ b/openfisca_france/tests/json/f7gh-86578f37143d659a001fbeea03944a373e80d1d293037084b8bfdd027e6e0e11.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-9511a284ac2881359ac7e3104a06d42ed10f7c9e6107e0631537d200eb134812.json
+++ b/openfisca_france/tests/json/f7gh-9511a284ac2881359ac7e3104a06d42ed10f7c9e6107e0631537d200eb134812.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-97fc952a95b2ac3aeb54bd8d0cbe0fda2260155443684f34056d60eec8a08ec9.json
+++ b/openfisca_france/tests/json/f7gh-97fc952a95b2ac3aeb54bd8d0cbe0fda2260155443684f34056d60eec8a08ec9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-a6fd964d46b7cfe298d1cc5a4ca364673742f371138192d95ed35eabf0c6b866.json
+++ b/openfisca_france/tests/json/f7gh-a6fd964d46b7cfe298d1cc5a4ca364673742f371138192d95ed35eabf0c6b866.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-aecbcede35cbb0b2874b5b73b7eaa9e2b94b301c61403264614805ee2a64a998.json
+++ b/openfisca_france/tests/json/f7gh-aecbcede35cbb0b2874b5b73b7eaa9e2b94b301c61403264614805ee2a64a998.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-d64322e7fee9defabe93d4d152d60ecf1ef4e0276b4e90c9f05f348d6cea4302.json
+++ b/openfisca_france/tests/json/f7gh-d64322e7fee9defabe93d4d152d60ecf1ef4e0276b4e90c9f05f348d6cea4302.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-df0fe8e39cf87d316ced3c82867976ed86e3488a00449273234805c48d607c36.json
+++ b/openfisca_france/tests/json/f7gh-df0fe8e39cf87d316ced3c82867976ed86e3488a00449273234805c48d607c36.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-df63ac94a4047e994affb0fee92534f92b9088b1acd6671f5c941a01f0388395.json
+++ b/openfisca_france/tests/json/f7gh-df63ac94a4047e994affb0fee92534f92b9088b1acd6671f5c941a01f0388395.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-f3fc8bf1d3a18b4f2419ed2d859b6c2250176ed2892d6356c35bf857819dbe4d.json
+++ b/openfisca_france/tests/json/f7gh-f3fc8bf1d3a18b4f2419ed2d859b6c2250176ed2892d6356c35bf857819dbe4d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-f4973868584138b7caf148dfd3c641513ce93f03e1cae8957b2d27d736a14ea2.json
+++ b/openfisca_france/tests/json/f7gh-f4973868584138b7caf148dfd3c641513ce93f03e1cae8957b2d27d736a14ea2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gh-f54f5c49cbd5ed1f1d2e1e038a1505934d2a151c581a097a076d0305bab28b35.json
+++ b/openfisca_france/tests/json/f7gh-f54f5c49cbd5ed1f1d2e1e038a1505934d2a151c581a097a076d0305bab28b35.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gi-466fbfdc448b6af18234c91eef5e73a189924109fb21017c40e2c1135cd8f8e9.json
+++ b/openfisca_france/tests/json/f7gi-466fbfdc448b6af18234c91eef5e73a189924109fb21017c40e2c1135cd8f8e9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gi-58cecd24d6a13dab868e7a9ab3c934f3480013ca9e6d58a4174dd4530e7b3e97.json
+++ b/openfisca_france/tests/json/f7gi-58cecd24d6a13dab868e7a9ab3c934f3480013ca9e6d58a4174dd4530e7b3e97.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gi-6ca3fa59a1e2e056683891f22510c39279ec0c95769fff5da1751b42a24113cd.json
+++ b/openfisca_france/tests/json/f7gi-6ca3fa59a1e2e056683891f22510c39279ec0c95769fff5da1751b42a24113cd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gi-8375da9c4c63c35275d2affc22a8ec7e4cacc17ec34f7e6e071e9eb2418e1775.json
+++ b/openfisca_france/tests/json/f7gi-8375da9c4c63c35275d2affc22a8ec7e4cacc17ec34f7e6e071e9eb2418e1775.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gi-ac639db7fae431e0b88079bc329245b93e2562648bd878786a940fc595bd93c5.json
+++ b/openfisca_france/tests/json/f7gi-ac639db7fae431e0b88079bc329245b93e2562648bd878786a940fc595bd93c5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gi-b9545d78e4f2f1f52e85a0cf6fee5b24f303d2e6a2b2cc43de8e58111af87771.json
+++ b/openfisca_france/tests/json/f7gi-b9545d78e4f2f1f52e85a0cf6fee5b24f303d2e6a2b2cc43de8e58111af87771.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gi-d5a9947a2a7bae2a4034d00defead060c3c13bcee78f3ac6bf29552dcee2afcf.json
+++ b/openfisca_france/tests/json/f7gi-d5a9947a2a7bae2a4034d00defead060c3c13bcee78f3ac6bf29552dcee2afcf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gi-df5fe830d284a7d57c3083b3741ecc1394abb3be60a2e9c6cb19d44b86539540.json
+++ b/openfisca_france/tests/json/f7gi-df5fe830d284a7d57c3083b3741ecc1394abb3be60a2e9c6cb19d44b86539540.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gi-f965717f3bc65d16e401aa1bc1ebe8c791bcfd1250833b719289fe3898675fc5.json
+++ b/openfisca_france/tests/json/f7gi-f965717f3bc65d16e401aa1bc1ebe8c791bcfd1250833b719289fe3898675fc5.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gj-0008cc0b6907b4c5f3eb4464f47af75951edccd6027d9610978be33e173259cf.json
+++ b/openfisca_france/tests/json/f7gj-0008cc0b6907b4c5f3eb4464f47af75951edccd6027d9610978be33e173259cf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gj-13f97c1349061fdd67d3fe6aef44aed6846090902a55feb44513624fba1c0d67.json
+++ b/openfisca_france/tests/json/f7gj-13f97c1349061fdd67d3fe6aef44aed6846090902a55feb44513624fba1c0d67.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gj-353fb0eb3c6366b26c2631bf9a5b0d87f3d459af46c0699e95a9ff3b9338060c.json
+++ b/openfisca_france/tests/json/f7gj-353fb0eb3c6366b26c2631bf9a5b0d87f3d459af46c0699e95a9ff3b9338060c.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gj-511471f41634b17411b7bc14733deb849aa472fb0ca7acc86f079097e28e4d90.json
+++ b/openfisca_france/tests/json/f7gj-511471f41634b17411b7bc14733deb849aa472fb0ca7acc86f079097e28e4d90.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gj-5cf63f6362607c186a3b2e85203d4668b113616286b8ca6a15b20ddaf5c6a96c.json
+++ b/openfisca_france/tests/json/f7gj-5cf63f6362607c186a3b2e85203d4668b113616286b8ca6a15b20ddaf5c6a96c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gj-5d7e9cbf1e8aaf8cc35773f8e7f01565e94f3cc6c4c52781d2c1ee12def22727.json
+++ b/openfisca_france/tests/json/f7gj-5d7e9cbf1e8aaf8cc35773f8e7f01565e94f3cc6c4c52781d2c1ee12def22727.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gj-6b9b6930c4dc8714881d00dd93fd3a881f35047f81b819d1b1327203cce86a30.json
+++ b/openfisca_france/tests/json/f7gj-6b9b6930c4dc8714881d00dd93fd3a881f35047f81b819d1b1327203cce86a30.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gj-c76bf6cae8f380f935ad0f39b4b8ac616dc145e329b0592e6d709e1ed331786a.json
+++ b/openfisca_france/tests/json/f7gj-c76bf6cae8f380f935ad0f39b4b8ac616dc145e329b0592e6d709e1ed331786a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gj-f545c8fcddff94af1639a3141d791dfdda88b0af598d5ce8eec0372f6c30316d.json
+++ b/openfisca_france/tests/json/f7gj-f545c8fcddff94af1639a3141d791dfdda88b0af598d5ce8eec0372f6c30316d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gk-24085614282b8d2d30d6082c46eb494895965964ece2449ebfc1b70a0daa6be7.json
+++ b/openfisca_france/tests/json/f7gk-24085614282b8d2d30d6082c46eb494895965964ece2449ebfc1b70a0daa6be7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gk-8230a1c8f59d30e809b24f958ad026eb2f3ab5dc62b07baf7c60ba964480afc3.json
+++ b/openfisca_france/tests/json/f7gk-8230a1c8f59d30e809b24f958ad026eb2f3ab5dc62b07baf7c60ba964480afc3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gk-b70d44fc999e327f06b0cfc08c9b4160535b23aef43d0654f8e164381fa7b668.json
+++ b/openfisca_france/tests/json/f7gk-b70d44fc999e327f06b0cfc08c9b4160535b23aef43d0654f8e164381fa7b668.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gk-c6949e049cc19fcd21820f902116590532314e41ac3c197788231052c97bef74.json
+++ b/openfisca_france/tests/json/f7gk-c6949e049cc19fcd21820f902116590532314e41ac3c197788231052c97bef74.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gk-c7052e4d0a4829d7e2b039bd4b4d6ce32451fa399c161b41f66a60869395d36a.json
+++ b/openfisca_france/tests/json/f7gk-c7052e4d0a4829d7e2b039bd4b4d6ce32451fa399c161b41f66a60869395d36a.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gk-c8efca6c371b65c6209a51210fe251e0878b704ccff672ca177e8c63e927bd28.json
+++ b/openfisca_france/tests/json/f7gk-c8efca6c371b65c6209a51210fe251e0878b704ccff672ca177e8c63e927bd28.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gk-da9108111d436ffbea523b6fc246cf8b0c025e9e01f2160236ba1fdc29014630.json
+++ b/openfisca_france/tests/json/f7gk-da9108111d436ffbea523b6fc246cf8b0c025e9e01f2160236ba1fdc29014630.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gk-f7a51f224beea6e42d3f1c599b9bf7e096af95e5dedfb139753d208a2a77eb48.json
+++ b/openfisca_france/tests/json/f7gk-f7a51f224beea6e42d3f1c599b9bf7e096af95e5dedfb139753d208a2a77eb48.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gk-f7ac4adffe8594bd6633ad934a214766cc61fc7f70c30a5cdb7763acce462a0d.json
+++ b/openfisca_france/tests/json/f7gk-f7ac4adffe8594bd6633ad934a214766cc61fc7f70c30a5cdb7763acce462a0d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gl-04273202756577a9f23553c131c04fbf6d78d7dfee286d138563d60b7a34c13a.json
+++ b/openfisca_france/tests/json/f7gl-04273202756577a9f23553c131c04fbf6d78d7dfee286d138563d60b7a34c13a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gl-49969523bc6409df11efd84c8b417b396bcee469231c240e6c30a96848909032.json
+++ b/openfisca_france/tests/json/f7gl-49969523bc6409df11efd84c8b417b396bcee469231c240e6c30a96848909032.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gl-6121104773400a9c9a2ac8b2b11870710d5b3e606a9730017cc8df0d5d7ac042.json
+++ b/openfisca_france/tests/json/f7gl-6121104773400a9c9a2ac8b2b11870710d5b3e606a9730017cc8df0d5d7ac042.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gl-801c03b8caff0114fb7cc1c25cce324fee0261184dcc1ebd954cb971e31f4ff3.json
+++ b/openfisca_france/tests/json/f7gl-801c03b8caff0114fb7cc1c25cce324fee0261184dcc1ebd954cb971e31f4ff3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gl-891ba26ac2706e68fcd776086141c6b30f4629f765b7de21d2b610dd147d2d6e.json
+++ b/openfisca_france/tests/json/f7gl-891ba26ac2706e68fcd776086141c6b30f4629f765b7de21d2b610dd147d2d6e.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gl-b64085a45a4e7949a489fb9dd30857e5f9e926eabac84950578ed0974e2dc655.json
+++ b/openfisca_france/tests/json/f7gl-b64085a45a4e7949a489fb9dd30857e5f9e926eabac84950578ed0974e2dc655.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gl-e56cdb707033a212484f400efd2470ba027842524939cc6a9697c3764c946ea8.json
+++ b/openfisca_france/tests/json/f7gl-e56cdb707033a212484f400efd2470ba027842524939cc6a9697c3764c946ea8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gl-f12727c76e9fad934865d7a385b6e4f3d773e161c7b961ff83b5d467eedbdc08.json
+++ b/openfisca_france/tests/json/f7gl-f12727c76e9fad934865d7a385b6e4f3d773e161c7b961ff83b5d467eedbdc08.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gl-f8e20101fadf5dc3dbb0b05bbc4d78c4ed10a27a22f4e90332d99b16d839b30a.json
+++ b/openfisca_france/tests/json/f7gl-f8e20101fadf5dc3dbb0b05bbc4d78c4ed10a27a22f4e90332d99b16d839b30a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gn-04eb10d6a7a1ab772b66ca06b83abbff95d7ccf39bc0c9961282c842f1ad9092.json
+++ b/openfisca_france/tests/json/f7gn-04eb10d6a7a1ab772b66ca06b83abbff95d7ccf39bc0c9961282c842f1ad9092.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gn-4e7513207fd8d33bed195a59c6d01c21de7298ebcc6556f6a0262b105aa6bd1c.json
+++ b/openfisca_france/tests/json/f7gn-4e7513207fd8d33bed195a59c6d01c21de7298ebcc6556f6a0262b105aa6bd1c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gn-5724cc477ceec4d2540ddee304139aea6c789f3ba067b3b190a40b86bd178d25.json
+++ b/openfisca_france/tests/json/f7gn-5724cc477ceec4d2540ddee304139aea6c789f3ba067b3b190a40b86bd178d25.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gn-57eeefd76a3dbd7fddc7734a2d789d18a20ca3892f52d65bb7689c03c6a31061.json
+++ b/openfisca_france/tests/json/f7gn-57eeefd76a3dbd7fddc7734a2d789d18a20ca3892f52d65bb7689c03c6a31061.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gn-63322926e6ab692cbaf72d3eed0e64809f32c9a02558fd63396832552462dcf4.json
+++ b/openfisca_france/tests/json/f7gn-63322926e6ab692cbaf72d3eed0e64809f32c9a02558fd63396832552462dcf4.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gn-6a535bcbad30c292b0250c7522de748b88affc68bb678a3a227e2bb1dba6d688.json
+++ b/openfisca_france/tests/json/f7gn-6a535bcbad30c292b0250c7522de748b88affc68bb678a3a227e2bb1dba6d688.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gn-9106b8408f32302dfb8946c7bec57408733f79aad5cb997248a08d6e31d476a8.json
+++ b/openfisca_france/tests/json/f7gn-9106b8408f32302dfb8946c7bec57408733f79aad5cb997248a08d6e31d476a8.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gn-e01fdffcd4b66f20a842f1ab796c5973c192aeb2692ea0ed6d7e9dee0ec276e1.json
+++ b/openfisca_france/tests/json/f7gn-e01fdffcd4b66f20a842f1ab796c5973c192aeb2692ea0ed6d7e9dee0ec276e1.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gn-f3bac4cd55fec16052e2eff3e6bd3325110f8f820a0e5edccdb3b24363327416.json
+++ b/openfisca_france/tests/json/f7gn-f3bac4cd55fec16052e2eff3e6bd3325110f8f820a0e5edccdb3b24363327416.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gp-0059d3f61b5af892461d5df3c283c5fb0495a00a7981e008082899baa753a80e.json
+++ b/openfisca_france/tests/json/f7gp-0059d3f61b5af892461d5df3c283c5fb0495a00a7981e008082899baa753a80e.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gp-08d66c0f905a9db8bd7710f28c256d28884fc179d7290666d91a56382d46eef6.json
+++ b/openfisca_france/tests/json/f7gp-08d66c0f905a9db8bd7710f28c256d28884fc179d7290666d91a56382d46eef6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gp-0c2523bb660779a6e66826dd35ab862cb91ed3f55671786f76dc7a48ac13367a.json
+++ b/openfisca_france/tests/json/f7gp-0c2523bb660779a6e66826dd35ab862cb91ed3f55671786f76dc7a48ac13367a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gp-635d59e6def4d7d434027998d5522efd06904de5d34bce5dae2e6ba4885be1b6.json
+++ b/openfisca_france/tests/json/f7gp-635d59e6def4d7d434027998d5522efd06904de5d34bce5dae2e6ba4885be1b6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gp-93b000635363a95850b51a449d69eed994d2a4b79b7c0d67c1416ca3e491be57.json
+++ b/openfisca_france/tests/json/f7gp-93b000635363a95850b51a449d69eed994d2a4b79b7c0d67c1416ca3e491be57.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gp-97af9c2125ef7fdf8498ce99795cc82fa3d8ddecb703c8eea6446cdb83453a14.json
+++ b/openfisca_france/tests/json/f7gp-97af9c2125ef7fdf8498ce99795cc82fa3d8ddecb703c8eea6446cdb83453a14.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gp-b968b6bd66b74f3619a2eae5f8f2cc131301f0fbd7640eb14ac95cece6837330.json
+++ b/openfisca_france/tests/json/f7gp-b968b6bd66b74f3619a2eae5f8f2cc131301f0fbd7640eb14ac95cece6837330.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gp-ea7d8e831015a7da409a2a9aa03a27bf38118d90fedd13706ff5355e8a104d38.json
+++ b/openfisca_france/tests/json/f7gp-ea7d8e831015a7da409a2a9aa03a27bf38118d90fedd13706ff5355e8a104d38.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gp-fa0280dcc999123d2eabc60b18148af699ad0d55e0ba1d61ccbbf8c0c5c789c8.json
+++ b/openfisca_france/tests/json/f7gp-fa0280dcc999123d2eabc60b18148af699ad0d55e0ba1d61ccbbf8c0c5c789c8.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gq-00adcbd3387dce0c7d46d7f8b7ad607470e11ae97e2acf4e75a5c779851ddf61.json
+++ b/openfisca_france/tests/json/f7gq-00adcbd3387dce0c7d46d7f8b7ad607470e11ae97e2acf4e75a5c779851ddf61.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gq-0c0375a4721b8474b8aed0fa32cc6d6123fc4a3ba9179e980b280d766abb3c08.json
+++ b/openfisca_france/tests/json/f7gq-0c0375a4721b8474b8aed0fa32cc6d6123fc4a3ba9179e980b280d766abb3c08.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gq-2f936928e8bcabee5c33aa881e322751ad08261720e408f60f9368d4752e32b4.json
+++ b/openfisca_france/tests/json/f7gq-2f936928e8bcabee5c33aa881e322751ad08261720e408f60f9368d4752e32b4.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gq-44acff810513e53dd59943a3ef2c0e6144a4f0be3a9593561a8d07e9003c6afe.json
+++ b/openfisca_france/tests/json/f7gq-44acff810513e53dd59943a3ef2c0e6144a4f0be3a9593561a8d07e9003c6afe.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gq-4cb35eb26a6d0110976ff6bf5a732138adec784eba76fe02401186e9611d548b.json
+++ b/openfisca_france/tests/json/f7gq-4cb35eb26a6d0110976ff6bf5a732138adec784eba76fe02401186e9611d548b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gq-557177cfa13118b510f4cf73d55e6e3816e9fa1738aea8cfd7954bfbcd36ea40.json
+++ b/openfisca_france/tests/json/f7gq-557177cfa13118b510f4cf73d55e6e3816e9fa1738aea8cfd7954bfbcd36ea40.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gq-7366fc418f510c4feacf6bf880d34e4903e85b43b0505b8b42a08fcfda407f3c.json
+++ b/openfisca_france/tests/json/f7gq-7366fc418f510c4feacf6bf880d34e4903e85b43b0505b8b42a08fcfda407f3c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gq-dc567df6d1efadc217409d4b5b021da0572e414debb0bcfe83ded2a59409ac4e.json
+++ b/openfisca_france/tests/json/f7gq-dc567df6d1efadc217409d4b5b021da0572e414debb0bcfe83ded2a59409ac4e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gq-ed63b0b3975eee16c42769902ebca2dd11440d00eb1f5b60be68ae29fd19874a.json
+++ b/openfisca_france/tests/json/f7gq-ed63b0b3975eee16c42769902ebca2dd11440d00eb1f5b60be68ae29fd19874a.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gs-3948318dfb6ab6d4de3ac8ccf6467cb8ea0d895ad0497cbea1d8d0f4d12e5893.json
+++ b/openfisca_france/tests/json/f7gs-3948318dfb6ab6d4de3ac8ccf6467cb8ea0d895ad0497cbea1d8d0f4d12e5893.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gs-63c7886aa19910f17b0c18f1b650d0917f87c75ea7d5fbfa1b6a98d4e8e28fad.json
+++ b/openfisca_france/tests/json/f7gs-63c7886aa19910f17b0c18f1b650d0917f87c75ea7d5fbfa1b6a98d4e8e28fad.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gs-7b2dfaef39e96cdbe378ba2660840ee7379512d264b521dbdad51a5ce2828245.json
+++ b/openfisca_france/tests/json/f7gs-7b2dfaef39e96cdbe378ba2660840ee7379512d264b521dbdad51a5ce2828245.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gs-a51f31adc6f4a1be28855cddb50c2a1ab7d5db83312479973245771a313e5c1a.json
+++ b/openfisca_france/tests/json/f7gs-a51f31adc6f4a1be28855cddb50c2a1ab7d5db83312479973245771a313e5c1a.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gs-b045d8b6f954eda67af9a50328e8f1d61d71669aa788c9f019bcb5e9ec15553d.json
+++ b/openfisca_france/tests/json/f7gs-b045d8b6f954eda67af9a50328e8f1d61d71669aa788c9f019bcb5e9ec15553d.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gs-c6f041619a72744b06d3d6e16e2ef28c85fb65def42854008d1ab330c75568fb.json
+++ b/openfisca_france/tests/json/f7gs-c6f041619a72744b06d3d6e16e2ef28c85fb65def42854008d1ab330c75568fb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gs-c8e799cdd821511f8569e6cc554cf39fe42de210a7607a9bced204971a038a40.json
+++ b/openfisca_france/tests/json/f7gs-c8e799cdd821511f8569e6cc554cf39fe42de210a7607a9bced204971a038a40.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gs-e2d9624caea155639ec3a624a1e1ad51b4afa13ca05b738bed0d977bfe8d8f49.json
+++ b/openfisca_france/tests/json/f7gs-e2d9624caea155639ec3a624a1e1ad51b4afa13ca05b738bed0d977bfe8d8f49.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gs-fbdafeb6778ab41f8694013651e21e5f81268ab602e6b1048031ca652588a387.json
+++ b/openfisca_france/tests/json/f7gs-fbdafeb6778ab41f8694013651e21e5f81268ab602e6b1048031ca652588a387.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gt-03fddca835cea450b5f4b4948904cb9a437b7009e7e80b7b5a36922c678ccd00.json
+++ b/openfisca_france/tests/json/f7gt-03fddca835cea450b5f4b4948904cb9a437b7009e7e80b7b5a36922c678ccd00.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gt-2f390cf7bc31c0b872cc629d6cf5a714c625620edea15ec62c20955ac84d23ab.json
+++ b/openfisca_france/tests/json/f7gt-2f390cf7bc31c0b872cc629d6cf5a714c625620edea15ec62c20955ac84d23ab.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gt-457d0d21534972907aaad0b4027f9e4e943dd74e2f0d0df0f46b10c8f32a0377.json
+++ b/openfisca_france/tests/json/f7gt-457d0d21534972907aaad0b4027f9e4e943dd74e2f0d0df0f46b10c8f32a0377.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gt-5f78efe5d8679ef9aad9da77e64f34b336b46ad8b37c9ee61c2545b0b5724918.json
+++ b/openfisca_france/tests/json/f7gt-5f78efe5d8679ef9aad9da77e64f34b336b46ad8b37c9ee61c2545b0b5724918.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gt-79efe2ec32f373e0c391888f9913436794d99876768cf88df1c91d6194876e07.json
+++ b/openfisca_france/tests/json/f7gt-79efe2ec32f373e0c391888f9913436794d99876768cf88df1c91d6194876e07.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gt-8ab5de840e294bb88b30b4bedb7bef3b3cfb1dad185843f614e275c8488498e5.json
+++ b/openfisca_france/tests/json/f7gt-8ab5de840e294bb88b30b4bedb7bef3b3cfb1dad185843f614e275c8488498e5.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gt-97881a3488db2174e39bb1790aa33fd86449eb80cef9dfd93ffa8f6be2489566.json
+++ b/openfisca_france/tests/json/f7gt-97881a3488db2174e39bb1790aa33fd86449eb80cef9dfd93ffa8f6be2489566.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gt-ccf47dbd80be639cd073e0190b050b9fc141f64a8bd7fd113c53b8f7b830285c.json
+++ b/openfisca_france/tests/json/f7gt-ccf47dbd80be639cd073e0190b050b9fc141f64a8bd7fd113c53b8f7b830285c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gt-d1a145a233969ef8c3c32beed06a739f8d8a586d418423950d6cbc529d454b9c.json
+++ b/openfisca_france/tests/json/f7gt-d1a145a233969ef8c3c32beed06a739f8d8a586d418423950d6cbc529d454b9c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gu-45c4de523deb026450c0c3468f007cd0553bcae125668395cb82c757fc046aeb.json
+++ b/openfisca_france/tests/json/f7gu-45c4de523deb026450c0c3468f007cd0553bcae125668395cb82c757fc046aeb.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gu-7b13626a41569c628a58489815d9bafafba57be7fb116a1ea818ff9d3277af20.json
+++ b/openfisca_france/tests/json/f7gu-7b13626a41569c628a58489815d9bafafba57be7fb116a1ea818ff9d3277af20.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gu-8bbbf6eaa4fc4b401b605535efa72f9db489976479734ef86e9f9ff9154b74e0.json
+++ b/openfisca_france/tests/json/f7gu-8bbbf6eaa4fc4b401b605535efa72f9db489976479734ef86e9f9ff9154b74e0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gu-956452da538499addd65e45420122505cd3b6dd18a43d2edaf36f55a09255f96.json
+++ b/openfisca_france/tests/json/f7gu-956452da538499addd65e45420122505cd3b6dd18a43d2edaf36f55a09255f96.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gu-97f8437b941d222d3cc252bdbc08e7b950d29c0475bb22279ab16958bac72fef.json
+++ b/openfisca_france/tests/json/f7gu-97f8437b941d222d3cc252bdbc08e7b950d29c0475bb22279ab16958bac72fef.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gu-9c35d2e993b11c76b12a236b22bd97c235462f3441716cd878b3b384a4ba52e3.json
+++ b/openfisca_france/tests/json/f7gu-9c35d2e993b11c76b12a236b22bd97c235462f3441716cd878b3b384a4ba52e3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gu-c23cf580774153cc402dd041fe2d7c8e63c2243aed32711ca78c67d3b48b2888.json
+++ b/openfisca_france/tests/json/f7gu-c23cf580774153cc402dd041fe2d7c8e63c2243aed32711ca78c67d3b48b2888.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gu-eb4bfb19e4ab4ee34ee0cf96f1fb9078ab32ae5514ab17c253bed5a7d51d7761.json
+++ b/openfisca_france/tests/json/f7gu-eb4bfb19e4ab4ee34ee0cf96f1fb9078ab32ae5514ab17c253bed5a7d51d7761.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gu-f70a7bee39e984174c0f27048883b4bab54586445cfb11c4f3f3bd3cd05d6401.json
+++ b/openfisca_france/tests/json/f7gu-f70a7bee39e984174c0f27048883b4bab54586445cfb11c4f3f3bd3cd05d6401.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gv-4ba73a2974fe9a5e4b2e844d2d4bade48715e558609177d99a457a14da8e2b6a.json
+++ b/openfisca_france/tests/json/f7gv-4ba73a2974fe9a5e4b2e844d2d4bade48715e558609177d99a457a14da8e2b6a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gv-5f899992fb8fb4859237fb5093c96d9028d49509a973e773b5de79df386f331b.json
+++ b/openfisca_france/tests/json/f7gv-5f899992fb8fb4859237fb5093c96d9028d49509a973e773b5de79df386f331b.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gv-69934046518b9d5cc39028b424348cba00ce35c5ed0050ce6399c2ce02626c90.json
+++ b/openfisca_france/tests/json/f7gv-69934046518b9d5cc39028b424348cba00ce35c5ed0050ce6399c2ce02626c90.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gv-7d72188448a1a8a304abe7244919387085cf631f6c4b78ce5a5397db940daeb4.json
+++ b/openfisca_france/tests/json/f7gv-7d72188448a1a8a304abe7244919387085cf631f6c4b78ce5a5397db940daeb4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gv-9d5fc2b492fca13e62ed037011bdbc4745a42440e355183dfcb8214ecf7bd7cb.json
+++ b/openfisca_france/tests/json/f7gv-9d5fc2b492fca13e62ed037011bdbc4745a42440e355183dfcb8214ecf7bd7cb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gv-d6b0ee87e47dc2891581cc595bd8e8d6eec4c0dc0ee7a73e4491a6841a1bcd6e.json
+++ b/openfisca_france/tests/json/f7gv-d6b0ee87e47dc2891581cc595bd8e8d6eec4c0dc0ee7a73e4491a6841a1bcd6e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gv-e8b0ff84235334f35266f76d4e6d90df15a3dcb62fcf127af0b9827c8278b501.json
+++ b/openfisca_france/tests/json/f7gv-e8b0ff84235334f35266f76d4e6d90df15a3dcb62fcf127af0b9827c8278b501.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gv-eec3107780998171d7efa2bfa7f5049ba487fb81dd552795efc739ea9626a90a.json
+++ b/openfisca_france/tests/json/f7gv-eec3107780998171d7efa2bfa7f5049ba487fb81dd552795efc739ea9626a90a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gv-f7d4fac8192eaa5fd246d06489cb0f61967da6ebfd5ff06bbea20780e6b83c7e.json
+++ b/openfisca_france/tests/json/f7gv-f7d4fac8192eaa5fd246d06489cb0f61967da6ebfd5ff06bbea20780e6b83c7e.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gw-1091f1d76b2bbc269f9bda6a62093032f28a839f85f0b2ffb1daf7a7aa625afa.json
+++ b/openfisca_france/tests/json/f7gw-1091f1d76b2bbc269f9bda6a62093032f28a839f85f0b2ffb1daf7a7aa625afa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gw-135c8ced0529028d560b1237548142e96f547563fbaf391bd6990c93212076a0.json
+++ b/openfisca_france/tests/json/f7gw-135c8ced0529028d560b1237548142e96f547563fbaf391bd6990c93212076a0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gw-2971b29ef350b64e720282fcde5070d352ac9e981d5e0c8aa6153ec2a27fb9ff.json
+++ b/openfisca_france/tests/json/f7gw-2971b29ef350b64e720282fcde5070d352ac9e981d5e0c8aa6153ec2a27fb9ff.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gw-376a8323f75dc3f1d7b54f37e815edf017c7f10ef16b9035629f4bb5454e6b92.json
+++ b/openfisca_france/tests/json/f7gw-376a8323f75dc3f1d7b54f37e815edf017c7f10ef16b9035629f4bb5454e6b92.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gw-5680eda0c98019c15d15efa34895b8c6f6d3b5d0eed15a35e8bd0ea0c4117996.json
+++ b/openfisca_france/tests/json/f7gw-5680eda0c98019c15d15efa34895b8c6f6d3b5d0eed15a35e8bd0ea0c4117996.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gw-79a6be3b1e4a4552e14bc3a1309eccf75eb555ab81296179ddb5d80430c9e0d4.json
+++ b/openfisca_france/tests/json/f7gw-79a6be3b1e4a4552e14bc3a1309eccf75eb555ab81296179ddb5d80430c9e0d4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gw-7d963f43eb666721f2f5d8b3ecc87e7a12fd0286698c84b0bcc5a46b8fadaa01.json
+++ b/openfisca_france/tests/json/f7gw-7d963f43eb666721f2f5d8b3ecc87e7a12fd0286698c84b0bcc5a46b8fadaa01.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gw-a12a88a523b3dd806625cf7267453c7ec057f8a0b8be9947cb358568ab008382.json
+++ b/openfisca_france/tests/json/f7gw-a12a88a523b3dd806625cf7267453c7ec057f8a0b8be9947cb358568ab008382.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gw-ce815e697621c6c459933170ea01df80ea80f507b28da0fe998afcb301e21d1f.json
+++ b/openfisca_france/tests/json/f7gw-ce815e697621c6c459933170ea01df80ea80f507b28da0fe998afcb301e21d1f.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gx-05772840d827b651050ebe17eb95d8e8b3c9a9efcc54e7e7bac6e8788e919ba1.json
+++ b/openfisca_france/tests/json/f7gx-05772840d827b651050ebe17eb95d8e8b3c9a9efcc54e7e7bac6e8788e919ba1.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gx-0d2f666e8048a5320dd76cd24d13bae5b407877133deba5c0df71c77034b9118.json
+++ b/openfisca_france/tests/json/f7gx-0d2f666e8048a5320dd76cd24d13bae5b407877133deba5c0df71c77034b9118.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gx-14ee603cf2c9b44820e0ce305e8337a61cf0d652b74c69536cc2323e0279d0fb.json
+++ b/openfisca_france/tests/json/f7gx-14ee603cf2c9b44820e0ce305e8337a61cf0d652b74c69536cc2323e0279d0fb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gx-a05d2d5138374eaddd23c8fa434413eb13ea04d13bbef6000605fb594637bb21.json
+++ b/openfisca_france/tests/json/f7gx-a05d2d5138374eaddd23c8fa434413eb13ea04d13bbef6000605fb594637bb21.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gx-aee85bfd12e210fd33fb0fb5696d72c1bf98d4849f20f0034f3b3d9fcb05488a.json
+++ b/openfisca_france/tests/json/f7gx-aee85bfd12e210fd33fb0fb5696d72c1bf98d4849f20f0034f3b3d9fcb05488a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gx-bff07c6669e2e551c6a8c7ea65bcad7eeeceef6d91e5afa84510d34c8241c2d5.json
+++ b/openfisca_france/tests/json/f7gx-bff07c6669e2e551c6a8c7ea65bcad7eeeceef6d91e5afa84510d34c8241c2d5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gx-d91b933ce759070bd112101eed66e00020f5bd8d081f0197a6aeb6cc636dabe2.json
+++ b/openfisca_france/tests/json/f7gx-d91b933ce759070bd112101eed66e00020f5bd8d081f0197a6aeb6cc636dabe2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gx-ef8b9f94629199252b933ca286431019dfb33f0efeb27067784c2a67b84a51fb.json
+++ b/openfisca_france/tests/json/f7gx-ef8b9f94629199252b933ca286431019dfb33f0efeb27067784c2a67b84a51fb.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gx-ff0335b70dd3def36363f8dc814f063c2089b845e9a1bd319fcf936da8e33c51.json
+++ b/openfisca_france/tests/json/f7gx-ff0335b70dd3def36363f8dc814f063c2089b845e9a1bd319fcf936da8e33c51.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gy-1547f1d128b6ff906201c853d602e631448fe7dc93d917d37e0d267066bddd1a.json
+++ b/openfisca_france/tests/json/f7gy-1547f1d128b6ff906201c853d602e631448fe7dc93d917d37e0d267066bddd1a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gz-0e554768324d4233c8995d837c4450fc368d6cf6ef3770b425f665d28b52dd4c.json
+++ b/openfisca_france/tests/json/f7gz-0e554768324d4233c8995d837c4450fc368d6cf6ef3770b425f665d28b52dd4c.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gz-28c3bab67bf06aa46b85ae8b8af1aad8072e157ac5119963f53ab6f809188834.json
+++ b/openfisca_france/tests/json/f7gz-28c3bab67bf06aa46b85ae8b8af1aad8072e157ac5119963f53ab6f809188834.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gz-5e2de8d252d579fff05682df8468bea2a11b08a27763d7189bb1883ec98c354b.json
+++ b/openfisca_france/tests/json/f7gz-5e2de8d252d579fff05682df8468bea2a11b08a27763d7189bb1883ec98c354b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gz-5e7989ca0548c569f38782759271830b00d06a202e74f1d7a92e796bf80395ae.json
+++ b/openfisca_france/tests/json/f7gz-5e7989ca0548c569f38782759271830b00d06a202e74f1d7a92e796bf80395ae.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gz-6a8886a39f8b22cbee5ca06e4025b002a3a5713700b06992440ddb67f7c08189.json
+++ b/openfisca_france/tests/json/f7gz-6a8886a39f8b22cbee5ca06e4025b002a3a5713700b06992440ddb67f7c08189.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gz-7bd3359bfd7a2919646ea83f150275bedb8a1647d5422c393c86ff7f4a865421.json
+++ b/openfisca_france/tests/json/f7gz-7bd3359bfd7a2919646ea83f150275bedb8a1647d5422c393c86ff7f4a865421.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gz-b0f4cb90116f1ac44717c97c02ce53806159c5a05f031953c6be45063a8a25c5.json
+++ b/openfisca_france/tests/json/f7gz-b0f4cb90116f1ac44717c97c02ce53806159c5a05f031953c6be45063a8a25c5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gz-e77bda5227131c90728e287c267f57a7feb43dcdb81a25a93433a896fc93e66e.json
+++ b/openfisca_france/tests/json/f7gz-e77bda5227131c90728e287c267f57a7feb43dcdb81a25a93433a896fc93e66e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7gz-f19ad733b97e6c5277896d6aeb26cd5787387c95a3d00b4042f17e934549aa48.json
+++ b/openfisca_france/tests/json/f7gz-f19ad733b97e6c5277896d6aeb26cd5787387c95a3d00b4042f17e934549aa48.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ha-04254b643066238bb3415e41a2c42d7448c917baa12b3148712179d75d7fb9a0.json
+++ b/openfisca_france/tests/json/f7ha-04254b643066238bb3415e41a2c42d7448c917baa12b3148712179d75d7fb9a0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ha-1f853707f826ad59b332b331ada6433aa28bd9c5a818a87fed2f62dc1aea3bc4.json
+++ b/openfisca_france/tests/json/f7ha-1f853707f826ad59b332b331ada6433aa28bd9c5a818a87fed2f62dc1aea3bc4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ha-33cffcc9fd877a35bfdc857dc0437f92b25c92ef6a210edf2699288ef82ccc79.json
+++ b/openfisca_france/tests/json/f7ha-33cffcc9fd877a35bfdc857dc0437f92b25c92ef6a210edf2699288ef82ccc79.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ha-5f72c2eee6907441b0e91d6f1cec866cd40ea0125ae5e33f04a6c314bc52e602.json
+++ b/openfisca_france/tests/json/f7ha-5f72c2eee6907441b0e91d6f1cec866cd40ea0125ae5e33f04a6c314bc52e602.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ha-681da0afaccecc4f9eab378be239fefc83b466b7c1013f79e90ccf2e63910d56.json
+++ b/openfisca_france/tests/json/f7ha-681da0afaccecc4f9eab378be239fefc83b466b7c1013f79e90ccf2e63910d56.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ha-b41e08a7faa70cfbe59eefabab96334f1d2fdb7f18cd64db24c58b69969e8051.json
+++ b/openfisca_france/tests/json/f7ha-b41e08a7faa70cfbe59eefabab96334f1d2fdb7f18cd64db24c58b69969e8051.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ha-c5c1532918d626895e6fa796556c6d45ffbc3cf85fb77443bf424f674a8927e3.json
+++ b/openfisca_france/tests/json/f7ha-c5c1532918d626895e6fa796556c6d45ffbc3cf85fb77443bf424f674a8927e3.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ha-c7d92d98b65b78c2ecbf6f49adefc81f217bcd6aec3fbb4618c9220d39d13c79.json
+++ b/openfisca_france/tests/json/f7ha-c7d92d98b65b78c2ecbf6f49adefc81f217bcd6aec3fbb4618c9220d39d13c79.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ha-ca122211b0b46802a7c800526c93b57a0eb03c3d10213f13e207dad216cc7682.json
+++ b/openfisca_france/tests/json/f7ha-ca122211b0b46802a7c800526c93b57a0eb03c3d10213f13e207dad216cc7682.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hb-3e1e8327db4875fae563808133b851518d81589b4ad9fb7a9dec4befcd4d251b.json
+++ b/openfisca_france/tests/json/f7hb-3e1e8327db4875fae563808133b851518d81589b4ad9fb7a9dec4befcd4d251b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hb-3e65d9316fded0c2a16fbf2ef448362164ca024a095e5b5023e962e2f38159f1.json
+++ b/openfisca_france/tests/json/f7hb-3e65d9316fded0c2a16fbf2ef448362164ca024a095e5b5023e962e2f38159f1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hb-4290ed3e62093c933ea05384b053a4eb2512948c6b178bf36d146f0fe842c532.json
+++ b/openfisca_france/tests/json/f7hb-4290ed3e62093c933ea05384b053a4eb2512948c6b178bf36d146f0fe842c532.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hb-4f97d27be542a367e7b8dccf4e7c560c5e6fd99cc80a390f1b20680b463fd827.json
+++ b/openfisca_france/tests/json/f7hb-4f97d27be542a367e7b8dccf4e7c560c5e6fd99cc80a390f1b20680b463fd827.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hb-6faca6d069e49525cb5805ddcb0806afc955487fff640b49096eea2eab1688fb.json
+++ b/openfisca_france/tests/json/f7hb-6faca6d069e49525cb5805ddcb0806afc955487fff640b49096eea2eab1688fb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hb-71e5a87e72233aa673a3646c4a5b23ee453c80f80e5e73c0ee7b040e9310b9d6.json
+++ b/openfisca_france/tests/json/f7hb-71e5a87e72233aa673a3646c4a5b23ee453c80f80e5e73c0ee7b040e9310b9d6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hb-80f339f2083c9148249bc0561c8d619522072f25e2921d14c6eff09d6a329b72.json
+++ b/openfisca_france/tests/json/f7hb-80f339f2083c9148249bc0561c8d619522072f25e2921d14c6eff09d6a329b72.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hb-861773f7d4e325744ebb77741c3b8e29dfb00c9beb6a9ac1347221b40d409f02.json
+++ b/openfisca_france/tests/json/f7hb-861773f7d4e325744ebb77741c3b8e29dfb00c9beb6a9ac1347221b40d409f02.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hb-e68e0863e169789b7b0fed69ce922c8a3498a12ff358eda1ea1a3552de9d43ba.json
+++ b/openfisca_france/tests/json/f7hb-e68e0863e169789b7b0fed69ce922c8a3498a12ff358eda1ea1a3552de9d43ba.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hd-0e2162e74ce8bfd8dd2211fff49e8f28af827d21f9c2f2604a99f540ac00e808.json
+++ b/openfisca_france/tests/json/f7hd-0e2162e74ce8bfd8dd2211fff49e8f28af827d21f9c2f2604a99f540ac00e808.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hd-1d79f9c1e950e4e1e6e8d24c00378ce9ebfd4df64823714cfabf7d9df2481d59.json
+++ b/openfisca_france/tests/json/f7hd-1d79f9c1e950e4e1e6e8d24c00378ce9ebfd4df64823714cfabf7d9df2481d59.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hd-3bc97052ffb43a54e1ef20141c97bd6fbd1f413192d03be0e44140943bd39533.json
+++ b/openfisca_france/tests/json/f7hd-3bc97052ffb43a54e1ef20141c97bd6fbd1f413192d03be0e44140943bd39533.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hd-5e34878d9e92db22a240a8615f2171cbca94abe0d7726e542d2bd16fd447e780.json
+++ b/openfisca_france/tests/json/f7hd-5e34878d9e92db22a240a8615f2171cbca94abe0d7726e542d2bd16fd447e780.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hd-5f9453fa649107e83d44556a88565fd0ba2642ba042eb982b3fc77be4e6c12e2.json
+++ b/openfisca_france/tests/json/f7hd-5f9453fa649107e83d44556a88565fd0ba2642ba042eb982b3fc77be4e6c12e2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hd-7579b18130ee88f0d150fec8deff735a7e3fe8fde54e45171fc41bedef05d7d3.json
+++ b/openfisca_france/tests/json/f7hd-7579b18130ee88f0d150fec8deff735a7e3fe8fde54e45171fc41bedef05d7d3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hd-bcd4245ea93fc8135d8a0d93ca182a835503de1ce55a2c8fef88b457c8d027b6.json
+++ b/openfisca_france/tests/json/f7hd-bcd4245ea93fc8135d8a0d93ca182a835503de1ce55a2c8fef88b457c8d027b6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hd-ccfe3b4169b2c9400be2adfb3ee496b47c64eea518770f466e51a033f7504bc4.json
+++ b/openfisca_france/tests/json/f7hd-ccfe3b4169b2c9400be2adfb3ee496b47c64eea518770f466e51a033f7504bc4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hd-d2d1b6c7643c722b19e1edf82512b2da24348571f5654bef9210639c0835a822.json
+++ b/openfisca_france/tests/json/f7hd-d2d1b6c7643c722b19e1edf82512b2da24348571f5654bef9210639c0835a822.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7he-19db168580e55e593250b8e4589d23dd01f140421b9f8e817fc3d668e8762e8c.json
+++ b/openfisca_france/tests/json/f7he-19db168580e55e593250b8e4589d23dd01f140421b9f8e817fc3d668e8762e8c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7he-4108bfda2f6bb9d57315f0ab2a5b080e6b158977a8cb2b26be9fa395c02881e4.json
+++ b/openfisca_france/tests/json/f7he-4108bfda2f6bb9d57315f0ab2a5b080e6b158977a8cb2b26be9fa395c02881e4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7he-758c29cd1df5fd551964a5b1e719e6f0644a531dfc6079b1816b932a673c5fab.json
+++ b/openfisca_france/tests/json/f7he-758c29cd1df5fd551964a5b1e719e6f0644a531dfc6079b1816b932a673c5fab.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7he-8e031cfb773e9a828e81be07d15623f582d052d401ebdf5d2639172fd8ee75e7.json
+++ b/openfisca_france/tests/json/f7he-8e031cfb773e9a828e81be07d15623f582d052d401ebdf5d2639172fd8ee75e7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7he-932e5539388e70ab9e82402662d504033a9ca067ee968e8110133457ed826fa2.json
+++ b/openfisca_france/tests/json/f7he-932e5539388e70ab9e82402662d504033a9ca067ee968e8110133457ed826fa2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7he-98566f222640221cb4ac45cb4e27de343cbaf6f93f6eed20efb2c2d9a6ba2def.json
+++ b/openfisca_france/tests/json/f7he-98566f222640221cb4ac45cb4e27de343cbaf6f93f6eed20efb2c2d9a6ba2def.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7he-d48fb52cb7ee0e1df451da707050ce646eb913151aa59b6cf6519db8eb7966fe.json
+++ b/openfisca_france/tests/json/f7he-d48fb52cb7ee0e1df451da707050ce646eb913151aa59b6cf6519db8eb7966fe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7he-da7a7546181bb23f376a430f7bd4ddc9fdd12c9b78f03e06bbb6344d57a1b2b4.json
+++ b/openfisca_france/tests/json/f7he-da7a7546181bb23f376a430f7bd4ddc9fdd12c9b78f03e06bbb6344d57a1b2b4.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7he-e407a8c5b2fe817142f34d751fe49fc04c1e55af89c3480e648ed4f51ffb68cd.json
+++ b/openfisca_france/tests/json/f7he-e407a8c5b2fe817142f34d751fe49fc04c1e55af89c3480e648ed4f51ffb68cd.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hf-4d8bfc6987423f0127afb1f29c402153268f25574c72111efd5f4da30a62ef00.json
+++ b/openfisca_france/tests/json/f7hf-4d8bfc6987423f0127afb1f29c402153268f25574c72111efd5f4da30a62ef00.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hf-5ca63d56bce40e09a1e23e7a2e2c102cccfbe9287a06b48c91814193d5095308.json
+++ b/openfisca_france/tests/json/f7hf-5ca63d56bce40e09a1e23e7a2e2c102cccfbe9287a06b48c91814193d5095308.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hf-79058a17d8de08dc9a46c25ec7c74082feaa202d60bf6f13064a33640a41da0d.json
+++ b/openfisca_france/tests/json/f7hf-79058a17d8de08dc9a46c25ec7c74082feaa202d60bf6f13064a33640a41da0d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hf-b4742607d3e89f67386f71610096029ad4c9b37c2169c9d2535e3e59089d5bca.json
+++ b/openfisca_france/tests/json/f7hf-b4742607d3e89f67386f71610096029ad4c9b37c2169c9d2535e3e59089d5bca.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hf-bd39774455af16048216d95d79133dd17b767389fe4d94efd96b5bdeea22cd3c.json
+++ b/openfisca_france/tests/json/f7hf-bd39774455af16048216d95d79133dd17b767389fe4d94efd96b5bdeea22cd3c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hf-d0bbf708d817e9cbc245f4f65db763453cdcbcc88cc3c7c2a1540b4eca1bc0c5.json
+++ b/openfisca_france/tests/json/f7hf-d0bbf708d817e9cbc245f4f65db763453cdcbcc88cc3c7c2a1540b4eca1bc0c5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hf-d8caa121ee6003526479426b5c0979447ab2bd0cdd53b1de7ca671b13fb4d732.json
+++ b/openfisca_france/tests/json/f7hf-d8caa121ee6003526479426b5c0979447ab2bd0cdd53b1de7ca671b13fb4d732.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hf-e74607b04551ff3038c37dd1094d2d380cb9d5415f7cb59a8e9f6367c5193687.json
+++ b/openfisca_france/tests/json/f7hf-e74607b04551ff3038c37dd1094d2d380cb9d5415f7cb59a8e9f6367c5193687.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hf-ed3d268d341c228dc8cc25ef34fe1489cd039bfe171db52bf63ae111ef99d4aa.json
+++ b/openfisca_france/tests/json/f7hf-ed3d268d341c228dc8cc25ef34fe1489cd039bfe171db52bf63ae111ef99d4aa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hg-2c45a8d485e670cf57ee6ac0e2a25ed67f8d716745c6810d9607397298228ad3.json
+++ b/openfisca_france/tests/json/f7hg-2c45a8d485e670cf57ee6ac0e2a25ed67f8d716745c6810d9607397298228ad3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hg-68676b8daaf1b64f76d44a1e57578a7653ee324ae931f70d59877ee86f2e8394.json
+++ b/openfisca_france/tests/json/f7hg-68676b8daaf1b64f76d44a1e57578a7653ee324ae931f70d59877ee86f2e8394.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hg-8d063764ec5ee5ef1ab306f1be6935807c8c0f0c88630d1c6f730a0801f30086.json
+++ b/openfisca_france/tests/json/f7hg-8d063764ec5ee5ef1ab306f1be6935807c8c0f0c88630d1c6f730a0801f30086.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hg-902e144bb126a726e31426fc87ff0a1ad595acf1925ce036eab12d541312adc1.json
+++ b/openfisca_france/tests/json/f7hg-902e144bb126a726e31426fc87ff0a1ad595acf1925ce036eab12d541312adc1.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hg-9abd371ca57bd3dae3525aec2b3bb8c4ea0100bb367a40ea0c60479d404ae0ba.json
+++ b/openfisca_france/tests/json/f7hg-9abd371ca57bd3dae3525aec2b3bb8c4ea0100bb367a40ea0c60479d404ae0ba.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hg-c77c84ef2adb689f9674c4c57e54a1abdda7b601144a56f010cae88eea736f4e.json
+++ b/openfisca_france/tests/json/f7hg-c77c84ef2adb689f9674c4c57e54a1abdda7b601144a56f010cae88eea736f4e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hg-e92048e14d4bff1486e1b5cda8775ccec419b8cc41d89712d6c93e9b96bbe657.json
+++ b/openfisca_france/tests/json/f7hg-e92048e14d4bff1486e1b5cda8775ccec419b8cc41d89712d6c93e9b96bbe657.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hg-f220e75cd08f7d1d14f315a1ecce72d59012ff033c45ae93e03561736d91b9ce.json
+++ b/openfisca_france/tests/json/f7hg-f220e75cd08f7d1d14f315a1ecce72d59012ff033c45ae93e03561736d91b9ce.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hg-f678fe0539ebd483a1ee302188b0ff0a55c23fd9e291dba6987cf6dab12fd5af.json
+++ b/openfisca_france/tests/json/f7hg-f678fe0539ebd483a1ee302188b0ff0a55c23fd9e291dba6987cf6dab12fd5af.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hh-218a9c7c7c41911c974db755b5e9ce419cd9e671e7f30df3d102007e3bd55ebe.json
+++ b/openfisca_france/tests/json/f7hh-218a9c7c7c41911c974db755b5e9ce419cd9e671e7f30df3d102007e3bd55ebe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hh-26b89679cd9e0740a6615309279de4ac8733472967ccef250d536661ef8a8207.json
+++ b/openfisca_france/tests/json/f7hh-26b89679cd9e0740a6615309279de4ac8733472967ccef250d536661ef8a8207.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hh-2b2e0df4386e0c19d600bf831ff78e3c16e34fbc566df84c09b02324145fc7b7.json
+++ b/openfisca_france/tests/json/f7hh-2b2e0df4386e0c19d600bf831ff78e3c16e34fbc566df84c09b02324145fc7b7.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hh-365f43b9da288c7d813fd4b92b607feb5701bfcee181bd4b4084fc8dcbb30b9a.json
+++ b/openfisca_france/tests/json/f7hh-365f43b9da288c7d813fd4b92b607feb5701bfcee181bd4b4084fc8dcbb30b9a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hh-3c7ca46b4eb8796d95e8bad1c92fa474b31425aa13412b6825968f42ce9b8c4e.json
+++ b/openfisca_france/tests/json/f7hh-3c7ca46b4eb8796d95e8bad1c92fa474b31425aa13412b6825968f42ce9b8c4e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hh-8a27965142fdfb30112234aefad91fa061aa7dbec133ed947da7d82e09ea3f0a.json
+++ b/openfisca_france/tests/json/f7hh-8a27965142fdfb30112234aefad91fa061aa7dbec133ed947da7d82e09ea3f0a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hh-8da965051820ab58c8eeae8b539c608b625ff42f038a71c6a64aaa872f76abff.json
+++ b/openfisca_france/tests/json/f7hh-8da965051820ab58c8eeae8b539c608b625ff42f038a71c6a64aaa872f76abff.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hh-aa461d455fb3021a24d416ba02eb63fc84991435b30da0b8ecc7736ecd90f96a.json
+++ b/openfisca_france/tests/json/f7hh-aa461d455fb3021a24d416ba02eb63fc84991435b30da0b8ecc7736ecd90f96a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hh-ed68b9823dc63b3a4608486f0207f4312161fa98adb9586ac34292a2e934e91f.json
+++ b/openfisca_france/tests/json/f7hh-ed68b9823dc63b3a4608486f0207f4312161fa98adb9586ac34292a2e934e91f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hj-00f9c79d8c92f427e307bc3246267f490879016a3d76eb5a560e3535d36ffb96.json
+++ b/openfisca_france/tests/json/f7hj-00f9c79d8c92f427e307bc3246267f490879016a3d76eb5a560e3535d36ffb96.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hj-0eb36db465cec3f9e8c8396d60786469ab031da01dc81929faffdf29e771fa96.json
+++ b/openfisca_france/tests/json/f7hj-0eb36db465cec3f9e8c8396d60786469ab031da01dc81929faffdf29e771fa96.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hj-6ff926780d5702387fda17e72a686ebd6f364f0619a25d3f8ae72954f92e027f.json
+++ b/openfisca_france/tests/json/f7hj-6ff926780d5702387fda17e72a686ebd6f364f0619a25d3f8ae72954f92e027f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hj-9902a3b4763e1c57128d7952f303bf609a2c8bddd6d52915b260f36bbe94e06d.json
+++ b/openfisca_france/tests/json/f7hj-9902a3b4763e1c57128d7952f303bf609a2c8bddd6d52915b260f36bbe94e06d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hj-9d65730668fb1a97c855c6a43f520b54e723607d3250bda1e82f574eaa1f3ff4.json
+++ b/openfisca_france/tests/json/f7hj-9d65730668fb1a97c855c6a43f520b54e723607d3250bda1e82f574eaa1f3ff4.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hj-a536744417a34a178b9cfa8da16587484d14995edc8ff97560228d5c6976dd9d.json
+++ b/openfisca_france/tests/json/f7hj-a536744417a34a178b9cfa8da16587484d14995edc8ff97560228d5c6976dd9d.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hj-d0911d3d78d92ca8ccbe9c87c78e6720ba19fe9f93b7abc707e030b86b8a086e.json
+++ b/openfisca_france/tests/json/f7hj-d0911d3d78d92ca8ccbe9c87c78e6720ba19fe9f93b7abc707e030b86b8a086e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hj-d336edaefcfb5ee663ac0e2c8cf12562fc7fc252dccef44913b4793f340282a6.json
+++ b/openfisca_france/tests/json/f7hj-d336edaefcfb5ee663ac0e2c8cf12562fc7fc252dccef44913b4793f340282a6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hj-f7ec5527471060c8f16128ee391387658579b8420ec1f5be9c06cfcc88f018ba.json
+++ b/openfisca_france/tests/json/f7hj-f7ec5527471060c8f16128ee391387658579b8420ec1f5be9c06cfcc88f018ba.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hk-0ae632e43026fa011df450522f8ca7e01fd4104e9ca28010697984c460e6d9c4.json
+++ b/openfisca_france/tests/json/f7hk-0ae632e43026fa011df450522f8ca7e01fd4104e9ca28010697984c460e6d9c4.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hk-0ce47f504b7a07d6a88127cb9f1ccc64492a32437cb17bad0cb6704795d9bde4.json
+++ b/openfisca_france/tests/json/f7hk-0ce47f504b7a07d6a88127cb9f1ccc64492a32437cb17bad0cb6704795d9bde4.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hk-1430c46255ac947ec0c1b7721febf67ab0860e44e5189c3ac3c19e480fed8f2b.json
+++ b/openfisca_france/tests/json/f7hk-1430c46255ac947ec0c1b7721febf67ab0860e44e5189c3ac3c19e480fed8f2b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hk-407876a4167ecc612e0236edb127771e7e81885ec3670ef633d4e890f4da91cf.json
+++ b/openfisca_france/tests/json/f7hk-407876a4167ecc612e0236edb127771e7e81885ec3670ef633d4e890f4da91cf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hk-6e50c6257e172eb3fdb7efd017e2eb77fd870bfdbf967861c11452b76af9e191.json
+++ b/openfisca_france/tests/json/f7hk-6e50c6257e172eb3fdb7efd017e2eb77fd870bfdbf967861c11452b76af9e191.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hk-a22b9e8affab538b30faebd4f1f82d8379f7696eee708745c9690ff99d8c83aa.json
+++ b/openfisca_france/tests/json/f7hk-a22b9e8affab538b30faebd4f1f82d8379f7696eee708745c9690ff99d8c83aa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hk-d90082914780bc875d7bcbb163976408331286b75adf01386798ea9bbd5703a2.json
+++ b/openfisca_france/tests/json/f7hk-d90082914780bc875d7bcbb163976408331286b75adf01386798ea9bbd5703a2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hk-e853b6c6fe76190008194def9473bd635c767545998ce26603880cc13b473e17.json
+++ b/openfisca_france/tests/json/f7hk-e853b6c6fe76190008194def9473bd635c767545998ce26603880cc13b473e17.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hk-f7ef27f6c78bb6138ce32f9752cc0bdbd0d1e4d5c9dc004743aa7d06f3fdb4e1.json
+++ b/openfisca_france/tests/json/f7hk-f7ef27f6c78bb6138ce32f9752cc0bdbd0d1e4d5c9dc004743aa7d06f3fdb4e1.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hl-01450d649031452d880201fa5a6c3a6ca5c889dad7963a55ea2c88d42d922062.json
+++ b/openfisca_france/tests/json/f7hl-01450d649031452d880201fa5a6c3a6ca5c889dad7963a55ea2c88d42d922062.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hl-07d2be58191eda14d003512958d2d8349f14bc79a3e2d0e2050d9614026a3218.json
+++ b/openfisca_france/tests/json/f7hl-07d2be58191eda14d003512958d2d8349f14bc79a3e2d0e2050d9614026a3218.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hl-18ae327b551b20b558f0c5b653c791fd659eb4eff8f229889fc155b53e7a4f2b.json
+++ b/openfisca_france/tests/json/f7hl-18ae327b551b20b558f0c5b653c791fd659eb4eff8f229889fc155b53e7a4f2b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hl-283240c402748e59663310439720fd8bf63c9eafb7bd7dfa309eafeb652401b2.json
+++ b/openfisca_france/tests/json/f7hl-283240c402748e59663310439720fd8bf63c9eafb7bd7dfa309eafeb652401b2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hl-662ba885e3232243a4468da8e7c0999ce1b0c0b6e14e75092bb6bcc1c06d8b57.json
+++ b/openfisca_france/tests/json/f7hl-662ba885e3232243a4468da8e7c0999ce1b0c0b6e14e75092bb6bcc1c06d8b57.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hl-829537d6ecf43ab6761a606f47db6b0073fb01fcbf38dd7cf81c2301213745ad.json
+++ b/openfisca_france/tests/json/f7hl-829537d6ecf43ab6761a606f47db6b0073fb01fcbf38dd7cf81c2301213745ad.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hl-87e5ae094796eb2d717b36f88ed39077cfbafa87f9344a32246b6c1b509861ac.json
+++ b/openfisca_france/tests/json/f7hl-87e5ae094796eb2d717b36f88ed39077cfbafa87f9344a32246b6c1b509861ac.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hl-b3b9a5b27b7909912e54039581065df543caf2da8215a508dfcac4963329a245.json
+++ b/openfisca_france/tests/json/f7hl-b3b9a5b27b7909912e54039581065df543caf2da8215a508dfcac4963329a245.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hl-be977c62cbc603a5044827cf73b8acf35901907e128da770ea786939bdd5c411.json
+++ b/openfisca_france/tests/json/f7hl-be977c62cbc603a5044827cf73b8acf35901907e128da770ea786939bdd5c411.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hm-1e53ef1646ff0e1851152a22045c924019edbdc43598ed8fcb3759a6fd7b46d6.json
+++ b/openfisca_france/tests/json/f7hm-1e53ef1646ff0e1851152a22045c924019edbdc43598ed8fcb3759a6fd7b46d6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hm-27f5a44b944fb34e03fa23a5eb964c68355660f4425cfbd1912436b808e3daf9.json
+++ b/openfisca_france/tests/json/f7hm-27f5a44b944fb34e03fa23a5eb964c68355660f4425cfbd1912436b808e3daf9.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hm-3229eb98c7d215a8ade7b901eadd6c4904588ba21b20d552c92b15a4b2842a0e.json
+++ b/openfisca_france/tests/json/f7hm-3229eb98c7d215a8ade7b901eadd6c4904588ba21b20d552c92b15a4b2842a0e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hm-76a9b9ee8ed473858cde7ebd297bbae3e4f12dc9461a883864a29fa5aae9e89f.json
+++ b/openfisca_france/tests/json/f7hm-76a9b9ee8ed473858cde7ebd297bbae3e4f12dc9461a883864a29fa5aae9e89f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hm-9e47d1709b56efdb1d64eedbb7c1bd9e6cc93f7450a53a5cea9d9e73175bb70e.json
+++ b/openfisca_france/tests/json/f7hm-9e47d1709b56efdb1d64eedbb7c1bd9e6cc93f7450a53a5cea9d9e73175bb70e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hm-bcfff89ef11bef3296bbf6342b16b2e6f168bcb0456934fb96c95d22e3606a0e.json
+++ b/openfisca_france/tests/json/f7hm-bcfff89ef11bef3296bbf6342b16b2e6f168bcb0456934fb96c95d22e3606a0e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hm-e2ff04f5e264386c089f079aca51961ee5712844fdedd910b3de9b20cd93d743.json
+++ b/openfisca_france/tests/json/f7hm-e2ff04f5e264386c089f079aca51961ee5712844fdedd910b3de9b20cd93d743.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hm-e957812e8a1b75b7094d39fed2032b211b64dcafd5dfb2471be231f8d4384319.json
+++ b/openfisca_france/tests/json/f7hm-e957812e8a1b75b7094d39fed2032b211b64dcafd5dfb2471be231f8d4384319.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hm-f03b8d79def03b7aa9ff3cd941b6e108c76642efce9adae3a40cd23ba8249746.json
+++ b/openfisca_france/tests/json/f7hm-f03b8d79def03b7aa9ff3cd941b6e108c76642efce9adae3a40cd23ba8249746.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hn-1446d6e3216a0a6cb4a520015e2d02a58d9d16dc95dfda081382098e62ceeabc.json
+++ b/openfisca_france/tests/json/f7hn-1446d6e3216a0a6cb4a520015e2d02a58d9d16dc95dfda081382098e62ceeabc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hn-1f6c08b2a01c78b084d3041f055c56e4a26aa7dd02c6da97fa0a0de50afea1ee.json
+++ b/openfisca_france/tests/json/f7hn-1f6c08b2a01c78b084d3041f055c56e4a26aa7dd02c6da97fa0a0de50afea1ee.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hn-4cc392a81e6282b365bdd75c58d64d288d37c23d741281fb72fac73679839073.json
+++ b/openfisca_france/tests/json/f7hn-4cc392a81e6282b365bdd75c58d64d288d37c23d741281fb72fac73679839073.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hn-57e1d07c72aed00d80b37b7f2903e7a70bb29ba52af1e482453b58c8d2c2ae76.json
+++ b/openfisca_france/tests/json/f7hn-57e1d07c72aed00d80b37b7f2903e7a70bb29ba52af1e482453b58c8d2c2ae76.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hn-97bebe36e63eb50f01c81bcdef9f1db1b534842b4749a14186c1be65b53c3238.json
+++ b/openfisca_france/tests/json/f7hn-97bebe36e63eb50f01c81bcdef9f1db1b534842b4749a14186c1be65b53c3238.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hn-ad73db5d1a78b7ebce57ac2128303745536e2de90de9483ba0f781043e3594fa.json
+++ b/openfisca_france/tests/json/f7hn-ad73db5d1a78b7ebce57ac2128303745536e2de90de9483ba0f781043e3594fa.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hn-d89992bd1e36f2474cccf85b8bc279ad67674eebd534aa4352e5a03074cdada9.json
+++ b/openfisca_france/tests/json/f7hn-d89992bd1e36f2474cccf85b8bc279ad67674eebd534aa4352e5a03074cdada9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hn-daba4945e9dfb9c828bf441ff46f859404042870cf2babe0378a0350197c0564.json
+++ b/openfisca_france/tests/json/f7hn-daba4945e9dfb9c828bf441ff46f859404042870cf2babe0378a0350197c0564.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hn-e87c0889bd664842b6b7d8501afc405bdff0ae3c0708c30b0729b2b7571e8067.json
+++ b/openfisca_france/tests/json/f7hn-e87c0889bd664842b6b7d8501afc405bdff0ae3c0708c30b0729b2b7571e8067.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ho-0c5e4b8dc14fad129e42968da5f5dd13445e782ffe6b1bd83a00de2069d3430d.json
+++ b/openfisca_france/tests/json/f7ho-0c5e4b8dc14fad129e42968da5f5dd13445e782ffe6b1bd83a00de2069d3430d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ho-269fe76eabfb516a145199e84fa0902fd329ccf1193f4310f3e620e8fe1e45db.json
+++ b/openfisca_france/tests/json/f7ho-269fe76eabfb516a145199e84fa0902fd329ccf1193f4310f3e620e8fe1e45db.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ho-383702891fcfaf0ec6a9d18ad33e27ebb99b2a2ac7ef9ed05bf6ef0fb23065ed.json
+++ b/openfisca_france/tests/json/f7ho-383702891fcfaf0ec6a9d18ad33e27ebb99b2a2ac7ef9ed05bf6ef0fb23065ed.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ho-57dc99d546e161c5501434ca05c06d2528d431a2584201c539d2657aa6259bbd.json
+++ b/openfisca_france/tests/json/f7ho-57dc99d546e161c5501434ca05c06d2528d431a2584201c539d2657aa6259bbd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ho-7a42e7d07b7a1d9a646355d6811617b38263567600907ad40a888b3518f79632.json
+++ b/openfisca_france/tests/json/f7ho-7a42e7d07b7a1d9a646355d6811617b38263567600907ad40a888b3518f79632.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ho-96ab382e991ee9ebeda56db1488fb71005ca7c95b74b793917b70c5f69d00e1a.json
+++ b/openfisca_france/tests/json/f7ho-96ab382e991ee9ebeda56db1488fb71005ca7c95b74b793917b70c5f69d00e1a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ho-96c1f63e27ead38731550470c7904f6cca1d842e3709eb5bc31f24475c4652fc.json
+++ b/openfisca_france/tests/json/f7ho-96c1f63e27ead38731550470c7904f6cca1d842e3709eb5bc31f24475c4652fc.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ho-a658ebf535aba8352a865dd2840aa525ffd2b3db31a05044ca4c669f11148ce5.json
+++ b/openfisca_france/tests/json/f7ho-a658ebf535aba8352a865dd2840aa525ffd2b3db31a05044ca4c669f11148ce5.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ho-ce84c9a273fe8583d7c1a7dc63fa259fc4dbc95d6481d62112dcb49d75167cf6.json
+++ b/openfisca_france/tests/json/f7ho-ce84c9a273fe8583d7c1a7dc63fa259fc4dbc95d6481d62112dcb49d75167cf6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hr-0166c5e757434d7a58d1e075c85d8f2052ed4e77c3885a8d0ce3334599d8ec7b.json
+++ b/openfisca_france/tests/json/f7hr-0166c5e757434d7a58d1e075c85d8f2052ed4e77c3885a8d0ce3334599d8ec7b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hr-08707ca46cd6b84c0d5eb9e53a65e51efa320ef624dfc64f20bf30d86451f64f.json
+++ b/openfisca_france/tests/json/f7hr-08707ca46cd6b84c0d5eb9e53a65e51efa320ef624dfc64f20bf30d86451f64f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hr-58dd5107739efbde38b7905d6fb04c3988d5664a54d1319466567433e67c4bd1.json
+++ b/openfisca_france/tests/json/f7hr-58dd5107739efbde38b7905d6fb04c3988d5664a54d1319466567433e67c4bd1.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hr-6b679ddd4198cd10725531293d0610877ec1d58554e5dc19b461b87f715d749b.json
+++ b/openfisca_france/tests/json/f7hr-6b679ddd4198cd10725531293d0610877ec1d58554e5dc19b461b87f715d749b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hr-704669dc81e609e2e415bc070e3088721996321dd9f2c97117f8f88b582b8b45.json
+++ b/openfisca_france/tests/json/f7hr-704669dc81e609e2e415bc070e3088721996321dd9f2c97117f8f88b582b8b45.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hr-73eb7b84668032f61cf5b49157d7ac8b5cdd7dd2cd8ec2173520d852aa3017d6.json
+++ b/openfisca_france/tests/json/f7hr-73eb7b84668032f61cf5b49157d7ac8b5cdd7dd2cd8ec2173520d852aa3017d6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hr-962481ccb3d6f0eeef895277fcd13d3f5abe5c195af0ef2fd5d5c9a54d3b2ffe.json
+++ b/openfisca_france/tests/json/f7hr-962481ccb3d6f0eeef895277fcd13d3f5abe5c195af0ef2fd5d5c9a54d3b2ffe.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hr-a864546638e61916198c293ea0b7c7a889a65d3beaf5eb6487036034ceb79897.json
+++ b/openfisca_france/tests/json/f7hr-a864546638e61916198c293ea0b7c7a889a65d3beaf5eb6487036034ceb79897.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hr-b41537ff4d723b61976115c1fb7fac47e06377c603bf5fdaff8a82aeb712cd42.json
+++ b/openfisca_france/tests/json/f7hr-b41537ff4d723b61976115c1fb7fac47e06377c603bf5fdaff8a82aeb712cd42.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hs-02a7e2619e9a11617a57eebfc9cc2372a089570a7c1d21d384a101945bad27aa.json
+++ b/openfisca_france/tests/json/f7hs-02a7e2619e9a11617a57eebfc9cc2372a089570a7c1d21d384a101945bad27aa.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hs-7323b0b470db142a3b843c5fcfdbe7a8624852758bde6836a85f1b260c5f1e8f.json
+++ b/openfisca_france/tests/json/f7hs-7323b0b470db142a3b843c5fcfdbe7a8624852758bde6836a85f1b260c5f1e8f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hs-87da490c652d771522725137e43d1a8d494d2aab0beb527e726fb6d12c25d851.json
+++ b/openfisca_france/tests/json/f7hs-87da490c652d771522725137e43d1a8d494d2aab0beb527e726fb6d12c25d851.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hs-9322f5034711f0be5af3b2055d20494ae974760242a70056f51aa21e3445beaa.json
+++ b/openfisca_france/tests/json/f7hs-9322f5034711f0be5af3b2055d20494ae974760242a70056f51aa21e3445beaa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hs-9f222ebba2550129bfad4e36129800d641ef0ef57cbce6855ebd10e0bf4cf0a7.json
+++ b/openfisca_france/tests/json/f7hs-9f222ebba2550129bfad4e36129800d641ef0ef57cbce6855ebd10e0bf4cf0a7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hs-af1f37d7aae594e74f2ed9b227c2678b4301b5f0e8e30f3c03fb0b7262c136bd.json
+++ b/openfisca_france/tests/json/f7hs-af1f37d7aae594e74f2ed9b227c2678b4301b5f0e8e30f3c03fb0b7262c136bd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hs-bb0cf8f94ea0d61e5d53886178a43230624f62e8a8fdcd2c9dd5446a42e5f483.json
+++ b/openfisca_france/tests/json/f7hs-bb0cf8f94ea0d61e5d53886178a43230624f62e8a8fdcd2c9dd5446a42e5f483.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hs-d860886c857661fafc306ec43f9d04b0f1cf5f71d9ec25ce72074936e817e964.json
+++ b/openfisca_france/tests/json/f7hs-d860886c857661fafc306ec43f9d04b0f1cf5f71d9ec25ce72074936e817e964.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hs-df76cbe787a0599246b1645e010b572d8a63d2fe3584e7cbe7359a2ac1c735a7.json
+++ b/openfisca_france/tests/json/f7hs-df76cbe787a0599246b1645e010b572d8a63d2fe3584e7cbe7359a2ac1c735a7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ht-0fe3cd05a6410e8650fe551fbef60d09e1de5e92c7b0f481055f77fc697a0cf8.json
+++ b/openfisca_france/tests/json/f7ht-0fe3cd05a6410e8650fe551fbef60d09e1de5e92c7b0f481055f77fc697a0cf8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ht-23d53b0113d2834a69a780a3107683e4310d780ac2b9e9430c0838faf355447b.json
+++ b/openfisca_france/tests/json/f7ht-23d53b0113d2834a69a780a3107683e4310d780ac2b9e9430c0838faf355447b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ht-59835397bd3f01113d18e7e44a5247393ff87a623dabaaef73819373e321e79d.json
+++ b/openfisca_france/tests/json/f7ht-59835397bd3f01113d18e7e44a5247393ff87a623dabaaef73819373e321e79d.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ht-5a14476c976dcf1369a4056a78d0268ed801c031a3dc13e09ddb2ac603358b37.json
+++ b/openfisca_france/tests/json/f7ht-5a14476c976dcf1369a4056a78d0268ed801c031a3dc13e09ddb2ac603358b37.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ht-7671d14beefcf6d2e2f8621b5d2d94434aa4f171229a944c1ad90b61cb1c3899.json
+++ b/openfisca_france/tests/json/f7ht-7671d14beefcf6d2e2f8621b5d2d94434aa4f171229a944c1ad90b61cb1c3899.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ht-81987505475c189bbb38a388f8486223d7e7a0242f640324a3cc54ac887ccddc.json
+++ b/openfisca_france/tests/json/f7ht-81987505475c189bbb38a388f8486223d7e7a0242f640324a3cc54ac887ccddc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ht-ab0011585b328bd1b3eeb9943d389d305ddc9a6d778c67b3a30243d5f57f87e2.json
+++ b/openfisca_france/tests/json/f7ht-ab0011585b328bd1b3eeb9943d389d305ddc9a6d778c67b3a30243d5f57f87e2.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ht-d6bc8a9b9777f1193bd38646f1b1275f3cb451420b1bb6348e403d07db438a06.json
+++ b/openfisca_france/tests/json/f7ht-d6bc8a9b9777f1193bd38646f1b1275f3cb451420b1bb6348e403d07db438a06.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ht-f2cd6a738ee481fc11ef55d41dea011a656ec77d506d28217913c85828169e29.json
+++ b/openfisca_france/tests/json/f7ht-f2cd6a738ee481fc11ef55d41dea011a656ec77d506d28217913c85828169e29.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hu-32ca02e8ff34d3484bafc26cfa76eab5e75d8864b1ac32fa9a112044bdc75e0e.json
+++ b/openfisca_france/tests/json/f7hu-32ca02e8ff34d3484bafc26cfa76eab5e75d8864b1ac32fa9a112044bdc75e0e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hu-52b911756ed1bbced21d231f2dfab8ffc1e8f8023380460bf483e11bdc4f9f35.json
+++ b/openfisca_france/tests/json/f7hu-52b911756ed1bbced21d231f2dfab8ffc1e8f8023380460bf483e11bdc4f9f35.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hu-7242d14ba3a26b06215699a91d92188bb28fecdf6629541708e14298325b8d8c.json
+++ b/openfisca_france/tests/json/f7hu-7242d14ba3a26b06215699a91d92188bb28fecdf6629541708e14298325b8d8c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hu-837d0951d79c64bf7d758417fc343deaf64fe09873cf36d17bbaf9fffc944319.json
+++ b/openfisca_france/tests/json/f7hu-837d0951d79c64bf7d758417fc343deaf64fe09873cf36d17bbaf9fffc944319.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hu-95f8a6466967eeeb68e76643b502cff668c0afc3a5f0559a7a473992182c09ea.json
+++ b/openfisca_france/tests/json/f7hu-95f8a6466967eeeb68e76643b502cff668c0afc3a5f0559a7a473992182c09ea.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hu-96dcc40c9295edd0b16e973c490158d0454b4f2fd908086320012616ec409127.json
+++ b/openfisca_france/tests/json/f7hu-96dcc40c9295edd0b16e973c490158d0454b4f2fd908086320012616ec409127.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hu-a1bdc360c9a26e5a7dfff9dfca6c93366638799b899ba52a59dfa44d75f9323a.json
+++ b/openfisca_france/tests/json/f7hu-a1bdc360c9a26e5a7dfff9dfca6c93366638799b899ba52a59dfa44d75f9323a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hu-c32136fd2e7a484d7639dcd76e707c9ca57fb3191755d95a3f3b899f38b44332.json
+++ b/openfisca_france/tests/json/f7hu-c32136fd2e7a484d7639dcd76e707c9ca57fb3191755d95a3f3b899f38b44332.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hu-eca05ce4bfb6894b59548f1234ddd9f732e4256de686373ed061e463a5507add.json
+++ b/openfisca_france/tests/json/f7hu-eca05ce4bfb6894b59548f1234ddd9f732e4256de686373ed061e463a5507add.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hv-4c01845ae77341503e79838c023106db51f1b45b6b3c88e815b30ce813519cb1.json
+++ b/openfisca_france/tests/json/f7hv-4c01845ae77341503e79838c023106db51f1b45b6b3c88e815b30ce813519cb1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hv-891219d2cb1ec1b3f7c02d3090c49a83c23d32d687870d1925f2cd2e9d3629f8.json
+++ b/openfisca_france/tests/json/f7hv-891219d2cb1ec1b3f7c02d3090c49a83c23d32d687870d1925f2cd2e9d3629f8.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hv-976af89531693195470254d0eb4a727870c291d2968b48e78b0dea0ad1a4dd5b.json
+++ b/openfisca_france/tests/json/f7hv-976af89531693195470254d0eb4a727870c291d2968b48e78b0dea0ad1a4dd5b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hv-abf8a62e6f4b9931443fb0b6c33d8a69213ecf97600fee114684750d29af95fd.json
+++ b/openfisca_france/tests/json/f7hv-abf8a62e6f4b9931443fb0b6c33d8a69213ecf97600fee114684750d29af95fd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hv-b97690087d220e98c25ee448299d04d1aa635ca010b6fb9351cf474faa4fc5a0.json
+++ b/openfisca_france/tests/json/f7hv-b97690087d220e98c25ee448299d04d1aa635ca010b6fb9351cf474faa4fc5a0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hv-e91268263d6ad0024e4a1ae7fcef7a36d019de68a016ee25daa7c33678cc6dbf.json
+++ b/openfisca_france/tests/json/f7hv-e91268263d6ad0024e4a1ae7fcef7a36d019de68a016ee25daa7c33678cc6dbf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hv-ebd4a2187798aae311a9efba2c3347bbf31604ba3c246734ddc65286e8863c08.json
+++ b/openfisca_france/tests/json/f7hv-ebd4a2187798aae311a9efba2c3347bbf31604ba3c246734ddc65286e8863c08.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hv-f40106f48c9e77c308594547116185dc9ca1adc904fc1908feaeff9e9a995c23.json
+++ b/openfisca_france/tests/json/f7hv-f40106f48c9e77c308594547116185dc9ca1adc904fc1908feaeff9e9a995c23.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hv-fe96e2963d63fff6c2eeb99b11ff114e6c1dd6f71c6d1e41b08016e57679ac6d.json
+++ b/openfisca_france/tests/json/f7hv-fe96e2963d63fff6c2eeb99b11ff114e6c1dd6f71c6d1e41b08016e57679ac6d.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hw-272543d5c4332553b3d5adfdb1b14da88e22255bce1a11b9bd40fc4a4f69dfbb.json
+++ b/openfisca_france/tests/json/f7hw-272543d5c4332553b3d5adfdb1b14da88e22255bce1a11b9bd40fc4a4f69dfbb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hw-3b6f480f3bab61a2229fce0f07cace3e168f918f29bc5017c5c73450c1b0ec0d.json
+++ b/openfisca_france/tests/json/f7hw-3b6f480f3bab61a2229fce0f07cace3e168f918f29bc5017c5c73450c1b0ec0d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hw-49182d55725ed4adf8fb0ce6614ba5f176bbfd8f583e245ed6af66f8ff78f8e0.json
+++ b/openfisca_france/tests/json/f7hw-49182d55725ed4adf8fb0ce6614ba5f176bbfd8f583e245ed6af66f8ff78f8e0.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hw-7c978291df821adf8ac0fe5315889970a37704396de28890a843506d6b2094c9.json
+++ b/openfisca_france/tests/json/f7hw-7c978291df821adf8ac0fe5315889970a37704396de28890a843506d6b2094c9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hw-8a9ec79d3f09052c07c035f1db8065a688270762541ca46eec0c8ad554778a7b.json
+++ b/openfisca_france/tests/json/f7hw-8a9ec79d3f09052c07c035f1db8065a688270762541ca46eec0c8ad554778a7b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hw-91db80486ce9238ba9ea153cd35e967c26a4529ba65deddef3251aeda472231e.json
+++ b/openfisca_france/tests/json/f7hw-91db80486ce9238ba9ea153cd35e967c26a4529ba65deddef3251aeda472231e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hw-a80512257d5663e5a18daa42354e3c3bef50a61aad44fe42ac4f8fcec8121987.json
+++ b/openfisca_france/tests/json/f7hw-a80512257d5663e5a18daa42354e3c3bef50a61aad44fe42ac4f8fcec8121987.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hw-c39f30b93f3b44ae6d2c90cbd1222d08666242c754183c3bbbd6606794fda8d8.json
+++ b/openfisca_france/tests/json/f7hw-c39f30b93f3b44ae6d2c90cbd1222d08666242c754183c3bbbd6606794fda8d8.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hw-c97e4ca004e376909b0fbce4f9e6ff99f130df3ee696f6568d81812962938ab0.json
+++ b/openfisca_france/tests/json/f7hw-c97e4ca004e376909b0fbce4f9e6ff99f130df3ee696f6568d81812962938ab0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hx-03bb8a4278fb5b29679a213ea48a519cce91b5ce6e7bc42c81a7d4bb620ae1f6.json
+++ b/openfisca_france/tests/json/f7hx-03bb8a4278fb5b29679a213ea48a519cce91b5ce6e7bc42c81a7d4bb620ae1f6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hx-35ac2bfba66d579fc2aaca91fd273a5a6f8720e3517cbe4ea2a70187305d7a91.json
+++ b/openfisca_france/tests/json/f7hx-35ac2bfba66d579fc2aaca91fd273a5a6f8720e3517cbe4ea2a70187305d7a91.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hx-42dda0aa513aaa66996e73f49e2b83757a79e20942f4896b304eb646dd6c16ed.json
+++ b/openfisca_france/tests/json/f7hx-42dda0aa513aaa66996e73f49e2b83757a79e20942f4896b304eb646dd6c16ed.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hx-4538a1324acb9e209de88c127d5e9f81742004a2fc0469586ebecef899f3917f.json
+++ b/openfisca_france/tests/json/f7hx-4538a1324acb9e209de88c127d5e9f81742004a2fc0469586ebecef899f3917f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hx-4f82e8edb09cf4b269d60efa012ecd57c931949c61dfcb58e56726ef1b98a151.json
+++ b/openfisca_france/tests/json/f7hx-4f82e8edb09cf4b269d60efa012ecd57c931949c61dfcb58e56726ef1b98a151.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hx-63dfdc72179a25b4542536cf4a75c6b248369293f5d085ca21b67d3193551121.json
+++ b/openfisca_france/tests/json/f7hx-63dfdc72179a25b4542536cf4a75c6b248369293f5d085ca21b67d3193551121.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hx-6d46a036e6e5ba58cfe9f43dc5ff3816834d06b66a1802e17216823b6c19ec3b.json
+++ b/openfisca_france/tests/json/f7hx-6d46a036e6e5ba58cfe9f43dc5ff3816834d06b66a1802e17216823b6c19ec3b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hx-a00236c68251dd26f1b9a83716c46fd09723ed1ec6f6494728075c76ef2ed33d.json
+++ b/openfisca_france/tests/json/f7hx-a00236c68251dd26f1b9a83716c46fd09723ed1ec6f6494728075c76ef2ed33d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hx-c7edacb73c45befbdd9420279a94b8c936d37fdb38310479fe82e2f31db4bf02.json
+++ b/openfisca_france/tests/json/f7hx-c7edacb73c45befbdd9420279a94b8c936d37fdb38310479fe82e2f31db4bf02.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hy-50d8912a491ca6a40326c2d7d6d929b140f4f24f907fd650380d3adfd4ff10f8.json
+++ b/openfisca_france/tests/json/f7hy-50d8912a491ca6a40326c2d7d6d929b140f4f24f907fd650380d3adfd4ff10f8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hy-8c6cbe5f473d41b1ccde5d7da4f4731d363e40cddf39c01c24052ae29fff4c57.json
+++ b/openfisca_france/tests/json/f7hy-8c6cbe5f473d41b1ccde5d7da4f4731d363e40cddf39c01c24052ae29fff4c57.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hy-9081defbb2f4527d5c894d505493a99042921828af0ca5f1190785bc8385297d.json
+++ b/openfisca_france/tests/json/f7hy-9081defbb2f4527d5c894d505493a99042921828af0ca5f1190785bc8385297d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hy-c3bd7e949a1263c6a16eb4c17ec07a54d3feda773d62b0c51b5be84d15930c24.json
+++ b/openfisca_france/tests/json/f7hy-c3bd7e949a1263c6a16eb4c17ec07a54d3feda773d62b0c51b5be84d15930c24.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hz-5710f6baa0b63352b14d88e90aca645dd9caca88ce515ce946209eeced408eeb.json
+++ b/openfisca_france/tests/json/f7hz-5710f6baa0b63352b14d88e90aca645dd9caca88ce515ce946209eeced408eeb.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hz-5729407be1f57474f5628ba2c2da0728bc1e0344841f5caa5aaeea6defba1b08.json
+++ b/openfisca_france/tests/json/f7hz-5729407be1f57474f5628ba2c2da0728bc1e0344841f5caa5aaeea6defba1b08.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hz-583ad446fd89c26c026930d2209b52ca7cfad6d19f536076aea54a0a92143e5c.json
+++ b/openfisca_france/tests/json/f7hz-583ad446fd89c26c026930d2209b52ca7cfad6d19f536076aea54a0a92143e5c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hz-6b776f25b3d963b0a69431d09c83ed414025bc39a2ccb973c5db7902e6040d1b.json
+++ b/openfisca_france/tests/json/f7hz-6b776f25b3d963b0a69431d09c83ed414025bc39a2ccb973c5db7902e6040d1b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hz-8c68bbd7de1e9a8e71febb294941a68cab81c988049d1310e865ac868c2d57b7.json
+++ b/openfisca_france/tests/json/f7hz-8c68bbd7de1e9a8e71febb294941a68cab81c988049d1310e865ac868c2d57b7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hz-9a9950f3f09d2c9f3b37c381429c70f92c6cc6d020dea336a7669f566a443587.json
+++ b/openfisca_france/tests/json/f7hz-9a9950f3f09d2c9f3b37c381429c70f92c6cc6d020dea336a7669f566a443587.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hz-db44e62a522609b9da650e6cf27f9262a62f89fb25c5a0864cbbcf96de02b46f.json
+++ b/openfisca_france/tests/json/f7hz-db44e62a522609b9da650e6cf27f9262a62f89fb25c5a0864cbbcf96de02b46f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hz-e4c4ba0da8a5657017caf86cd0a80568f940b45b306e0a2c031fbb88dd9a4ce5.json
+++ b/openfisca_france/tests/json/f7hz-e4c4ba0da8a5657017caf86cd0a80568f940b45b306e0a2c031fbb88dd9a4ce5.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7hz-fbe4ea5f2b3a2c14c44370f52a607e80dc50ee13dee19c0e1bba8dbff0f4293d.json
+++ b/openfisca_france/tests/json/f7hz-fbe4ea5f2b3a2c14c44370f52a607e80dc50ee13dee19c0e1bba8dbff0f4293d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ia-04dc574ae683e680495ae97150b537c42bedd399d4a6f8e533f016d19f92e16a.json
+++ b/openfisca_france/tests/json/f7ia-04dc574ae683e680495ae97150b537c42bedd399d4a6f8e533f016d19f92e16a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ia-06a5a15411e67192926011b4b617b6f91d2d90c9d499b7ee6e61c434f554e4a9.json
+++ b/openfisca_france/tests/json/f7ia-06a5a15411e67192926011b4b617b6f91d2d90c9d499b7ee6e61c434f554e4a9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ia-2fe234c67b634add1e1fddf77029d630e42a7b6c8fdc791fd9c894c090ad4923.json
+++ b/openfisca_france/tests/json/f7ia-2fe234c67b634add1e1fddf77029d630e42a7b6c8fdc791fd9c894c090ad4923.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ia-45edd04660c31c633ae76072520078cb15d194675f5f3a542d25ff55efc38c85.json
+++ b/openfisca_france/tests/json/f7ia-45edd04660c31c633ae76072520078cb15d194675f5f3a542d25ff55efc38c85.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ia-614de301dee14946051ae8f76262223ecc80affa4ae1da7dd4b0fd6082754413.json
+++ b/openfisca_france/tests/json/f7ia-614de301dee14946051ae8f76262223ecc80affa4ae1da7dd4b0fd6082754413.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ia-b3e1f06eb8231e054f8de991ba57e37a79e15ead071195e893a563bcba15824e.json
+++ b/openfisca_france/tests/json/f7ia-b3e1f06eb8231e054f8de991ba57e37a79e15ead071195e893a563bcba15824e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ia-cd0a10059a958d0d7bceb7f5689dd3e7a8083280924079aaa777fbf2e360710a.json
+++ b/openfisca_france/tests/json/f7ia-cd0a10059a958d0d7bceb7f5689dd3e7a8083280924079aaa777fbf2e360710a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ia-e4920323c8a0c104bf8bbe042645c12755d727326f12aef326136f516aba6c8a.json
+++ b/openfisca_france/tests/json/f7ia-e4920323c8a0c104bf8bbe042645c12755d727326f12aef326136f516aba6c8a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ia-f785d378c4fb3b374f69b81f051a179f0d71eec56ae3ba9957acee37539160ed.json
+++ b/openfisca_france/tests/json/f7ia-f785d378c4fb3b374f69b81f051a179f0d71eec56ae3ba9957acee37539160ed.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ib-26d65a5b2b3ffb98ecd1525333b3367ed27da6cd9b941494110188962e6cd910.json
+++ b/openfisca_france/tests/json/f7ib-26d65a5b2b3ffb98ecd1525333b3367ed27da6cd9b941494110188962e6cd910.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ib-4a708092db63799d1c1700f6d70d15b018617e0f8adb61adc8e097800f6e3978.json
+++ b/openfisca_france/tests/json/f7ib-4a708092db63799d1c1700f6d70d15b018617e0f8adb61adc8e097800f6e3978.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ib-5dec2f08063fb465d2ca8f402926f6dc2a15b7cd4a205c794f6c45ec7c69d72a.json
+++ b/openfisca_france/tests/json/f7ib-5dec2f08063fb465d2ca8f402926f6dc2a15b7cd4a205c794f6c45ec7c69d72a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ib-6caf3d80a89fb2ce423df551c9313d5f4abd09e9a8f67a6394afae6fbfab89b0.json
+++ b/openfisca_france/tests/json/f7ib-6caf3d80a89fb2ce423df551c9313d5f4abd09e9a8f67a6394afae6fbfab89b0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ib-6df4f875164e5e727b73ca3f84de201d58e35ad60ab962220b6728a1a595fb30.json
+++ b/openfisca_france/tests/json/f7ib-6df4f875164e5e727b73ca3f84de201d58e35ad60ab962220b6728a1a595fb30.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ib-9364beea501079613c960867ef98be5d9d7d43ee88ceb6707d57bacdf85bbffe.json
+++ b/openfisca_france/tests/json/f7ib-9364beea501079613c960867ef98be5d9d7d43ee88ceb6707d57bacdf85bbffe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ib-b7bbc94c31f549856936eefc1bb25b0a7185e44fac4002ae28b9129f991fe3d4.json
+++ b/openfisca_france/tests/json/f7ib-b7bbc94c31f549856936eefc1bb25b0a7185e44fac4002ae28b9129f991fe3d4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ib-d42967727f8fb887de99afc0bec8b4a10895907d9ed6010ba17e74db371f11df.json
+++ b/openfisca_france/tests/json/f7ib-d42967727f8fb887de99afc0bec8b4a10895907d9ed6010ba17e74db371f11df.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ib-fc217bdffd456e48f4c2b1260fa3dd0d7cb6b897826cb71cf04af8645334c5a2.json
+++ b/openfisca_france/tests/json/f7ib-fc217bdffd456e48f4c2b1260fa3dd0d7cb6b897826cb71cf04af8645334c5a2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ic-1f5d84a5fe428263ca590a2f4cdffa68033a921dbedbd187922db403fe053915.json
+++ b/openfisca_france/tests/json/f7ic-1f5d84a5fe428263ca590a2f4cdffa68033a921dbedbd187922db403fe053915.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ic-2f74f6107c3d5c008a5a68840b8c2a2595360c62eba73b0b09a18c85b548b9de.json
+++ b/openfisca_france/tests/json/f7ic-2f74f6107c3d5c008a5a68840b8c2a2595360c62eba73b0b09a18c85b548b9de.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ic-35655d2900cd47f44deab1abd0d0183be8e26157dee6107ef5aabc6ca9568243.json
+++ b/openfisca_france/tests/json/f7ic-35655d2900cd47f44deab1abd0d0183be8e26157dee6107ef5aabc6ca9568243.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ic-4d32846e5e2edd35270f203c3ae2e886feb89d867b5b044aea403734c626d97a.json
+++ b/openfisca_france/tests/json/f7ic-4d32846e5e2edd35270f203c3ae2e886feb89d867b5b044aea403734c626d97a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ic-612baaec2af92959f8c4c37055fd7f5632a18332dd975f5a75ae17beab50ece2.json
+++ b/openfisca_france/tests/json/f7ic-612baaec2af92959f8c4c37055fd7f5632a18332dd975f5a75ae17beab50ece2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ic-6c7b5e550157c68c9619fd471caaa26c53f421207d3d825ada47e531202c84eb.json
+++ b/openfisca_france/tests/json/f7ic-6c7b5e550157c68c9619fd471caaa26c53f421207d3d825ada47e531202c84eb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ic-7020b9efbf9153b72049be5baef70a60c0531e4a7f38dbc0ebc4905ab188c354.json
+++ b/openfisca_france/tests/json/f7ic-7020b9efbf9153b72049be5baef70a60c0531e4a7f38dbc0ebc4905ab188c354.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ic-7e075fb7c34f2b6304213896cd7bda34afee5b9bd1715a2e458ceef5d383877d.json
+++ b/openfisca_france/tests/json/f7ic-7e075fb7c34f2b6304213896cd7bda34afee5b9bd1715a2e458ceef5d383877d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ic-8a1e78bae924874cc72020e2cf970d7ab5530a23f7e23fd69edb7405096caa6b.json
+++ b/openfisca_france/tests/json/f7ic-8a1e78bae924874cc72020e2cf970d7ab5530a23f7e23fd69edb7405096caa6b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7id-1b0ae415558049b1144b9c9ed2179a7189508de8de2af31722338c948ef49ee5.json
+++ b/openfisca_france/tests/json/f7id-1b0ae415558049b1144b9c9ed2179a7189508de8de2af31722338c948ef49ee5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7id-874ec13d525ee9f7679b9f0a28c756da6acb2ec5cf65830464f8c2262dc2555d.json
+++ b/openfisca_france/tests/json/f7id-874ec13d525ee9f7679b9f0a28c756da6acb2ec5cf65830464f8c2262dc2555d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7id-8c3ce8fa44e8b9bf078251a6f7ca1f271d1a8accafc899f47fdd836f074d1e1b.json
+++ b/openfisca_france/tests/json/f7id-8c3ce8fa44e8b9bf078251a6f7ca1f271d1a8accafc899f47fdd836f074d1e1b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7id-9b6ad32bea7087db99c6ce3a0e8e43309c40dc97f220afc91357544e5cf13b5a.json
+++ b/openfisca_france/tests/json/f7id-9b6ad32bea7087db99c6ce3a0e8e43309c40dc97f220afc91357544e5cf13b5a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7id-a57e35f4eb5dbc214099e37d9e822d0c000ccd7bbceeb33e1587ce44b4f652c6.json
+++ b/openfisca_france/tests/json/f7id-a57e35f4eb5dbc214099e37d9e822d0c000ccd7bbceeb33e1587ce44b4f652c6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7id-b85b1e5b393e848c00b01f843e75a48700a9979a997228bfb78eed762d32e7db.json
+++ b/openfisca_france/tests/json/f7id-b85b1e5b393e848c00b01f843e75a48700a9979a997228bfb78eed762d32e7db.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7id-be6090290ee4f2eaa14b6e16bda9e1932e3a68e8def8e4856702399d7a750cf7.json
+++ b/openfisca_france/tests/json/f7id-be6090290ee4f2eaa14b6e16bda9e1932e3a68e8def8e4856702399d7a750cf7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7id-c32d463d5c158e9b64e4b7e5165e627e9672ebaf79c72e523c385cc0418829a5.json
+++ b/openfisca_france/tests/json/f7id-c32d463d5c158e9b64e4b7e5165e627e9672ebaf79c72e523c385cc0418829a5.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7id-ea8370bd096b0455117060d82062560512cc04ff0f142c66ae12936a8f1c3d6c.json
+++ b/openfisca_france/tests/json/f7id-ea8370bd096b0455117060d82062560512cc04ff0f142c66ae12936a8f1c3d6c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ie-02beafc85626b27cf026643f146397b207a5d6e0856491cc07d07f6c0b420a44.json
+++ b/openfisca_france/tests/json/f7ie-02beafc85626b27cf026643f146397b207a5d6e0856491cc07d07f6c0b420a44.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ie-05fbcba1e4255ccf03aa4a0737aa1cc0feb60ad6dfc103d4f635dda9c17462da.json
+++ b/openfisca_france/tests/json/f7ie-05fbcba1e4255ccf03aa4a0737aa1cc0feb60ad6dfc103d4f635dda9c17462da.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ie-1d4470c2f9d7f2f29faf8d3e216c3682708a521b8fa71c4440d5346299a7af34.json
+++ b/openfisca_france/tests/json/f7ie-1d4470c2f9d7f2f29faf8d3e216c3682708a521b8fa71c4440d5346299a7af34.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ie-5528dd14374ef62239834f190fa1cfa1cd9c63b84ca8138ca53fbe5e932cb308.json
+++ b/openfisca_france/tests/json/f7ie-5528dd14374ef62239834f190fa1cfa1cd9c63b84ca8138ca53fbe5e932cb308.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ie-684d6fbd053a713924cf22b589228097aba8126eeb5b86ac347749390446711f.json
+++ b/openfisca_france/tests/json/f7ie-684d6fbd053a713924cf22b589228097aba8126eeb5b86ac347749390446711f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ie-72097ab760561a14686376dde763f31d619924fad6ae2fc3d47d36086ef2d046.json
+++ b/openfisca_france/tests/json/f7ie-72097ab760561a14686376dde763f31d619924fad6ae2fc3d47d36086ef2d046.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ie-7e623cd30c510a79326bb7a95f37fdb06c296892ff61c0271dbb6ce3836b3ce0.json
+++ b/openfisca_france/tests/json/f7ie-7e623cd30c510a79326bb7a95f37fdb06c296892ff61c0271dbb6ce3836b3ce0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ie-8ac15dcb96ce20a80dc830c15ba21262c48d684586868c09afc992a3a9dd1a86.json
+++ b/openfisca_france/tests/json/f7ie-8ac15dcb96ce20a80dc830c15ba21262c48d684586868c09afc992a3a9dd1a86.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ie-9c6f2b430c13a9babdd864a8eebf0c8a9dd719434055b9dfd902435489149935.json
+++ b/openfisca_france/tests/json/f7ie-9c6f2b430c13a9babdd864a8eebf0c8a9dd719434055b9dfd902435489149935.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7if-3d513857f4388f15f61c4ccd1ff7011bfb96c4126172ac8761d8a661f5a694d5.json
+++ b/openfisca_france/tests/json/f7if-3d513857f4388f15f61c4ccd1ff7011bfb96c4126172ac8761d8a661f5a694d5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7if-41d95c92e303b1314e0f1f8ab81cd7dca5ff57728680addfed92e62307bc0138.json
+++ b/openfisca_france/tests/json/f7if-41d95c92e303b1314e0f1f8ab81cd7dca5ff57728680addfed92e62307bc0138.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7if-444288aec56b09a21d27466604d650355a96c97c91ef23b725182a65dd1e04b5.json
+++ b/openfisca_france/tests/json/f7if-444288aec56b09a21d27466604d650355a96c97c91ef23b725182a65dd1e04b5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7if-45895521851ed2405ed483ac00858f5c39f40c9a5edb353b9d0ec9b30d908b11.json
+++ b/openfisca_france/tests/json/f7if-45895521851ed2405ed483ac00858f5c39f40c9a5edb353b9d0ec9b30d908b11.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7if-b1af63e889c8137fd02ccc58396f8bcab806a5e1f3b87a912af3449f423ec428.json
+++ b/openfisca_france/tests/json/f7if-b1af63e889c8137fd02ccc58396f8bcab806a5e1f3b87a912af3449f423ec428.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7if-b5f6294b3eae8514869a9d2a04786a8e1ea9dfe978b22bdd3cfa07930d0948e5.json
+++ b/openfisca_france/tests/json/f7if-b5f6294b3eae8514869a9d2a04786a8e1ea9dfe978b22bdd3cfa07930d0948e5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7if-b8069fb86620d8b410974223c83e2b2887d6bccd70989b91973fe42db6d58623.json
+++ b/openfisca_france/tests/json/f7if-b8069fb86620d8b410974223c83e2b2887d6bccd70989b91973fe42db6d58623.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7if-b8ea302fde1d3c5d720e296eb05a23ab405b4e02b53c0d8736c568858a3b0ed6.json
+++ b/openfisca_france/tests/json/f7if-b8ea302fde1d3c5d720e296eb05a23ab405b4e02b53c0d8736c568858a3b0ed6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7if-e440fd9464964fcb23004cb53229ab34b0f5b2957376932902fe5f2a54d5c2ee.json
+++ b/openfisca_france/tests/json/f7if-e440fd9464964fcb23004cb53229ab34b0f5b2957376932902fe5f2a54d5c2ee.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ig-0835e24c03e3c56121a3a990dc4f09b973ef30ae862c351d90265fcae8cc137e.json
+++ b/openfisca_france/tests/json/f7ig-0835e24c03e3c56121a3a990dc4f09b973ef30ae862c351d90265fcae8cc137e.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ig-1f5a781288112699665fae9322927a7f8e776b233befe4c35d59165fd11d8821.json
+++ b/openfisca_france/tests/json/f7ig-1f5a781288112699665fae9322927a7f8e776b233befe4c35d59165fd11d8821.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ig-2051b199f6901c1afd5cf7710ad87dca95d89e72d4ed4e74f8dde7f8b6f6425b.json
+++ b/openfisca_france/tests/json/f7ig-2051b199f6901c1afd5cf7710ad87dca95d89e72d4ed4e74f8dde7f8b6f6425b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ig-37c22ea353d1d133188aaa383c22a8468a9fdc85a65cf6f07078ef9c9f0dbaa1.json
+++ b/openfisca_france/tests/json/f7ig-37c22ea353d1d133188aaa383c22a8468a9fdc85a65cf6f07078ef9c9f0dbaa1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ig-7cd655ebc9070aa34fda599e95156260833f53635316648086137711bb6543a3.json
+++ b/openfisca_france/tests/json/f7ig-7cd655ebc9070aa34fda599e95156260833f53635316648086137711bb6543a3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ig-abd947cf1146b7711924ddee10a721f7cfb8bf32764e6b93c6907647aced23d1.json
+++ b/openfisca_france/tests/json/f7ig-abd947cf1146b7711924ddee10a721f7cfb8bf32764e6b93c6907647aced23d1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ig-cf8a6815e2a95beb23d8668a071ad810d5bcf11c105ec4ad71ed8f4fa81a474a.json
+++ b/openfisca_france/tests/json/f7ig-cf8a6815e2a95beb23d8668a071ad810d5bcf11c105ec4ad71ed8f4fa81a474a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ig-d80786a5d5d1a2158aab4d4aeeb30a91bacbae6c85c55602b606abc36042dfff.json
+++ b/openfisca_france/tests/json/f7ig-d80786a5d5d1a2158aab4d4aeeb30a91bacbae6c85c55602b606abc36042dfff.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ig-f9910688f704f1974e65be4e47e69ebc95f3b05623dbe55e4082e2eef996ccf8.json
+++ b/openfisca_france/tests/json/f7ig-f9910688f704f1974e65be4e47e69ebc95f3b05623dbe55e4082e2eef996ccf8.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ih-02aa6f29c4edb54b281317e33bb6108b6ff2d8ea48f71811070f2216aa3a77d8.json
+++ b/openfisca_france/tests/json/f7ih-02aa6f29c4edb54b281317e33bb6108b6ff2d8ea48f71811070f2216aa3a77d8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ih-060f4d1d8ce22e0c3c076930796cec1bf0ea8a9c9a31d9fa22abe318ff1f5aef.json
+++ b/openfisca_france/tests/json/f7ih-060f4d1d8ce22e0c3c076930796cec1bf0ea8a9c9a31d9fa22abe318ff1f5aef.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ih-31609cb63736be6dde12ffe2eba9fd654f654311fce4ba3f9af59f683d292c71.json
+++ b/openfisca_france/tests/json/f7ih-31609cb63736be6dde12ffe2eba9fd654f654311fce4ba3f9af59f683d292c71.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ih-39a2cb9546b52cfb0b5cbe6a932384eaa1bf43a687505a6368c77781a41cdd39.json
+++ b/openfisca_france/tests/json/f7ih-39a2cb9546b52cfb0b5cbe6a932384eaa1bf43a687505a6368c77781a41cdd39.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ih-39e725d7408522cdaafbf1451cf8011e8078437a75ccd4c6ab43997191ae2d88.json
+++ b/openfisca_france/tests/json/f7ih-39e725d7408522cdaafbf1451cf8011e8078437a75ccd4c6ab43997191ae2d88.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ih-a7c3b864184cad31186e864d2451890f029508f4c90b5c04bf2c4281e1ea2acb.json
+++ b/openfisca_france/tests/json/f7ih-a7c3b864184cad31186e864d2451890f029508f4c90b5c04bf2c4281e1ea2acb.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ih-cb5b75f03856f66136b35cd4879f05e10c9108802174c4845863aff6e8f9a834.json
+++ b/openfisca_france/tests/json/f7ih-cb5b75f03856f66136b35cd4879f05e10c9108802174c4845863aff6e8f9a834.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ih-d974fb2babd44ae8809708a5d1401aecea5d833b7870deb49883ab0447c7d14d.json
+++ b/openfisca_france/tests/json/f7ih-d974fb2babd44ae8809708a5d1401aecea5d833b7870deb49883ab0447c7d14d.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ih-fdf7038a1d6653ab0c929d0a00cc2ef3413b54e1f0098b1c73615c1d77b74690.json
+++ b/openfisca_france/tests/json/f7ih-fdf7038a1d6653ab0c929d0a00cc2ef3413b54e1f0098b1c73615c1d77b74690.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ij-260849576849c628fe0380e3ecd4345b2a7815d024215a8691098c53e6e44ca1.json
+++ b/openfisca_france/tests/json/f7ij-260849576849c628fe0380e3ecd4345b2a7815d024215a8691098c53e6e44ca1.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ij-3815842e8b0e2504376090cccf0c408f93cc950153f0e8e4cee10aa55ff77ed5.json
+++ b/openfisca_france/tests/json/f7ij-3815842e8b0e2504376090cccf0c408f93cc950153f0e8e4cee10aa55ff77ed5.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ij-427cb702452665539f05917984d6daf78ab6dd58ea956ec77e619739f19d6559.json
+++ b/openfisca_france/tests/json/f7ij-427cb702452665539f05917984d6daf78ab6dd58ea956ec77e619739f19d6559.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ij-7e662913324dfcd3f9551a88b5bce837fd3128c8d48a3a29c7c275d45d136436.json
+++ b/openfisca_france/tests/json/f7ij-7e662913324dfcd3f9551a88b5bce837fd3128c8d48a3a29c7c275d45d136436.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ij-a2b7b722510c6197eeab0515c4fddf9ad9a4e5af60f6447311c9adf51dddce20.json
+++ b/openfisca_france/tests/json/f7ij-a2b7b722510c6197eeab0515c4fddf9ad9a4e5af60f6447311c9adf51dddce20.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ij-bffd4c7d37ff9a328b90b7f2f9db43d483788d4cd1d45705ff0b1d3c2cf1bb27.json
+++ b/openfisca_france/tests/json/f7ij-bffd4c7d37ff9a328b90b7f2f9db43d483788d4cd1d45705ff0b1d3c2cf1bb27.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ij-c0e389afa57ef9ab68e3da91fba5759a72ad07f3850c6f54946c4c2c6e93ba37.json
+++ b/openfisca_france/tests/json/f7ij-c0e389afa57ef9ab68e3da91fba5759a72ad07f3850c6f54946c4c2c6e93ba37.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ij-c4052e3eb932cba502976005aa85051adfbe63361c372c1e864786afaacc5a35.json
+++ b/openfisca_france/tests/json/f7ij-c4052e3eb932cba502976005aa85051adfbe63361c372c1e864786afaacc5a35.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ij-ee1847f7869e874d2597fe5907cfc06fb3f394faf0206db720d42a49a122ec87.json
+++ b/openfisca_france/tests/json/f7ij-ee1847f7869e874d2597fe5907cfc06fb3f394faf0206db720d42a49a122ec87.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ik-152344f05fdd14f9f5c83e246f3ab0ee86a6eb08f15e255ff9c9b4eda723ae33.json
+++ b/openfisca_france/tests/json/f7ik-152344f05fdd14f9f5c83e246f3ab0ee86a6eb08f15e255ff9c9b4eda723ae33.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ik-202980fd97c11cacc3737397fb0ae4d88fcc6cd0435022c8fd16b3ff9a6b0a80.json
+++ b/openfisca_france/tests/json/f7ik-202980fd97c11cacc3737397fb0ae4d88fcc6cd0435022c8fd16b3ff9a6b0a80.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ik-24eaaaecfd88f99a8fcc250445b3062d6881bcb67fe575891e3d91333e5969dc.json
+++ b/openfisca_france/tests/json/f7ik-24eaaaecfd88f99a8fcc250445b3062d6881bcb67fe575891e3d91333e5969dc.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ik-3c924d7a1ebcda905573f7c3b62dfc76a4fc336b193730be1e66348534af1dc5.json
+++ b/openfisca_france/tests/json/f7ik-3c924d7a1ebcda905573f7c3b62dfc76a4fc336b193730be1e66348534af1dc5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ik-44254bc01d675f950ce401330e3b00f09c4c5034d047d7106f0a441b54119bef.json
+++ b/openfisca_france/tests/json/f7ik-44254bc01d675f950ce401330e3b00f09c4c5034d047d7106f0a441b54119bef.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ik-83a5adb5bf0b1297d5c75dbfec4cf7bbb05b69f8813e451c908c9e33aa4179c1.json
+++ b/openfisca_france/tests/json/f7ik-83a5adb5bf0b1297d5c75dbfec4cf7bbb05b69f8813e451c908c9e33aa4179c1.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ik-b08605582e30f75ab2cd516a7041b3718c99602fc9992b0d36c4150e67c5211f.json
+++ b/openfisca_france/tests/json/f7ik-b08605582e30f75ab2cd516a7041b3718c99602fc9992b0d36c4150e67c5211f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ik-c749241881df51dd2069408617ac3c0514681bba901028e937dae3b053a79d20.json
+++ b/openfisca_france/tests/json/f7ik-c749241881df51dd2069408617ac3c0514681bba901028e937dae3b053a79d20.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ik-d615e0f25ffff5f75c988b1624cae1b9bbcf7c4a349ed685debeb670574123dd.json
+++ b/openfisca_france/tests/json/f7ik-d615e0f25ffff5f75c988b1624cae1b9bbcf7c4a349ed685debeb670574123dd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7il-11abe361e900e680c155dee3ef2efd0282d5c387596da0c595cbb7019dfff0cc.json
+++ b/openfisca_france/tests/json/f7il-11abe361e900e680c155dee3ef2efd0282d5c387596da0c595cbb7019dfff0cc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7il-1d0921d53ec71865e5ab463bafe8485533adfe95a0b39b3a8d5d20a9d4cdba5e.json
+++ b/openfisca_france/tests/json/f7il-1d0921d53ec71865e5ab463bafe8485533adfe95a0b39b3a8d5d20a9d4cdba5e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7il-25d97b46e5f8d3b4f1daf4603a71eec32bd1189b279a869c1413c92eff3e2d67.json
+++ b/openfisca_france/tests/json/f7il-25d97b46e5f8d3b4f1daf4603a71eec32bd1189b279a869c1413c92eff3e2d67.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7il-50fd96a94a863a1484a6e68d2c16c6f93c41f06cdf25766b032baceefabda2ea.json
+++ b/openfisca_france/tests/json/f7il-50fd96a94a863a1484a6e68d2c16c6f93c41f06cdf25766b032baceefabda2ea.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7il-a87e184cf5357636cc1119d3cb743ca1d8c55580b731568021e0ee076f4e481a.json
+++ b/openfisca_france/tests/json/f7il-a87e184cf5357636cc1119d3cb743ca1d8c55580b731568021e0ee076f4e481a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7il-b175981fe4bd3b86944f29cd53d2ef74e565c431832be719bce3da6c9fc3d88e.json
+++ b/openfisca_france/tests/json/f7il-b175981fe4bd3b86944f29cd53d2ef74e565c431832be719bce3da6c9fc3d88e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7il-be701e29f5214b26224750ae4e6a10729321f17c2cc915588f549169c571a62b.json
+++ b/openfisca_france/tests/json/f7il-be701e29f5214b26224750ae4e6a10729321f17c2cc915588f549169c571a62b.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7il-eed4e36f4cbad395c9520932ef97651941666dda679695aba945911c77e3e0f5.json
+++ b/openfisca_france/tests/json/f7il-eed4e36f4cbad395c9520932ef97651941666dda679695aba945911c77e3e0f5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7il-ef8e03c43b019739bf1beb2426cc2bf2ae7741ec3e4d8b3ea4a4c9f694d650ea.json
+++ b/openfisca_france/tests/json/f7il-ef8e03c43b019739bf1beb2426cc2bf2ae7741ec3e4d8b3ea4a4c9f694d650ea.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7im-0cb7166e1a9ed8a05eef07f721c337e5584839a399ed722923a894dd6fc43bab.json
+++ b/openfisca_france/tests/json/f7im-0cb7166e1a9ed8a05eef07f721c337e5584839a399ed722923a894dd6fc43bab.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7im-0cbb1cb93bfd4223b2896103a2551de5fb130a492ac9bf00caad318caf7d919c.json
+++ b/openfisca_france/tests/json/f7im-0cbb1cb93bfd4223b2896103a2551de5fb130a492ac9bf00caad318caf7d919c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7im-677670887c2d18c80858760f9693c0c1f86d6b63d7bf734a7496b8570c3df5ad.json
+++ b/openfisca_france/tests/json/f7im-677670887c2d18c80858760f9693c0c1f86d6b63d7bf734a7496b8570c3df5ad.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7im-70879dcb1117a23169aa05eb4a03a45128174e6dec50daa27f6a4a4a39ed2a17.json
+++ b/openfisca_france/tests/json/f7im-70879dcb1117a23169aa05eb4a03a45128174e6dec50daa27f6a4a4a39ed2a17.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7im-a352b1fbe45a7faab467137fac4fcb93e4667c451d06d68cb5636da3beabb494.json
+++ b/openfisca_france/tests/json/f7im-a352b1fbe45a7faab467137fac4fcb93e4667c451d06d68cb5636da3beabb494.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7im-a4a6a149a2a1e5d101f0ff4b96f52f9f6fcc274f331b023adfd723beff93285b.json
+++ b/openfisca_france/tests/json/f7im-a4a6a149a2a1e5d101f0ff4b96f52f9f6fcc274f331b023adfd723beff93285b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7im-dab6469eb6c1aca4115118dee4f5619bf37a4cd2384008db7571e45cc8ab6f69.json
+++ b/openfisca_france/tests/json/f7im-dab6469eb6c1aca4115118dee4f5619bf37a4cd2384008db7571e45cc8ab6f69.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7im-e371aafd8fbedc7c299d576e66d5e94919adebae0b220db786ffb49c4770df6e.json
+++ b/openfisca_france/tests/json/f7im-e371aafd8fbedc7c299d576e66d5e94919adebae0b220db786ffb49c4770df6e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7im-f92e45de0ff661a05d0f7b6652a8c089c399cc46dcb4de3e269794650aaecd52.json
+++ b/openfisca_france/tests/json/f7im-f92e45de0ff661a05d0f7b6652a8c089c399cc46dcb4de3e269794650aaecd52.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7in-085e141fc71c4080108587d7fa44b724055919d21976517c7a86e3e4b2b45411.json
+++ b/openfisca_france/tests/json/f7in-085e141fc71c4080108587d7fa44b724055919d21976517c7a86e3e4b2b45411.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7in-5d9a1ab956e8e1ceacdf6e37015b80d8cbe3831ce7c6e5727758ce88139285f2.json
+++ b/openfisca_france/tests/json/f7in-5d9a1ab956e8e1ceacdf6e37015b80d8cbe3831ce7c6e5727758ce88139285f2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7in-699c6345893d5650bebffff6e8d88c744177fcb1040fbe07908b0761a8c71037.json
+++ b/openfisca_france/tests/json/f7in-699c6345893d5650bebffff6e8d88c744177fcb1040fbe07908b0761a8c71037.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7in-7064247a73123a11eb17178296d6b7b48669301a46675908768f4b8d97e3b052.json
+++ b/openfisca_france/tests/json/f7in-7064247a73123a11eb17178296d6b7b48669301a46675908768f4b8d97e3b052.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7in-72bac87a5da2a712be8a41cf14af7b0cc86d4f758ccfacec5e71cde5f5305494.json
+++ b/openfisca_france/tests/json/f7in-72bac87a5da2a712be8a41cf14af7b0cc86d4f758ccfacec5e71cde5f5305494.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7in-8920314429479dc9d7f1251328ee0361293cd262ce100e554435a31fb82cb3ec.json
+++ b/openfisca_france/tests/json/f7in-8920314429479dc9d7f1251328ee0361293cd262ce100e554435a31fb82cb3ec.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7in-a345274dd9174ce52af0d38cbfa8def0513a7b97c841c89de7694d6cf9bdfc39.json
+++ b/openfisca_france/tests/json/f7in-a345274dd9174ce52af0d38cbfa8def0513a7b97c841c89de7694d6cf9bdfc39.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7in-a9ce5c7e3137fe3303a57343ab9adfd56e387359b41f29e71f86effe1285fad8.json
+++ b/openfisca_france/tests/json/f7in-a9ce5c7e3137fe3303a57343ab9adfd56e387359b41f29e71f86effe1285fad8.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7in-b7802c70d7b5b4efdad18bf03f77dd6ae67085d4452f9411fb66f6cdc64649e1.json
+++ b/openfisca_france/tests/json/f7in-b7802c70d7b5b4efdad18bf03f77dd6ae67085d4452f9411fb66f6cdc64649e1.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7io-08dfb24f28554a25e7e28bb32ab873cfa3ef1ab16bc79296f5f65866360059ca.json
+++ b/openfisca_france/tests/json/f7io-08dfb24f28554a25e7e28bb32ab873cfa3ef1ab16bc79296f5f65866360059ca.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7io-14f0c3d939d7eb5835a471412f6c42b8f9bfcea565ce30a92c3b7751c0f95429.json
+++ b/openfisca_france/tests/json/f7io-14f0c3d939d7eb5835a471412f6c42b8f9bfcea565ce30a92c3b7751c0f95429.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7io-608167735b38bcaac83a8311266e7acbf1208712cd60ec02539b02b2be00e117.json
+++ b/openfisca_france/tests/json/f7io-608167735b38bcaac83a8311266e7acbf1208712cd60ec02539b02b2be00e117.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7io-6e921743ee85ef90f318b9a598779e3516212a8a17443018a78828d73712394c.json
+++ b/openfisca_france/tests/json/f7io-6e921743ee85ef90f318b9a598779e3516212a8a17443018a78828d73712394c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7io-7c53d3e126d71a34607a1fcffe8c270eb90fa05b3853479fd970a27b7eaeac12.json
+++ b/openfisca_france/tests/json/f7io-7c53d3e126d71a34607a1fcffe8c270eb90fa05b3853479fd970a27b7eaeac12.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7io-88f02e71574b64ab4a026cb42ca84c3ba1866ede6ef95ed4f9c31fe18c235156.json
+++ b/openfisca_france/tests/json/f7io-88f02e71574b64ab4a026cb42ca84c3ba1866ede6ef95ed4f9c31fe18c235156.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7io-a4eeb22816b747e06e52225f3ef5a6a53128c80cad82b7b2826fa90b7bce31b3.json
+++ b/openfisca_france/tests/json/f7io-a4eeb22816b747e06e52225f3ef5a6a53128c80cad82b7b2826fa90b7bce31b3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7io-cfb99695289da567526b0bf056cf6a3978443c32c704f3bc76b7ff11669d3614.json
+++ b/openfisca_france/tests/json/f7io-cfb99695289da567526b0bf056cf6a3978443c32c704f3bc76b7ff11669d3614.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7io-d58e8a8fe542b67516979e367bb23577d9f85a0f46d250acc649a6ca8a2b9508.json
+++ b/openfisca_france/tests/json/f7io-d58e8a8fe542b67516979e367bb23577d9f85a0f46d250acc649a6ca8a2b9508.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ip-0307b991dfde1bc97c2d671e6d8be2dc086b691de3593d6ea5652309d177149b.json
+++ b/openfisca_france/tests/json/f7ip-0307b991dfde1bc97c2d671e6d8be2dc086b691de3593d6ea5652309d177149b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ip-20f29c65855aadb10a652a665c121bae323c75500b0dc5e5922cfbb9173a162e.json
+++ b/openfisca_france/tests/json/f7ip-20f29c65855aadb10a652a665c121bae323c75500b0dc5e5922cfbb9173a162e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ip-830ec39d2ba7ec3a694597cf13026358c5da8c078d9b8b395190482e037381ab.json
+++ b/openfisca_france/tests/json/f7ip-830ec39d2ba7ec3a694597cf13026358c5da8c078d9b8b395190482e037381ab.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ip-90d2d39327ba4b4bd848fb77e88633096593754d7bb926d2d607e94d3b00c7c2.json
+++ b/openfisca_france/tests/json/f7ip-90d2d39327ba4b4bd848fb77e88633096593754d7bb926d2d607e94d3b00c7c2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ip-c79cd17f17635b2b00b5152df3a701ffdfa1d0fa34b4a6e6eccd49b0c29bba97.json
+++ b/openfisca_france/tests/json/f7ip-c79cd17f17635b2b00b5152df3a701ffdfa1d0fa34b4a6e6eccd49b0c29bba97.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ip-c912e5c54ef76e135c7beed12a501f9e1c12073ea337803d0381e34adf2c6bf3.json
+++ b/openfisca_france/tests/json/f7ip-c912e5c54ef76e135c7beed12a501f9e1c12073ea337803d0381e34adf2c6bf3.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ip-d6d684bb3fd3b740cf9c71391dc525a67dc4dab82d3449cae1477342f983fe3d.json
+++ b/openfisca_france/tests/json/f7ip-d6d684bb3fd3b740cf9c71391dc525a67dc4dab82d3449cae1477342f983fe3d.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ip-f5c6949fb692ccf3288135f267303dd6a0ecde06f52734116ca30e39b5e8fb76.json
+++ b/openfisca_france/tests/json/f7ip-f5c6949fb692ccf3288135f267303dd6a0ecde06f52734116ca30e39b5e8fb76.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ip-f82c2ce61691e4dd13435a9e3f76111e48c2784972268fdf132b7fa9dd9073ff.json
+++ b/openfisca_france/tests/json/f7ip-f82c2ce61691e4dd13435a9e3f76111e48c2784972268fdf132b7fa9dd9073ff.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iq-3760b07027ff36d7cb0edb24e6aae5e8aea44ccfbd80d573de82a8974a363822.json
+++ b/openfisca_france/tests/json/f7iq-3760b07027ff36d7cb0edb24e6aae5e8aea44ccfbd80d573de82a8974a363822.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iq-4405359eef54edf601940f33ce5e4cd10d0ea03b7e83094fa850c188bf5186af.json
+++ b/openfisca_france/tests/json/f7iq-4405359eef54edf601940f33ce5e4cd10d0ea03b7e83094fa850c188bf5186af.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iq-5bee32c82877bdb50f769cdc13089b17988f0d0b3d3f0a69254fb370eae13b5e.json
+++ b/openfisca_france/tests/json/f7iq-5bee32c82877bdb50f769cdc13089b17988f0d0b3d3f0a69254fb370eae13b5e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iq-5c7135362777d81f1b86a6bf7b7e031fe9e9da2d167574d449e2bb5813b062f0.json
+++ b/openfisca_france/tests/json/f7iq-5c7135362777d81f1b86a6bf7b7e031fe9e9da2d167574d449e2bb5813b062f0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iq-681a113bbe9421395e29f27cac8ff7899370775563a304856f7162c2d3552056.json
+++ b/openfisca_france/tests/json/f7iq-681a113bbe9421395e29f27cac8ff7899370775563a304856f7162c2d3552056.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iq-69c48c7971b36f19e69ad84467e6e06f9101840dff2bd0ee71db158287b1208c.json
+++ b/openfisca_france/tests/json/f7iq-69c48c7971b36f19e69ad84467e6e06f9101840dff2bd0ee71db158287b1208c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iq-a72b7ca2b58e615c38d7a99e48f29eb43ddf1b67f1a0470283594700d3506e17.json
+++ b/openfisca_france/tests/json/f7iq-a72b7ca2b58e615c38d7a99e48f29eb43ddf1b67f1a0470283594700d3506e17.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iq-c6d24eab52a240c583944c8b3c4d8c9aa15f9c6e1b42607da75310ff073a89f6.json
+++ b/openfisca_france/tests/json/f7iq-c6d24eab52a240c583944c8b3c4d8c9aa15f9c6e1b42607da75310ff073a89f6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iq-d7517b5cb99018289e21536293f527b5ffd18fe2533a5fc1e136f0143cd1ce90.json
+++ b/openfisca_france/tests/json/f7iq-d7517b5cb99018289e21536293f527b5ffd18fe2533a5fc1e136f0143cd1ce90.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ir-179ce661d4062811126378bf3ecbe5c171bdf885aa60cf28c5c430e112513883.json
+++ b/openfisca_france/tests/json/f7ir-179ce661d4062811126378bf3ecbe5c171bdf885aa60cf28c5c430e112513883.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ir-3ebcc5ec81ddef8647b37759a4a232dfba101a546d702efc1e7c0d896865754d.json
+++ b/openfisca_france/tests/json/f7ir-3ebcc5ec81ddef8647b37759a4a232dfba101a546d702efc1e7c0d896865754d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ir-4a649be9abd766bbf4f9b972c8a2d5128db973475687a54488c33d5f314cc774.json
+++ b/openfisca_france/tests/json/f7ir-4a649be9abd766bbf4f9b972c8a2d5128db973475687a54488c33d5f314cc774.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ir-5c389670ad770fcf880bd1e77d96df5a1af471193f437ea5f59582c245d40086.json
+++ b/openfisca_france/tests/json/f7ir-5c389670ad770fcf880bd1e77d96df5a1af471193f437ea5f59582c245d40086.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ir-66b01db330c2f34746e60857a1313e6fb4869f87462e3445cdf10faff5fac037.json
+++ b/openfisca_france/tests/json/f7ir-66b01db330c2f34746e60857a1313e6fb4869f87462e3445cdf10faff5fac037.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ir-b29ee93b165779e0e06d1678cee98f44899e02fb30142f8dcdfeb5c2a241d648.json
+++ b/openfisca_france/tests/json/f7ir-b29ee93b165779e0e06d1678cee98f44899e02fb30142f8dcdfeb5c2a241d648.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ir-b40185bb675c7f056d5fa1989109e55293afe83f32a54312eed25783adb93523.json
+++ b/openfisca_france/tests/json/f7ir-b40185bb675c7f056d5fa1989109e55293afe83f32a54312eed25783adb93523.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ir-c506c9ad126e17acb048a999cd1ddbdc26b077508f9f3aa13e829dde28e218c4.json
+++ b/openfisca_france/tests/json/f7ir-c506c9ad126e17acb048a999cd1ddbdc26b077508f9f3aa13e829dde28e218c4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ir-d090cd7fa7cd2cea21fa6d71ec16f62f40a4357a506d83e0b78de81c8a8e9c2d.json
+++ b/openfisca_france/tests/json/f7ir-d090cd7fa7cd2cea21fa6d71ec16f62f40a4357a506d83e0b78de81c8a8e9c2d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7is-04ef11b036c608d6c4c7283e577d5c97c6992c224abc9ee8e54bb96c9b4446cb.json
+++ b/openfisca_france/tests/json/f7is-04ef11b036c608d6c4c7283e577d5c97c6992c224abc9ee8e54bb96c9b4446cb.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7is-0cbd49b200bc68ff58f23edc1cd3b8f45bfddb42c008dd96a8fae0696659099b.json
+++ b/openfisca_france/tests/json/f7is-0cbd49b200bc68ff58f23edc1cd3b8f45bfddb42c008dd96a8fae0696659099b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7is-263c99b1c8953e8ae1e0a08c1f126d2af2e6a5a99e8e5a881a51fbb6e1734e1c.json
+++ b/openfisca_france/tests/json/f7is-263c99b1c8953e8ae1e0a08c1f126d2af2e6a5a99e8e5a881a51fbb6e1734e1c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7is-44489bf0fc91ca39dca401475ec222130cd1ee449767ff2e299121d5d477c22c.json
+++ b/openfisca_france/tests/json/f7is-44489bf0fc91ca39dca401475ec222130cd1ee449767ff2e299121d5d477c22c.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7is-80b2858899d42b86d2f9ecd485627da4c6b2ee1ad4d0726d81efde6ae69019cb.json
+++ b/openfisca_france/tests/json/f7is-80b2858899d42b86d2f9ecd485627da4c6b2ee1ad4d0726d81efde6ae69019cb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7is-95a7a2bbbff3c322d4a9143119a16d68c940cb8b2af39631aa87adc91e7518f8.json
+++ b/openfisca_france/tests/json/f7is-95a7a2bbbff3c322d4a9143119a16d68c940cb8b2af39631aa87adc91e7518f8.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7is-eb1482cc5bc6c05f314374047122e4857a77952a8c40f29ff9bf65b50ee738aa.json
+++ b/openfisca_france/tests/json/f7is-eb1482cc5bc6c05f314374047122e4857a77952a8c40f29ff9bf65b50ee738aa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7is-ef617d3cb4a51a10fd0757bc6c48a9b7c7fd074d689b1d1a3f5eb34b8ec576b5.json
+++ b/openfisca_france/tests/json/f7is-ef617d3cb4a51a10fd0757bc6c48a9b7c7fd074d689b1d1a3f5eb34b8ec576b5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7is-fca677d08f20d8c282372f02035a5c7e5ef34cae0089b6df04f6ae6aa79fdf57.json
+++ b/openfisca_france/tests/json/f7is-fca677d08f20d8c282372f02035a5c7e5ef34cae0089b6df04f6ae6aa79fdf57.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7it-104095181c61942f47374d73c28afde22570d01e8bc3b3738bffc3f62c3f2128.json
+++ b/openfisca_france/tests/json/f7it-104095181c61942f47374d73c28afde22570d01e8bc3b3738bffc3f62c3f2128.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7it-6c3951ad29845508e6eb4af401e27a44668b78f00059d657c788c268abb9e092.json
+++ b/openfisca_france/tests/json/f7it-6c3951ad29845508e6eb4af401e27a44668b78f00059d657c788c268abb9e092.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7it-6ec19c589d1d35bbd1147f954c0183e2f4ddec1ccadbd6911382776cc4556063.json
+++ b/openfisca_france/tests/json/f7it-6ec19c589d1d35bbd1147f954c0183e2f4ddec1ccadbd6911382776cc4556063.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7it-7b4394881dc8ea1d31f2ad6968336a8d9b191bf5373d9891880a909ef8166b39.json
+++ b/openfisca_france/tests/json/f7it-7b4394881dc8ea1d31f2ad6968336a8d9b191bf5373d9891880a909ef8166b39.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7it-8277b7088d12d42624885137f78a25520d3252a8bfee122a9a8594952c526ba1.json
+++ b/openfisca_france/tests/json/f7it-8277b7088d12d42624885137f78a25520d3252a8bfee122a9a8594952c526ba1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7it-9572b91d2f979896c829c608105e18ed2704a72e21ce90488ce42c48e3c1ed2e.json
+++ b/openfisca_france/tests/json/f7it-9572b91d2f979896c829c608105e18ed2704a72e21ce90488ce42c48e3c1ed2e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7it-d35ee725d5345f6002c27902460e4a51e06562db7c5ddcc0f022ff9559af2dc0.json
+++ b/openfisca_france/tests/json/f7it-d35ee725d5345f6002c27902460e4a51e06562db7c5ddcc0f022ff9559af2dc0.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7it-f7a4e39c1846b9d41e74158e95d788f071696f4cf31bbbf4fa990535b0f7a55c.json
+++ b/openfisca_france/tests/json/f7it-f7a4e39c1846b9d41e74158e95d788f071696f4cf31bbbf4fa990535b0f7a55c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7it-fad152e9a5415b74bad23db07b8cae529ab37bd6b8c4ed8aea168e038ec78f07.json
+++ b/openfisca_france/tests/json/f7it-fad152e9a5415b74bad23db07b8cae529ab37bd6b8c4ed8aea168e038ec78f07.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iu-0ed713402080ac39aacdd16354ffbd16eb4d0f74a1ada33c9d4ec0408c9b141a.json
+++ b/openfisca_france/tests/json/f7iu-0ed713402080ac39aacdd16354ffbd16eb4d0f74a1ada33c9d4ec0408c9b141a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iu-1028636094ee7f4dad882d3c9f14f3b804f92a386c83d35dafccbdebcd91d6f5.json
+++ b/openfisca_france/tests/json/f7iu-1028636094ee7f4dad882d3c9f14f3b804f92a386c83d35dafccbdebcd91d6f5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iu-3564f5edd1e31cc4fb1151793feb28e0eeb44653bd1c2bc4d59efd3c67ef3f74.json
+++ b/openfisca_france/tests/json/f7iu-3564f5edd1e31cc4fb1151793feb28e0eeb44653bd1c2bc4d59efd3c67ef3f74.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iu-3cfee4d76e7296d3ef980212f6b8b7bac2ea9e66167b630770bef811120b0641.json
+++ b/openfisca_france/tests/json/f7iu-3cfee4d76e7296d3ef980212f6b8b7bac2ea9e66167b630770bef811120b0641.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iu-43209f9744cd0b1e082e53c1d50c54ffb4b930490d9f96e64caf77a8a9948b8d.json
+++ b/openfisca_france/tests/json/f7iu-43209f9744cd0b1e082e53c1d50c54ffb4b930490d9f96e64caf77a8a9948b8d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iu-64d2ffdc873cc559206dd75d42392bbc884fc4272b2e58f8c314b38a7f716bdf.json
+++ b/openfisca_france/tests/json/f7iu-64d2ffdc873cc559206dd75d42392bbc884fc4272b2e58f8c314b38a7f716bdf.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iu-8862a5c6c81ca06e6667cebd846ee4fef19be299fb7aff56a1b1d6683f85caf4.json
+++ b/openfisca_france/tests/json/f7iu-8862a5c6c81ca06e6667cebd846ee4fef19be299fb7aff56a1b1d6683f85caf4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iu-930ebf178f36f13b8c22833a2da378bfba131f3adc1d9cd1483d2850e3ff1463.json
+++ b/openfisca_france/tests/json/f7iu-930ebf178f36f13b8c22833a2da378bfba131f3adc1d9cd1483d2850e3ff1463.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iu-e114ff60044a1859ed830f9aaf1150fe7efead363c021e5850d0ca2fd9fce022.json
+++ b/openfisca_france/tests/json/f7iu-e114ff60044a1859ed830f9aaf1150fe7efead363c021e5850d0ca2fd9fce022.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iv-0c7e54b9cbb83a6f38325616b7c66fa812b680fcef96a1c8868a40c34bf95bf6.json
+++ b/openfisca_france/tests/json/f7iv-0c7e54b9cbb83a6f38325616b7c66fa812b680fcef96a1c8868a40c34bf95bf6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iv-11f3cf2f040cae9fee49f4d9396277efca9e2c3bed9e2b1a4293ed33ebd534ab.json
+++ b/openfisca_france/tests/json/f7iv-11f3cf2f040cae9fee49f4d9396277efca9e2c3bed9e2b1a4293ed33ebd534ab.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iv-149bd3d6e799ad9a198443ed3cadc894e0f718918da5bafbd60f64d6c84ea4ba.json
+++ b/openfisca_france/tests/json/f7iv-149bd3d6e799ad9a198443ed3cadc894e0f718918da5bafbd60f64d6c84ea4ba.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iv-2f182d74daca7d426706df93db051f0819edf4d7bbc8650731fdff2905f35332.json
+++ b/openfisca_france/tests/json/f7iv-2f182d74daca7d426706df93db051f0819edf4d7bbc8650731fdff2905f35332.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iv-46f24dc5ed3cb9fbd7929faa5fe1ba9fcc8a9c2e23952fc1e05c44de6927f24a.json
+++ b/openfisca_france/tests/json/f7iv-46f24dc5ed3cb9fbd7929faa5fe1ba9fcc8a9c2e23952fc1e05c44de6927f24a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iv-4bf98620de49ac40ecf1541dc42ad195a7aa838c0cf712517ebbf957f68688ad.json
+++ b/openfisca_france/tests/json/f7iv-4bf98620de49ac40ecf1541dc42ad195a7aa838c0cf712517ebbf957f68688ad.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iv-73b8eb6c3b6861ae83f134bb9f38a27c68ecbad26404337ce61242e36c1882a2.json
+++ b/openfisca_france/tests/json/f7iv-73b8eb6c3b6861ae83f134bb9f38a27c68ecbad26404337ce61242e36c1882a2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iv-a9259268e0122bdebc16488f9759080bcb0ad3db1b86fce0304fe0145a67c8b4.json
+++ b/openfisca_france/tests/json/f7iv-a9259268e0122bdebc16488f9759080bcb0ad3db1b86fce0304fe0145a67c8b4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iv-f5ee450511e90dca04f4fffeedea6c2d1931bdc6b6204d56c035ff414cb3796e.json
+++ b/openfisca_france/tests/json/f7iv-f5ee450511e90dca04f4fffeedea6c2d1931bdc6b6204d56c035ff414cb3796e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iw-28b9a13d848bdac15296a7c232aca9c6910018f2998f4bd3a52ed58273d5d8e5.json
+++ b/openfisca_france/tests/json/f7iw-28b9a13d848bdac15296a7c232aca9c6910018f2998f4bd3a52ed58273d5d8e5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iw-327a4c4d579cc7c263dd3910cd2110ec18bb89bb9e8170cdb33a73bf0618ee1d.json
+++ b/openfisca_france/tests/json/f7iw-327a4c4d579cc7c263dd3910cd2110ec18bb89bb9e8170cdb33a73bf0618ee1d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iw-56b72cfca9e43cd818b5b92678219c905c041242a69716d9653124d25658ae68.json
+++ b/openfisca_france/tests/json/f7iw-56b72cfca9e43cd818b5b92678219c905c041242a69716d9653124d25658ae68.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iw-602bd4e247f649dd936274e52638dd43a732221759d059299da64cf3c10092b6.json
+++ b/openfisca_france/tests/json/f7iw-602bd4e247f649dd936274e52638dd43a732221759d059299da64cf3c10092b6.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iw-855d2cd235d20b13a66e1cae9b4682ba9b0e9de8ad20f9510efb573b8edf54f8.json
+++ b/openfisca_france/tests/json/f7iw-855d2cd235d20b13a66e1cae9b4682ba9b0e9de8ad20f9510efb573b8edf54f8.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iw-8e53cd8331325754fed36afda23e1e794f39855d1282f0be00a05e9c0e621ab0.json
+++ b/openfisca_france/tests/json/f7iw-8e53cd8331325754fed36afda23e1e794f39855d1282f0be00a05e9c0e621ab0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iw-ba7d744c62c0905be56638bd8666c980bd455c62f1300f5cb3067516289290b5.json
+++ b/openfisca_france/tests/json/f7iw-ba7d744c62c0905be56638bd8666c980bd455c62f1300f5cb3067516289290b5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iw-bffab29ee263177ea999a7db1640ee048683f5cc135a7a4869e0ad02b8aefc92.json
+++ b/openfisca_france/tests/json/f7iw-bffab29ee263177ea999a7db1640ee048683f5cc135a7a4869e0ad02b8aefc92.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iw-f93f1be617c75d7641885aa8ebeb5f42dad78953a82019593811af6d1416ead6.json
+++ b/openfisca_france/tests/json/f7iw-f93f1be617c75d7641885aa8ebeb5f42dad78953a82019593811af6d1416ead6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ix-2080c4ee38a847c0ead5adee0a06cf1fc38e80ee17ce7a8cd1dc755e5b321360.json
+++ b/openfisca_france/tests/json/f7ix-2080c4ee38a847c0ead5adee0a06cf1fc38e80ee17ce7a8cd1dc755e5b321360.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ix-3e07ac5b77fc01e860a6f622ab727a53bcd0da054c5a12eb3d67faf35f9c026f.json
+++ b/openfisca_france/tests/json/f7ix-3e07ac5b77fc01e860a6f622ab727a53bcd0da054c5a12eb3d67faf35f9c026f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ix-41209d88fba9430f3b12957cc49ddfa798bbae92c965bb55610bbf5029ac172c.json
+++ b/openfisca_france/tests/json/f7ix-41209d88fba9430f3b12957cc49ddfa798bbae92c965bb55610bbf5029ac172c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ix-42764ff64579b3802a8aa7f1cb5a5e570de5a05890942f0d90b96d42a995fa94.json
+++ b/openfisca_france/tests/json/f7ix-42764ff64579b3802a8aa7f1cb5a5e570de5a05890942f0d90b96d42a995fa94.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ix-6783a76a04d2f83e4c4a858023692bfe98871b57174de88d5946ea747752ff78.json
+++ b/openfisca_france/tests/json/f7ix-6783a76a04d2f83e4c4a858023692bfe98871b57174de88d5946ea747752ff78.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ix-79a4c3822e77c740d86d189846b7079b89496135362d15b15029d00b4fd77fd3.json
+++ b/openfisca_france/tests/json/f7ix-79a4c3822e77c740d86d189846b7079b89496135362d15b15029d00b4fd77fd3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ix-8e25845f65721257213d567f7c89ffaa76a59a9021f492ecfe86eb50317f6f40.json
+++ b/openfisca_france/tests/json/f7ix-8e25845f65721257213d567f7c89ffaa76a59a9021f492ecfe86eb50317f6f40.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ix-eb2a6db02763d4cbf41f21d76a71081dc095a6de5815ee65e8a984fde09d9a89.json
+++ b/openfisca_france/tests/json/f7ix-eb2a6db02763d4cbf41f21d76a71081dc095a6de5815ee65e8a984fde09d9a89.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ix-fb72f820ca7b7caf01cd7251421152e09c999a227c6fe00684705a4293068e20.json
+++ b/openfisca_france/tests/json/f7ix-fb72f820ca7b7caf01cd7251421152e09c999a227c6fe00684705a4293068e20.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iy-11fb7a50b08c2f5324dd66309008bcc51802636313e2e659fcee0e203fa105c1.json
+++ b/openfisca_france/tests/json/f7iy-11fb7a50b08c2f5324dd66309008bcc51802636313e2e659fcee0e203fa105c1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iy-352e71258a3718a2c20b5a920e4eef62ec51e3906674c8db24aa795bd05bf8f8.json
+++ b/openfisca_france/tests/json/f7iy-352e71258a3718a2c20b5a920e4eef62ec51e3906674c8db24aa795bd05bf8f8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iy-d3569c5e3a6c912a98c3bb92c9cd1f42a7a453cb740c658d036617b485f4ffe4.json
+++ b/openfisca_france/tests/json/f7iy-d3569c5e3a6c912a98c3bb92c9cd1f42a7a453cb740c658d036617b485f4ffe4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iy-eef4436ac3d65e2f0dee7fa3dc6c98c96804e4d9eadfd317a9301342d498506b.json
+++ b/openfisca_france/tests/json/f7iy-eef4436ac3d65e2f0dee7fa3dc6c98c96804e4d9eadfd317a9301342d498506b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iz-03ae30f81fa0bf5cea1e0b6d5c9a07c3148933d526e6701cf382ae774afffc8e.json
+++ b/openfisca_france/tests/json/f7iz-03ae30f81fa0bf5cea1e0b6d5c9a07c3148933d526e6701cf382ae774afffc8e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iz-0e6c8ab12aa93d75917e4fdf899019e3b0cc0a025c3e7ad73c78181b1ab92dd7.json
+++ b/openfisca_france/tests/json/f7iz-0e6c8ab12aa93d75917e4fdf899019e3b0cc0a025c3e7ad73c78181b1ab92dd7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iz-0f7039537e9dc5d68c89d8efd9d1a7e19ef8d96c61ec372851ba696818dd52f3.json
+++ b/openfisca_france/tests/json/f7iz-0f7039537e9dc5d68c89d8efd9d1a7e19ef8d96c61ec372851ba696818dd52f3.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iz-209d5ba3bc361b906063fdc733a439c80e21290747d73b0bda85503e4888b541.json
+++ b/openfisca_france/tests/json/f7iz-209d5ba3bc361b906063fdc733a439c80e21290747d73b0bda85503e4888b541.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iz-3396a2706684ed159acf5a4c2b541f5dbd2e79af7d865c1ac477cc1b9d4c2c80.json
+++ b/openfisca_france/tests/json/f7iz-3396a2706684ed159acf5a4c2b541f5dbd2e79af7d865c1ac477cc1b9d4c2c80.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iz-59137a10781109fbb96035f45a2dac81fa71efc5a19897d2ee53eaa0a6009fad.json
+++ b/openfisca_france/tests/json/f7iz-59137a10781109fbb96035f45a2dac81fa71efc5a19897d2ee53eaa0a6009fad.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iz-7d71c07c45315e8035eb292845b1747845301975d5d69d30a85fd806d9a29ad5.json
+++ b/openfisca_france/tests/json/f7iz-7d71c07c45315e8035eb292845b1747845301975d5d69d30a85fd806d9a29ad5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iz-978a5a23f51b539d006f867ed2dd88e44c493a50dd1feacaeeae6c81fb78e26f.json
+++ b/openfisca_france/tests/json/f7iz-978a5a23f51b539d006f867ed2dd88e44c493a50dd1feacaeeae6c81fb78e26f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7iz-f9bb32ec9d3512bd981a966417abac468d27b99156c1486f0609e5796e87a895.json
+++ b/openfisca_france/tests/json/f7iz-f9bb32ec9d3512bd981a966417abac468d27b99156c1486f0609e5796e87a895.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ja-0143f38352bfb3dd351267c72575342ae5d0a2852476ac4644857cdfc3b97f36.json
+++ b/openfisca_france/tests/json/f7ja-0143f38352bfb3dd351267c72575342ae5d0a2852476ac4644857cdfc3b97f36.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ja-0e956aa6c08ca29e5aee2b262c0ad9cc2ce9df615a972f229a2da206386cec52.json
+++ b/openfisca_france/tests/json/f7ja-0e956aa6c08ca29e5aee2b262c0ad9cc2ce9df615a972f229a2da206386cec52.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ja-0f99e767858b6dfe1a0bc93363a5958c85c89f5d1c9fa13f65f60cdb900ed2db.json
+++ b/openfisca_france/tests/json/f7ja-0f99e767858b6dfe1a0bc93363a5958c85c89f5d1c9fa13f65f60cdb900ed2db.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ja-16a71bd60b8584937357b3461796e9b591a121709f7b9a748ebef749d6359400.json
+++ b/openfisca_france/tests/json/f7ja-16a71bd60b8584937357b3461796e9b591a121709f7b9a748ebef749d6359400.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ja-48ec88d828aca561739ec5c7459c32e8e48b08ba97eb375dd2db39a5b55f9ab7.json
+++ b/openfisca_france/tests/json/f7ja-48ec88d828aca561739ec5c7459c32e8e48b08ba97eb375dd2db39a5b55f9ab7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ja-5e197c28588d9874c1805e6f2c87605d3497d2d40cb8e68c45b9af7f2c60ec13.json
+++ b/openfisca_france/tests/json/f7ja-5e197c28588d9874c1805e6f2c87605d3497d2d40cb8e68c45b9af7f2c60ec13.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ja-78f500537d3ac7c942790614b6fdd1f4361540b50dbb076e026f77c9fe01fe39.json
+++ b/openfisca_france/tests/json/f7ja-78f500537d3ac7c942790614b6fdd1f4361540b50dbb076e026f77c9fe01fe39.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ja-7e63003895dc18aba3d356459ba5c2a8fae15e5d076824da250882ed107867c6.json
+++ b/openfisca_france/tests/json/f7ja-7e63003895dc18aba3d356459ba5c2a8fae15e5d076824da250882ed107867c6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ja-9129fbf8661aa344cf64a61bcc157d0707332423785cb7a40994ed15b96bb9d3.json
+++ b/openfisca_france/tests/json/f7ja-9129fbf8661aa344cf64a61bcc157d0707332423785cb7a40994ed15b96bb9d3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jb-16923d4573fc1ca600e7b27a1a1e51b65f4bd8ceee207458d502c5db46163d80.json
+++ b/openfisca_france/tests/json/f7jb-16923d4573fc1ca600e7b27a1a1e51b65f4bd8ceee207458d502c5db46163d80.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jb-25b04fb6533e22847ddfd603cf16c542b66bab3427d595926a710d828bc1219b.json
+++ b/openfisca_france/tests/json/f7jb-25b04fb6533e22847ddfd603cf16c542b66bab3427d595926a710d828bc1219b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jb-6b7b7e3c6b95ba999115680f354b0537076254f7c103c6f52c152124b5938362.json
+++ b/openfisca_france/tests/json/f7jb-6b7b7e3c6b95ba999115680f354b0537076254f7c103c6f52c152124b5938362.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jb-75843df49511fc2dcc052c0bdb4e2b6effa8c663eae4b00a01fbb0dda5700763.json
+++ b/openfisca_france/tests/json/f7jb-75843df49511fc2dcc052c0bdb4e2b6effa8c663eae4b00a01fbb0dda5700763.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jb-8b76209b2b22f2b9751c9448451083a467c8d3aa5d397607f91a9d53afa9c6a9.json
+++ b/openfisca_france/tests/json/f7jb-8b76209b2b22f2b9751c9448451083a467c8d3aa5d397607f91a9d53afa9c6a9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jb-8f38223c720c7cc509da99b36e4991eb60820886ff92719c29ed889b5c6f826f.json
+++ b/openfisca_france/tests/json/f7jb-8f38223c720c7cc509da99b36e4991eb60820886ff92719c29ed889b5c6f826f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jb-a11cc2d16f416bee8ce1cad04a23934447f0afbfef1acf587667d0b34580a685.json
+++ b/openfisca_france/tests/json/f7jb-a11cc2d16f416bee8ce1cad04a23934447f0afbfef1acf587667d0b34580a685.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jb-b2480e1dadff2004c78e11c5937db63669564a0d80ea9c1f7bb235b263449a07.json
+++ b/openfisca_france/tests/json/f7jb-b2480e1dadff2004c78e11c5937db63669564a0d80ea9c1f7bb235b263449a07.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jb-db88bbae10d7fc1e1f750b2aeea075f8b287a384d7f0745d15834c2afd29a46c.json
+++ b/openfisca_france/tests/json/f7jb-db88bbae10d7fc1e1f750b2aeea075f8b287a384d7f0745d15834c2afd29a46c.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jd-027e14f73ca8b6f09a4d02781d23fb1fc728bab2bae6724aeefa8ed5849118e3.json
+++ b/openfisca_france/tests/json/f7jd-027e14f73ca8b6f09a4d02781d23fb1fc728bab2bae6724aeefa8ed5849118e3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jd-5f78a471705ff0a2a18879780b576304e44639a3998fdfc6c1064d7d4bdeb17a.json
+++ b/openfisca_france/tests/json/f7jd-5f78a471705ff0a2a18879780b576304e44639a3998fdfc6c1064d7d4bdeb17a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jd-ad5f0562dbf58a0db78b4d586d916b41cd69429a5db785e10bd5836cc8ed6cca.json
+++ b/openfisca_france/tests/json/f7jd-ad5f0562dbf58a0db78b4d586d916b41cd69429a5db785e10bd5836cc8ed6cca.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jd-b40d46df1b71c6536c7055c421d789f115c40262cedec8f7e878495a797dead5.json
+++ b/openfisca_france/tests/json/f7jd-b40d46df1b71c6536c7055c421d789f115c40262cedec8f7e878495a797dead5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jd-d531cd87f0d386abc8b5e95271dd966d6d3fc42c32c3d2ea1930688a4f562039.json
+++ b/openfisca_france/tests/json/f7jd-d531cd87f0d386abc8b5e95271dd966d6d3fc42c32c3d2ea1930688a4f562039.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jd-e0d94353700146da27654073bb6e8ad60c361168d4094e793f8ae0380d34a7e4.json
+++ b/openfisca_france/tests/json/f7jd-e0d94353700146da27654073bb6e8ad60c361168d4094e793f8ae0380d34a7e4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jd-e498a501e53ac1bb5cc19755ccbb8a07f7ef63585e3a2376dc48749bd22015c3.json
+++ b/openfisca_france/tests/json/f7jd-e498a501e53ac1bb5cc19755ccbb8a07f7ef63585e3a2376dc48749bd22015c3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jd-eba9d4cabbb82fc2fa6e76d5bcc7529c42062c1c7b57e0e9458d3fb4865ce4b4.json
+++ b/openfisca_france/tests/json/f7jd-eba9d4cabbb82fc2fa6e76d5bcc7529c42062c1c7b57e0e9458d3fb4865ce4b4.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jd-f1db7e48b58100962fd497ce10d444e4618b6e9b75a328463082042229ac2d9a.json
+++ b/openfisca_france/tests/json/f7jd-f1db7e48b58100962fd497ce10d444e4618b6e9b75a328463082042229ac2d9a.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7je-17ef86c608f55aef0274cc94b1236296a6cb5944fa97f4f16178a17006ce8560.json
+++ b/openfisca_france/tests/json/f7je-17ef86c608f55aef0274cc94b1236296a6cb5944fa97f4f16178a17006ce8560.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7je-200516874c51db4ba59ea32a7398cee56f8c3ca9594075e3d47dab9110ff876a.json
+++ b/openfisca_france/tests/json/f7je-200516874c51db4ba59ea32a7398cee56f8c3ca9594075e3d47dab9110ff876a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7je-3082f8115a1abca0100a64682e382271416ef3aa6a8e78f9cdbde49059436cb3.json
+++ b/openfisca_france/tests/json/f7je-3082f8115a1abca0100a64682e382271416ef3aa6a8e78f9cdbde49059436cb3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7je-42df1da211132bda8f74fac23cdeca8e383d3941964d2893b3e78a7b4be05916.json
+++ b/openfisca_france/tests/json/f7je-42df1da211132bda8f74fac23cdeca8e383d3941964d2893b3e78a7b4be05916.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7je-53037cc0b12f470ad6f5e46518622c8eb77835580c33ba3d3337e3db2326ea00.json
+++ b/openfisca_france/tests/json/f7je-53037cc0b12f470ad6f5e46518622c8eb77835580c33ba3d3337e3db2326ea00.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7je-76393545a5c9e977685489ce23cc28dec34ea0f26b0a081192b7ceaec3573a1d.json
+++ b/openfisca_france/tests/json/f7je-76393545a5c9e977685489ce23cc28dec34ea0f26b0a081192b7ceaec3573a1d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7je-7b4b2dddb7e1ff6f95ca4dc309798238d32b846981217c6567aeee4f15f866bd.json
+++ b/openfisca_france/tests/json/f7je-7b4b2dddb7e1ff6f95ca4dc309798238d32b846981217c6567aeee4f15f866bd.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7je-91121fbe991d4ab07b3080cc4f09d6816681537a8dd0d8adcf98ce57262af223.json
+++ b/openfisca_france/tests/json/f7je-91121fbe991d4ab07b3080cc4f09d6816681537a8dd0d8adcf98ce57262af223.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7je-eb0e5c3821402519cbc5b285db7bd487c73537795b9618aa1257c38394a6b01d.json
+++ b/openfisca_france/tests/json/f7je-eb0e5c3821402519cbc5b285db7bd487c73537795b9618aa1257c38394a6b01d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jf-38ebc5fcf7ad37d6bcd27f57a2a0e25be359e93aadd1fb44913902a0cf5aab53.json
+++ b/openfisca_france/tests/json/f7jf-38ebc5fcf7ad37d6bcd27f57a2a0e25be359e93aadd1fb44913902a0cf5aab53.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jf-3a3d7ba52e83f36bd0258b5d1b82974bcb9de6bb703ab8e384350a7c57bafc81.json
+++ b/openfisca_france/tests/json/f7jf-3a3d7ba52e83f36bd0258b5d1b82974bcb9de6bb703ab8e384350a7c57bafc81.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jf-46589ced7b135e8f9c63df144c92772978fc744cd52f6eac4a9d99f1e8883d82.json
+++ b/openfisca_france/tests/json/f7jf-46589ced7b135e8f9c63df144c92772978fc744cd52f6eac4a9d99f1e8883d82.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jf-95c10743236b389ea687ee7ae49389cee2d68bdfe6deafacb9502e29c0ffe09a.json
+++ b/openfisca_france/tests/json/f7jf-95c10743236b389ea687ee7ae49389cee2d68bdfe6deafacb9502e29c0ffe09a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jf-9863e37b2eedc11afc899261ce185791678e848396fc4752310591371e11cd7c.json
+++ b/openfisca_france/tests/json/f7jf-9863e37b2eedc11afc899261ce185791678e848396fc4752310591371e11cd7c.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jf-b20a4ac5231730520cdce44f6a13c13809cb761f7cecb5b371d727791ae68911.json
+++ b/openfisca_france/tests/json/f7jf-b20a4ac5231730520cdce44f6a13c13809cb761f7cecb5b371d727791ae68911.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jf-c8d1182dc5a4d94cbc5a0ecbe5d3cbe0ffff7e386b85d49e8cbb8e548b42349d.json
+++ b/openfisca_france/tests/json/f7jf-c8d1182dc5a4d94cbc5a0ecbe5d3cbe0ffff7e386b85d49e8cbb8e548b42349d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jf-ecaf70688ef9c73999414f9508bb44ac8f0077f4b4f7263fd8d924031a698383.json
+++ b/openfisca_france/tests/json/f7jf-ecaf70688ef9c73999414f9508bb44ac8f0077f4b4f7263fd8d924031a698383.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jf-f00853ac9964e430e70df64f8b668eb411545e6caa6fede71dd2d2827869ddfa.json
+++ b/openfisca_france/tests/json/f7jf-f00853ac9964e430e70df64f8b668eb411545e6caa6fede71dd2d2827869ddfa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jg-1087174809932c3593328360dac788e82eba8ad232a4cc6c779f0d7b3305ead1.json
+++ b/openfisca_france/tests/json/f7jg-1087174809932c3593328360dac788e82eba8ad232a4cc6c779f0d7b3305ead1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jg-2200f14d898a54775ce98d9293b290cdb64e60f99e1939a91c9cf2e409e07e93.json
+++ b/openfisca_france/tests/json/f7jg-2200f14d898a54775ce98d9293b290cdb64e60f99e1939a91c9cf2e409e07e93.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jg-224395a75ca4ea25ded25912f720cad03f2e512ad6d7381af4354fbade7a9462.json
+++ b/openfisca_france/tests/json/f7jg-224395a75ca4ea25ded25912f720cad03f2e512ad6d7381af4354fbade7a9462.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jg-407db5cb533ab1d6040faaf6e552e5a1dcef7f160b37b60b2e00eba7de26ff08.json
+++ b/openfisca_france/tests/json/f7jg-407db5cb533ab1d6040faaf6e552e5a1dcef7f160b37b60b2e00eba7de26ff08.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jg-5684bddd6ff4c713d8a4cefda964f35ec18418c4e50b2440863510a28342bf68.json
+++ b/openfisca_france/tests/json/f7jg-5684bddd6ff4c713d8a4cefda964f35ec18418c4e50b2440863510a28342bf68.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jg-6bac00351b2e008e19c244c80ab8666d726cd5911ecb2bc843d76d0fcbc52a67.json
+++ b/openfisca_france/tests/json/f7jg-6bac00351b2e008e19c244c80ab8666d726cd5911ecb2bc843d76d0fcbc52a67.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jg-784d1b55c7f5182decc9bb3e7bca3b274b30a2898e9ad1135a4762c2f2f16420.json
+++ b/openfisca_france/tests/json/f7jg-784d1b55c7f5182decc9bb3e7bca3b274b30a2898e9ad1135a4762c2f2f16420.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jg-988485ce9669df4693435624a7f341f053a33737fdf1afc4e42882ab2430fde4.json
+++ b/openfisca_france/tests/json/f7jg-988485ce9669df4693435624a7f341f053a33737fdf1afc4e42882ab2430fde4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jg-9da28f87a9f3d3aaa249465d16720e8d2df8159d2f529a0bf560d5346a43b807.json
+++ b/openfisca_france/tests/json/f7jg-9da28f87a9f3d3aaa249465d16720e8d2df8159d2f529a0bf560d5346a43b807.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jh-10078066be1ea2298ed197b3fcf809ecbab1f4d9ee94a425604b7425f4db3acb.json
+++ b/openfisca_france/tests/json/f7jh-10078066be1ea2298ed197b3fcf809ecbab1f4d9ee94a425604b7425f4db3acb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jh-308d9fffa0639ebe9879f65c968bc942cecf43b968b9a7d41f507ac6bad681bf.json
+++ b/openfisca_france/tests/json/f7jh-308d9fffa0639ebe9879f65c968bc942cecf43b968b9a7d41f507ac6bad681bf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jh-5f90a95fbbced7612108e70a7539e96f5e661feedaadd9357f7971afdeb924ea.json
+++ b/openfisca_france/tests/json/f7jh-5f90a95fbbced7612108e70a7539e96f5e661feedaadd9357f7971afdeb924ea.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jh-68a2177929260567d2891c28a8ebef0f9083fe9c287935a07f84cbcb08e8d812.json
+++ b/openfisca_france/tests/json/f7jh-68a2177929260567d2891c28a8ebef0f9083fe9c287935a07f84cbcb08e8d812.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jh-6da972efd65db1f74408820ebf40229b6a85d186ed125346a4383d08996eca4d.json
+++ b/openfisca_france/tests/json/f7jh-6da972efd65db1f74408820ebf40229b6a85d186ed125346a4383d08996eca4d.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jh-861a616871d3f962a7e04396762395eb3eeac30681e37322c1993ae3074c165b.json
+++ b/openfisca_france/tests/json/f7jh-861a616871d3f962a7e04396762395eb3eeac30681e37322c1993ae3074c165b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jh-ad2cf337aad4bb5a91680294baaa5e51776e41d9a06e2ba89cf179535b37c557.json
+++ b/openfisca_france/tests/json/f7jh-ad2cf337aad4bb5a91680294baaa5e51776e41d9a06e2ba89cf179535b37c557.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jh-bd2f65da27b249e50c3b987994868feda6f1df0d46f8ffcc330837f5a14d320a.json
+++ b/openfisca_france/tests/json/f7jh-bd2f65da27b249e50c3b987994868feda6f1df0d46f8ffcc330837f5a14d320a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jh-c33dcb381b26e956bc42419a7ebdd3e14f5f3f68d0af6c67aa89810bc0986fc7.json
+++ b/openfisca_france/tests/json/f7jh-c33dcb381b26e956bc42419a7ebdd3e14f5f3f68d0af6c67aa89810bc0986fc7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ji-06c0e035bd02705aae1ef4738d523a2c77409d8a4456b236c9a22005cedbcee3.json
+++ b/openfisca_france/tests/json/f7ji-06c0e035bd02705aae1ef4738d523a2c77409d8a4456b236c9a22005cedbcee3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ji-56dc3203eaa4676434a873de0deb5380a12c9ba648329adc22b98a5a1d91e794.json
+++ b/openfisca_france/tests/json/f7ji-56dc3203eaa4676434a873de0deb5380a12c9ba648329adc22b98a5a1d91e794.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ji-7cce0e55edf38bfdcbe6ce862c0e5b0428379bc43db7e4d1c26cb841a8956c9d.json
+++ b/openfisca_france/tests/json/f7ji-7cce0e55edf38bfdcbe6ce862c0e5b0428379bc43db7e4d1c26cb841a8956c9d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ji-84582e7ded1bf057ad416ed00db64c19c96b8d2f4fa60747cbace0d7ab1e4e0f.json
+++ b/openfisca_france/tests/json/f7ji-84582e7ded1bf057ad416ed00db64c19c96b8d2f4fa60747cbace0d7ab1e4e0f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ji-84687cd1717fa9618df1cbaddf59f9c8877af0ef121e4588172f13ec3bfab77f.json
+++ b/openfisca_france/tests/json/f7ji-84687cd1717fa9618df1cbaddf59f9c8877af0ef121e4588172f13ec3bfab77f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ji-9bb3160d4fe8b93c934ee68e5d6f4ff8f823037603a9345ec93362d404777153.json
+++ b/openfisca_france/tests/json/f7ji-9bb3160d4fe8b93c934ee68e5d6f4ff8f823037603a9345ec93362d404777153.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ji-9c178b22d800be9e488eccec392e2f47743f3d81c9786b3a94eb7f0285065992.json
+++ b/openfisca_france/tests/json/f7ji-9c178b22d800be9e488eccec392e2f47743f3d81c9786b3a94eb7f0285065992.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ji-dded4c9c00aa746106f5712ab6f95599f3620d8a60fbe0710084f1b9a5ea0157.json
+++ b/openfisca_france/tests/json/f7ji-dded4c9c00aa746106f5712ab6f95599f3620d8a60fbe0710084f1b9a5ea0157.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ji-e4fb8ab330afcc60a3ec7b5072e9987e6f60a592fc78d2acd710af947b018eea.json
+++ b/openfisca_france/tests/json/f7ji-e4fb8ab330afcc60a3ec7b5072e9987e6f60a592fc78d2acd710af947b018eea.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jj-0688d00d7d10c59347de6a13362c33698b6a6ac6b34f4f8d42e8bec9816e1d25.json
+++ b/openfisca_france/tests/json/f7jj-0688d00d7d10c59347de6a13362c33698b6a6ac6b34f4f8d42e8bec9816e1d25.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jj-304a4162032daf2039a6d1c10b1b8527b353d15fa5668f2c6741352f2a1df3c9.json
+++ b/openfisca_france/tests/json/f7jj-304a4162032daf2039a6d1c10b1b8527b353d15fa5668f2c6741352f2a1df3c9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jj-3c96bdecfe0a51c21310d2a2d81f8e20bf592ac29787272a9f583d2f48b579cc.json
+++ b/openfisca_france/tests/json/f7jj-3c96bdecfe0a51c21310d2a2d81f8e20bf592ac29787272a9f583d2f48b579cc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jj-4bcab650b71db2f857dc9b367f16fe47b69012f8a57b88b3f7f099b18cc0e5ec.json
+++ b/openfisca_france/tests/json/f7jj-4bcab650b71db2f857dc9b367f16fe47b69012f8a57b88b3f7f099b18cc0e5ec.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jj-866054245cf47757242e7c274f0af7d8059c512c1d6c61bcbd981a7253556d88.json
+++ b/openfisca_france/tests/json/f7jj-866054245cf47757242e7c274f0af7d8059c512c1d6c61bcbd981a7253556d88.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jj-895cb37cf3c6e450bf3e4582526ddc2346bf746f4290b30c20cf573c6276b8c9.json
+++ b/openfisca_france/tests/json/f7jj-895cb37cf3c6e450bf3e4582526ddc2346bf746f4290b30c20cf573c6276b8c9.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jj-987894560fdd67cb6ac567b0e57ccdc6a11df045d5256a0e484d27658757ac75.json
+++ b/openfisca_france/tests/json/f7jj-987894560fdd67cb6ac567b0e57ccdc6a11df045d5256a0e484d27658757ac75.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jj-ed51b1a394331d51b34084b1f6fa040cfd69daa8d42cb88e84df7b580469c295.json
+++ b/openfisca_france/tests/json/f7jj-ed51b1a394331d51b34084b1f6fa040cfd69daa8d42cb88e84df7b580469c295.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jj-f0069d2fc880d083d0f0c6a176a39341e9f5bb53843f0be4a72f8c9a82ff22cf.json
+++ b/openfisca_france/tests/json/f7jj-f0069d2fc880d083d0f0c6a176a39341e9f5bb53843f0be4a72f8c9a82ff22cf.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jk-18b119c447df62efae79f6f7dd9923ab655db3704868e6c08b6f10655a149ea4.json
+++ b/openfisca_france/tests/json/f7jk-18b119c447df62efae79f6f7dd9923ab655db3704868e6c08b6f10655a149ea4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jk-4ef7b75a192893a43fe84bea9e19e1cc6274514cba5baf8405da8e6967ea93bb.json
+++ b/openfisca_france/tests/json/f7jk-4ef7b75a192893a43fe84bea9e19e1cc6274514cba5baf8405da8e6967ea93bb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jk-59c7fd8545fb99400348fac681207f08838cfb477b8607fee57ba19b7e82ed33.json
+++ b/openfisca_france/tests/json/f7jk-59c7fd8545fb99400348fac681207f08838cfb477b8607fee57ba19b7e82ed33.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jk-83e92859f01940b529bb96802d7c55af8bcbeb2735615ae1a7b0a3e9c9fe0b38.json
+++ b/openfisca_france/tests/json/f7jk-83e92859f01940b529bb96802d7c55af8bcbeb2735615ae1a7b0a3e9c9fe0b38.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jk-8571c7cc7d97dbc0357bd0701cd3640d2cfe292ae3e4956c0dab6a6b48f21398.json
+++ b/openfisca_france/tests/json/f7jk-8571c7cc7d97dbc0357bd0701cd3640d2cfe292ae3e4956c0dab6a6b48f21398.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jk-afe79ec27bfeda38ea0b617a7707b63a5d12d400dd4fb4f75b17aa437fb32a90.json
+++ b/openfisca_france/tests/json/f7jk-afe79ec27bfeda38ea0b617a7707b63a5d12d400dd4fb4f75b17aa437fb32a90.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jk-b6d8b496938a84d237ec200e71af940f910d1e4a6604deb4253514945ca80f6d.json
+++ b/openfisca_france/tests/json/f7jk-b6d8b496938a84d237ec200e71af940f910d1e4a6604deb4253514945ca80f6d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jk-bf1c2423195b88a08a1191405b5afbe7a4d01701f29b1f3dfa54f0fbf1fe6a0c.json
+++ b/openfisca_france/tests/json/f7jk-bf1c2423195b88a08a1191405b5afbe7a4d01701f29b1f3dfa54f0fbf1fe6a0c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jk-e85ba6fb2f14f69e28706ccb8469705d51c327e2fccbaa3fae1075d2ea52da08.json
+++ b/openfisca_france/tests/json/f7jk-e85ba6fb2f14f69e28706ccb8469705d51c327e2fccbaa3fae1075d2ea52da08.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jl-13b97d9577de73f9772ddffb0b02b2f7b82ff086cf9cecf2bff3ed2cae945994.json
+++ b/openfisca_france/tests/json/f7jl-13b97d9577de73f9772ddffb0b02b2f7b82ff086cf9cecf2bff3ed2cae945994.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jl-728c3289f6433f1115f2f843fda5413370206a581f8e6f54da7798d2588aef7c.json
+++ b/openfisca_france/tests/json/f7jl-728c3289f6433f1115f2f843fda5413370206a581f8e6f54da7798d2588aef7c.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jl-7a32ed4c61b793ce2dc1ef065bfea49836ab4a3c18a4eb5090226fd77213fefd.json
+++ b/openfisca_france/tests/json/f7jl-7a32ed4c61b793ce2dc1ef065bfea49836ab4a3c18a4eb5090226fd77213fefd.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jl-7c882d5517b0a59159b705d1b1726d50ef85ed3eef09459fcd0898b49dd40b43.json
+++ b/openfisca_france/tests/json/f7jl-7c882d5517b0a59159b705d1b1726d50ef85ed3eef09459fcd0898b49dd40b43.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jl-7d24e3bd813fac65c3ca65e56363da215ab2c1b92c869c8078d4e0eee5b3b500.json
+++ b/openfisca_france/tests/json/f7jl-7d24e3bd813fac65c3ca65e56363da215ab2c1b92c869c8078d4e0eee5b3b500.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jl-7e1fdcd9d04e8a5916f34872c3c21006087092d08318cfd3e00772604cb97892.json
+++ b/openfisca_france/tests/json/f7jl-7e1fdcd9d04e8a5916f34872c3c21006087092d08318cfd3e00772604cb97892.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jl-96f6de574b554e6166ba3febdb5bb409f4ca953501cf009b5cfdfdf4489853cc.json
+++ b/openfisca_france/tests/json/f7jl-96f6de574b554e6166ba3febdb5bb409f4ca953501cf009b5cfdfdf4489853cc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jl-b9ded8345ab57ea535701fe943c51ac5fe2166f4af3f430d59689b3bd5f1199f.json
+++ b/openfisca_france/tests/json/f7jl-b9ded8345ab57ea535701fe943c51ac5fe2166f4af3f430d59689b3bd5f1199f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jl-e6e652561859428494dfb38e68103eb9604a77f5717b5e0ff6d95cf95691e52d.json
+++ b/openfisca_france/tests/json/f7jl-e6e652561859428494dfb38e68103eb9604a77f5717b5e0ff6d95cf95691e52d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jm-1d4c00fb4eaedb0ad9e2121827bb581ebfad3d61dfef99c37662666baf3e48d9.json
+++ b/openfisca_france/tests/json/f7jm-1d4c00fb4eaedb0ad9e2121827bb581ebfad3d61dfef99c37662666baf3e48d9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jm-351e13ffdac4ff310c56ac259383d99650a389604cbb08ba2afa4e1d3b2f8824.json
+++ b/openfisca_france/tests/json/f7jm-351e13ffdac4ff310c56ac259383d99650a389604cbb08ba2afa4e1d3b2f8824.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jm-3cc17fca912157ea33793d4786749f533b560ad4c91de7e6cd3998f756c2da86.json
+++ b/openfisca_france/tests/json/f7jm-3cc17fca912157ea33793d4786749f533b560ad4c91de7e6cd3998f756c2da86.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jm-5718e08197a3a3e07ce29d4ced63ee436ffb2053be04949cd1a704033086653f.json
+++ b/openfisca_france/tests/json/f7jm-5718e08197a3a3e07ce29d4ced63ee436ffb2053be04949cd1a704033086653f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jm-577d12f49ba56e4a0d089a68fa76c5812bbcd86f4a5194b0a1aeab81c695bb7f.json
+++ b/openfisca_france/tests/json/f7jm-577d12f49ba56e4a0d089a68fa76c5812bbcd86f4a5194b0a1aeab81c695bb7f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jm-5d958160bce9ff4106fd4b4dfdca98a1a673480f565d5bc9eacbe91ec15a131c.json
+++ b/openfisca_france/tests/json/f7jm-5d958160bce9ff4106fd4b4dfdca98a1a673480f565d5bc9eacbe91ec15a131c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jm-ce288a0b6da2e8417c44585b97e10f53e8d3dd2987e958c7cb34feb9a20e1d83.json
+++ b/openfisca_france/tests/json/f7jm-ce288a0b6da2e8417c44585b97e10f53e8d3dd2987e958c7cb34feb9a20e1d83.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jm-e273d2fff25a4961acaa82c2e7ddc73ad1323ab7271ce536843fe292e8d62313.json
+++ b/openfisca_france/tests/json/f7jm-e273d2fff25a4961acaa82c2e7ddc73ad1323ab7271ce536843fe292e8d62313.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jm-fd950be45b2011c84d3fbeb0783b591b21f60dcb5f63b9248f2e33ea50e2611c.json
+++ b/openfisca_france/tests/json/f7jm-fd950be45b2011c84d3fbeb0783b591b21f60dcb5f63b9248f2e33ea50e2611c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jn-1631d412e58d2e91b12b7498e7509311c29e8d04fc3aaafc6c05e31d7ce96526.json
+++ b/openfisca_france/tests/json/f7jn-1631d412e58d2e91b12b7498e7509311c29e8d04fc3aaafc6c05e31d7ce96526.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jn-30f834d18dde0bbd12aa737343317f238cd4bee15a74d2c7904e4adccdfc99a9.json
+++ b/openfisca_france/tests/json/f7jn-30f834d18dde0bbd12aa737343317f238cd4bee15a74d2c7904e4adccdfc99a9.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jn-3bec92908db2bf3979b24c0c73d2acd55b805ebeb926f41a73caa9252c4fbf7c.json
+++ b/openfisca_france/tests/json/f7jn-3bec92908db2bf3979b24c0c73d2acd55b805ebeb926f41a73caa9252c4fbf7c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jn-490cbf4624e58da6aa2ea42079035a69ce93e9ae89793614a49bfc3579b6039d.json
+++ b/openfisca_france/tests/json/f7jn-490cbf4624e58da6aa2ea42079035a69ce93e9ae89793614a49bfc3579b6039d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jn-5d6c00eed766d8981d0047d2840342e00a36574c80acf28378ff6566b0ee328d.json
+++ b/openfisca_france/tests/json/f7jn-5d6c00eed766d8981d0047d2840342e00a36574c80acf28378ff6566b0ee328d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jn-6ee547fdc97edfc68e3f766746d92e10ffd410395fb9098520c842d6ba589a6d.json
+++ b/openfisca_france/tests/json/f7jn-6ee547fdc97edfc68e3f766746d92e10ffd410395fb9098520c842d6ba589a6d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jn-b14ff4678ff1f85e4629d283cd202e44fffd88cd85b6ef30234dc42cd904579d.json
+++ b/openfisca_france/tests/json/f7jn-b14ff4678ff1f85e4629d283cd202e44fffd88cd85b6ef30234dc42cd904579d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jn-eb467f16f0e116c100cd1eccbe0f5954737602796d82419c4d4919d987b3bdb8.json
+++ b/openfisca_france/tests/json/f7jn-eb467f16f0e116c100cd1eccbe0f5954737602796d82419c4d4919d987b3bdb8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jn-ec0cc1f5ec4be279c40b1c96e5a7c6d00139faa19ef11d8ecc5c5fecafbb16b0.json
+++ b/openfisca_france/tests/json/f7jn-ec0cc1f5ec4be279c40b1c96e5a7c6d00139faa19ef11d8ecc5c5fecafbb16b0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jo-05af109670b874421b5f242e95397f1250b9c9652d89bdc083617535f83403b0.json
+++ b/openfisca_france/tests/json/f7jo-05af109670b874421b5f242e95397f1250b9c9652d89bdc083617535f83403b0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jo-221811e04a150223f8d761433bc1f450f0776ba52eeac33e13c222c3d3567fc2.json
+++ b/openfisca_france/tests/json/f7jo-221811e04a150223f8d761433bc1f450f0776ba52eeac33e13c222c3d3567fc2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jo-37022657ac99907d4a9445811a84634575322b6d39c17459875979fd78992ebe.json
+++ b/openfisca_france/tests/json/f7jo-37022657ac99907d4a9445811a84634575322b6d39c17459875979fd78992ebe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jo-6f2a98b39eea75ff9c373a2272cb51c8a0368ea26e94c2b3ba97b4c6a524269a.json
+++ b/openfisca_france/tests/json/f7jo-6f2a98b39eea75ff9c373a2272cb51c8a0368ea26e94c2b3ba97b4c6a524269a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jo-735d69a66ec1905ccdc907a6e10c7b7f123283a43aace8a6819eb751c48cdaa9.json
+++ b/openfisca_france/tests/json/f7jo-735d69a66ec1905ccdc907a6e10c7b7f123283a43aace8a6819eb751c48cdaa9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jo-9a5f134340409af016b113275cbec9337a544e53e6742ae21f1b5b8be4abb919.json
+++ b/openfisca_france/tests/json/f7jo-9a5f134340409af016b113275cbec9337a544e53e6742ae21f1b5b8be4abb919.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jo-a0a583c59c2745ab9d0e1a509e49f100083fef32a640f75f1bee00cdfc23249b.json
+++ b/openfisca_france/tests/json/f7jo-a0a583c59c2745ab9d0e1a509e49f100083fef32a640f75f1bee00cdfc23249b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jo-b18d431905afe98f5e61ead9e46c10d4de79bd03a7b7cee77703310ebb6998a1.json
+++ b/openfisca_france/tests/json/f7jo-b18d431905afe98f5e61ead9e46c10d4de79bd03a7b7cee77703310ebb6998a1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jo-f0784a8844dbe0c59eff48dbecad815d8b00444a2d36380613bc606d512a52c7.json
+++ b/openfisca_france/tests/json/f7jo-f0784a8844dbe0c59eff48dbecad815d8b00444a2d36380613bc606d512a52c7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jp-3d1e58d199ce09d3cbb6f94adf6750b27d9fe765817ce4f37fce6bfb829aaddc.json
+++ b/openfisca_france/tests/json/f7jp-3d1e58d199ce09d3cbb6f94adf6750b27d9fe765817ce4f37fce6bfb829aaddc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jp-4fcbafa61100b0a24929f34b7e019bd6254388e7452e821bb262f8decd4e968c.json
+++ b/openfisca_france/tests/json/f7jp-4fcbafa61100b0a24929f34b7e019bd6254388e7452e821bb262f8decd4e968c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jp-6aca53f487f3d2381f6bf27cfcfde25ac87f77668699dbc68fcad4b2f2c9a3f9.json
+++ b/openfisca_france/tests/json/f7jp-6aca53f487f3d2381f6bf27cfcfde25ac87f77668699dbc68fcad4b2f2c9a3f9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jp-79cb0cf3d66652c1eaedf8758cc5fd8184405e7bab0c9e4e70f615d9a9a59275.json
+++ b/openfisca_france/tests/json/f7jp-79cb0cf3d66652c1eaedf8758cc5fd8184405e7bab0c9e4e70f615d9a9a59275.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jp-9b5542477377d2b1228e239d2490b3d4d9682b2edc079b799bddc4f8d981c851.json
+++ b/openfisca_france/tests/json/f7jp-9b5542477377d2b1228e239d2490b3d4d9682b2edc079b799bddc4f8d981c851.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jp-b2f863d8cdacfc8d16d22333c392bf034ba505b8d2ecea3b7f4c11647beb6d08.json
+++ b/openfisca_france/tests/json/f7jp-b2f863d8cdacfc8d16d22333c392bf034ba505b8d2ecea3b7f4c11647beb6d08.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jp-dac4937a9c738b211aed89c8b993312f077c29b4bc30a834ba10e01f3d0e230f.json
+++ b/openfisca_france/tests/json/f7jp-dac4937a9c738b211aed89c8b993312f077c29b4bc30a834ba10e01f3d0e230f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jp-e10c195431296a52ea4baa59430855c82e86a5803481ea0837b917fb0603266a.json
+++ b/openfisca_france/tests/json/f7jp-e10c195431296a52ea4baa59430855c82e86a5803481ea0837b917fb0603266a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jp-e78f732b1b176ab061c2ec5a7c20dd6e758f23ed68106ebd5a56a565445976f5.json
+++ b/openfisca_france/tests/json/f7jp-e78f732b1b176ab061c2ec5a7c20dd6e758f23ed68106ebd5a56a565445976f5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jq-1d93af46f4d1d8666972fa96655f2a33ba1ec567ca39e85818cf94c17c5c623b.json
+++ b/openfisca_france/tests/json/f7jq-1d93af46f4d1d8666972fa96655f2a33ba1ec567ca39e85818cf94c17c5c623b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jq-2b8c9d5d57e1377683e2df963b707f6359adb1637995f205629849fb92868676.json
+++ b/openfisca_france/tests/json/f7jq-2b8c9d5d57e1377683e2df963b707f6359adb1637995f205629849fb92868676.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jq-2ed9d901712aa194efe502f36051f68ab55403c10f6e31282a815e0f903302af.json
+++ b/openfisca_france/tests/json/f7jq-2ed9d901712aa194efe502f36051f68ab55403c10f6e31282a815e0f903302af.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jq-3285b0b231c84ca75edc2bf46558473cc53ba730ad7c9b2d3553e9a99ffdbbb5.json
+++ b/openfisca_france/tests/json/f7jq-3285b0b231c84ca75edc2bf46558473cc53ba730ad7c9b2d3553e9a99ffdbbb5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jq-7a1da4e118880d26d53ad17a3dead3d524e36066fe9cda213bde53acc02a1eb6.json
+++ b/openfisca_france/tests/json/f7jq-7a1da4e118880d26d53ad17a3dead3d524e36066fe9cda213bde53acc02a1eb6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jq-9acc740f82d3c347271efff065097ef73b53e9a156d3b19c88b5d728c95b1b8c.json
+++ b/openfisca_france/tests/json/f7jq-9acc740f82d3c347271efff065097ef73b53e9a156d3b19c88b5d728c95b1b8c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jq-c3f522ebc397779d62d6b91f065b9975c4bd2961b91fe832bab38d1e973bd592.json
+++ b/openfisca_france/tests/json/f7jq-c3f522ebc397779d62d6b91f065b9975c4bd2961b91fe832bab38d1e973bd592.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jq-edcb20e37761626e4b4a0daf15128065cd2202f2aaf4ed2d1955d21ddddb3a07.json
+++ b/openfisca_france/tests/json/f7jq-edcb20e37761626e4b4a0daf15128065cd2202f2aaf4ed2d1955d21ddddb3a07.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jq-f184274b9ae0e7e11cd8bfee6b9a08d5e6cc605b0f1d37780abeab2c9bef2df6.json
+++ b/openfisca_france/tests/json/f7jq-f184274b9ae0e7e11cd8bfee6b9a08d5e6cc605b0f1d37780abeab2c9bef2df6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jr-2375b5bd991c4b64f6371ffeff2b726fa145faab596a25357265bc925698ca58.json
+++ b/openfisca_france/tests/json/f7jr-2375b5bd991c4b64f6371ffeff2b726fa145faab596a25357265bc925698ca58.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jr-3a4328941b1cbd645a59aa19576b1668540d3827a8a7e614fb972e89e726925f.json
+++ b/openfisca_france/tests/json/f7jr-3a4328941b1cbd645a59aa19576b1668540d3827a8a7e614fb972e89e726925f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jr-422b2cf0c2d5875749fed097fcb3eb2fcc932592fa48fb6bea50d755feccf197.json
+++ b/openfisca_france/tests/json/f7jr-422b2cf0c2d5875749fed097fcb3eb2fcc932592fa48fb6bea50d755feccf197.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jr-46f894f2bffe8f34a8643c983a087912bdf2d5a410fe3eb560789bf40c2bdb92.json
+++ b/openfisca_france/tests/json/f7jr-46f894f2bffe8f34a8643c983a087912bdf2d5a410fe3eb560789bf40c2bdb92.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jr-49777288b5563d8a14771a57b7c5431daec83f4888355ba32d941204db4fa89d.json
+++ b/openfisca_france/tests/json/f7jr-49777288b5563d8a14771a57b7c5431daec83f4888355ba32d941204db4fa89d.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jr-4d5604def6e7b4951f598b6fd19117bc18796e50de6075388c5d8e1cab870e42.json
+++ b/openfisca_france/tests/json/f7jr-4d5604def6e7b4951f598b6fd19117bc18796e50de6075388c5d8e1cab870e42.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jr-5eed0b25e323d12dfbf52eb4c379abfb7203f9741433a99adacb324108d90dfc.json
+++ b/openfisca_france/tests/json/f7jr-5eed0b25e323d12dfbf52eb4c379abfb7203f9741433a99adacb324108d90dfc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jr-7cda56d4449f1fc29611161e529a9debb7fc30497fa6cda471d1615f30340142.json
+++ b/openfisca_france/tests/json/f7jr-7cda56d4449f1fc29611161e529a9debb7fc30497fa6cda471d1615f30340142.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jr-db05103f4226ad3f69743ce58440991c7af15c8f18233cac1e7801e47935fda4.json
+++ b/openfisca_france/tests/json/f7jr-db05103f4226ad3f69743ce58440991c7af15c8f18233cac1e7801e47935fda4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7js-1a171a0387c0540e11339c1ff884b7c5608b426d37e198810782f1e91895d259.json
+++ b/openfisca_france/tests/json/f7js-1a171a0387c0540e11339c1ff884b7c5608b426d37e198810782f1e91895d259.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7js-210a0a5ef8964243a7810db98c12d8180c1ab88130809b5bcc388b76d93392e5.json
+++ b/openfisca_france/tests/json/f7js-210a0a5ef8964243a7810db98c12d8180c1ab88130809b5bcc388b76d93392e5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7js-2f39542e2af62448ca1d120ca545a27247dc06bbcf26ecd193f03b3953d021df.json
+++ b/openfisca_france/tests/json/f7js-2f39542e2af62448ca1d120ca545a27247dc06bbcf26ecd193f03b3953d021df.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7js-30817dd4cd1275111e99a82a022bf2c64c8492d2f31316019cd7705d5dba0e1d.json
+++ b/openfisca_france/tests/json/f7js-30817dd4cd1275111e99a82a022bf2c64c8492d2f31316019cd7705d5dba0e1d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7js-407ac787e791e4a779ab18f18838d0abd0d0059d6fed6b919b04fa12546f52df.json
+++ b/openfisca_france/tests/json/f7js-407ac787e791e4a779ab18f18838d0abd0d0059d6fed6b919b04fa12546f52df.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7js-5097eb931e11b667786f0a12543ea9337d4fa76a3ca9c129e30d9b4d2b1a9f5c.json
+++ b/openfisca_france/tests/json/f7js-5097eb931e11b667786f0a12543ea9337d4fa76a3ca9c129e30d9b4d2b1a9f5c.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7js-b70cb62f8ecb67eb8dfb98d72745b34434ea84d1b2ba73307d7f69a6014008e3.json
+++ b/openfisca_france/tests/json/f7js-b70cb62f8ecb67eb8dfb98d72745b34434ea84d1b2ba73307d7f69a6014008e3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7js-cc8dd745323c5fe5f5115d2dfef7f12eeb983c4e21b32f8a5cbd67a9b40de044.json
+++ b/openfisca_france/tests/json/f7js-cc8dd745323c5fe5f5115d2dfef7f12eeb983c4e21b32f8a5cbd67a9b40de044.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7js-d4e6006db75a618ea38d27c6650ca1277d0f8f45f1a7d011cb9b6f05472dc4d5.json
+++ b/openfisca_france/tests/json/f7js-d4e6006db75a618ea38d27c6650ca1277d0f8f45f1a7d011cb9b6f05472dc4d5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jt-0cf03156a0da5d8eb2aa9f7f7b6aadfe728ce72980e30523f6a2e407525c5764.json
+++ b/openfisca_france/tests/json/f7jt-0cf03156a0da5d8eb2aa9f7f7b6aadfe728ce72980e30523f6a2e407525c5764.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jt-2781a86e8fcd1f7db5d3f47afad189954c5d237cc205625205ecaaa551723d6b.json
+++ b/openfisca_france/tests/json/f7jt-2781a86e8fcd1f7db5d3f47afad189954c5d237cc205625205ecaaa551723d6b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jt-2c7801071e37ce4d2aac04a1a1b2b3e556f2e8f56aaee0f93527aab9161bf1b9.json
+++ b/openfisca_france/tests/json/f7jt-2c7801071e37ce4d2aac04a1a1b2b3e556f2e8f56aaee0f93527aab9161bf1b9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jt-3019d5194c2bbd027a2525ffb89b7e4a9e7c67c01e0923c2c1bfe894c0852f5a.json
+++ b/openfisca_france/tests/json/f7jt-3019d5194c2bbd027a2525ffb89b7e4a9e7c67c01e0923c2c1bfe894c0852f5a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jt-7c3f6c7804314b66480f867ba590af9e4ba0ffb83866c9525233d4302bd8fb55.json
+++ b/openfisca_france/tests/json/f7jt-7c3f6c7804314b66480f867ba590af9e4ba0ffb83866c9525233d4302bd8fb55.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jt-c3ca3a8fd93e2df43b2db14cb46c1da1f4c50ddc7b35500e4929c8b720a41f5e.json
+++ b/openfisca_france/tests/json/f7jt-c3ca3a8fd93e2df43b2db14cb46c1da1f4c50ddc7b35500e4929c8b720a41f5e.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jt-cceb7245754402c74be0c7a9165de5e17a8c88867294b703357f0464d2e602cd.json
+++ b/openfisca_france/tests/json/f7jt-cceb7245754402c74be0c7a9165de5e17a8c88867294b703357f0464d2e602cd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jt-dd54b359aadc96e533954b0d6a860d1fdd3fd435ddab3843e0b54a31c4e50ea5.json
+++ b/openfisca_france/tests/json/f7jt-dd54b359aadc96e533954b0d6a860d1fdd3fd435ddab3843e0b54a31c4e50ea5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jt-e6dcc0906e4eb4c2f92ac3d84db50ac0a10041410fc57ad7365255c869178631.json
+++ b/openfisca_france/tests/json/f7jt-e6dcc0906e4eb4c2f92ac3d84db50ac0a10041410fc57ad7365255c869178631.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ju-1e8b1f8beeadc59c5e8b5a0301d52207e3ce4e337fcbb1564c774d722e07cd34.json
+++ b/openfisca_france/tests/json/f7ju-1e8b1f8beeadc59c5e8b5a0301d52207e3ce4e337fcbb1564c774d722e07cd34.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ju-380dbc4feaa6f97a4c7968f8a82759c38ea0c133ad3f7c50ff883201880583e0.json
+++ b/openfisca_france/tests/json/f7ju-380dbc4feaa6f97a4c7968f8a82759c38ea0c133ad3f7c50ff883201880583e0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ju-44f8f080b54eb30ed0796b9641f8d4ebb26749984c025ebce04e91b3a0b98713.json
+++ b/openfisca_france/tests/json/f7ju-44f8f080b54eb30ed0796b9641f8d4ebb26749984c025ebce04e91b3a0b98713.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ju-548b6f3738cc8960ae716c67d8285a72b1d9c7e3b3f5bf21bd684a8eb85a63bf.json
+++ b/openfisca_france/tests/json/f7ju-548b6f3738cc8960ae716c67d8285a72b1d9c7e3b3f5bf21bd684a8eb85a63bf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ju-649e0c093588b25434a59d67a931ec99945e131f83842a89039b7394cfb800a4.json
+++ b/openfisca_france/tests/json/f7ju-649e0c093588b25434a59d67a931ec99945e131f83842a89039b7394cfb800a4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ju-8711992c0e41ac31c958acf172878b0209f9f2210788f790960d46ee703cdf21.json
+++ b/openfisca_france/tests/json/f7ju-8711992c0e41ac31c958acf172878b0209f9f2210788f790960d46ee703cdf21.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ju-c7b092e2695e1862438471b62f3488e6186f87091f10134fd342d4513bc66da7.json
+++ b/openfisca_france/tests/json/f7ju-c7b092e2695e1862438471b62f3488e6186f87091f10134fd342d4513bc66da7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ju-d4f3f09f32d032cbab8962d9df9c93fca0976d1b16859ff52285c8a2c862dac3.json
+++ b/openfisca_france/tests/json/f7ju-d4f3f09f32d032cbab8962d9df9c93fca0976d1b16859ff52285c8a2c862dac3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ju-e1de5f96254b06b5dfeb2275d91280b1f7371c19a671f211ad7316b9782d2327.json
+++ b/openfisca_france/tests/json/f7ju-e1de5f96254b06b5dfeb2275d91280b1f7371c19a671f211ad7316b9782d2327.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jv-03af1b4dbe6b3df789bd313c9eaab65f9df6aeee08814e15595f80cb0c8e88f0.json
+++ b/openfisca_france/tests/json/f7jv-03af1b4dbe6b3df789bd313c9eaab65f9df6aeee08814e15595f80cb0c8e88f0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jv-2b3359d40019186a4525e98fd69e45d0c72c8f88932d2b5fc565b8a294484354.json
+++ b/openfisca_france/tests/json/f7jv-2b3359d40019186a4525e98fd69e45d0c72c8f88932d2b5fc565b8a294484354.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jv-5b0c01ef25f6847236ef08b839acf362491b87d19d6f4aa2842f17e3afbfc82c.json
+++ b/openfisca_france/tests/json/f7jv-5b0c01ef25f6847236ef08b839acf362491b87d19d6f4aa2842f17e3afbfc82c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jv-6a011016d7aad4a04ea80849708a13641f148ccac3ee7e248a7f272f8109d7ad.json
+++ b/openfisca_france/tests/json/f7jv-6a011016d7aad4a04ea80849708a13641f148ccac3ee7e248a7f272f8109d7ad.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jv-7d49d5e6662f9c1fccc5d715677774985a195f69008d86778d4949f0185eea7c.json
+++ b/openfisca_france/tests/json/f7jv-7d49d5e6662f9c1fccc5d715677774985a195f69008d86778d4949f0185eea7c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jv-b1cfd18586091fb43766ec19f0018dc1cbfdde6736628a905226218a92284c82.json
+++ b/openfisca_france/tests/json/f7jv-b1cfd18586091fb43766ec19f0018dc1cbfdde6736628a905226218a92284c82.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jv-c1fff7ecdf8de9beef7cedcdf0fcf10d0d4a7bd46dd92e05a5fb3fabf5d6cec3.json
+++ b/openfisca_france/tests/json/f7jv-c1fff7ecdf8de9beef7cedcdf0fcf10d0d4a7bd46dd92e05a5fb3fabf5d6cec3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jv-ca68d5328b8a373a5d490d539cd8ce02925178c233987df09229a934223f788e.json
+++ b/openfisca_france/tests/json/f7jv-ca68d5328b8a373a5d490d539cd8ce02925178c233987df09229a934223f788e.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jv-cdf91ab61e074f9bedfdaa0e6609b1545a888bf712d76ec8115ad555cb56c11e.json
+++ b/openfisca_france/tests/json/f7jv-cdf91ab61e074f9bedfdaa0e6609b1545a888bf712d76ec8115ad555cb56c11e.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jw-02e20c71eb263f503b42b1443ac1ca482c5419343c02686861cb0331db22e4bb.json
+++ b/openfisca_france/tests/json/f7jw-02e20c71eb263f503b42b1443ac1ca482c5419343c02686861cb0331db22e4bb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jw-1151d10b33fdeafa57ed010a78a04c5f1280de9fa2cd32780b276f952069cd53.json
+++ b/openfisca_france/tests/json/f7jw-1151d10b33fdeafa57ed010a78a04c5f1280de9fa2cd32780b276f952069cd53.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jw-1cff979c7d0c4415cb6f43eb6317b31762c64d1b06b5b24a0fff0f2daab2ee1b.json
+++ b/openfisca_france/tests/json/f7jw-1cff979c7d0c4415cb6f43eb6317b31762c64d1b06b5b24a0fff0f2daab2ee1b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jw-1f7ac8dd478aa2cb11fae7c3d214215dbdb82adaa2454cf6af3b1082644d2c1e.json
+++ b/openfisca_france/tests/json/f7jw-1f7ac8dd478aa2cb11fae7c3d214215dbdb82adaa2454cf6af3b1082644d2c1e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jw-3d1da2d1fccd9c0ad400e2981f73f5bc024e888765f4131d56bc129c1af4c4f1.json
+++ b/openfisca_france/tests/json/f7jw-3d1da2d1fccd9c0ad400e2981f73f5bc024e888765f4131d56bc129c1af4c4f1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jw-446147f2a67bda596021779b7be053711862aee47f8ee188732e260d92de39d1.json
+++ b/openfisca_france/tests/json/f7jw-446147f2a67bda596021779b7be053711862aee47f8ee188732e260d92de39d1.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jw-9ad015a40c425318a85c8ff0f3d316ea08e8c50e54d1fa5904d3171eed1cf49a.json
+++ b/openfisca_france/tests/json/f7jw-9ad015a40c425318a85c8ff0f3d316ea08e8c50e54d1fa5904d3171eed1cf49a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jw-d6db980b87cbe39eafce1b77e0aa8fa1c3c4d5a6aa73d94c5b699351e0509e9f.json
+++ b/openfisca_france/tests/json/f7jw-d6db980b87cbe39eafce1b77e0aa8fa1c3c4d5a6aa73d94c5b699351e0509e9f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jw-efbc5a7fe3c1066ac68c62b67f76d65dd0751d0d5911382bb2ded55ebbcdddea.json
+++ b/openfisca_france/tests/json/f7jw-efbc5a7fe3c1066ac68c62b67f76d65dd0751d0d5911382bb2ded55ebbcdddea.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jx-47af694807ad215c2a557a282a70b0113aea369471e051418b39887abd0ca900.json
+++ b/openfisca_france/tests/json/f7jx-47af694807ad215c2a557a282a70b0113aea369471e051418b39887abd0ca900.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jx-49f0238754f2050d1744f4f72bcd7fa4619d2d5ebf1bfb9229e4bfe76d39adf4.json
+++ b/openfisca_france/tests/json/f7jx-49f0238754f2050d1744f4f72bcd7fa4619d2d5ebf1bfb9229e4bfe76d39adf4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jx-5c2d9c5d2c27896c689afe34d494581413469f0af483fa45e41b4914fd3358b1.json
+++ b/openfisca_france/tests/json/f7jx-5c2d9c5d2c27896c689afe34d494581413469f0af483fa45e41b4914fd3358b1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jx-8a11196193bdf4a1e415b7a780e3831f50364439ba7e064f82b2df88cd905db1.json
+++ b/openfisca_france/tests/json/f7jx-8a11196193bdf4a1e415b7a780e3831f50364439ba7e064f82b2df88cd905db1.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jx-c9abd42653a37c8272537096d6806dfa54454bc88411b432c7ca0d6443b99238.json
+++ b/openfisca_france/tests/json/f7jx-c9abd42653a37c8272537096d6806dfa54454bc88411b432c7ca0d6443b99238.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jx-db46f7b2cd9ae221c5c4714e2859c49d327c0546665446cfd1949d12fdef5e29.json
+++ b/openfisca_france/tests/json/f7jx-db46f7b2cd9ae221c5c4714e2859c49d327c0546665446cfd1949d12fdef5e29.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jx-e8f17f1e77a27d9626df483574b0d1d1e357525eca835325513804bb840582ca.json
+++ b/openfisca_france/tests/json/f7jx-e8f17f1e77a27d9626df483574b0d1d1e357525eca835325513804bb840582ca.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jx-eef947bda3fc3396b799eebcea02fc00165763972938470ebcfdf210c9ce8a87.json
+++ b/openfisca_france/tests/json/f7jx-eef947bda3fc3396b799eebcea02fc00165763972938470ebcfdf210c9ce8a87.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jx-ffff8d2257b6a8b254d80b30d37ea6596c9a8f06e5857d3f5568432e2a65b9e6.json
+++ b/openfisca_france/tests/json/f7jx-ffff8d2257b6a8b254d80b30d37ea6596c9a8f06e5857d3f5568432e2a65b9e6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jy-ad6674dfad781423a1666f193aec1e36eaa50b9bd62f111d059bb1aae3c75666.json
+++ b/openfisca_france/tests/json/f7jy-ad6674dfad781423a1666f193aec1e36eaa50b9bd62f111d059bb1aae3c75666.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jy-dc8920cd874eabafc34ccbeaa905c5b5cafe239c379f0b6b0233cfb3b59698a8.json
+++ b/openfisca_france/tests/json/f7jy-dc8920cd874eabafc34ccbeaa905c5b5cafe239c379f0b6b0233cfb3b59698a8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jy-e3f65ccf8c3299a6d97fdbd23f01efc4a3db1fd3e19a30317fe5ba401ae57ed5.json
+++ b/openfisca_france/tests/json/f7jy-e3f65ccf8c3299a6d97fdbd23f01efc4a3db1fd3e19a30317fe5ba401ae57ed5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7jy-eeb09aecaf1ce204ba683cfbaf67107955fa01e05957c11c2066a1ef3e4cff52.json
+++ b/openfisca_france/tests/json/f7jy-eeb09aecaf1ce204ba683cfbaf67107955fa01e05957c11c2066a1ef3e4cff52.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ka-072140b3e692d585ebfd667956f8c3b3ed1b84e0c0c7f1fa05578fa9400d27e6.json
+++ b/openfisca_france/tests/json/f7ka-072140b3e692d585ebfd667956f8c3b3ed1b84e0c0c7f1fa05578fa9400d27e6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ka-454e2796761becb72b3c3b038abcfb7addf0b0706051a2cb3016dcc1f75e0c61.json
+++ b/openfisca_france/tests/json/f7ka-454e2796761becb72b3c3b038abcfb7addf0b0706051a2cb3016dcc1f75e0c61.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ka-5651be954cf4b5c8c9ff8ac6501c5a935aa22fd62dde36770363ccadf49bd48e.json
+++ b/openfisca_france/tests/json/f7ka-5651be954cf4b5c8c9ff8ac6501c5a935aa22fd62dde36770363ccadf49bd48e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ka-56735d5f6f69296c87130f8cfd18daf2b9a95bc2d59628070d7770b58aebd928.json
+++ b/openfisca_france/tests/json/f7ka-56735d5f6f69296c87130f8cfd18daf2b9a95bc2d59628070d7770b58aebd928.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ka-6f7babd0bcd137878445abad7c535ca423d13afba237ec5f942078a7ec305bd6.json
+++ b/openfisca_france/tests/json/f7ka-6f7babd0bcd137878445abad7c535ca423d13afba237ec5f942078a7ec305bd6.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ka-837a312688e7a995761d00697415bc371179cca7f44a362876ecce0ebbb264ad.json
+++ b/openfisca_france/tests/json/f7ka-837a312688e7a995761d00697415bc371179cca7f44a362876ecce0ebbb264ad.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ka-9998706e0f2ead885070308d57bf85e2010c34fd250cc5c58ddfd6470b868f1d.json
+++ b/openfisca_france/tests/json/f7ka-9998706e0f2ead885070308d57bf85e2010c34fd250cc5c58ddfd6470b868f1d.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ka-a2aa273ecb035bb72bf9f4632b8a8e2398f7404fb57c286848f74ffd4fb2be65.json
+++ b/openfisca_france/tests/json/f7ka-a2aa273ecb035bb72bf9f4632b8a8e2398f7404fb57c286848f74ffd4fb2be65.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ka-ee5e0616258126e68d499592aa6bfbd987c90ef406411932268943c2a12b2294.json
+++ b/openfisca_france/tests/json/f7ka-ee5e0616258126e68d499592aa6bfbd987c90ef406411932268943c2a12b2294.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kb-39074b23fabef9db5f3308ec859d07ca418d6ed0f0390e047f8e0480f792f0dc.json
+++ b/openfisca_france/tests/json/f7kb-39074b23fabef9db5f3308ec859d07ca418d6ed0f0390e047f8e0480f792f0dc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kb-492e1f4706515ce3bd788e2fa78209e4484b2f9fd8e3156e3a79ef0864043ce5.json
+++ b/openfisca_france/tests/json/f7kb-492e1f4706515ce3bd788e2fa78209e4484b2f9fd8e3156e3a79ef0864043ce5.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kb-612ca15f2bb990255fec3c5df4b1bcfeab424a4f7899791df3321ddfdaefec58.json
+++ b/openfisca_france/tests/json/f7kb-612ca15f2bb990255fec3c5df4b1bcfeab424a4f7899791df3321ddfdaefec58.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kb-6c8ac20247feaeb0914617a80f085b09bf4843325c82c255f6b6642cf9fa06a2.json
+++ b/openfisca_france/tests/json/f7kb-6c8ac20247feaeb0914617a80f085b09bf4843325c82c255f6b6642cf9fa06a2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kb-82542e0e5da3d4ab2211bb36063c532202f5a559a953a599a6d6a209ad810c75.json
+++ b/openfisca_france/tests/json/f7kb-82542e0e5da3d4ab2211bb36063c532202f5a559a953a599a6d6a209ad810c75.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kb-a6f70cab924f2af3c24286990932e4ed5d9b4a5ffdea1f4537ec79135111895d.json
+++ b/openfisca_france/tests/json/f7kb-a6f70cab924f2af3c24286990932e4ed5d9b4a5ffdea1f4537ec79135111895d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kb-c6de22f22d49adf140ceec4f53e7569bc8927a04b64de8643adf27d97fdfc80c.json
+++ b/openfisca_france/tests/json/f7kb-c6de22f22d49adf140ceec4f53e7569bc8927a04b64de8643adf27d97fdfc80c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kb-d16c04e75d76f41f85fc4af5a6b604f7cd50f66273c77c0b35af594bcf3b8c96.json
+++ b/openfisca_france/tests/json/f7kb-d16c04e75d76f41f85fc4af5a6b604f7cd50f66273c77c0b35af594bcf3b8c96.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kb-ee699740f9926c6a70400f1378c685c5377f818e442b91fac8268f03364c4df6.json
+++ b/openfisca_france/tests/json/f7kb-ee699740f9926c6a70400f1378c685c5377f818e442b91fac8268f03364c4df6.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kc-0aca68be89df053f44de5d32a3426166fbe415b3b444a1a9f70f37134b615ac6.json
+++ b/openfisca_france/tests/json/f7kc-0aca68be89df053f44de5d32a3426166fbe415b3b444a1a9f70f37134b615ac6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kc-14202a56a033a116d1d934cf556ffd1cdb34dc665b5514e944c638e247d82df7.json
+++ b/openfisca_france/tests/json/f7kc-14202a56a033a116d1d934cf556ffd1cdb34dc665b5514e944c638e247d82df7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kc-2a868313d2ed9fb8f412f238c064e9d6d34b7a1ca73868d48f2f82882818b9f4.json
+++ b/openfisca_france/tests/json/f7kc-2a868313d2ed9fb8f412f238c064e9d6d34b7a1ca73868d48f2f82882818b9f4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kc-3fd0deee8411bcbe1a6692850ddc07ba9510934c11f56bcae0bac5dadb114c8d.json
+++ b/openfisca_france/tests/json/f7kc-3fd0deee8411bcbe1a6692850ddc07ba9510934c11f56bcae0bac5dadb114c8d.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kc-5b52ab43ac421e5ee96917ab0003cbab4340520ae7d02a592b6276db1d3f9b65.json
+++ b/openfisca_france/tests/json/f7kc-5b52ab43ac421e5ee96917ab0003cbab4340520ae7d02a592b6276db1d3f9b65.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kc-73515099752a7948965fcaae2197a0d4dbe580090eed732b4a2f95c41830d9ba.json
+++ b/openfisca_france/tests/json/f7kc-73515099752a7948965fcaae2197a0d4dbe580090eed732b4a2f95c41830d9ba.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kc-ad8b0a6253249fd9429dd852e92d73a87a45e227c0e30b209ccbfd27d837fdb5.json
+++ b/openfisca_france/tests/json/f7kc-ad8b0a6253249fd9429dd852e92d73a87a45e227c0e30b209ccbfd27d837fdb5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kc-bec8abccb434187114318d85fbe1b37ebc3a5256513cd2eed818f348ad41c463.json
+++ b/openfisca_france/tests/json/f7kc-bec8abccb434187114318d85fbe1b37ebc3a5256513cd2eed818f348ad41c463.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kc-c4c450c3068f1fe559104ff6b6af37c4918445e03446bd269ca4f34eec290de9.json
+++ b/openfisca_france/tests/json/f7kc-c4c450c3068f1fe559104ff6b6af37c4918445e03446bd269ca4f34eec290de9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kd-19956a7a53847aafb98f7851b3019519df79e7a8f9f2796adf44e074d05e8a89.json
+++ b/openfisca_france/tests/json/f7kd-19956a7a53847aafb98f7851b3019519df79e7a8f9f2796adf44e074d05e8a89.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kd-42a5baf6bf957ac8422ef5ffb62bb31dea0d55af1dbc1ea9d07d9930f7758bf2.json
+++ b/openfisca_france/tests/json/f7kd-42a5baf6bf957ac8422ef5ffb62bb31dea0d55af1dbc1ea9d07d9930f7758bf2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kd-8658a7af5fc0a54dd9b441dcece25dbcce9435a81a5db7bab975a80cd000c06b.json
+++ b/openfisca_france/tests/json/f7kd-8658a7af5fc0a54dd9b441dcece25dbcce9435a81a5db7bab975a80cd000c06b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kd-869d5fa3fb7f6e8e49742810cbca9aabc07ff1a1936c4ed4e57fbd206192eae4.json
+++ b/openfisca_france/tests/json/f7kd-869d5fa3fb7f6e8e49742810cbca9aabc07ff1a1936c4ed4e57fbd206192eae4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kd-b42a9a12f7eeb1b17f4aa1915612bd8ac7e45fbbb561f344c82f03e1bba76bf3.json
+++ b/openfisca_france/tests/json/f7kd-b42a9a12f7eeb1b17f4aa1915612bd8ac7e45fbbb561f344c82f03e1bba76bf3.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kd-c36a469829dc0c05ed28366ad29f820a5c1b589d770c076252ecaeac041b6dce.json
+++ b/openfisca_france/tests/json/f7kd-c36a469829dc0c05ed28366ad29f820a5c1b589d770c076252ecaeac041b6dce.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kd-d1be370d1a4bd2dc33c006ac7a77d303d4e37b69b01c54d62a2b4eeabe4d1bf9.json
+++ b/openfisca_france/tests/json/f7kd-d1be370d1a4bd2dc33c006ac7a77d303d4e37b69b01c54d62a2b4eeabe4d1bf9.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kd-d61a7ad0bef5f122359f39dd84a6e62e94cb119838e752cc7cc2f5757b812e0a.json
+++ b/openfisca_france/tests/json/f7kd-d61a7ad0bef5f122359f39dd84a6e62e94cb119838e752cc7cc2f5757b812e0a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kd-d8f8fb25e0f7a9279819bf42ec92981a4e217d5e1af27743d67f8e6d8102ae2d.json
+++ b/openfisca_france/tests/json/f7kd-d8f8fb25e0f7a9279819bf42ec92981a4e217d5e1af27743d67f8e6d8102ae2d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ks-150cef8abb92909062496c692ed447c07b53dad5cbff2a3988074cec21c88092.json
+++ b/openfisca_france/tests/json/f7ks-150cef8abb92909062496c692ed447c07b53dad5cbff2a3988074cec21c88092.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ks-286de6144be7332c3525a0ed6208403de5608e7f125a21ea66dd3d07820baa61.json
+++ b/openfisca_france/tests/json/f7ks-286de6144be7332c3525a0ed6208403de5608e7f125a21ea66dd3d07820baa61.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ks-3aa6feafce73eb68e0ef761687c2c22031e252bd82cc094f06cab46493ef8de7.json
+++ b/openfisca_france/tests/json/f7ks-3aa6feafce73eb68e0ef761687c2c22031e252bd82cc094f06cab46493ef8de7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ks-4614a06d2bcb245d0f7e200547f57c884939882b170ef22760f3e22613e4d56a.json
+++ b/openfisca_france/tests/json/f7ks-4614a06d2bcb245d0f7e200547f57c884939882b170ef22760f3e22613e4d56a.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ks-b575f707daecf1df104a4d0ca9a98744ec82e02a6a8704f530a14f36370abafa.json
+++ b/openfisca_france/tests/json/f7ks-b575f707daecf1df104a4d0ca9a98744ec82e02a6a8704f530a14f36370abafa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ks-baa753ab961aeca0ad1865ce60919a213f69ef2e01e54f68c71f050eb5c482df.json
+++ b/openfisca_france/tests/json/f7ks-baa753ab961aeca0ad1865ce60919a213f69ef2e01e54f68c71f050eb5c482df.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ks-c821282827eab26850952d8be269cf836d7c75f71194a9de59e881f704555e2b.json
+++ b/openfisca_france/tests/json/f7ks-c821282827eab26850952d8be269cf836d7c75f71194a9de59e881f704555e2b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ks-c85c9686bb3aa15584824d4b9a134e25d8cbb61c321a57e7adec35b17b735ffe.json
+++ b/openfisca_france/tests/json/f7ks-c85c9686bb3aa15584824d4b9a134e25d8cbb61c321a57e7adec35b17b735ffe.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ks-e2ebf931c683c21f640ac22747f6750764b6a0fdf273f0b0a89c0376dae89b62.json
+++ b/openfisca_france/tests/json/f7ks-e2ebf931c683c21f640ac22747f6750764b6a0fdf273f0b0a89c0376dae89b62.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kt-4822f6b4e6bc5820f2177f9df14cdd62dc34818b70bd902b0c3cdaaf85ede822.json
+++ b/openfisca_france/tests/json/f7kt-4822f6b4e6bc5820f2177f9df14cdd62dc34818b70bd902b0c3cdaaf85ede822.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kt-4a6747efa133170c2d8ccaae7387359f612ace70b6830912c51dfdcace426fd6.json
+++ b/openfisca_france/tests/json/f7kt-4a6747efa133170c2d8ccaae7387359f612ace70b6830912c51dfdcace426fd6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kt-4f081228ae4812c4bb985e8731caafcabcb93f9eae1dff8fd3ccda18dae507c0.json
+++ b/openfisca_france/tests/json/f7kt-4f081228ae4812c4bb985e8731caafcabcb93f9eae1dff8fd3ccda18dae507c0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kt-661f35cd43c37105460bdd9bc85fc22d3b35e598892c1b0b35eb5a1c248cdbc2.json
+++ b/openfisca_france/tests/json/f7kt-661f35cd43c37105460bdd9bc85fc22d3b35e598892c1b0b35eb5a1c248cdbc2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kt-8961fd6350a30953ce1948ebf9b8977c5135c050a90edc3c1eb0af0bd81077cf.json
+++ b/openfisca_france/tests/json/f7kt-8961fd6350a30953ce1948ebf9b8977c5135c050a90edc3c1eb0af0bd81077cf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kt-b1fb9d1e45257a4d3500d5bdd68ccc1510497a5efa3a30c650067148c0a10722.json
+++ b/openfisca_france/tests/json/f7kt-b1fb9d1e45257a4d3500d5bdd68ccc1510497a5efa3a30c650067148c0a10722.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kt-b6026a618866cfeae120e25b3ff39d2b7ac80f5391b47745d18404d1c6ca5c61.json
+++ b/openfisca_france/tests/json/f7kt-b6026a618866cfeae120e25b3ff39d2b7ac80f5391b47745d18404d1c6ca5c61.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7kt-e46b8875aaad530153799ee2aea41f18cf12c274120381f1d4efaa69294c3040.json
+++ b/openfisca_france/tests/json/f7kt-e46b8875aaad530153799ee2aea41f18cf12c274120381f1d4efaa69294c3040.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ku-47158caf22facc83065fb437c042940fd73fa624a64468b1cb7502741665a657.json
+++ b/openfisca_france/tests/json/f7ku-47158caf22facc83065fb437c042940fd73fa624a64468b1cb7502741665a657.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ku-72c819532cd47587cd3b3565f35ef96e6f2dee1468fb3c2cf2a4814814fcf186.json
+++ b/openfisca_france/tests/json/f7ku-72c819532cd47587cd3b3565f35ef96e6f2dee1468fb3c2cf2a4814814fcf186.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ku-96495864e7bdece7c6780861c6afbcc4cff77ea09ffb1cfbcef168903136da6a.json
+++ b/openfisca_france/tests/json/f7ku-96495864e7bdece7c6780861c6afbcc4cff77ea09ffb1cfbcef168903136da6a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ku-a3487a78a8b12b5270c40375a860755f0e99389663d06f440a16e0e5e84326d7.json
+++ b/openfisca_france/tests/json/f7ku-a3487a78a8b12b5270c40375a860755f0e99389663d06f440a16e0e5e84326d7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ku-e409c4c66e531aeffa8e7306261c8a6db88118dd843ba61ce72bb5f7d862fba5.json
+++ b/openfisca_france/tests/json/f7ku-e409c4c66e531aeffa8e7306261c8a6db88118dd843ba61ce72bb5f7d862fba5.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ku-e96efefb2bdb37ac18bb6ef0b7735668154287c3941892d80a9f6441cc633df0.json
+++ b/openfisca_france/tests/json/f7ku-e96efefb2bdb37ac18bb6ef0b7735668154287c3941892d80a9f6441cc633df0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ku-ed80c1ad3446ecf3773f611708ba893a1841227572b9aa3474d7590772290cbc.json
+++ b/openfisca_france/tests/json/f7ku-ed80c1ad3446ecf3773f611708ba893a1841227572b9aa3474d7590772290cbc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ku-f0e9d3b9ca6ca861af45ae09951a4da48fbdb275a6c84ccfc8cc8c1e855035b4.json
+++ b/openfisca_france/tests/json/f7ku-f0e9d3b9ca6ca861af45ae09951a4da48fbdb275a6c84ccfc8cc8c1e855035b4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ku-fff61e3d7a57d40ba4daa488fb9882c995513375dd981adff7b2612b18f431a5.json
+++ b/openfisca_france/tests/json/f7ku-fff61e3d7a57d40ba4daa488fb9882c995513375dd981adff7b2612b18f431a5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ky-03931c6bd9011db0572d47a5845e3bc9c7be1289eb5630101f2cd7537523577c.json
+++ b/openfisca_france/tests/json/f7ky-03931c6bd9011db0572d47a5845e3bc9c7be1289eb5630101f2cd7537523577c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ky-213c7f2ce56d87dfc9c3b2a4b5babe21270b60b43d3c563bbe85b66d3e4b94ed.json
+++ b/openfisca_france/tests/json/f7ky-213c7f2ce56d87dfc9c3b2a4b5babe21270b60b43d3c563bbe85b66d3e4b94ed.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ky-548ef6623da7b0129ff354b0c7d7c4cb713da4698bbb743e9ed87e90c8d6f458.json
+++ b/openfisca_france/tests/json/f7ky-548ef6623da7b0129ff354b0c7d7c4cb713da4698bbb743e9ed87e90c8d6f458.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ky-5c6ca8e87c5494b38ea8ac6030d8720ef5d157945b30323c8841523f90a0ba69.json
+++ b/openfisca_france/tests/json/f7ky-5c6ca8e87c5494b38ea8ac6030d8720ef5d157945b30323c8841523f90a0ba69.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7la-1bde67766a98a7083d8911d5481febe407581fc88790001c38b072e92a5b8fd9.json
+++ b/openfisca_france/tests/json/f7la-1bde67766a98a7083d8911d5481febe407581fc88790001c38b072e92a5b8fd9.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7la-2c336b3acf25429f4b358176c13e1a2795ba2c4c0b465b60bebf8ea27345a705.json
+++ b/openfisca_france/tests/json/f7la-2c336b3acf25429f4b358176c13e1a2795ba2c4c0b465b60bebf8ea27345a705.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7la-2df3bac86d6feff622ae429a1399c59ea37a357b1776ccaf2447243c49fcdd65.json
+++ b/openfisca_france/tests/json/f7la-2df3bac86d6feff622ae429a1399c59ea37a357b1776ccaf2447243c49fcdd65.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7la-5792fdf944ff0b74b9ef50a9be974549d74adaf2e38458ef8a3924b220bf7465.json
+++ b/openfisca_france/tests/json/f7la-5792fdf944ff0b74b9ef50a9be974549d74adaf2e38458ef8a3924b220bf7465.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7la-5df72ed8f2fdb3ba0f1ff72520014a5764fb93824ac84d8f7d08b119b54d31d3.json
+++ b/openfisca_france/tests/json/f7la-5df72ed8f2fdb3ba0f1ff72520014a5764fb93824ac84d8f7d08b119b54d31d3.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7la-80352628062f67dd0d0b2534f8ffb23bb523b1ca6c24d4edb90cbaee00c915ac.json
+++ b/openfisca_france/tests/json/f7la-80352628062f67dd0d0b2534f8ffb23bb523b1ca6c24d4edb90cbaee00c915ac.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7la-8af3988d97b5491183510588ee66cf812a559cbca37f829d165893866391b49b.json
+++ b/openfisca_france/tests/json/f7la-8af3988d97b5491183510588ee66cf812a559cbca37f829d165893866391b49b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7la-b16905bc0c2ccebe675c0f72bceab31902bfffbd13c4ed86e20f6f49e2ef30b1.json
+++ b/openfisca_france/tests/json/f7la-b16905bc0c2ccebe675c0f72bceab31902bfffbd13c4ed86e20f6f49e2ef30b1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7la-dd678f98e2a4a3c958c276823c628a5cea9d42a87af7ac761fb149e8873ebcd0.json
+++ b/openfisca_france/tests/json/f7la-dd678f98e2a4a3c958c276823c628a5cea9d42a87af7ac761fb149e8873ebcd0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lb-07f0fe0e1117537590e5f69bf9a358a0c6b630aa3a9606ffffb3851269531364.json
+++ b/openfisca_france/tests/json/f7lb-07f0fe0e1117537590e5f69bf9a358a0c6b630aa3a9606ffffb3851269531364.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lb-166a491d9276d48ead90ad264fa20f27bf78e12eb69505b99190a678b471251b.json
+++ b/openfisca_france/tests/json/f7lb-166a491d9276d48ead90ad264fa20f27bf78e12eb69505b99190a678b471251b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lb-22aad01ab5534d42ca848a87c05c93e9622cc91adafee659b649a4042344ec25.json
+++ b/openfisca_france/tests/json/f7lb-22aad01ab5534d42ca848a87c05c93e9622cc91adafee659b649a4042344ec25.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lb-5910c2e491d1f63b29ebd4e9a12919b13b99bbc2bddb5815681185313f93be0d.json
+++ b/openfisca_france/tests/json/f7lb-5910c2e491d1f63b29ebd4e9a12919b13b99bbc2bddb5815681185313f93be0d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lb-7c58b32a1e91ea420713a5c38708ccd280373b565167a5dd6f87891c03a6bb12.json
+++ b/openfisca_france/tests/json/f7lb-7c58b32a1e91ea420713a5c38708ccd280373b565167a5dd6f87891c03a6bb12.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lb-ae9fa7388c005af1e5ac2443d972c36875eb662513f60eed137af43fccddfc90.json
+++ b/openfisca_france/tests/json/f7lb-ae9fa7388c005af1e5ac2443d972c36875eb662513f60eed137af43fccddfc90.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lb-da53409109a4f30e067200b5f58913699fe3ab3dc5ca839fd0953e009bee64be.json
+++ b/openfisca_france/tests/json/f7lb-da53409109a4f30e067200b5f58913699fe3ab3dc5ca839fd0953e009bee64be.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lb-ec516c40bcc7f2649a5f0fc82e4e27af545673c3a359d5c4c9e09a69da218d8e.json
+++ b/openfisca_france/tests/json/f7lb-ec516c40bcc7f2649a5f0fc82e4e27af545673c3a359d5c4c9e09a69da218d8e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lb-fe01b214c2df4ccd7263c3a91aeca0648389dc39c1f35151045d97d8b612abb1.json
+++ b/openfisca_france/tests/json/f7lb-fe01b214c2df4ccd7263c3a91aeca0648389dc39c1f35151045d97d8b612abb1.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lc-233769bd934ae64ca8deaa8ae535997f26ef1f2b1a78473cf46dbf886a59ab32.json
+++ b/openfisca_france/tests/json/f7lc-233769bd934ae64ca8deaa8ae535997f26ef1f2b1a78473cf46dbf886a59ab32.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lc-29f543ddc5079c3a927dcb6e882df15b7d03e53af9f8f84f699dcace751c28a7.json
+++ b/openfisca_france/tests/json/f7lc-29f543ddc5079c3a927dcb6e882df15b7d03e53af9f8f84f699dcace751c28a7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lc-3c278412d6c34b76c5eaf091ee9fc6625ebf10fe5faf84c7c206301cef8bb704.json
+++ b/openfisca_france/tests/json/f7lc-3c278412d6c34b76c5eaf091ee9fc6625ebf10fe5faf84c7c206301cef8bb704.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lc-502a15a30fd393fff56eb8eeb70b0df46490ca493103429db0138e26c5816bb2.json
+++ b/openfisca_france/tests/json/f7lc-502a15a30fd393fff56eb8eeb70b0df46490ca493103429db0138e26c5816bb2.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lc-6fdab925d33f35cdb81d9cb2d7444e537fa4a4f11d2a09b90388def838c90053.json
+++ b/openfisca_france/tests/json/f7lc-6fdab925d33f35cdb81d9cb2d7444e537fa4a4f11d2a09b90388def838c90053.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lc-800edd98bb932bb2d6ff0581721d0af20c561542439215ef1f106bd1bafb9384.json
+++ b/openfisca_france/tests/json/f7lc-800edd98bb932bb2d6ff0581721d0af20c561542439215ef1f106bd1bafb9384.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lc-8f2bb6c0ecd73c134704c7f652cfb8f3de985ba22ad1615e5649a3c716aff3b0.json
+++ b/openfisca_france/tests/json/f7lc-8f2bb6c0ecd73c134704c7f652cfb8f3de985ba22ad1615e5649a3c716aff3b0.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lc-d9a22ce445ed1287d58614f3e8358059c644dd3732b67af00c5ba1cd5cde5b97.json
+++ b/openfisca_france/tests/json/f7lc-d9a22ce445ed1287d58614f3e8358059c644dd3732b67af00c5ba1cd5cde5b97.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lc-f8b4fe9533e5a786c0b26eb83b6c45a7da69bd96313a3bddc90a48f738aa94f9.json
+++ b/openfisca_france/tests/json/f7lc-f8b4fe9533e5a786c0b26eb83b6c45a7da69bd96313a3bddc90a48f738aa94f9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ld-25f92e0bb2d648c8e53b1176fde5e12f94554ee80be221cd9e7cdd56eaf49476.json
+++ b/openfisca_france/tests/json/f7ld-25f92e0bb2d648c8e53b1176fde5e12f94554ee80be221cd9e7cdd56eaf49476.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ld-2daa955e1dc54a00c044e6d7c1537336b9e24fb2157554ebb8a5346c64a69694.json
+++ b/openfisca_france/tests/json/f7ld-2daa955e1dc54a00c044e6d7c1537336b9e24fb2157554ebb8a5346c64a69694.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ld-39566ac86bd52a7ba8aed122ce538bf51197061b0dc32dc9c0f8832886565dbd.json
+++ b/openfisca_france/tests/json/f7ld-39566ac86bd52a7ba8aed122ce538bf51197061b0dc32dc9c0f8832886565dbd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ld-544145bc9e9fe84e29cd751ed045bd41b97cae65e36230306eef7c2a785a63d9.json
+++ b/openfisca_france/tests/json/f7ld-544145bc9e9fe84e29cd751ed045bd41b97cae65e36230306eef7c2a785a63d9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ld-b0a8618261ec5b12531d7ea75d709ec2b876e90eda51bda651d5be9e0ca48252.json
+++ b/openfisca_france/tests/json/f7ld-b0a8618261ec5b12531d7ea75d709ec2b876e90eda51bda651d5be9e0ca48252.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ld-b3218c2204b3a420f2eb352182ec6165e78eae03f9a8856f34eb77117356e6c5.json
+++ b/openfisca_france/tests/json/f7ld-b3218c2204b3a420f2eb352182ec6165e78eae03f9a8856f34eb77117356e6c5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ld-b583f2d45e5002ae9d93931cbff859593621a149e061f47c52ba477d00a9efd9.json
+++ b/openfisca_france/tests/json/f7ld-b583f2d45e5002ae9d93931cbff859593621a149e061f47c52ba477d00a9efd9.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ld-bb1a1503dda0d1a1d2531c8b240233775039b90722b263b88596feb16a41ea54.json
+++ b/openfisca_france/tests/json/f7ld-bb1a1503dda0d1a1d2531c8b240233775039b90722b263b88596feb16a41ea54.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ld-eb12e9c3db4f1c8b6479c6dd9481ec88a47cd4e2668fbc56ef0c47cff41d188b.json
+++ b/openfisca_france/tests/json/f7ld-eb12e9c3db4f1c8b6479c6dd9481ec88a47cd4e2668fbc56ef0c47cff41d188b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7le-05949dbb357b10b2f2ac2442a5640f620a757e190f0541df3c1bf89f2e2c628e.json
+++ b/openfisca_france/tests/json/f7le-05949dbb357b10b2f2ac2442a5640f620a757e190f0541df3c1bf89f2e2c628e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7le-2ab5c1860bcf45f2aa4e232012ff1935b3fe4c661c78fad3c11c1d82cae82308.json
+++ b/openfisca_france/tests/json/f7le-2ab5c1860bcf45f2aa4e232012ff1935b3fe4c661c78fad3c11c1d82cae82308.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7le-30cfb7235396a5b20cf863dceb2cf2f732322f5587e3df393c9a264a25c26dc6.json
+++ b/openfisca_france/tests/json/f7le-30cfb7235396a5b20cf863dceb2cf2f732322f5587e3df393c9a264a25c26dc6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7le-360e09a8ff2104d536532caba352ab915e47e0a8e9fba8c48659d38a630c1e5f.json
+++ b/openfisca_france/tests/json/f7le-360e09a8ff2104d536532caba352ab915e47e0a8e9fba8c48659d38a630c1e5f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7le-4f6ac265cd256597fc1c883ccf80f1b06e139ea7bb4475a8d8e90cbe68ff5d36.json
+++ b/openfisca_france/tests/json/f7le-4f6ac265cd256597fc1c883ccf80f1b06e139ea7bb4475a8d8e90cbe68ff5d36.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7le-5b7f0a366b4c0b06fe0d1b4adb6fa21314b28da92098b81bf43a3da1b72b6ffe.json
+++ b/openfisca_france/tests/json/f7le-5b7f0a366b4c0b06fe0d1b4adb6fa21314b28da92098b81bf43a3da1b72b6ffe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7le-d32957f310be5c8d3856832e71b1c86a77bba306cc4006ee7034f49a43eefd9f.json
+++ b/openfisca_france/tests/json/f7le-d32957f310be5c8d3856832e71b1c86a77bba306cc4006ee7034f49a43eefd9f.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7le-e5b00953eef8eb048fe75a80bbea5e55ff142f74bf25d785b4939486edd3a682.json
+++ b/openfisca_france/tests/json/f7le-e5b00953eef8eb048fe75a80bbea5e55ff142f74bf25d785b4939486edd3a682.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7le-e8f1c63801c0ba523a87cf2fcff6d7a6c82fbdf78b02f59c21869cb58d6e9ae2.json
+++ b/openfisca_france/tests/json/f7le-e8f1c63801c0ba523a87cf2fcff6d7a6c82fbdf78b02f59c21869cb58d6e9ae2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lf-1a4d8d1398a0cefe8912067c9ef973d14a57543a9df38e40b7c87d0439f1f333.json
+++ b/openfisca_france/tests/json/f7lf-1a4d8d1398a0cefe8912067c9ef973d14a57543a9df38e40b7c87d0439f1f333.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lf-34918a8effaf1ba54b235a922c9d2857793ee78a4d9cfea40a676ef653c79110.json
+++ b/openfisca_france/tests/json/f7lf-34918a8effaf1ba54b235a922c9d2857793ee78a4d9cfea40a676ef653c79110.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lf-4a32334d60d740b91c95869bb350f203f7827ec6364e3b016fdf3af60a00b0d7.json
+++ b/openfisca_france/tests/json/f7lf-4a32334d60d740b91c95869bb350f203f7827ec6364e3b016fdf3af60a00b0d7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lf-652b0d024d2fc8a1f556fbe40569be99b406b3e4408a2f440e755c655b62710f.json
+++ b/openfisca_france/tests/json/f7lf-652b0d024d2fc8a1f556fbe40569be99b406b3e4408a2f440e755c655b62710f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lf-6f7ed42d6ad13939926d4bd81be998b2d595828d21ffccf928e59062c137c37a.json
+++ b/openfisca_france/tests/json/f7lf-6f7ed42d6ad13939926d4bd81be998b2d595828d21ffccf928e59062c137c37a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lf-7038397ceb4b48a1f86d2f834ad5d8cf20567e773994c8d06b39a0594c606723.json
+++ b/openfisca_france/tests/json/f7lf-7038397ceb4b48a1f86d2f834ad5d8cf20567e773994c8d06b39a0594c606723.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lf-8c4186a315f30b4324961b00ab0b4d668cbc056a387eaeaa292dade8069b0d2a.json
+++ b/openfisca_france/tests/json/f7lf-8c4186a315f30b4324961b00ab0b4d668cbc056a387eaeaa292dade8069b0d2a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lf-a14b3a4eb73f1835776b0f2406f1bccf29dd375d9e55f1a657e7bc581560508f.json
+++ b/openfisca_france/tests/json/f7lf-a14b3a4eb73f1835776b0f2406f1bccf29dd375d9e55f1a657e7bc581560508f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lf-ea0c797faaa841368d99c00d3d82cb58562e9c9466236e8ce39c25d92b809041.json
+++ b/openfisca_france/tests/json/f7lf-ea0c797faaa841368d99c00d3d82cb58562e9c9466236e8ce39c25d92b809041.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lg-1527e96b72f347cb4682033c9eb4d6c6a78b5948fdd322eb561951041f1dbcab.json
+++ b/openfisca_france/tests/json/f7lg-1527e96b72f347cb4682033c9eb4d6c6a78b5948fdd322eb561951041f1dbcab.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lg-29e87b49ffec81c7281e8b7fd439cee3812ff3cfd1a512af1778e0dfaf4c9aa1.json
+++ b/openfisca_france/tests/json/f7lg-29e87b49ffec81c7281e8b7fd439cee3812ff3cfd1a512af1778e0dfaf4c9aa1.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lg-379fb23453c06a6f9064dda131a02439caf8f3d4fb67cde380a2dfc02e6e8e7c.json
+++ b/openfisca_france/tests/json/f7lg-379fb23453c06a6f9064dda131a02439caf8f3d4fb67cde380a2dfc02e6e8e7c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lg-3b58efead83d77bc2aba5608878de00cd9754ce5a57d8d7a7bd0a35630a7c288.json
+++ b/openfisca_france/tests/json/f7lg-3b58efead83d77bc2aba5608878de00cd9754ce5a57d8d7a7bd0a35630a7c288.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lg-3d42b5793622bd4cfbcc7b5d51a93220ed21a8b2079f08cfbef363225fc05743.json
+++ b/openfisca_france/tests/json/f7lg-3d42b5793622bd4cfbcc7b5d51a93220ed21a8b2079f08cfbef363225fc05743.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lg-6a0793d3d1c0890949ed20668a94cf22d8b4f3e1b9effcf35a7201fd0e232be2.json
+++ b/openfisca_france/tests/json/f7lg-6a0793d3d1c0890949ed20668a94cf22d8b4f3e1b9effcf35a7201fd0e232be2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lg-8c611a4b30660c5d9fb5318a3bfd39280e88d5a723f8ba82a5afbc5451069570.json
+++ b/openfisca_france/tests/json/f7lg-8c611a4b30660c5d9fb5318a3bfd39280e88d5a723f8ba82a5afbc5451069570.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lg-ab5d90fac8005413a79523f9e530357c09828c5d6abb2ba7e4a9689dd0e354bf.json
+++ b/openfisca_france/tests/json/f7lg-ab5d90fac8005413a79523f9e530357c09828c5d6abb2ba7e4a9689dd0e354bf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lg-e77e4934efdcf05dabbd17475727d0efc0eba5f2abb8893e930ade9b2087814f.json
+++ b/openfisca_france/tests/json/f7lg-e77e4934efdcf05dabbd17475727d0efc0eba5f2abb8893e930ade9b2087814f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lh-008ccf84fd3127e0654fa7f7f8e6c42547cb3476fc0ea9dd82c9bc9f20e31510.json
+++ b/openfisca_france/tests/json/f7lh-008ccf84fd3127e0654fa7f7f8e6c42547cb3476fc0ea9dd82c9bc9f20e31510.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lh-12087a47ade0cf01e6ad6435c3c861cf58959f9b4214d00da107af35a3668930.json
+++ b/openfisca_france/tests/json/f7lh-12087a47ade0cf01e6ad6435c3c861cf58959f9b4214d00da107af35a3668930.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lh-173525dac762d7d4cf7f3749cbb07fe0a015b25074f7461643d90791a75ecb94.json
+++ b/openfisca_france/tests/json/f7lh-173525dac762d7d4cf7f3749cbb07fe0a015b25074f7461643d90791a75ecb94.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lh-31135ea40898c70bc641896936613eec592dd4b3bc0dc3742b560adadd54e3eb.json
+++ b/openfisca_france/tests/json/f7lh-31135ea40898c70bc641896936613eec592dd4b3bc0dc3742b560adadd54e3eb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lh-4e2a0f67411847c84c930be66b66fa5db63e41edd86e89fc626ae30cf296c442.json
+++ b/openfisca_france/tests/json/f7lh-4e2a0f67411847c84c930be66b66fa5db63e41edd86e89fc626ae30cf296c442.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lh-6e3e04948f15d13ed0e7d16307ee87f541961382814acee9f35cfdc47f9b3d1d.json
+++ b/openfisca_france/tests/json/f7lh-6e3e04948f15d13ed0e7d16307ee87f541961382814acee9f35cfdc47f9b3d1d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lh-a08abbc5615f272647379209df2aeb8e5c329ad7be8961d33b687fc66c9a05dd.json
+++ b/openfisca_france/tests/json/f7lh-a08abbc5615f272647379209df2aeb8e5c329ad7be8961d33b687fc66c9a05dd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lh-b31066660655e217d9e1b14ffbb8f575e2b443a71b36e6f77640466ead25c1c4.json
+++ b/openfisca_france/tests/json/f7lh-b31066660655e217d9e1b14ffbb8f575e2b443a71b36e6f77640466ead25c1c4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lh-ecd9400e26205f73e4f6a89e0ee826a4c3578c4549d62b805d9d8626603aaa2f.json
+++ b/openfisca_france/tests/json/f7lh-ecd9400e26205f73e4f6a89e0ee826a4c3578c4549d62b805d9d8626603aaa2f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7li-0307f03de285a493f944a4600fee9cd275f809264d6d2aa642afdc51e39ef81a.json
+++ b/openfisca_france/tests/json/f7li-0307f03de285a493f944a4600fee9cd275f809264d6d2aa642afdc51e39ef81a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7li-0b16a679c2a36b9af1efef568472f7699061136208be996852fa8b196d8b5dcd.json
+++ b/openfisca_france/tests/json/f7li-0b16a679c2a36b9af1efef568472f7699061136208be996852fa8b196d8b5dcd.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7li-37af94eedca782850a9e5b2b6a91fcffaf70c9d6bff0513420d75407cb29eaea.json
+++ b/openfisca_france/tests/json/f7li-37af94eedca782850a9e5b2b6a91fcffaf70c9d6bff0513420d75407cb29eaea.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7li-3eee2f5ce1cfafa59e1f6b71d6ac25e40fed5b5eafbfb53be0018b112afa1af3.json
+++ b/openfisca_france/tests/json/f7li-3eee2f5ce1cfafa59e1f6b71d6ac25e40fed5b5eafbfb53be0018b112afa1af3.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7li-46e266041547a9a3d513f99f6657b0fcf46d6a33afb211de6c4db4fb6c70df7c.json
+++ b/openfisca_france/tests/json/f7li-46e266041547a9a3d513f99f6657b0fcf46d6a33afb211de6c4db4fb6c70df7c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7li-7560ca3a61da848ad19c57d60bba0a3aa8e69c49361ea0e1343e09a420fe0de6.json
+++ b/openfisca_france/tests/json/f7li-7560ca3a61da848ad19c57d60bba0a3aa8e69c49361ea0e1343e09a420fe0de6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7li-7b4526a1d90aa78cdc066740ca666259bc56e0ecfe38aa08e75e2c33a39dc3eb.json
+++ b/openfisca_france/tests/json/f7li-7b4526a1d90aa78cdc066740ca666259bc56e0ecfe38aa08e75e2c33a39dc3eb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7li-86a224641bba7ea7a3d32b61bb1711c7cf93277b4641c3eade58a6dbe5565905.json
+++ b/openfisca_france/tests/json/f7li-86a224641bba7ea7a3d32b61bb1711c7cf93277b4641c3eade58a6dbe5565905.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7li-a55f78f9ace37ab6e266c52f89b887ec2c31e6f2d5670cbf96ad5f5d7a88c60c.json
+++ b/openfisca_france/tests/json/f7li-a55f78f9ace37ab6e266c52f89b887ec2c31e6f2d5670cbf96ad5f5d7a88c60c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lm-00002a31524e1fe41ca95660b3926d2478479ff7a4bfae0283c8c46e8b025e30.json
+++ b/openfisca_france/tests/json/f7lm-00002a31524e1fe41ca95660b3926d2478479ff7a4bfae0283c8c46e8b025e30.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lm-115cc5aeebd44054c8b0f269acf88e77e9084f7007a97bfe6d7b2c365aea1a1a.json
+++ b/openfisca_france/tests/json/f7lm-115cc5aeebd44054c8b0f269acf88e77e9084f7007a97bfe6d7b2c365aea1a1a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lm-208f476db781c4e6bd9bcfb45b834fd876102b74432c847778edb9fb33b83bcd.json
+++ b/openfisca_france/tests/json/f7lm-208f476db781c4e6bd9bcfb45b834fd876102b74432c847778edb9fb33b83bcd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lm-7a678e58f0fc02288bb903f773a8ea545b16df55259b2b5e8e3bed99d445d622.json
+++ b/openfisca_france/tests/json/f7lm-7a678e58f0fc02288bb903f773a8ea545b16df55259b2b5e8e3bed99d445d622.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lm-acbd350413dabf2934b3e88ca320130c5009554ec9ca914193744a84fb0ab8cf.json
+++ b/openfisca_france/tests/json/f7lm-acbd350413dabf2934b3e88ca320130c5009554ec9ca914193744a84fb0ab8cf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lm-c8e14b1110a133790b061b873b240deb8a7642c2d141287860e77a2cc395423e.json
+++ b/openfisca_france/tests/json/f7lm-c8e14b1110a133790b061b873b240deb8a7642c2d141287860e77a2cc395423e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lm-cae1013322691c1ee383c9c466cc4eb5ab2c07969ce2ea259b3f1f1bba8334ed.json
+++ b/openfisca_france/tests/json/f7lm-cae1013322691c1ee383c9c466cc4eb5ab2c07969ce2ea259b3f1f1bba8334ed.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lm-e50050d8edbdbc3a734be74cac7f4056beecd08728302b619d760fd8be929fee.json
+++ b/openfisca_france/tests/json/f7lm-e50050d8edbdbc3a734be74cac7f4056beecd08728302b619d760fd8be929fee.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lm-fcfe55efd2e709d7ee15f994d5500a7858531dbb848021ce4eea036268559331.json
+++ b/openfisca_france/tests/json/f7lm-fcfe55efd2e709d7ee15f994d5500a7858531dbb848021ce4eea036268559331.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ls-0ffa1353f65f7bbecf799ec0dda395406ca5a52bc6f53d4536f24c80b41e7546.json
+++ b/openfisca_france/tests/json/f7ls-0ffa1353f65f7bbecf799ec0dda395406ca5a52bc6f53d4536f24c80b41e7546.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ls-2affb66db183b19ff238cbd1364d9f2e96325317d2dbbe7d04b8c3a5ea370bc8.json
+++ b/openfisca_france/tests/json/f7ls-2affb66db183b19ff238cbd1364d9f2e96325317d2dbbe7d04b8c3a5ea370bc8.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ls-33303990f1596be16a3532618e369a036658012e06ffb820524d7b622273c43a.json
+++ b/openfisca_france/tests/json/f7ls-33303990f1596be16a3532618e369a036658012e06ffb820524d7b622273c43a.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ls-42465e0df4273aa03ae47f4ef62388d72e356c7c36cc0eb347c546ce3561577b.json
+++ b/openfisca_france/tests/json/f7ls-42465e0df4273aa03ae47f4ef62388d72e356c7c36cc0eb347c546ce3561577b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ls-66a12cd9099b6b7c36b444ef799f50d6818e1b8f43079ca9c0e9ffe991674df0.json
+++ b/openfisca_france/tests/json/f7ls-66a12cd9099b6b7c36b444ef799f50d6818e1b8f43079ca9c0e9ffe991674df0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ls-7194fd317ec1e22ce049bd1d0889be0e00d08ee2af31c20a8f05d83defcbd722.json
+++ b/openfisca_france/tests/json/f7ls-7194fd317ec1e22ce049bd1d0889be0e00d08ee2af31c20a8f05d83defcbd722.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ls-82481441d38b8ca2fdba86945cf230f681d5b87d502cdf19012fae474bb631a3.json
+++ b/openfisca_france/tests/json/f7ls-82481441d38b8ca2fdba86945cf230f681d5b87d502cdf19012fae474bb631a3.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ls-a3e65b4959243346dc134432bfc7461cc0b60b10be5c0714d74461f277dcb32b.json
+++ b/openfisca_france/tests/json/f7ls-a3e65b4959243346dc134432bfc7461cc0b60b10be5c0714d74461f277dcb32b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ls-f80e50f1af87bd75e0bb04fee3692b654fb20dcedb8a24e1bc352819c7c19006.json
+++ b/openfisca_france/tests/json/f7ls-f80e50f1af87bd75e0bb04fee3692b654fb20dcedb8a24e1bc352819c7c19006.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ly-1a54e3d1c2a273b4e0354c6cf795740e3f7000797f87999b7b53954c8df865e9.json
+++ b/openfisca_france/tests/json/f7ly-1a54e3d1c2a273b4e0354c6cf795740e3f7000797f87999b7b53954c8df865e9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ly-5c5875fc60c99ccbe23fc893383b082aca3990b7b35ac8d301f769954297a574.json
+++ b/openfisca_france/tests/json/f7ly-5c5875fc60c99ccbe23fc893383b082aca3990b7b35ac8d301f769954297a574.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ly-b4981bc513a34227c85d8d5d7c3c37fb0bf2d6093a7c6189a35c4b1138017cb3.json
+++ b/openfisca_france/tests/json/f7ly-b4981bc513a34227c85d8d5d7c3c37fb0bf2d6093a7c6189a35c4b1138017cb3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ly-cf8ed35815f15c67a958c4a34b7d7e4807087b1a3418c288753d733c5ba7fbb8.json
+++ b/openfisca_france/tests/json/f7ly-cf8ed35815f15c67a958c4a34b7d7e4807087b1a3418c288753d733c5ba7fbb8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ly-e3fb5f303a563620ca92be39c3c28aadebb4263c75fdb8fd4dfdde89fec629c2.json
+++ b/openfisca_france/tests/json/f7ly-e3fb5f303a563620ca92be39c3c28aadebb4263c75fdb8fd4dfdde89fec629c2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lz-04517ccb43312e6531153b8792d7d9a81bcd77edf95d321655c265482497d120.json
+++ b/openfisca_france/tests/json/f7lz-04517ccb43312e6531153b8792d7d9a81bcd77edf95d321655c265482497d120.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lz-0891f8fe2cca89c3464967e8e950d25cf6b96bbf2896423d498562f83de88598.json
+++ b/openfisca_france/tests/json/f7lz-0891f8fe2cca89c3464967e8e950d25cf6b96bbf2896423d498562f83de88598.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lz-1e0994fb016543ca8ec28749f7fc33e4041e671ee96fcd4d773b1406e8d5e66e.json
+++ b/openfisca_france/tests/json/f7lz-1e0994fb016543ca8ec28749f7fc33e4041e671ee96fcd4d773b1406e8d5e66e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lz-2a09571fec711df4c6e5b1a87bac5c0a8534e6287dd8a6e3b984eaeaf9760c6d.json
+++ b/openfisca_france/tests/json/f7lz-2a09571fec711df4c6e5b1a87bac5c0a8534e6287dd8a6e3b984eaeaf9760c6d.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lz-3a27c27fca1658ff95f838485a5eeb5cd73ee5f96d313be363dc875b9802a0ee.json
+++ b/openfisca_france/tests/json/f7lz-3a27c27fca1658ff95f838485a5eeb5cd73ee5f96d313be363dc875b9802a0ee.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lz-59c4400a20a9ef0d172d67b6358aec2602bbda573ce1029db473e8ca82190ec0.json
+++ b/openfisca_france/tests/json/f7lz-59c4400a20a9ef0d172d67b6358aec2602bbda573ce1029db473e8ca82190ec0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lz-d75e5b5acfc11122d3b10bcb43269583ce6275ce2701fe0a55666ebd5e4684fe.json
+++ b/openfisca_france/tests/json/f7lz-d75e5b5acfc11122d3b10bcb43269583ce6275ce2701fe0a55666ebd5e4684fe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lz-e8f4521212dcc9073fa15a7ec236ee82d6e56bfe2beaba3869fa0b8a7290283f.json
+++ b/openfisca_france/tests/json/f7lz-e8f4521212dcc9073fa15a7ec236ee82d6e56bfe2beaba3869fa0b8a7290283f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7lz-ff226b7c3ffd2dc03e6c2c2678e7920a3a30c0181031ebd60ae5c9df990621b2.json
+++ b/openfisca_france/tests/json/f7lz-ff226b7c3ffd2dc03e6c2c2678e7920a3a30c0181031ebd60ae5c9df990621b2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ma-0bc8a46f8e429bc0894ec09e87eb4fd6edd46676dcdd7e1cb3706ff296f96155.json
+++ b/openfisca_france/tests/json/f7ma-0bc8a46f8e429bc0894ec09e87eb4fd6edd46676dcdd7e1cb3706ff296f96155.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ma-315b37a2ec07fa91045d7cfc4b8f095567c81d11f94b3ee5ad8864e275da54cc.json
+++ b/openfisca_france/tests/json/f7ma-315b37a2ec07fa91045d7cfc4b8f095567c81d11f94b3ee5ad8864e275da54cc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ma-4d6ce0dfe6f5e59286a409f07fa9475a243dd37dde7a5f00926197e969ce6279.json
+++ b/openfisca_france/tests/json/f7ma-4d6ce0dfe6f5e59286a409f07fa9475a243dd37dde7a5f00926197e969ce6279.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ma-720140765f5ba43d747991c8d5b94f9ae6775b4d9e49de97d91d62e2d68a7dec.json
+++ b/openfisca_france/tests/json/f7ma-720140765f5ba43d747991c8d5b94f9ae6775b4d9e49de97d91d62e2d68a7dec.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ma-8773cdd00592e9d80bc85f9a1dc5055765bedc2967faf02246ec8b5adc25b3e1.json
+++ b/openfisca_france/tests/json/f7ma-8773cdd00592e9d80bc85f9a1dc5055765bedc2967faf02246ec8b5adc25b3e1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ma-95b321812fff129a458c9ef97fb1165e4fd248ee25e2559e57a8a8ef5723ae15.json
+++ b/openfisca_france/tests/json/f7ma-95b321812fff129a458c9ef97fb1165e4fd248ee25e2559e57a8a8ef5723ae15.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ma-bd8458e553b13d0334bc193d2febe61543042233ecfbe5d7f6745ca5402c88b1.json
+++ b/openfisca_france/tests/json/f7ma-bd8458e553b13d0334bc193d2febe61543042233ecfbe5d7f6745ca5402c88b1.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ma-d7ac673bb8ef564dff175edcbd1268b5eae0dbe9ea39a41a442ca7e855c7b51f.json
+++ b/openfisca_france/tests/json/f7ma-d7ac673bb8ef564dff175edcbd1268b5eae0dbe9ea39a41a442ca7e855c7b51f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ma-e95a970831b99805b0b5b5d9b8b66e7e6feeeb964cfa01affc7cce5587a118c9.json
+++ b/openfisca_france/tests/json/f7ma-e95a970831b99805b0b5b5d9b8b66e7e6feeeb964cfa01affc7cce5587a118c9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mb-121f1ae38c29824bd1ea99bce4e90c054607fe4de653e1d95378eaac5fc52a25.json
+++ b/openfisca_france/tests/json/f7mb-121f1ae38c29824bd1ea99bce4e90c054607fe4de653e1d95378eaac5fc52a25.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mb-504c6ba26e2aef7d37f9d6a8364292436faa2fea9bf09d846055ddbf50eb1862.json
+++ b/openfisca_france/tests/json/f7mb-504c6ba26e2aef7d37f9d6a8364292436faa2fea9bf09d846055ddbf50eb1862.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mb-50a2db42e8496aaec1ad7b71cd26d18653d73ae8a22f1c07c66e448f5d6f3b48.json
+++ b/openfisca_france/tests/json/f7mb-50a2db42e8496aaec1ad7b71cd26d18653d73ae8a22f1c07c66e448f5d6f3b48.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mb-583220ebedd65cd6dd60003303280e98da19dd476eee3c1938de14388b3a0bb4.json
+++ b/openfisca_france/tests/json/f7mb-583220ebedd65cd6dd60003303280e98da19dd476eee3c1938de14388b3a0bb4.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mb-5f7d88e3cd18fcfc76fa3e7eace9cd43abb86c29734212bb663efd1713dfcc49.json
+++ b/openfisca_france/tests/json/f7mb-5f7d88e3cd18fcfc76fa3e7eace9cd43abb86c29734212bb663efd1713dfcc49.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mb-69da06f81c8d67b40faf66fff338fad1f83f01f12707de8216ffcb97146baab9.json
+++ b/openfisca_france/tests/json/f7mb-69da06f81c8d67b40faf66fff338fad1f83f01f12707de8216ffcb97146baab9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mb-71fdaf3b1cc41b60ac6101dc95d4f35088c6c63277811bd4deffbe50bcb4fd2b.json
+++ b/openfisca_france/tests/json/f7mb-71fdaf3b1cc41b60ac6101dc95d4f35088c6c63277811bd4deffbe50bcb4fd2b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mb-8962e44c79c51e635ec164c005364d5cfb94326e09f2e739fcc80913119b6ed0.json
+++ b/openfisca_france/tests/json/f7mb-8962e44c79c51e635ec164c005364d5cfb94326e09f2e739fcc80913119b6ed0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mb-94d782a4659cf7d582ca0a4e1359877816eee45329018e957eb0f3f0241850a6.json
+++ b/openfisca_france/tests/json/f7mb-94d782a4659cf7d582ca0a4e1359877816eee45329018e957eb0f3f0241850a6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mc-14fe3dd61c89310cf5eda9ba47ff0c961d5611701269acf81f976422449767f6.json
+++ b/openfisca_france/tests/json/f7mc-14fe3dd61c89310cf5eda9ba47ff0c961d5611701269acf81f976422449767f6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mc-1e4bf37be738d49979f3ffda21d44cd821ed94aef4b5507b864ceb3e2eee0d7f.json
+++ b/openfisca_france/tests/json/f7mc-1e4bf37be738d49979f3ffda21d44cd821ed94aef4b5507b864ceb3e2eee0d7f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mc-5e8f605ed815680b3c7ddf3aa410eaa54d225af718197e120e6c13823f6c8a1d.json
+++ b/openfisca_france/tests/json/f7mc-5e8f605ed815680b3c7ddf3aa410eaa54d225af718197e120e6c13823f6c8a1d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mc-7af947ec02bdb7996a389794698b6fecd04e8c221f7d62aa0956ecc9a5717256.json
+++ b/openfisca_france/tests/json/f7mc-7af947ec02bdb7996a389794698b6fecd04e8c221f7d62aa0956ecc9a5717256.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mc-8a8b5a970dff7d7b997fa11babd9e83f60bb9c5a3a7c644ea1044753837f4ecd.json
+++ b/openfisca_france/tests/json/f7mc-8a8b5a970dff7d7b997fa11babd9e83f60bb9c5a3a7c644ea1044753837f4ecd.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mc-8e75a1609c62c31ca049a825a1518367addedfa41d320781c1382f5ecb08b159.json
+++ b/openfisca_france/tests/json/f7mc-8e75a1609c62c31ca049a825a1518367addedfa41d320781c1382f5ecb08b159.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mc-97e31bc0ce7ef74c7bc456bcf168e14e3408671a6a589f98b705c1a63707e7ef.json
+++ b/openfisca_france/tests/json/f7mc-97e31bc0ce7ef74c7bc456bcf168e14e3408671a6a589f98b705c1a63707e7ef.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mc-aed13d0bbdcdea8f5f78badd6b8b7600bf68f03ea1fecf56f0a6e633b831f4a8.json
+++ b/openfisca_france/tests/json/f7mc-aed13d0bbdcdea8f5f78badd6b8b7600bf68f03ea1fecf56f0a6e633b831f4a8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mc-d49001af03b1ed391deec8738b854b54e2be3afa60c72d55a801f7c4d104eb18.json
+++ b/openfisca_france/tests/json/f7mc-d49001af03b1ed391deec8738b854b54e2be3afa60c72d55a801f7c4d104eb18.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mg-19876cca448b69213ba92a940d72a10cf3aba6179323de8909d45c22ffe75e9a.json
+++ b/openfisca_france/tests/json/f7mg-19876cca448b69213ba92a940d72a10cf3aba6179323de8909d45c22ffe75e9a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mg-4b6807f25c8a13c01054aeb0700c156255ea5478bf1ca283ea6c39318f12ea2d.json
+++ b/openfisca_france/tests/json/f7mg-4b6807f25c8a13c01054aeb0700c156255ea5478bf1ca283ea6c39318f12ea2d.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mg-5943f0ec4a2c7605c09dc2fcb5247e83a60930d25016724c840b4db26b4b8f73.json
+++ b/openfisca_france/tests/json/f7mg-5943f0ec4a2c7605c09dc2fcb5247e83a60930d25016724c840b4db26b4b8f73.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mg-8ae406b668c48e062b785ab4de4e1b3a4add894bbba8eab9bddbc035edbe6aee.json
+++ b/openfisca_france/tests/json/f7mg-8ae406b668c48e062b785ab4de4e1b3a4add894bbba8eab9bddbc035edbe6aee.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mg-9b679fc2850a303fe86e1445b28c2f6fef7acd1fe9158533676bb6ea7d023791.json
+++ b/openfisca_france/tests/json/f7mg-9b679fc2850a303fe86e1445b28c2f6fef7acd1fe9158533676bb6ea7d023791.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mg-ab28287e9f86cb0a3009dae20957233f87f83cd8aeeb6ef984c6cb15440391b3.json
+++ b/openfisca_france/tests/json/f7mg-ab28287e9f86cb0a3009dae20957233f87f83cd8aeeb6ef984c6cb15440391b3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mg-b948eb50efb2de592e150fd165dad4b41195050ef6e0f937d249f14bdde06ec0.json
+++ b/openfisca_france/tests/json/f7mg-b948eb50efb2de592e150fd165dad4b41195050ef6e0f937d249f14bdde06ec0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mg-c5a037aa6461e94d624ff85792811538c187512ff9a9c9568507a7748b7e49b0.json
+++ b/openfisca_france/tests/json/f7mg-c5a037aa6461e94d624ff85792811538c187512ff9a9c9568507a7748b7e49b0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mg-ca7bd209157a74f4a98d4077f57b72274d487d1444540332a2c1da10aa43d284.json
+++ b/openfisca_france/tests/json/f7mg-ca7bd209157a74f4a98d4077f57b72274d487d1444540332a2c1da10aa43d284.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mm-04ecf3b9e69baa24b526a76da1f084bc721634f260eb637e387f20df56865ba4.json
+++ b/openfisca_france/tests/json/f7mm-04ecf3b9e69baa24b526a76da1f084bc721634f260eb637e387f20df56865ba4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mm-418336217fdc5a72f4638d12cf337a895f1ed267151dc26416e7e4abe29b05f2.json
+++ b/openfisca_france/tests/json/f7mm-418336217fdc5a72f4638d12cf337a895f1ed267151dc26416e7e4abe29b05f2.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mm-5670d1e102054a5d88fc6bd70f9e903bfead3144e58ea1529ca3a41f04f8fe98.json
+++ b/openfisca_france/tests/json/f7mm-5670d1e102054a5d88fc6bd70f9e903bfead3144e58ea1529ca3a41f04f8fe98.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mm-73bfd5bda36a3e71cfbef84c77c2b6da72d499dba8aefe801329ede03c0e9d4f.json
+++ b/openfisca_france/tests/json/f7mm-73bfd5bda36a3e71cfbef84c77c2b6da72d499dba8aefe801329ede03c0e9d4f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mm-743d9c3836e276444acac8d0802add50ed93f198a5d59b02ac7edaae79653af5.json
+++ b/openfisca_france/tests/json/f7mm-743d9c3836e276444acac8d0802add50ed93f198a5d59b02ac7edaae79653af5.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mm-7b51eb48a7e4dde62f88dce6e7ba28032615b99ba941572a870e8bb5d05ba6b6.json
+++ b/openfisca_france/tests/json/f7mm-7b51eb48a7e4dde62f88dce6e7ba28032615b99ba941572a870e8bb5d05ba6b6.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mm-85edfb355c8cfb6a817d60a52a67e7b5590fa67e6dd3833569fd4b3d3ae56ed8.json
+++ b/openfisca_france/tests/json/f7mm-85edfb355c8cfb6a817d60a52a67e7b5590fa67e6dd3833569fd4b3d3ae56ed8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mm-c12c4052a0334df3645a52cdf373d5d0fb831928b0b17c69f5bd523dae859ebe.json
+++ b/openfisca_france/tests/json/f7mm-c12c4052a0334df3645a52cdf373d5d0fb831928b0b17c69f5bd523dae859ebe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mm-fd8f140c5d710aabdaff39754847ee290221ee109ff37cdbdea108a182fc4762.json
+++ b/openfisca_france/tests/json/f7mm-fd8f140c5d710aabdaff39754847ee290221ee109ff37cdbdea108a182fc4762.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mn-0e96fea4a70c8d55b5581a2bb460c44de957a845a8721418068b877adc2b57d5.json
+++ b/openfisca_france/tests/json/f7mn-0e96fea4a70c8d55b5581a2bb460c44de957a845a8721418068b877adc2b57d5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mn-28e1abfc6d3a115e522956210d887c6aff5fe197cb294908fb5a7c61e5fc877e.json
+++ b/openfisca_france/tests/json/f7mn-28e1abfc6d3a115e522956210d887c6aff5fe197cb294908fb5a7c61e5fc877e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mn-303d245f9fc0a73e9a7f6d6d6e498ec6eb2ee0efc2eea5e8e7bb568e33241a0a.json
+++ b/openfisca_france/tests/json/f7mn-303d245f9fc0a73e9a7f6d6d6e498ec6eb2ee0efc2eea5e8e7bb568e33241a0a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mn-39491e1c761245082acd27ad8d685c8db0161f884de8a69a8266b9aa7da7c3e5.json
+++ b/openfisca_france/tests/json/f7mn-39491e1c761245082acd27ad8d685c8db0161f884de8a69a8266b9aa7da7c3e5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mn-5ea91290e2d52d978c554c9f71b04785a3dff54af43ab27299788ecac0029fe9.json
+++ b/openfisca_france/tests/json/f7mn-5ea91290e2d52d978c554c9f71b04785a3dff54af43ab27299788ecac0029fe9.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mn-91f845407162469aad09f1d2e0aae2b87284af7276204479c3c62ebc460105e9.json
+++ b/openfisca_france/tests/json/f7mn-91f845407162469aad09f1d2e0aae2b87284af7276204479c3c62ebc460105e9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mn-9f2da3b851245221cca4bf160b73d7c98b69a04143e587dd91a04113c6f8e506.json
+++ b/openfisca_france/tests/json/f7mn-9f2da3b851245221cca4bf160b73d7c98b69a04143e587dd91a04113c6f8e506.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mn-d0642d8b6fbc7063785018c751152dd8063a13cb7f41625a65502daf0a5840e5.json
+++ b/openfisca_france/tests/json/f7mn-d0642d8b6fbc7063785018c751152dd8063a13cb7f41625a65502daf0a5840e5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7mn-e27c89026155ad7ab8e992264395532efd2794c4f60070a2e0dee29b1a975465.json
+++ b/openfisca_france/tests/json/f7mn-e27c89026155ad7ab8e992264395532efd2794c4f60070a2e0dee29b1a975465.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7my-3eb2093bafcc15335193ad259559f9abca54ef407fb7c485d99a5f2fca9ff676.json
+++ b/openfisca_france/tests/json/f7my-3eb2093bafcc15335193ad259559f9abca54ef407fb7c485d99a5f2fca9ff676.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7my-880b8feb30e5206a0b109eba146d34b2a40a222af24ae80c2189897eae852625.json
+++ b/openfisca_france/tests/json/f7my-880b8feb30e5206a0b109eba146d34b2a40a222af24ae80c2189897eae852625.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7my-9f38f9044a04be76978924b3c8a02b589ef9e9d977ba185f5fbe7ecf28d85a65.json
+++ b/openfisca_france/tests/json/f7my-9f38f9044a04be76978924b3c8a02b589ef9e9d977ba185f5fbe7ecf28d85a65.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7my-c32cf6735f7f77be48f7c121669e91d4c366d9a35e20704a29b7ac88e47d6388.json
+++ b/openfisca_france/tests/json/f7my-c32cf6735f7f77be48f7c121669e91d4c366d9a35e20704a29b7ac88e47d6388.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7my-e68c20141dfafed7702b34ad85965824c76d250a4c17a81741c4c10d7be132a1.json
+++ b/openfisca_france/tests/json/f7my-e68c20141dfafed7702b34ad85965824c76d250a4c17a81741c4c10d7be132a1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7na-03a06f5f3cd830e8536b55149fc6991eeb77b2d5e32d6b4f59d9f690f5e96872.json
+++ b/openfisca_france/tests/json/f7na-03a06f5f3cd830e8536b55149fc6991eeb77b2d5e32d6b4f59d9f690f5e96872.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7na-0401f518812f2f5964449dda0ee168208f9802865c1c5636005f3b6afd40b939.json
+++ b/openfisca_france/tests/json/f7na-0401f518812f2f5964449dda0ee168208f9802865c1c5636005f3b6afd40b939.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7na-092e2bda661017daf55aa485b164a1927922f63249326d0446f125cf0baf9972.json
+++ b/openfisca_france/tests/json/f7na-092e2bda661017daf55aa485b164a1927922f63249326d0446f125cf0baf9972.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7na-13ec5e31d82c693ad67654076ca039fa5d35fd4eaf2ac7b0cc06fff78086e331.json
+++ b/openfisca_france/tests/json/f7na-13ec5e31d82c693ad67654076ca039fa5d35fd4eaf2ac7b0cc06fff78086e331.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7na-486428ad06e28863d554aafb9f55a66e58b0422a1604fe30e8f7f4be6b73a947.json
+++ b/openfisca_france/tests/json/f7na-486428ad06e28863d554aafb9f55a66e58b0422a1604fe30e8f7f4be6b73a947.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7na-5b5948ff0c3c5f812fef760c9afe835568a836b986e8b0016e09adf09e15998e.json
+++ b/openfisca_france/tests/json/f7na-5b5948ff0c3c5f812fef760c9afe835568a836b986e8b0016e09adf09e15998e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7na-70646944350e36c81fe1b9e8c70c874956e587c0c660b03cc027348e68cfb740.json
+++ b/openfisca_france/tests/json/f7na-70646944350e36c81fe1b9e8c70c874956e587c0c660b03cc027348e68cfb740.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7na-c4a44fd0a37a060f3a97250491fea68bd20a969ddabad74bf58a18b942deac6c.json
+++ b/openfisca_france/tests/json/f7na-c4a44fd0a37a060f3a97250491fea68bd20a969ddabad74bf58a18b942deac6c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7na-f7ccf9d78e292da8f9d7fc776d8b335ff956e8809b4b3e43944a4eb6099da431.json
+++ b/openfisca_france/tests/json/f7na-f7ccf9d78e292da8f9d7fc776d8b335ff956e8809b4b3e43944a4eb6099da431.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nb-2a61645e9a455f50d5cde6762e386c18d8c1248a6997110b15ae0ecfba3df7cc.json
+++ b/openfisca_france/tests/json/f7nb-2a61645e9a455f50d5cde6762e386c18d8c1248a6997110b15ae0ecfba3df7cc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nb-46ac2d2062e55ae9c4a9576e3a81a9d47689ed2b5f09b34345132ed662266938.json
+++ b/openfisca_france/tests/json/f7nb-46ac2d2062e55ae9c4a9576e3a81a9d47689ed2b5f09b34345132ed662266938.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nb-556f03287b6c372b9c20ee96c6e56857d53282638d3ff6af8f7c1f6301a1ed8f.json
+++ b/openfisca_france/tests/json/f7nb-556f03287b6c372b9c20ee96c6e56857d53282638d3ff6af8f7c1f6301a1ed8f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nb-675035c6e88c3a8a1d78f9bd3e44260ae4a2dd6aaea830373e86aab1f55f65f8.json
+++ b/openfisca_france/tests/json/f7nb-675035c6e88c3a8a1d78f9bd3e44260ae4a2dd6aaea830373e86aab1f55f65f8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nb-89d88c5eafb6ceaacd7a969cc72f2e0e7f3339dd9458e1cd94ac6369be4ddafc.json
+++ b/openfisca_france/tests/json/f7nb-89d88c5eafb6ceaacd7a969cc72f2e0e7f3339dd9458e1cd94ac6369be4ddafc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nb-8acb0c33cf1220211a916b668506b98766f502626a1526c22d92127ea33d4f12.json
+++ b/openfisca_france/tests/json/f7nb-8acb0c33cf1220211a916b668506b98766f502626a1526c22d92127ea33d4f12.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nb-a5f7ab3ec4e44819da8914dddecd7adb1086f16980632ca900b8f20a22f29b5c.json
+++ b/openfisca_france/tests/json/f7nb-a5f7ab3ec4e44819da8914dddecd7adb1086f16980632ca900b8f20a22f29b5c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nb-cc4d5d8558da731006ff11215d7c9672028882705cb0448e04570098715422e1.json
+++ b/openfisca_france/tests/json/f7nb-cc4d5d8558da731006ff11215d7c9672028882705cb0448e04570098715422e1.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nb-e6dc1a9406331937289d6e516641af60fe13f657799cc7a730070071636b7ad5.json
+++ b/openfisca_france/tests/json/f7nb-e6dc1a9406331937289d6e516641af60fe13f657799cc7a730070071636b7ad5.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nc-31e21dd515bf081bc843e4c76fd313543e89a05335030a313944f335722e22d3.json
+++ b/openfisca_france/tests/json/f7nc-31e21dd515bf081bc843e4c76fd313543e89a05335030a313944f335722e22d3.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nc-3e3722936e0e741d47f688a70750ac9fccde0c8b46b22eb55292c6e6ea4e6ddd.json
+++ b/openfisca_france/tests/json/f7nc-3e3722936e0e741d47f688a70750ac9fccde0c8b46b22eb55292c6e6ea4e6ddd.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nc-4b53ad3f2b977850aa2011da1a27e8c9fd2cbb1fc68ec8b7a5e8379f600dadfc.json
+++ b/openfisca_france/tests/json/f7nc-4b53ad3f2b977850aa2011da1a27e8c9fd2cbb1fc68ec8b7a5e8379f600dadfc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nc-5a41c33a8cef88b59d71d88c2200682d6d55a8ec93cfed15c1fe474b10f5a2a7.json
+++ b/openfisca_france/tests/json/f7nc-5a41c33a8cef88b59d71d88c2200682d6d55a8ec93cfed15c1fe474b10f5a2a7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nc-66e82154f4b6e85660b01b4c9071855625d10b4fdedb0b20eb29ea03f44023e1.json
+++ b/openfisca_france/tests/json/f7nc-66e82154f4b6e85660b01b4c9071855625d10b4fdedb0b20eb29ea03f44023e1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nc-870cb93e6a2a3d28c5636ac9523c66701cda4c5680ac3c44de7242d85783fae3.json
+++ b/openfisca_france/tests/json/f7nc-870cb93e6a2a3d28c5636ac9523c66701cda4c5680ac3c44de7242d85783fae3.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nc-be4dba3b640829ce1529ee306e56684ce294f6d79c8875a60247404aa4ff22b0.json
+++ b/openfisca_france/tests/json/f7nc-be4dba3b640829ce1529ee306e56684ce294f6d79c8875a60247404aa4ff22b0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nc-c6e7ed3eeec4120c14c8f1961c115ae4840d2c5b79d81e1ff994b1e8a91fdc7f.json
+++ b/openfisca_france/tests/json/f7nc-c6e7ed3eeec4120c14c8f1961c115ae4840d2c5b79d81e1ff994b1e8a91fdc7f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nc-dc74d7a09689360947f55a72157cf5c70eab515cdce18e85d411080c10424dc8.json
+++ b/openfisca_france/tests/json/f7nc-dc74d7a09689360947f55a72157cf5c70eab515cdce18e85d411080c10424dc8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nd-4f284bd3c825412d7806f9ef1f890fbc183f7301618d1475eee815073da08058.json
+++ b/openfisca_france/tests/json/f7nd-4f284bd3c825412d7806f9ef1f890fbc183f7301618d1475eee815073da08058.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nd-737f40bf5b217a4a11317d873724e375cac64cfe14443b501ccb6b1c23f84cb5.json
+++ b/openfisca_france/tests/json/f7nd-737f40bf5b217a4a11317d873724e375cac64cfe14443b501ccb6b1c23f84cb5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nd-86046de972475b593203249f9b07b1280e55cf111f4d2f525e3294591654b9fe.json
+++ b/openfisca_france/tests/json/f7nd-86046de972475b593203249f9b07b1280e55cf111f4d2f525e3294591654b9fe.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nd-88ca4bad48acbdea2549e8aa2ab2dd394827a9ab201d073f5f93ee099c98c410.json
+++ b/openfisca_france/tests/json/f7nd-88ca4bad48acbdea2549e8aa2ab2dd394827a9ab201d073f5f93ee099c98c410.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nd-9a4267832dd8568ee9f32504da82a767c1e781bd125e95be67ca2032fcb53094.json
+++ b/openfisca_france/tests/json/f7nd-9a4267832dd8568ee9f32504da82a767c1e781bd125e95be67ca2032fcb53094.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nd-9b189c74f9487b980de819b6931364603db44d13fae0b1e4158920b99d4fbe0c.json
+++ b/openfisca_france/tests/json/f7nd-9b189c74f9487b980de819b6931364603db44d13fae0b1e4158920b99d4fbe0c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nd-bed25ed985762605c7eedbcca002888cb1a5e0ed6f299f9680296180ea87fdc0.json
+++ b/openfisca_france/tests/json/f7nd-bed25ed985762605c7eedbcca002888cb1a5e0ed6f299f9680296180ea87fdc0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nd-d52b3aa094916d24f93a3dec9b8d1d37ce54889f2c7d3a19380b511fb87098a6.json
+++ b/openfisca_france/tests/json/f7nd-d52b3aa094916d24f93a3dec9b8d1d37ce54889f2c7d3a19380b511fb87098a6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nd-da89ff88f30ab86fb2b2913896ddc687a0244797dcd62c75cf1605e1d47dacb1.json
+++ b/openfisca_france/tests/json/f7nd-da89ff88f30ab86fb2b2913896ddc687a0244797dcd62c75cf1605e1d47dacb1.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ne-003d9e6a92810a2c130961b8e9e7be0333ef89b276894e4da10a254718b1f10b.json
+++ b/openfisca_france/tests/json/f7ne-003d9e6a92810a2c130961b8e9e7be0333ef89b276894e4da10a254718b1f10b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ne-0081e204eb4a2bed49f0556a229b16acac24919e9260fab65600cf00ccca4287.json
+++ b/openfisca_france/tests/json/f7ne-0081e204eb4a2bed49f0556a229b16acac24919e9260fab65600cf00ccca4287.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ne-4fc48cbcb66bd1a3147c675367b98520f361e739d98e55a746ed076504defb97.json
+++ b/openfisca_france/tests/json/f7ne-4fc48cbcb66bd1a3147c675367b98520f361e739d98e55a746ed076504defb97.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ne-94b737503398205b4dd55064d21e3c9c313baf28dfd3a96647da88a38f39a08c.json
+++ b/openfisca_france/tests/json/f7ne-94b737503398205b4dd55064d21e3c9c313baf28dfd3a96647da88a38f39a08c.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ne-99a0715aa48c54386696734f77ecf706d9e7ab51fe3e1499e2f098d43e441fbb.json
+++ b/openfisca_france/tests/json/f7ne-99a0715aa48c54386696734f77ecf706d9e7ab51fe3e1499e2f098d43e441fbb.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ne-b13a3165a5be1a5849af0368b61798bdebcdf04a49b9d6ca5aca6ed5175b7abc.json
+++ b/openfisca_france/tests/json/f7ne-b13a3165a5be1a5849af0368b61798bdebcdf04a49b9d6ca5aca6ed5175b7abc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ne-d4116a8c4a975459e142679ddbf581f2bcf73851f9e96b4abf06babc9d01be6f.json
+++ b/openfisca_france/tests/json/f7ne-d4116a8c4a975459e142679ddbf581f2bcf73851f9e96b4abf06babc9d01be6f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ne-d96c1e1a092278f57a5de3423fbc114c9363c87bf40d935a953f33a6d3f13804.json
+++ b/openfisca_france/tests/json/f7ne-d96c1e1a092278f57a5de3423fbc114c9363c87bf40d935a953f33a6d3f13804.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ne-dfec442025131e7c1f7aa610ce6aa2aff3ae3a6fdabd75a6e0462c6881050cad.json
+++ b/openfisca_france/tests/json/f7ne-dfec442025131e7c1f7aa610ce6aa2aff3ae3a6fdabd75a6e0462c6881050cad.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nf-18d7b66d4fde19abae88f09cd6c09e90a2f0e030467c31fd8970f4c318075a8b.json
+++ b/openfisca_france/tests/json/f7nf-18d7b66d4fde19abae88f09cd6c09e90a2f0e030467c31fd8970f4c318075a8b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nf-1e1464939a903c6494583fba55255ae7949f14917a08ca47cce03bc537fbba53.json
+++ b/openfisca_france/tests/json/f7nf-1e1464939a903c6494583fba55255ae7949f14917a08ca47cce03bc537fbba53.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nf-4f648583e7ec3fc8af719e0d8f4579961396d75458ed926b462dc28e1117791a.json
+++ b/openfisca_france/tests/json/f7nf-4f648583e7ec3fc8af719e0d8f4579961396d75458ed926b462dc28e1117791a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nf-5036982c723ca1974ce0549abc931202f32de98ac903e3cd7075f3580deeb45d.json
+++ b/openfisca_france/tests/json/f7nf-5036982c723ca1974ce0549abc931202f32de98ac903e3cd7075f3580deeb45d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nf-7a86b713bd48e197ca1226d33e2c37c2feab1475e89e95f3e2292a7df7c89df5.json
+++ b/openfisca_france/tests/json/f7nf-7a86b713bd48e197ca1226d33e2c37c2feab1475e89e95f3e2292a7df7c89df5.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nf-8d76733d6906290b99493823f4c242629f38a9c56d51618c733e53097d3fba71.json
+++ b/openfisca_france/tests/json/f7nf-8d76733d6906290b99493823f4c242629f38a9c56d51618c733e53097d3fba71.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nf-a63bfd3493d481f5d3904da8ee233252ecc3adc4427e83c9699f3a5ea65020a6.json
+++ b/openfisca_france/tests/json/f7nf-a63bfd3493d481f5d3904da8ee233252ecc3adc4427e83c9699f3a5ea65020a6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nf-ad0e82c9126d8e0e27eef20eb434219af11d4065720738d2af0ce8af605d7b1a.json
+++ b/openfisca_france/tests/json/f7nf-ad0e82c9126d8e0e27eef20eb434219af11d4065720738d2af0ce8af605d7b1a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nf-c988aaf54b95a435ca129d3bc46767db4a9586bba7ac25221d320abf037f9eec.json
+++ b/openfisca_france/tests/json/f7nf-c988aaf54b95a435ca129d3bc46767db4a9586bba7ac25221d320abf037f9eec.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ng-28db5ad950724722d7ece5aad1d781664629b463f1d068dc76ccad0b935d2c9a.json
+++ b/openfisca_france/tests/json/f7ng-28db5ad950724722d7ece5aad1d781664629b463f1d068dc76ccad0b935d2c9a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ng-38c7bb221b0c664f584ef4077873e4ae037afc6d18ddcb499a922c3bb5124761.json
+++ b/openfisca_france/tests/json/f7ng-38c7bb221b0c664f584ef4077873e4ae037afc6d18ddcb499a922c3bb5124761.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ng-3a339763afc8fd9ac42fc916c3d4d069c478717c797fc5b1cccda8177614e831.json
+++ b/openfisca_france/tests/json/f7ng-3a339763afc8fd9ac42fc916c3d4d069c478717c797fc5b1cccda8177614e831.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ng-3d0499f10af648477ed88aa217b1d9a0ba845ce41116a7c8ba1f9d83daf06911.json
+++ b/openfisca_france/tests/json/f7ng-3d0499f10af648477ed88aa217b1d9a0ba845ce41116a7c8ba1f9d83daf06911.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ng-41f0c3ba1d6e1e421df1f7a7e49e13d9f6757bc710b367827b8fe3f6dec53c0a.json
+++ b/openfisca_france/tests/json/f7ng-41f0c3ba1d6e1e421df1f7a7e49e13d9f6757bc710b367827b8fe3f6dec53c0a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ng-947643e47ea051149e2f34bc36f171e69f92c32838ffbd1c851e237aeb8e4e56.json
+++ b/openfisca_france/tests/json/f7ng-947643e47ea051149e2f34bc36f171e69f92c32838ffbd1c851e237aeb8e4e56.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ng-a6cd45e28d164546730a7f9cf3a0492fa6faae8b908c26b0142911f0885dd861.json
+++ b/openfisca_france/tests/json/f7ng-a6cd45e28d164546730a7f9cf3a0492fa6faae8b908c26b0142911f0885dd861.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ng-d43b6c1e7d0dc7204be85f87f0818fcfe4645ae21b5e2bfbc6abf53b7de5b182.json
+++ b/openfisca_france/tests/json/f7ng-d43b6c1e7d0dc7204be85f87f0818fcfe4645ae21b5e2bfbc6abf53b7de5b182.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ng-f3994b4c4f9320d45a30a22a15b15a5a61dccf29540d5fc2a5c29f01f47b1cb2.json
+++ b/openfisca_france/tests/json/f7ng-f3994b4c4f9320d45a30a22a15b15a5a61dccf29540d5fc2a5c29f01f47b1cb2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nh-1059e32569bcc36ece32bddbb56d5329c020b6b8ac0df0cf7986901b73972736.json
+++ b/openfisca_france/tests/json/f7nh-1059e32569bcc36ece32bddbb56d5329c020b6b8ac0df0cf7986901b73972736.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nh-5b8c5cd4622a4c0fd8eb3e3b29676d2561eaca5f220766b9c83b80594cb5774d.json
+++ b/openfisca_france/tests/json/f7nh-5b8c5cd4622a4c0fd8eb3e3b29676d2561eaca5f220766b9c83b80594cb5774d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nh-68fbca0dde726e3970268826bee4d34d164002225f291beaa9d756c2190003af.json
+++ b/openfisca_france/tests/json/f7nh-68fbca0dde726e3970268826bee4d34d164002225f291beaa9d756c2190003af.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nh-70410d7a29c3106d811322f7f120fe5d59375108269bcbcb3d5a9cfad4694e3b.json
+++ b/openfisca_france/tests/json/f7nh-70410d7a29c3106d811322f7f120fe5d59375108269bcbcb3d5a9cfad4694e3b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nh-a533fa3dc1c47e38fc37a2d0a19fdfd83d68088ae25eaff2157eef0bb9253e76.json
+++ b/openfisca_france/tests/json/f7nh-a533fa3dc1c47e38fc37a2d0a19fdfd83d68088ae25eaff2157eef0bb9253e76.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nh-d03978e5d58c366a4a324fc4949da91533412b32f338d4383ab799e295c1e8e4.json
+++ b/openfisca_france/tests/json/f7nh-d03978e5d58c366a4a324fc4949da91533412b32f338d4383ab799e295c1e8e4.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nh-ee2e839afc7e9fc77eb59182c5703502fd90023346fa97c74e977502df4ca8c3.json
+++ b/openfisca_france/tests/json/f7nh-ee2e839afc7e9fc77eb59182c5703502fd90023346fa97c74e977502df4ca8c3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nh-f2ad3086681edad5ec7debc6986c3667ec42866490db1a08e294f6e6676658b3.json
+++ b/openfisca_france/tests/json/f7nh-f2ad3086681edad5ec7debc6986c3667ec42866490db1a08e294f6e6676658b3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nh-f43c6ddb9aa11b0c4a1057e063fb23fb8c53c94256f5169c6170bdc48ba33490.json
+++ b/openfisca_france/tests/json/f7nh-f43c6ddb9aa11b0c4a1057e063fb23fb8c53c94256f5169c6170bdc48ba33490.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ni-03573b1bb6619ce1394b8c4e5387875cfd2a7daf46705a88dde24f7079f6727c.json
+++ b/openfisca_france/tests/json/f7ni-03573b1bb6619ce1394b8c4e5387875cfd2a7daf46705a88dde24f7079f6727c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ni-0888af232f9c4aa2b929e8b63ddf920fcca4999adce0dc332b2c36f7b71eea2e.json
+++ b/openfisca_france/tests/json/f7ni-0888af232f9c4aa2b929e8b63ddf920fcca4999adce0dc332b2c36f7b71eea2e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ni-2b17a9bce0a99ff69398b8f55883701044ac1232f7377886fd4a452bbaf9eab1.json
+++ b/openfisca_france/tests/json/f7ni-2b17a9bce0a99ff69398b8f55883701044ac1232f7377886fd4a452bbaf9eab1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ni-39dff703df28a789cb6fa432c1c241ca77e5e46dd41923d237631a6bc045c73a.json
+++ b/openfisca_france/tests/json/f7ni-39dff703df28a789cb6fa432c1c241ca77e5e46dd41923d237631a6bc045c73a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ni-404476d0920e5b2fc91023c4b2e56dcc5037b5d71a78344d8f71faf7bfe6c16a.json
+++ b/openfisca_france/tests/json/f7ni-404476d0920e5b2fc91023c4b2e56dcc5037b5d71a78344d8f71faf7bfe6c16a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ni-52ca26bdc7589dbad0693adacdd9d1256262ffb9be47c1ac8c6e0228059693d9.json
+++ b/openfisca_france/tests/json/f7ni-52ca26bdc7589dbad0693adacdd9d1256262ffb9be47c1ac8c6e0228059693d9.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ni-79c0c10ab7a037187861aef6244a6a7b039ba932ffae18fefc6136f29b50d9ec.json
+++ b/openfisca_france/tests/json/f7ni-79c0c10ab7a037187861aef6244a6a7b039ba932ffae18fefc6136f29b50d9ec.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ni-9d6cdf6f786ec974a8c2f1de24f3519d4aaa3d8eaad8ea615d30be8fc5ee8e71.json
+++ b/openfisca_france/tests/json/f7ni-9d6cdf6f786ec974a8c2f1de24f3519d4aaa3d8eaad8ea615d30be8fc5ee8e71.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ni-a713f5660c7711a30033611a4a2722348446209520d0133fa5e1bb7c0b91d3eb.json
+++ b/openfisca_france/tests/json/f7ni-a713f5660c7711a30033611a4a2722348446209520d0133fa5e1bb7c0b91d3eb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nj-0a22b0d5a70665b48ca60bdfde4b2055308221d287d246ebd5d107f6e11272f2.json
+++ b/openfisca_france/tests/json/f7nj-0a22b0d5a70665b48ca60bdfde4b2055308221d287d246ebd5d107f6e11272f2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nj-198ca6b09b0dd35d9b33d367fc6d0b4668dd62e9e49bded03c596629dfc3aae8.json
+++ b/openfisca_france/tests/json/f7nj-198ca6b09b0dd35d9b33d367fc6d0b4668dd62e9e49bded03c596629dfc3aae8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nj-289dcc9521fae9f3b31fe82f1f49acf99634c12e5b25413dd8344a81a4c5d1d9.json
+++ b/openfisca_france/tests/json/f7nj-289dcc9521fae9f3b31fe82f1f49acf99634c12e5b25413dd8344a81a4c5d1d9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nj-2a516ea6055f0679238419d8af4daa70b50acf5747c4ac1782f20c4ed8623961.json
+++ b/openfisca_france/tests/json/f7nj-2a516ea6055f0679238419d8af4daa70b50acf5747c4ac1782f20c4ed8623961.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nj-322d770434d9c292c989a2d1522638817e9a2c89ad1690c338fd0d38f1c01d83.json
+++ b/openfisca_france/tests/json/f7nj-322d770434d9c292c989a2d1522638817e9a2c89ad1690c338fd0d38f1c01d83.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nj-60a1249e93654ac42c5d600e9ca6c44f7e340ae236bda9c2bedd8f6c511eeb5e.json
+++ b/openfisca_france/tests/json/f7nj-60a1249e93654ac42c5d600e9ca6c44f7e340ae236bda9c2bedd8f6c511eeb5e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nj-97600fd5951eb7267b212ab150ec06de0fe6cc5867cedcc1b7802313bbdb4646.json
+++ b/openfisca_france/tests/json/f7nj-97600fd5951eb7267b212ab150ec06de0fe6cc5867cedcc1b7802313bbdb4646.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nj-d49c17b441a1f6be69b4c66c1e8f10abf6399f177d34d1b7e02d2887fbd7a9a8.json
+++ b/openfisca_france/tests/json/f7nj-d49c17b441a1f6be69b4c66c1e8f10abf6399f177d34d1b7e02d2887fbd7a9a8.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nj-df93ba33b91edd09b2d3831b4f2772dd067a72c820cda419261cef213bd00e7c.json
+++ b/openfisca_france/tests/json/f7nj-df93ba33b91edd09b2d3831b4f2772dd067a72c820cda419261cef213bd00e7c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nk-484ccd7f5cf37b32d5f5e49f6ef9f0e37a4b9b906a2b04a9bedba71b57bfb67d.json
+++ b/openfisca_france/tests/json/f7nk-484ccd7f5cf37b32d5f5e49f6ef9f0e37a4b9b906a2b04a9bedba71b57bfb67d.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nk-62cb85e475e70fb0a5ed2077ed50e3a5ae0247b82ea0600147e85c5a2f9f7cfe.json
+++ b/openfisca_france/tests/json/f7nk-62cb85e475e70fb0a5ed2077ed50e3a5ae0247b82ea0600147e85c5a2f9f7cfe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nk-64b96d99051d539454593f5f68edb4b7959edbf82fd7eefa997b9d101b3cf6f7.json
+++ b/openfisca_france/tests/json/f7nk-64b96d99051d539454593f5f68edb4b7959edbf82fd7eefa997b9d101b3cf6f7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nk-700f0b8fbd516af8fa29684ca6ecae17d300ae1a5110017ab025abbeea7684f0.json
+++ b/openfisca_france/tests/json/f7nk-700f0b8fbd516af8fa29684ca6ecae17d300ae1a5110017ab025abbeea7684f0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nk-9dcb38983d7cc49070679e941c35fa12663e4b09b2c5ee8c64c78775a879aa82.json
+++ b/openfisca_france/tests/json/f7nk-9dcb38983d7cc49070679e941c35fa12663e4b09b2c5ee8c64c78775a879aa82.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nk-9ecffe43a9dfc7c1b52ecf51a0edfa4c448bc33df0c2ce8fb08f7ae849ffcb7f.json
+++ b/openfisca_france/tests/json/f7nk-9ecffe43a9dfc7c1b52ecf51a0edfa4c448bc33df0c2ce8fb08f7ae849ffcb7f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nk-a8f99425c59c1737167378a1a302740dcae7e19307853ca64fe9e17365bbdf15.json
+++ b/openfisca_france/tests/json/f7nk-a8f99425c59c1737167378a1a302740dcae7e19307853ca64fe9e17365bbdf15.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nk-b10c560a244baaf0d6cc7ab239cd10c88bc6aded4790b5f72ff4d41ac2ef1e46.json
+++ b/openfisca_france/tests/json/f7nk-b10c560a244baaf0d6cc7ab239cd10c88bc6aded4790b5f72ff4d41ac2ef1e46.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nk-da98fd2d7c210caac0fc2accccfde51eb7141e318b6f1727d9103058bac20699.json
+++ b/openfisca_france/tests/json/f7nk-da98fd2d7c210caac0fc2accccfde51eb7141e318b6f1727d9103058bac20699.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nl-01a88525d5f2fc6109c8bc31718a8f37e0320d3e1a58ededdd524b636a384da5.json
+++ b/openfisca_france/tests/json/f7nl-01a88525d5f2fc6109c8bc31718a8f37e0320d3e1a58ededdd524b636a384da5.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nl-363312fb4769de58cd8be711a78318beb4cab50929f3f26c1e295f403e0b3418.json
+++ b/openfisca_france/tests/json/f7nl-363312fb4769de58cd8be711a78318beb4cab50929f3f26c1e295f403e0b3418.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nl-626a9fc2bf991eb4599b34c69155488e770b165be3d919c02495438b09cf7d41.json
+++ b/openfisca_france/tests/json/f7nl-626a9fc2bf991eb4599b34c69155488e770b165be3d919c02495438b09cf7d41.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nl-7fc4f3be8fd81a90b0e94f7c6a4a23df7d83db4b499a9639eb375751b6dbc917.json
+++ b/openfisca_france/tests/json/f7nl-7fc4f3be8fd81a90b0e94f7c6a4a23df7d83db4b499a9639eb375751b6dbc917.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nl-8ee3bdd613fec35ba5d2f76fd9af40d9d459e92faeebfa0553b6f0cb543e07f9.json
+++ b/openfisca_france/tests/json/f7nl-8ee3bdd613fec35ba5d2f76fd9af40d9d459e92faeebfa0553b6f0cb543e07f9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nl-a14ddb87cc48b66969507828b8d47b14f4e26f08c99d3ef5ae85cc00d4c50294.json
+++ b/openfisca_france/tests/json/f7nl-a14ddb87cc48b66969507828b8d47b14f4e26f08c99d3ef5ae85cc00d4c50294.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nl-d802ccd77a36aafbb0c9ae74fc46fad6d673e9988aae194ce580a90baadeb85e.json
+++ b/openfisca_france/tests/json/f7nl-d802ccd77a36aafbb0c9ae74fc46fad6d673e9988aae194ce580a90baadeb85e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nl-e79def5846f94b6a387e762163c78c197f03f5ab5f8ff4a87a63da6e548c0fb7.json
+++ b/openfisca_france/tests/json/f7nl-e79def5846f94b6a387e762163c78c197f03f5ab5f8ff4a87a63da6e548c0fb7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nl-f1d202f4dec19643b132e368459f571a678ed4ef46c230de795d32dd80940e45.json
+++ b/openfisca_france/tests/json/f7nl-f1d202f4dec19643b132e368459f571a678ed4ef46c230de795d32dd80940e45.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nm-0b446df8217b34844fa72fc760445968868177c2c728cdeb83a10cef9c91ed8d.json
+++ b/openfisca_france/tests/json/f7nm-0b446df8217b34844fa72fc760445968868177c2c728cdeb83a10cef9c91ed8d.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nm-0f7fd5b02b169e55fd9df97b033638d992deb1fdffbaae8284b8c0f17b88ca30.json
+++ b/openfisca_france/tests/json/f7nm-0f7fd5b02b169e55fd9df97b033638d992deb1fdffbaae8284b8c0f17b88ca30.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nm-27fc415cbc140f66c7a1a9e97fb54ac89a0c864353d15a3eb0140c78ca4d7544.json
+++ b/openfisca_france/tests/json/f7nm-27fc415cbc140f66c7a1a9e97fb54ac89a0c864353d15a3eb0140c78ca4d7544.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nm-a3654ab2e1d285953ea09629d5609e6ba59c4449033ace15f4efb357c00a3998.json
+++ b/openfisca_france/tests/json/f7nm-a3654ab2e1d285953ea09629d5609e6ba59c4449033ace15f4efb357c00a3998.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nm-a3a138285ed5bfad108a9f2167480ccfb73de5ea18c79277a4b865c9981668cd.json
+++ b/openfisca_france/tests/json/f7nm-a3a138285ed5bfad108a9f2167480ccfb73de5ea18c79277a4b865c9981668cd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nm-ab29d15216e622e2979326814ba1ba421efc5f7dfe53797b1bad2c67bd96fe2d.json
+++ b/openfisca_france/tests/json/f7nm-ab29d15216e622e2979326814ba1ba421efc5f7dfe53797b1bad2c67bd96fe2d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nm-c959ffee700fdc4b7a0897166e0b1971d75cbe6307116b450ff55bdfbddc82ce.json
+++ b/openfisca_france/tests/json/f7nm-c959ffee700fdc4b7a0897166e0b1971d75cbe6307116b450ff55bdfbddc82ce.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nm-d03897349ebe3d111ba9b5145ce03025e79a95e64c8ba9c437aaae42da5cff00.json
+++ b/openfisca_france/tests/json/f7nm-d03897349ebe3d111ba9b5145ce03025e79a95e64c8ba9c437aaae42da5cff00.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nm-d2be4e6aa0ab5316b1112b8519e8f91a9edb1563dc314d030c767aa69c54e21f.json
+++ b/openfisca_france/tests/json/f7nm-d2be4e6aa0ab5316b1112b8519e8f91a9edb1563dc314d030c767aa69c54e21f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nn-0e1bbda1f87ddee540ce6708077eee6f3b7bdd99b4de4b099fa07b881c8afd87.json
+++ b/openfisca_france/tests/json/f7nn-0e1bbda1f87ddee540ce6708077eee6f3b7bdd99b4de4b099fa07b881c8afd87.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nn-2f696ffb265d787d352682b2667922537dcc845aac89610b6a4d566847d0e1c7.json
+++ b/openfisca_france/tests/json/f7nn-2f696ffb265d787d352682b2667922537dcc845aac89610b6a4d566847d0e1c7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nn-4f34822123d28ea614c4622096691f0c8066325c0c3c29b6c78eb869aa391615.json
+++ b/openfisca_france/tests/json/f7nn-4f34822123d28ea614c4622096691f0c8066325c0c3c29b6c78eb869aa391615.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nn-5476b3dfb22e4bfe650ce587a4b91a6bb52f17acd68f32b33a2e57f516454ad7.json
+++ b/openfisca_france/tests/json/f7nn-5476b3dfb22e4bfe650ce587a4b91a6bb52f17acd68f32b33a2e57f516454ad7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nn-9d244d1a6afb14a9ee7ff6c4f7bce6ae418c096ea1d94c139f19f6e6ac63ed1f.json
+++ b/openfisca_france/tests/json/f7nn-9d244d1a6afb14a9ee7ff6c4f7bce6ae418c096ea1d94c139f19f6e6ac63ed1f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nn-a4293665cbd9c93d3645da33510fa90b4731fad3eecd03ae211d971881d59c37.json
+++ b/openfisca_france/tests/json/f7nn-a4293665cbd9c93d3645da33510fa90b4731fad3eecd03ae211d971881d59c37.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nn-a5d7527ebf890f51fb7cce1159482da5c3f385a679f4057bb9ea4682a9b49444.json
+++ b/openfisca_france/tests/json/f7nn-a5d7527ebf890f51fb7cce1159482da5c3f385a679f4057bb9ea4682a9b49444.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nn-ad2c63c102571f66012162fdafc0adb875aea1e2d78170ede8d660f229879c76.json
+++ b/openfisca_france/tests/json/f7nn-ad2c63c102571f66012162fdafc0adb875aea1e2d78170ede8d660f229879c76.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nn-b4588afecbc8e57887120e2cb1f00e974b4258eeba2d24f7f5e52ed6ccf38837.json
+++ b/openfisca_france/tests/json/f7nn-b4588afecbc8e57887120e2cb1f00e974b4258eeba2d24f7f5e52ed6ccf38837.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7no-1586db107dcfc57c533d4d05f5ce749282479c62b1d05655730e13dc77fc7aba.json
+++ b/openfisca_france/tests/json/f7no-1586db107dcfc57c533d4d05f5ce749282479c62b1d05655730e13dc77fc7aba.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7no-17fe1044aa29738100643bb33169b53748a379141679106ffd8ce7839fd173f0.json
+++ b/openfisca_france/tests/json/f7no-17fe1044aa29738100643bb33169b53748a379141679106ffd8ce7839fd173f0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7no-46eeaa6c8a15c2ba95c0192a9123c7e00b42a15981ee660b261efbeaf9588f1f.json
+++ b/openfisca_france/tests/json/f7no-46eeaa6c8a15c2ba95c0192a9123c7e00b42a15981ee660b261efbeaf9588f1f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7no-4dee3a06a798cd792151b7dd70aed1372ee15ea68772e7db1bd0c954778a29c0.json
+++ b/openfisca_france/tests/json/f7no-4dee3a06a798cd792151b7dd70aed1372ee15ea68772e7db1bd0c954778a29c0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7no-658e9125d2b1d9e023a8fe7d37f54923a145580e2e9cea095fbb57338e754abb.json
+++ b/openfisca_france/tests/json/f7no-658e9125d2b1d9e023a8fe7d37f54923a145580e2e9cea095fbb57338e754abb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7no-7608207db90c3a867a26813673f6e097026714c257d45511b21ff900ae115a0d.json
+++ b/openfisca_france/tests/json/f7no-7608207db90c3a867a26813673f6e097026714c257d45511b21ff900ae115a0d.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7no-a4ff07af3ced444935714371a5a0b2d174fdc7e025c6db10e6d66d32e0885242.json
+++ b/openfisca_france/tests/json/f7no-a4ff07af3ced444935714371a5a0b2d174fdc7e025c6db10e6d66d32e0885242.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7no-c455b1d7418c7957a8907e7b00063d3d1c1a1718e6b879d930a2bd01b49549c7.json
+++ b/openfisca_france/tests/json/f7no-c455b1d7418c7957a8907e7b00063d3d1c1a1718e6b879d930a2bd01b49549c7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7no-ecf06731614f88679f0c1cd761a9c57e97f6cc3143f5dd65c69b966ec7c1f1ab.json
+++ b/openfisca_france/tests/json/f7no-ecf06731614f88679f0c1cd761a9c57e97f6cc3143f5dd65c69b966ec7c1f1ab.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7np-3924c35f978b56fb0da3b7a31cadcd47fea53f1e9ab1e08b737950fccc90e9f2.json
+++ b/openfisca_france/tests/json/f7np-3924c35f978b56fb0da3b7a31cadcd47fea53f1e9ab1e08b737950fccc90e9f2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7np-73935ff48268ae2b03eaee1eeb603dacf50cab6884b7fb491fd348d84803acf7.json
+++ b/openfisca_france/tests/json/f7np-73935ff48268ae2b03eaee1eeb603dacf50cab6884b7fb491fd348d84803acf7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7np-812b7603f3f54fea3359015c36383a0c931a24acc3b7cc80c5c4735fc1d776b4.json
+++ b/openfisca_france/tests/json/f7np-812b7603f3f54fea3359015c36383a0c931a24acc3b7cc80c5c4735fc1d776b4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7np-8e9094c014cd9b1f5e0249a02687b53f7f679f6b74740ef67897ff4ff5ce7752.json
+++ b/openfisca_france/tests/json/f7np-8e9094c014cd9b1f5e0249a02687b53f7f679f6b74740ef67897ff4ff5ce7752.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7np-92afcb67c5fd91b354066bbbc9052ea740c7d451e421308a42de0b4411df1d7d.json
+++ b/openfisca_france/tests/json/f7np-92afcb67c5fd91b354066bbbc9052ea740c7d451e421308a42de0b4411df1d7d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7np-a8cc6a1391f36f7ff390e99feca352f4f562a92a99c9d17c3f234db794f4a0fa.json
+++ b/openfisca_france/tests/json/f7np-a8cc6a1391f36f7ff390e99feca352f4f562a92a99c9d17c3f234db794f4a0fa.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7np-b981cbc4ef57e9fb48a29cb68f5463c68bb5d80af5e230c13ce881c99b5aa778.json
+++ b/openfisca_france/tests/json/f7np-b981cbc4ef57e9fb48a29cb68f5463c68bb5d80af5e230c13ce881c99b5aa778.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7np-c59c4eea73ce0898f4ba694b5a17c9f20e410937ebd9ee18ad53fb67f6f8a25b.json
+++ b/openfisca_france/tests/json/f7np-c59c4eea73ce0898f4ba694b5a17c9f20e410937ebd9ee18ad53fb67f6f8a25b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7np-e1bcdcc995c18b1ed6bed437ae92306a154183f09e6291589437d0648e17196c.json
+++ b/openfisca_france/tests/json/f7np-e1bcdcc995c18b1ed6bed437ae92306a154183f09e6291589437d0648e17196c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nq-23701b49f6a133704a1248082b25933f989871a72e7438b6823532dc5b47bca2.json
+++ b/openfisca_france/tests/json/f7nq-23701b49f6a133704a1248082b25933f989871a72e7438b6823532dc5b47bca2.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nq-530537a892135bd0263751c503b375fed2ea61809beef704a0074c1006ba4a8a.json
+++ b/openfisca_france/tests/json/f7nq-530537a892135bd0263751c503b375fed2ea61809beef704a0074c1006ba4a8a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nq-6945d00e97b9fb2b01567163e75526220ec0009b2184ec7cb06373e623ccbe97.json
+++ b/openfisca_france/tests/json/f7nq-6945d00e97b9fb2b01567163e75526220ec0009b2184ec7cb06373e623ccbe97.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nq-75b2da7ce7d17539687c7250916649ebdb4f12d79d4613b15e412280344ca38f.json
+++ b/openfisca_france/tests/json/f7nq-75b2da7ce7d17539687c7250916649ebdb4f12d79d4613b15e412280344ca38f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nq-881406b7f575984a3b1845fd5cc11343273a5395bad3306691530ff7f0a56189.json
+++ b/openfisca_france/tests/json/f7nq-881406b7f575984a3b1845fd5cc11343273a5395bad3306691530ff7f0a56189.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nq-a5b7295d726f1be8a5b14e26892960f566e0c630ed87137f9c76860daceddfc1.json
+++ b/openfisca_france/tests/json/f7nq-a5b7295d726f1be8a5b14e26892960f566e0c630ed87137f9c76860daceddfc1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nq-aabfe4175c5f710f6c2364c79c674524030c42ba53941db2f37588fa68437fb4.json
+++ b/openfisca_france/tests/json/f7nq-aabfe4175c5f710f6c2364c79c674524030c42ba53941db2f37588fa68437fb4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nq-bb3318beb458aea564a3f29148619af6d9c6858d70fdd328913a8aee87b04141.json
+++ b/openfisca_france/tests/json/f7nq-bb3318beb458aea564a3f29148619af6d9c6858d70fdd328913a8aee87b04141.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nq-de2c878965fb6afed94519faec327807b8abad45c756a91e36f8afc7d4c973ed.json
+++ b/openfisca_france/tests/json/f7nq-de2c878965fb6afed94519faec327807b8abad45c756a91e36f8afc7d4c973ed.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nr-014ba2915e40b7ed026ad038f4b130c8b6e0fbd3b991f3ce386e659fb8c0da43.json
+++ b/openfisca_france/tests/json/f7nr-014ba2915e40b7ed026ad038f4b130c8b6e0fbd3b991f3ce386e659fb8c0da43.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nr-242a21a4129f35616994ff95d802604634f10dc1ea94e6c88eca17328da0caff.json
+++ b/openfisca_france/tests/json/f7nr-242a21a4129f35616994ff95d802604634f10dc1ea94e6c88eca17328da0caff.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nr-63c78ff8e48f4172203d51cd4e3a8399e9997e0d67e2a061e7880fd6efddba36.json
+++ b/openfisca_france/tests/json/f7nr-63c78ff8e48f4172203d51cd4e3a8399e9997e0d67e2a061e7880fd6efddba36.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nr-9be29e85fc888ebb24d2fd35f128b75d84d3f49f10314bd9675037a4b14d1679.json
+++ b/openfisca_france/tests/json/f7nr-9be29e85fc888ebb24d2fd35f128b75d84d3f49f10314bd9675037a4b14d1679.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nr-b8a0e22e76a7dbf5d6b95e65c835f7c13000b302338d23334593ce40cb585754.json
+++ b/openfisca_france/tests/json/f7nr-b8a0e22e76a7dbf5d6b95e65c835f7c13000b302338d23334593ce40cb585754.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nr-ba00ae509aaf63b7be3739ba424ee9368cbbc73edefc47b48eacbb106472303a.json
+++ b/openfisca_france/tests/json/f7nr-ba00ae509aaf63b7be3739ba424ee9368cbbc73edefc47b48eacbb106472303a.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nr-d97ec4de4bdbaab6e778c108e4cf211296a161c24081c233c792fabf60e4216b.json
+++ b/openfisca_france/tests/json/f7nr-d97ec4de4bdbaab6e778c108e4cf211296a161c24081c233c792fabf60e4216b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nr-faf5ca6a017a5da7a641b0008eacf865fdf4314aa8e73ef1e20a79cba318c119.json
+++ b/openfisca_france/tests/json/f7nr-faf5ca6a017a5da7a641b0008eacf865fdf4314aa8e73ef1e20a79cba318c119.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nr-fc0c8fcc7525fdab305fd94b62b3fe34ff7f69210887104e09da3cf512978bbd.json
+++ b/openfisca_france/tests/json/f7nr-fc0c8fcc7525fdab305fd94b62b3fe34ff7f69210887104e09da3cf512978bbd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ns-32d19a2c89514e07cec2713ff09ca9486034f7cbc4d89b0fef987122126308f1.json
+++ b/openfisca_france/tests/json/f7ns-32d19a2c89514e07cec2713ff09ca9486034f7cbc4d89b0fef987122126308f1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ns-3c480bd8e3c7c0a9a6cec274ce807c51f7b8c67a7cb3a622fd1588f4acf34933.json
+++ b/openfisca_france/tests/json/f7ns-3c480bd8e3c7c0a9a6cec274ce807c51f7b8c67a7cb3a622fd1588f4acf34933.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ns-4e77f1e44124479f12cf15ae369a11fd0962025e391ff147dbcde12cd03c902c.json
+++ b/openfisca_france/tests/json/f7ns-4e77f1e44124479f12cf15ae369a11fd0962025e391ff147dbcde12cd03c902c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ns-9f23175dd3a79d3c5ace85a6fa07e606672b055fe83c0b447586d045b135b1ca.json
+++ b/openfisca_france/tests/json/f7ns-9f23175dd3a79d3c5ace85a6fa07e606672b055fe83c0b447586d045b135b1ca.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ns-a6c97dd6e7bfdf21adfd71764061c8ebf5ebb17f04f478cc13600049042fdb7c.json
+++ b/openfisca_france/tests/json/f7ns-a6c97dd6e7bfdf21adfd71764061c8ebf5ebb17f04f478cc13600049042fdb7c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ns-c9e211ed487644cdda4fab381bb162620751414fd2aae0176a015e355e433e33.json
+++ b/openfisca_france/tests/json/f7ns-c9e211ed487644cdda4fab381bb162620751414fd2aae0176a015e355e433e33.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ns-d4217c668fe59c8b57fc745a4ca46f80d0d789be7314e27b829855e2a787b231.json
+++ b/openfisca_france/tests/json/f7ns-d4217c668fe59c8b57fc745a4ca46f80d0d789be7314e27b829855e2a787b231.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ns-e1e80d0440eb5bde5059b936678f42379b8dfdce3a72229b0cbdaa51af2434bf.json
+++ b/openfisca_france/tests/json/f7ns-e1e80d0440eb5bde5059b936678f42379b8dfdce3a72229b0cbdaa51af2434bf.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ns-f5cf25597dfcc5affb58b5b46b4a128f3db5cf38744361a403c819813df93854.json
+++ b/openfisca_france/tests/json/f7ns-f5cf25597dfcc5affb58b5b46b4a128f3db5cf38744361a403c819813df93854.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nt-11d4a34828e4a89a452db544947f204b90e5453993db635b58f512a517aaae6e.json
+++ b/openfisca_france/tests/json/f7nt-11d4a34828e4a89a452db544947f204b90e5453993db635b58f512a517aaae6e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nt-2b7fa754a251c7dd09e694ac8e5b3f27ab9b79dcbcbe1d15e57a6e9cc7c7b26c.json
+++ b/openfisca_france/tests/json/f7nt-2b7fa754a251c7dd09e694ac8e5b3f27ab9b79dcbcbe1d15e57a6e9cc7c7b26c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nt-6965838dd72866d392fe61ab644b132682c79c66fef8847e80048a5a5a2a0058.json
+++ b/openfisca_france/tests/json/f7nt-6965838dd72866d392fe61ab644b132682c79c66fef8847e80048a5a5a2a0058.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nt-729cd66e638694c5bad104799454dda253b9ad09cd85240effd3830554f3ba6c.json
+++ b/openfisca_france/tests/json/f7nt-729cd66e638694c5bad104799454dda253b9ad09cd85240effd3830554f3ba6c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nt-8815f00a5767eaae4cd5427438170edae60367efdda10908660b31143c0082c8.json
+++ b/openfisca_france/tests/json/f7nt-8815f00a5767eaae4cd5427438170edae60367efdda10908660b31143c0082c8.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nt-9bed958f4b5d3830c847ff62dcf2e21c547180558c1e2ecf6062f76ef5606ae5.json
+++ b/openfisca_france/tests/json/f7nt-9bed958f4b5d3830c847ff62dcf2e21c547180558c1e2ecf6062f76ef5606ae5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nt-a8b8ec168d9b65825ec271acc8f532077cf2f1ff30c813a1038b20a3968ee57c.json
+++ b/openfisca_france/tests/json/f7nt-a8b8ec168d9b65825ec271acc8f532077cf2f1ff30c813a1038b20a3968ee57c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nt-ea5678af6e44cbdbf07af5a3d31c302c47e6375cf66b119d5adc92a17e536a7d.json
+++ b/openfisca_france/tests/json/f7nt-ea5678af6e44cbdbf07af5a3d31c302c47e6375cf66b119d5adc92a17e536a7d.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nt-ecff9ec5e2e610da5c35cefd906fe778653bc2fa165534396cb31894d9f8babb.json
+++ b/openfisca_france/tests/json/f7nt-ecff9ec5e2e610da5c35cefd906fe778653bc2fa165534396cb31894d9f8babb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nu-2b55c4d2288c819e978963b0ff0b8bc1310c0e202a5a6a59dc034c50e6ce99af.json
+++ b/openfisca_france/tests/json/f7nu-2b55c4d2288c819e978963b0ff0b8bc1310c0e202a5a6a59dc034c50e6ce99af.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nu-3dc06c1bf411ac4a315e84be65610ce0f1d0c5540b48ef018b33bf1dbba489a6.json
+++ b/openfisca_france/tests/json/f7nu-3dc06c1bf411ac4a315e84be65610ce0f1d0c5540b48ef018b33bf1dbba489a6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nu-494e10bdbcec904a32b1b31b5008de48b6d7a05cc035a7b0b5ade394bd8d35a2.json
+++ b/openfisca_france/tests/json/f7nu-494e10bdbcec904a32b1b31b5008de48b6d7a05cc035a7b0b5ade394bd8d35a2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nu-49fc7aced104d1858e8bf98975c2fb21db6f17a5514acc1ad8e9301cf1777963.json
+++ b/openfisca_france/tests/json/f7nu-49fc7aced104d1858e8bf98975c2fb21db6f17a5514acc1ad8e9301cf1777963.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nu-5855ca35aa5f27e6587fe94fe22dfc92f0f0edb7b2636a55d190cbfbd760c49c.json
+++ b/openfisca_france/tests/json/f7nu-5855ca35aa5f27e6587fe94fe22dfc92f0f0edb7b2636a55d190cbfbd760c49c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nu-5e93aa4d67b0b7558579a5b05ca73ad62c667e7b17c251fef5a36440afd3b2b3.json
+++ b/openfisca_france/tests/json/f7nu-5e93aa4d67b0b7558579a5b05ca73ad62c667e7b17c251fef5a36440afd3b2b3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nu-eb4884b56edafa3c18f1c26a046973849d37803af6aa1ab5afa7108efd84ba25.json
+++ b/openfisca_france/tests/json/f7nu-eb4884b56edafa3c18f1c26a046973849d37803af6aa1ab5afa7108efd84ba25.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nv-13baee1efa9b30c0f487ffe3c82e4831d261085a1c104618b9ff81d20341d351.json
+++ b/openfisca_france/tests/json/f7nv-13baee1efa9b30c0f487ffe3c82e4831d261085a1c104618b9ff81d20341d351.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nv-1a6f97d7d8db1eb98ea915b322784991b03e156dede1b23a842adfea72ce077e.json
+++ b/openfisca_france/tests/json/f7nv-1a6f97d7d8db1eb98ea915b322784991b03e156dede1b23a842adfea72ce077e.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nv-37edfaa599abf68ad0efe8e193ac5741d88e3872495b957ca04a5a386e2761e1.json
+++ b/openfisca_france/tests/json/f7nv-37edfaa599abf68ad0efe8e193ac5741d88e3872495b957ca04a5a386e2761e1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nv-4b9cd2aaaa933362f058df11d2a5c7b3c2cdbcd85356dab87cf91a7af0dfafef.json
+++ b/openfisca_france/tests/json/f7nv-4b9cd2aaaa933362f058df11d2a5c7b3c2cdbcd85356dab87cf91a7af0dfafef.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nv-5098635acf0d7ff84ff128f6fef4a17981210387896a644f28f893fb2a24b783.json
+++ b/openfisca_france/tests/json/f7nv-5098635acf0d7ff84ff128f6fef4a17981210387896a644f28f893fb2a24b783.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nv-5d371c2605db27dbae97dc35f5fa1eacd87c52093be3803a64e19506753672a6.json
+++ b/openfisca_france/tests/json/f7nv-5d371c2605db27dbae97dc35f5fa1eacd87c52093be3803a64e19506753672a6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nv-6e546523ca834797527c8e17a0bc36d61988bae469c236ca5043453d01f1bb18.json
+++ b/openfisca_france/tests/json/f7nv-6e546523ca834797527c8e17a0bc36d61988bae469c236ca5043453d01f1bb18.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nv-7b5fe35d9056a657ec28cd783587e6b4a48c7aa0ca2121d2ff34d5e3c002d22a.json
+++ b/openfisca_france/tests/json/f7nv-7b5fe35d9056a657ec28cd783587e6b4a48c7aa0ca2121d2ff34d5e3c002d22a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nv-e353cc6f4d059b1cd93527d1edf5145e1d8fc8e08171e2c82d988afef1775966.json
+++ b/openfisca_france/tests/json/f7nv-e353cc6f4d059b1cd93527d1edf5145e1d8fc8e08171e2c82d988afef1775966.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nw-2e5f787df1b1caaeaf7818d248ec6d7c6a64aef575dc84d9a914dfbc5f98f63b.json
+++ b/openfisca_france/tests/json/f7nw-2e5f787df1b1caaeaf7818d248ec6d7c6a64aef575dc84d9a914dfbc5f98f63b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nw-390065966948a829ff97b80a0992289a1b75d891f2c15cb74f6922f52f49e49a.json
+++ b/openfisca_france/tests/json/f7nw-390065966948a829ff97b80a0992289a1b75d891f2c15cb74f6922f52f49e49a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nw-3b35985c3b11ed5035b62fb2542ff9ae77d9bb9946cfd1b077b3e3595639a878.json
+++ b/openfisca_france/tests/json/f7nw-3b35985c3b11ed5035b62fb2542ff9ae77d9bb9946cfd1b077b3e3595639a878.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nw-3d4482a48c4ca34f2999ae0927f9e51fc75624aba4cca316aa50f61dfd93413e.json
+++ b/openfisca_france/tests/json/f7nw-3d4482a48c4ca34f2999ae0927f9e51fc75624aba4cca316aa50f61dfd93413e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nw-518bddc13a4ce1c521729f20b6de2a2d7351c14a41365331e0a6efa25558a4a0.json
+++ b/openfisca_france/tests/json/f7nw-518bddc13a4ce1c521729f20b6de2a2d7351c14a41365331e0a6efa25558a4a0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nw-6902f3e3983f9141302611fefb140c6818196e83d443659d0906cd52fc1cd4e7.json
+++ b/openfisca_france/tests/json/f7nw-6902f3e3983f9141302611fefb140c6818196e83d443659d0906cd52fc1cd4e7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nw-9c4bb47da6e9d4ed0dcf082cba9ca712ae2202036384608618385c0ef6ade934.json
+++ b/openfisca_france/tests/json/f7nw-9c4bb47da6e9d4ed0dcf082cba9ca712ae2202036384608618385c0ef6ade934.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nw-bb38b8ec460c49ffc19a4dc6e05b80dc49cd9de3ba24c65c684897810a1c2e11.json
+++ b/openfisca_france/tests/json/f7nw-bb38b8ec460c49ffc19a4dc6e05b80dc49cd9de3ba24c65c684897810a1c2e11.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nw-dee06f6b048545a79eebe1c96c022f960a9a9b3231b3d5b3d8af036ab37bcdef.json
+++ b/openfisca_france/tests/json/f7nw-dee06f6b048545a79eebe1c96c022f960a9a9b3231b3d5b3d8af036ab37bcdef.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nx-069ca7ce183b71d4675c46e19c5107743f096b3e3903495a0c16fa21db1bbf7d.json
+++ b/openfisca_france/tests/json/f7nx-069ca7ce183b71d4675c46e19c5107743f096b3e3903495a0c16fa21db1bbf7d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nx-098aceb1f9e59989ae97e2ba93a9dfff1e7de84f1e087b57ea2c03e98b6a5944.json
+++ b/openfisca_france/tests/json/f7nx-098aceb1f9e59989ae97e2ba93a9dfff1e7de84f1e087b57ea2c03e98b6a5944.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nx-3673378b9f30beceeeb93ea84d8fe66c19c1387d9f20eeb9eb593414791696e5.json
+++ b/openfisca_france/tests/json/f7nx-3673378b9f30beceeeb93ea84d8fe66c19c1387d9f20eeb9eb593414791696e5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nx-4220e06800ade63631205dbc179006c718fa6b1cbc45fc79d0824df97283f681.json
+++ b/openfisca_france/tests/json/f7nx-4220e06800ade63631205dbc179006c718fa6b1cbc45fc79d0824df97283f681.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nx-a9ced23aa4281e289a40c8019fcdc393ebb715804f8de2ea29095d34d823d465.json
+++ b/openfisca_france/tests/json/f7nx-a9ced23aa4281e289a40c8019fcdc393ebb715804f8de2ea29095d34d823d465.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nx-bf206bdee41d6aa2f6f7aa7a5791520e62aec40dc5ffd038accb358fc390d3a3.json
+++ b/openfisca_france/tests/json/f7nx-bf206bdee41d6aa2f6f7aa7a5791520e62aec40dc5ffd038accb358fc390d3a3.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nx-ca902162ecde4eba278f9503baba4c238762affb35f3f4fb5bfc42f11813eea6.json
+++ b/openfisca_france/tests/json/f7nx-ca902162ecde4eba278f9503baba4c238762affb35f3f4fb5bfc42f11813eea6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nx-d332ea6813fe7df2dcbefbc509230600a3d82b74bcd190484bfdd582effb146b.json
+++ b/openfisca_france/tests/json/f7nx-d332ea6813fe7df2dcbefbc509230600a3d82b74bcd190484bfdd582effb146b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nx-e73db9fb36d12d8f80ac21238855b305c37ed7a2cb1505c4adfd429d72edea58.json
+++ b/openfisca_france/tests/json/f7nx-e73db9fb36d12d8f80ac21238855b305c37ed7a2cb1505c4adfd429d72edea58.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ny-1bdfe004a45150961239130007963743423a73d730e1a809fd2c08b70f00e661.json
+++ b/openfisca_france/tests/json/f7ny-1bdfe004a45150961239130007963743423a73d730e1a809fd2c08b70f00e661.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ny-3cacebe98443eb510179b0b79901a9268a4c4c7ec1f56353fbc8aa508f893fb3.json
+++ b/openfisca_france/tests/json/f7ny-3cacebe98443eb510179b0b79901a9268a4c4c7ec1f56353fbc8aa508f893fb3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ny-458901b3e4813aa83b1828bf9fda1327480299a23f54655eeb39ac498104b218.json
+++ b/openfisca_france/tests/json/f7ny-458901b3e4813aa83b1828bf9fda1327480299a23f54655eeb39ac498104b218.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ny-8cba3edfaf78e256016a5177ceb523f821abed4353748cdb33323230dc35eb4a.json
+++ b/openfisca_france/tests/json/f7ny-8cba3edfaf78e256016a5177ceb523f821abed4353748cdb33323230dc35eb4a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ny-91304411f8bac680225fd2b44f0b885f0a3d607e04b4cbbddd84f8ebd7d109cb.json
+++ b/openfisca_france/tests/json/f7ny-91304411f8bac680225fd2b44f0b885f0a3d607e04b4cbbddd84f8ebd7d109cb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ny-a204e500198d4e5010d5fd6da10a9154413f94ed90489a3d32a7277e66f79252.json
+++ b/openfisca_france/tests/json/f7ny-a204e500198d4e5010d5fd6da10a9154413f94ed90489a3d32a7277e66f79252.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ny-b7e1a27b4d8880f29bfb2390522927c5b517911388ec8411cd2def5611d7bc6f.json
+++ b/openfisca_france/tests/json/f7ny-b7e1a27b4d8880f29bfb2390522927c5b517911388ec8411cd2def5611d7bc6f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nz-23aada9b6e7bebd419772ebb5c610ec8eddd7162126da7650d35a90d3e073b80.json
+++ b/openfisca_france/tests/json/f7nz-23aada9b6e7bebd419772ebb5c610ec8eddd7162126da7650d35a90d3e073b80.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nz-26a9f66ea13a273ba1cfd03987053475ea18a2ae7158cf64f22cc38c0a32bc62.json
+++ b/openfisca_france/tests/json/f7nz-26a9f66ea13a273ba1cfd03987053475ea18a2ae7158cf64f22cc38c0a32bc62.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nz-72b7b8d8e16fa0b8166e443f342540f2f1fc2fb9d64f1d6b177f63cb4c06e91f.json
+++ b/openfisca_france/tests/json/f7nz-72b7b8d8e16fa0b8166e443f342540f2f1fc2fb9d64f1d6b177f63cb4c06e91f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nz-9243def20bfd3fe80b98acd2e55ed2698abf2003ab0bd0d04c1edb4f28088b28.json
+++ b/openfisca_france/tests/json/f7nz-9243def20bfd3fe80b98acd2e55ed2698abf2003ab0bd0d04c1edb4f28088b28.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nz-bf453e46641e9df7da63025c0f2c646a4a4fc183d0c29339b3a4872a02106190.json
+++ b/openfisca_france/tests/json/f7nz-bf453e46641e9df7da63025c0f2c646a4a4fc183d0c29339b3a4872a02106190.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nz-c4d51de6b605c00a3296c5dd704c5c1dd9ff617a5635013c0ab7bf319923b8f3.json
+++ b/openfisca_france/tests/json/f7nz-c4d51de6b605c00a3296c5dd704c5c1dd9ff617a5635013c0ab7bf319923b8f3.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nz-d30a19c433784e30cf53df4f133bb281ac24bd9a0f6afd13e70c74dd6cd9034f.json
+++ b/openfisca_france/tests/json/f7nz-d30a19c433784e30cf53df4f133bb281ac24bd9a0f6afd13e70c74dd6cd9034f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nz-d8b1481e71f6d2f5e515c758a03dc5705ba4c7f49c206794f1f18359d4f22583.json
+++ b/openfisca_france/tests/json/f7nz-d8b1481e71f6d2f5e515c758a03dc5705ba4c7f49c206794f1f18359d4f22583.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7nz-ef132dfce7ed7b6eed9cef13b3b30864640f3ae5833dc13145316c29cfe81ac7.json
+++ b/openfisca_france/tests/json/f7nz-ef132dfce7ed7b6eed9cef13b3b30864640f3ae5833dc13145316c29cfe81ac7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7oz-0caff9eeb8fca42c4d4c30c71feb21319600cad03c77c5ae041bf70b3fc20e25.json
+++ b/openfisca_france/tests/json/f7oz-0caff9eeb8fca42c4d4c30c71feb21319600cad03c77c5ae041bf70b3fc20e25.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7oz-18d6a40353b65f28358f92326e32453bb3bba15a958dacea65690a4a9d9515d7.json
+++ b/openfisca_france/tests/json/f7oz-18d6a40353b65f28358f92326e32453bb3bba15a958dacea65690a4a9d9515d7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7oz-53ab3542ee645656b9ab99e538d7e87849e2222149a1f79322d89fa40f216f52.json
+++ b/openfisca_france/tests/json/f7oz-53ab3542ee645656b9ab99e538d7e87849e2222149a1f79322d89fa40f216f52.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7oz-56e307745e2744d37e04de8179129ec8f3dc32501a44210b47c48d51120d81d1.json
+++ b/openfisca_france/tests/json/f7oz-56e307745e2744d37e04de8179129ec8f3dc32501a44210b47c48d51120d81d1.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7oz-71752117f987f5832e240f0290572e02e9ca59803abd09b41e3bb0f7caefbeff.json
+++ b/openfisca_france/tests/json/f7oz-71752117f987f5832e240f0290572e02e9ca59803abd09b41e3bb0f7caefbeff.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7oz-a7f349176ea2f781c652fa5d53d7c12c500fc2cc655cd79a66ac63cb4e60f022.json
+++ b/openfisca_france/tests/json/f7oz-a7f349176ea2f781c652fa5d53d7c12c500fc2cc655cd79a66ac63cb4e60f022.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7oz-ba71663c201caa1dfea73ad5f5b40ae231dd884aab6486783dceb56bae9fa4ed.json
+++ b/openfisca_france/tests/json/f7oz-ba71663c201caa1dfea73ad5f5b40ae231dd884aab6486783dceb56bae9fa4ed.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7oz-db96001d6faafee4a8e3deb396be909a4f2aa04a4cb951838f912240dccda140.json
+++ b/openfisca_france/tests/json/f7oz-db96001d6faafee4a8e3deb396be909a4f2aa04a4cb951838f912240dccda140.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pa-3a9c7fdd12394e8116dc0b4485f21190db262c6e0868e01629487b5e98c58566.json
+++ b/openfisca_france/tests/json/f7pa-3a9c7fdd12394e8116dc0b4485f21190db262c6e0868e01629487b5e98c58566.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pa-69913bbad38bd9e2d106c57a13063da94b7d1c6b01820242bfb75c7a5f2b4412.json
+++ b/openfisca_france/tests/json/f7pa-69913bbad38bd9e2d106c57a13063da94b7d1c6b01820242bfb75c7a5f2b4412.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pa-6b728fece7818c99c088171bc7b386a5b82557166d16980b9a96861712f61f53.json
+++ b/openfisca_france/tests/json/f7pa-6b728fece7818c99c088171bc7b386a5b82557166d16980b9a96861712f61f53.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pa-83067681978270bdb2aa02586b43a361b55290517c11072585e917fcf030167e.json
+++ b/openfisca_france/tests/json/f7pa-83067681978270bdb2aa02586b43a361b55290517c11072585e917fcf030167e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pa-8309914c6122473ce33feae752e07723690bbc5a5a7b3a04e036f3094aba7346.json
+++ b/openfisca_france/tests/json/f7pa-8309914c6122473ce33feae752e07723690bbc5a5a7b3a04e036f3094aba7346.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pa-9f251085f0389d96e8b51660a9353c8e2124eb05b5bf8085f9ed5a39ed5d4bab.json
+++ b/openfisca_france/tests/json/f7pa-9f251085f0389d96e8b51660a9353c8e2124eb05b5bf8085f9ed5a39ed5d4bab.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pa-ab6172e2150c7f894ffc68008e3cc80a72269ab23480738d527ae124d9425e6f.json
+++ b/openfisca_france/tests/json/f7pa-ab6172e2150c7f894ffc68008e3cc80a72269ab23480738d527ae124d9425e6f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pa-ca3299e84c9600211055bc073dba72400c25e5ecd011ce2e9caca278a29157fe.json
+++ b/openfisca_france/tests/json/f7pa-ca3299e84c9600211055bc073dba72400c25e5ecd011ce2e9caca278a29157fe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pa-d578944a16dc5a99f0a53aebb40e8a6a567a591c7a7c55acf9693210a48196ad.json
+++ b/openfisca_france/tests/json/f7pa-d578944a16dc5a99f0a53aebb40e8a6a567a591c7a7c55acf9693210a48196ad.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pb-0d1d95f37842397a82a412bc977ff45cd4df6868185056293744459488757d88.json
+++ b/openfisca_france/tests/json/f7pb-0d1d95f37842397a82a412bc977ff45cd4df6868185056293744459488757d88.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pb-5ce3c4fb94b59ee45a285130469537c578c393283a7b5911a36d2f1070a36d9f.json
+++ b/openfisca_france/tests/json/f7pb-5ce3c4fb94b59ee45a285130469537c578c393283a7b5911a36d2f1070a36d9f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pb-6ab7a3be56033b02a640869a263776a4340407655e2d1379e30e3961b6c04c9d.json
+++ b/openfisca_france/tests/json/f7pb-6ab7a3be56033b02a640869a263776a4340407655e2d1379e30e3961b6c04c9d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pb-79b5abfbdee619772c42462b63f71a52487445b5cb345258883ee2ee5249d054.json
+++ b/openfisca_france/tests/json/f7pb-79b5abfbdee619772c42462b63f71a52487445b5cb345258883ee2ee5249d054.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pb-bafbc550c414fe83a0e59fb46ff5fd147b86d66e2de94cf22e6886ca549946c8.json
+++ b/openfisca_france/tests/json/f7pb-bafbc550c414fe83a0e59fb46ff5fd147b86d66e2de94cf22e6886ca549946c8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pb-c0baaf114e30a2cd3cf5fb3bdb476b9ff42ddcd83d2613ffd94e6dc041f67f2f.json
+++ b/openfisca_france/tests/json/f7pb-c0baaf114e30a2cd3cf5fb3bdb476b9ff42ddcd83d2613ffd94e6dc041f67f2f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pb-d579d80927676851db4fba987a03a26ed2ab930cc2b3320a2820cf3d69e92cc7.json
+++ b/openfisca_france/tests/json/f7pb-d579d80927676851db4fba987a03a26ed2ab930cc2b3320a2820cf3d69e92cc7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pb-d8ea7505a98cc3ad7de6df090bfbf9f71f6f36f4b33312ded3ec3e39c8d7ff19.json
+++ b/openfisca_france/tests/json/f7pb-d8ea7505a98cc3ad7de6df090bfbf9f71f6f36f4b33312ded3ec3e39c8d7ff19.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pc-02e9b1fc3f73cb9e000d1a5c77a81f93c492d65e84af678213a07c1410a44b07.json
+++ b/openfisca_france/tests/json/f7pc-02e9b1fc3f73cb9e000d1a5c77a81f93c492d65e84af678213a07c1410a44b07.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pc-03e72b20694c6dcaa00905c57a197fa3f6e3dac5ecb47bcb1eeb32c98be51bd0.json
+++ b/openfisca_france/tests/json/f7pc-03e72b20694c6dcaa00905c57a197fa3f6e3dac5ecb47bcb1eeb32c98be51bd0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pc-19d9b8ba9a3a3ac019301b78843c9ca6832990df9ea6b2e20bcc98f848a0ebaa.json
+++ b/openfisca_france/tests/json/f7pc-19d9b8ba9a3a3ac019301b78843c9ca6832990df9ea6b2e20bcc98f848a0ebaa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pc-27a1c749f087e05488648c00eb5f5be33d795eb6edf89f307a8341d3e7874855.json
+++ b/openfisca_france/tests/json/f7pc-27a1c749f087e05488648c00eb5f5be33d795eb6edf89f307a8341d3e7874855.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pc-84b83958fb7034e95531a4d8932c88ad7fc57659dfdc6809987426865ad6e78f.json
+++ b/openfisca_france/tests/json/f7pc-84b83958fb7034e95531a4d8932c88ad7fc57659dfdc6809987426865ad6e78f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pc-be056bc15dabef7f18aa7be06123094340082fe37c58714f1017f6367e489c27.json
+++ b/openfisca_france/tests/json/f7pc-be056bc15dabef7f18aa7be06123094340082fe37c58714f1017f6367e489c27.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pc-c0bdd876c506742f75bedff405aaadeb11920855234f8756076770c02d3e8884.json
+++ b/openfisca_france/tests/json/f7pc-c0bdd876c506742f75bedff405aaadeb11920855234f8756076770c02d3e8884.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pc-f8bb2f31db1c20abd87632441d06016b5f9fc10019dc2d2cdcff6968c152e196.json
+++ b/openfisca_france/tests/json/f7pc-f8bb2f31db1c20abd87632441d06016b5f9fc10019dc2d2cdcff6968c152e196.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pc-fb0b0cef6826616dc2917510e1523ac1c2c21424089fc300901526710d20ff56.json
+++ b/openfisca_france/tests/json/f7pc-fb0b0cef6826616dc2917510e1523ac1c2c21424089fc300901526710d20ff56.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pd-3c9577c2ee9fdcf816023aadde5224aa12a5f5b3189fb317127562871fe292d1.json
+++ b/openfisca_france/tests/json/f7pd-3c9577c2ee9fdcf816023aadde5224aa12a5f5b3189fb317127562871fe292d1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pd-3d40dd0bc948e3b8206b2b04fc6f48f5d88e2013789c2539fa48d3ba89b47e3c.json
+++ b/openfisca_france/tests/json/f7pd-3d40dd0bc948e3b8206b2b04fc6f48f5d88e2013789c2539fa48d3ba89b47e3c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pd-80f3cb21f17b357574a09fbc65bf6b718098de678ccd2e83a886bb17a65e4646.json
+++ b/openfisca_france/tests/json/f7pd-80f3cb21f17b357574a09fbc65bf6b718098de678ccd2e83a886bb17a65e4646.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pd-a3a2559901d04912a3c4afd872df1f8bffb72e82759fe05834c8f20a24c9d551.json
+++ b/openfisca_france/tests/json/f7pd-a3a2559901d04912a3c4afd872df1f8bffb72e82759fe05834c8f20a24c9d551.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pd-b8d536d1acadfd3baab7a34fde7f408d8a82df5b5965419c960ac92ab9a74579.json
+++ b/openfisca_france/tests/json/f7pd-b8d536d1acadfd3baab7a34fde7f408d8a82df5b5965419c960ac92ab9a74579.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pd-ee8915a133e40ca8d8ffd4734dbae6a7766983f9272503dd73c2f73000b2b404.json
+++ b/openfisca_france/tests/json/f7pd-ee8915a133e40ca8d8ffd4734dbae6a7766983f9272503dd73c2f73000b2b404.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pe-11938c8389035ab3a1568f5f413bcfa8b629cbb9f0d26d894245b1a9b3324dad.json
+++ b/openfisca_france/tests/json/f7pe-11938c8389035ab3a1568f5f413bcfa8b629cbb9f0d26d894245b1a9b3324dad.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pe-303ea22595b33e4f96ec60c276d5a43eaab062b24761c45ff94258e709efb0d6.json
+++ b/openfisca_france/tests/json/f7pe-303ea22595b33e4f96ec60c276d5a43eaab062b24761c45ff94258e709efb0d6.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pe-3acd3032c30d9d6005849ebb22a5e017ecb967c08875cd8cfd7e9e159bc66399.json
+++ b/openfisca_france/tests/json/f7pe-3acd3032c30d9d6005849ebb22a5e017ecb967c08875cd8cfd7e9e159bc66399.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pe-65ff88fbd46eb77cf0f0bc84fb0ea13c26c40d4b13959431019f58ad7d8c9478.json
+++ b/openfisca_france/tests/json/f7pe-65ff88fbd46eb77cf0f0bc84fb0ea13c26c40d4b13959431019f58ad7d8c9478.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pe-9c3cc4c7a1762c690cafc5c5cbe004439ae6957f44467d1e7eefb560f03bc7de.json
+++ b/openfisca_france/tests/json/f7pe-9c3cc4c7a1762c690cafc5c5cbe004439ae6957f44467d1e7eefb560f03bc7de.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pe-a069acc8d4049314e32ef4262c34b13c2db4f0bfed4d6765c13ec937669fd002.json
+++ b/openfisca_france/tests/json/f7pe-a069acc8d4049314e32ef4262c34b13c2db4f0bfed4d6765c13ec937669fd002.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pe-af25c78ae233a673271026e69a121e17f1e625f30b420cd022e5756ec6d68837.json
+++ b/openfisca_france/tests/json/f7pe-af25c78ae233a673271026e69a121e17f1e625f30b420cd022e5756ec6d68837.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pe-b077101f1201925e247c15869386b02f9700471a6eae2e91cd787b28f3727472.json
+++ b/openfisca_france/tests/json/f7pe-b077101f1201925e247c15869386b02f9700471a6eae2e91cd787b28f3727472.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pe-b82d558c82edba059316d8296a356872d62c144d3a9d500456afffc7bbcfef26.json
+++ b/openfisca_france/tests/json/f7pe-b82d558c82edba059316d8296a356872d62c144d3a9d500456afffc7bbcfef26.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pf-0998b42d8cca02cf8bf66a2b0931d81c94bb5da0094cd7cfcf10e2eba315131b.json
+++ b/openfisca_france/tests/json/f7pf-0998b42d8cca02cf8bf66a2b0931d81c94bb5da0094cd7cfcf10e2eba315131b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pf-393a188dfe9d56c47f7f134fc5876cf3016f2e0a994fd889358c22a8b0e76456.json
+++ b/openfisca_france/tests/json/f7pf-393a188dfe9d56c47f7f134fc5876cf3016f2e0a994fd889358c22a8b0e76456.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pf-3a05e68ba75c2087aea762612e6f975ef76959e32e5e77651fb3ae07ed8e34de.json
+++ b/openfisca_france/tests/json/f7pf-3a05e68ba75c2087aea762612e6f975ef76959e32e5e77651fb3ae07ed8e34de.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pf-4eae1b31a92181ed18bc87ed7c9270f180e493027cc5d3a0fa5c7df8bb52fcb2.json
+++ b/openfisca_france/tests/json/f7pf-4eae1b31a92181ed18bc87ed7c9270f180e493027cc5d3a0fa5c7df8bb52fcb2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pf-5b63fa96f897a42a13dec0929937667b30e8db8f946e9906aad4a854e78b2bb0.json
+++ b/openfisca_france/tests/json/f7pf-5b63fa96f897a42a13dec0929937667b30e8db8f946e9906aad4a854e78b2bb0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pf-7bc6ffcfda0fecaef8b143d29c49204545387f9e9a7ff96cfe3fb6ec2f61bd8c.json
+++ b/openfisca_france/tests/json/f7pf-7bc6ffcfda0fecaef8b143d29c49204545387f9e9a7ff96cfe3fb6ec2f61bd8c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pf-e454c49d219e83826cd4c207522e9e4e09f7bafebb9080da7980590f86b1a486.json
+++ b/openfisca_france/tests/json/f7pf-e454c49d219e83826cd4c207522e9e4e09f7bafebb9080da7980590f86b1a486.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pf-e6ef6180c4977873731facae3f9ba31a994d2b83127e842b967b5a7c574ba991.json
+++ b/openfisca_france/tests/json/f7pf-e6ef6180c4977873731facae3f9ba31a994d2b83127e842b967b5a7c574ba991.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pf-efcffe95b01360d7e91cec702461ae6c422921c5fc76c60b92528ec6fdfac32f.json
+++ b/openfisca_france/tests/json/f7pf-efcffe95b01360d7e91cec702461ae6c422921c5fc76c60b92528ec6fdfac32f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pg-05ef3e20c3b1897ae32ad5ca8ad1d00bfb70dd9007c30ac5f24c6392561fe90a.json
+++ b/openfisca_france/tests/json/f7pg-05ef3e20c3b1897ae32ad5ca8ad1d00bfb70dd9007c30ac5f24c6392561fe90a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pg-1b8b2987a4d46b77863aa826e528d78ebe27ab4336b8d125c02c8562defbff20.json
+++ b/openfisca_france/tests/json/f7pg-1b8b2987a4d46b77863aa826e528d78ebe27ab4336b8d125c02c8562defbff20.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pg-2104bbc04c457a1cd76eead369933984572be851cfebf64ec4c0a7e49244831b.json
+++ b/openfisca_france/tests/json/f7pg-2104bbc04c457a1cd76eead369933984572be851cfebf64ec4c0a7e49244831b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pg-3b05c5ad1c0bab0ee359d1af653663e1411aeafbd967ba6784c7d40cfd034f95.json
+++ b/openfisca_france/tests/json/f7pg-3b05c5ad1c0bab0ee359d1af653663e1411aeafbd967ba6784c7d40cfd034f95.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pg-5daf0d8e0e51fe3ed341f120aa1b444bd07b8ddec074c052dbed24acd34a239d.json
+++ b/openfisca_france/tests/json/f7pg-5daf0d8e0e51fe3ed341f120aa1b444bd07b8ddec074c052dbed24acd34a239d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pg-6424109d358302b89ceb7368d6e25423d85886c5b17c519fffe6952a72f1acb0.json
+++ b/openfisca_france/tests/json/f7pg-6424109d358302b89ceb7368d6e25423d85886c5b17c519fffe6952a72f1acb0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pg-7247433076dc5504060ad9569203f29bc821b362de5d73a70bf81cd4c81fed50.json
+++ b/openfisca_france/tests/json/f7pg-7247433076dc5504060ad9569203f29bc821b362de5d73a70bf81cd4c81fed50.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pg-9a9c3c38ad5da5d9ab10978a11c082a36e6a2fb849c64473699211fc46365afe.json
+++ b/openfisca_france/tests/json/f7pg-9a9c3c38ad5da5d9ab10978a11c082a36e6a2fb849c64473699211fc46365afe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pg-ed24d2f71e98a0d39cc55c388119fac97b0e94b3336260baa3d5cf91b9dd2ff2.json
+++ b/openfisca_france/tests/json/f7pg-ed24d2f71e98a0d39cc55c388119fac97b0e94b3336260baa3d5cf91b9dd2ff2.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ph-57a22e829dd7f4c60f21633f37469547e447c5df0135b9682ca60f019df02d22.json
+++ b/openfisca_france/tests/json/f7ph-57a22e829dd7f4c60f21633f37469547e447c5df0135b9682ca60f019df02d22.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ph-6236fd760d13853f7c0cb94ab99a2d6639cde670dd26db8637247f59a69f7c69.json
+++ b/openfisca_france/tests/json/f7ph-6236fd760d13853f7c0cb94ab99a2d6639cde670dd26db8637247f59a69f7c69.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ph-7b9fdf1785f647c19d648b2ff25b8cd1d0dd749eab521e59d3cbf9c3dad2d618.json
+++ b/openfisca_france/tests/json/f7ph-7b9fdf1785f647c19d648b2ff25b8cd1d0dd749eab521e59d3cbf9c3dad2d618.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ph-80248a40128303085dc18413f5d6b8f5276d3633ea787cf08b60a1f531a6fad3.json
+++ b/openfisca_france/tests/json/f7ph-80248a40128303085dc18413f5d6b8f5276d3633ea787cf08b60a1f531a6fad3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ph-df7570f87a4b9f1196a45e1f286080e60d697f354deb43b0ba91cb472a8a439a.json
+++ b/openfisca_france/tests/json/f7ph-df7570f87a4b9f1196a45e1f286080e60d697f354deb43b0ba91cb472a8a439a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ph-e2ba36734ca5114c9f7c3a115481048ca0994a8c5c0ed311b9ecaa57c23314a0.json
+++ b/openfisca_france/tests/json/f7ph-e2ba36734ca5114c9f7c3a115481048ca0994a8c5c0ed311b9ecaa57c23314a0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pi-1835958bfda7a756604be899573d8c6630950fb0c130da3f159d935bcd54b396.json
+++ b/openfisca_france/tests/json/f7pi-1835958bfda7a756604be899573d8c6630950fb0c130da3f159d935bcd54b396.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pi-68fee40c05bffceec209b800f6132bc125094de8040004626edcd788fb41d1b9.json
+++ b/openfisca_france/tests/json/f7pi-68fee40c05bffceec209b800f6132bc125094de8040004626edcd788fb41d1b9.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pi-768cdcf03da2117aa78ad31cf963f011a18b6dd7440d45486c1ffd6bafbfbfe8.json
+++ b/openfisca_france/tests/json/f7pi-768cdcf03da2117aa78ad31cf963f011a18b6dd7440d45486c1ffd6bafbfbfe8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pi-7e838862a1bd284c1795f16f1bacd2724e635019da111409209a2ea08b2215d7.json
+++ b/openfisca_france/tests/json/f7pi-7e838862a1bd284c1795f16f1bacd2724e635019da111409209a2ea08b2215d7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pi-881d90d6f0a073769fd8f957434cd6af2a2dd4341310979b799eeef6c899d43d.json
+++ b/openfisca_france/tests/json/f7pi-881d90d6f0a073769fd8f957434cd6af2a2dd4341310979b799eeef6c899d43d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pi-9983c772398adb5013a6067e5939850161d129a656d59778726c69281c882126.json
+++ b/openfisca_france/tests/json/f7pi-9983c772398adb5013a6067e5939850161d129a656d59778726c69281c882126.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pi-c0dbc97a52a8d610a01b99a27fa763795d2c3f8d1a391d181490273ecb095619.json
+++ b/openfisca_france/tests/json/f7pi-c0dbc97a52a8d610a01b99a27fa763795d2c3f8d1a391d181490273ecb095619.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pi-c58b59ce1f3cb74e2acc0618f43d23a6530919b47801774213bd52fdc2cfd519.json
+++ b/openfisca_france/tests/json/f7pi-c58b59ce1f3cb74e2acc0618f43d23a6530919b47801774213bd52fdc2cfd519.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pi-fdb6a11658417ea499b22ac98973c8587721abce0222794240c012bda591f0db.json
+++ b/openfisca_france/tests/json/f7pi-fdb6a11658417ea499b22ac98973c8587721abce0222794240c012bda591f0db.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pj-00ee135b6085ccdbf12914bded013952a1b56bbfb8f1c09d8ba58ff8b62d496a.json
+++ b/openfisca_france/tests/json/f7pj-00ee135b6085ccdbf12914bded013952a1b56bbfb8f1c09d8ba58ff8b62d496a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pj-58b1fb58a4eb47eed80774c7ed9120a2d1146cdd4399e1344fe23860682f6172.json
+++ b/openfisca_france/tests/json/f7pj-58b1fb58a4eb47eed80774c7ed9120a2d1146cdd4399e1344fe23860682f6172.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pj-77236ce545bd6b3b4a90b0983bc5a35cf63d8bd040bdbdf799b59d86b106a3ad.json
+++ b/openfisca_france/tests/json/f7pj-77236ce545bd6b3b4a90b0983bc5a35cf63d8bd040bdbdf799b59d86b106a3ad.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pj-8ec33409c50dab98b2ec04609a34128cb4f47b23da44b92d0cc2aae43b1de91b.json
+++ b/openfisca_france/tests/json/f7pj-8ec33409c50dab98b2ec04609a34128cb4f47b23da44b92d0cc2aae43b1de91b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pj-b03929c78a00f1c1dafc27ab1f023c9eb29ed4a6b72ac8a3bf55b48de2390603.json
+++ b/openfisca_france/tests/json/f7pj-b03929c78a00f1c1dafc27ab1f023c9eb29ed4a6b72ac8a3bf55b48de2390603.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pj-be4d394726fe48e1324a5ba530a9ef99cb1639b8bafd301ede78f2e726f52f7c.json
+++ b/openfisca_france/tests/json/f7pj-be4d394726fe48e1324a5ba530a9ef99cb1639b8bafd301ede78f2e726f52f7c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pj-bea09364fdcfcb002246ea14f9e4f5e4a83b37eb6bf4b98b4d554dfa84b03a80.json
+++ b/openfisca_france/tests/json/f7pj-bea09364fdcfcb002246ea14f9e4f5e4a83b37eb6bf4b98b4d554dfa84b03a80.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pj-ce0dbfefae82f1281313e3dda3ebc8b9688f599597f3842753434753f5e2c949.json
+++ b/openfisca_france/tests/json/f7pj-ce0dbfefae82f1281313e3dda3ebc8b9688f599597f3842753434753f5e2c949.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pj-ed506a2fcfd3777b0788f2ec6c5893dd69b1af81068416fca691fe3b2634a223.json
+++ b/openfisca_france/tests/json/f7pj-ed506a2fcfd3777b0788f2ec6c5893dd69b1af81068416fca691fe3b2634a223.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pk-023777eab64cd29cd394d1af7be90a4bff085bd67fcc52af32dc6e18014c3442.json
+++ b/openfisca_france/tests/json/f7pk-023777eab64cd29cd394d1af7be90a4bff085bd67fcc52af32dc6e18014c3442.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pk-1416628950ee86c3f20c5450101d2d56c3aaf21f5db77a3f649b99395fa8875f.json
+++ b/openfisca_france/tests/json/f7pk-1416628950ee86c3f20c5450101d2d56c3aaf21f5db77a3f649b99395fa8875f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pk-2624875d714b2d2ac9e8ebdb8e2c06011275bc1ad9c22b53612e0a38489b8254.json
+++ b/openfisca_france/tests/json/f7pk-2624875d714b2d2ac9e8ebdb8e2c06011275bc1ad9c22b53612e0a38489b8254.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pk-3303bb1a1d2cc995a0d80e9ead1238fc8705e3145cae9536afc38a480e77f45a.json
+++ b/openfisca_france/tests/json/f7pk-3303bb1a1d2cc995a0d80e9ead1238fc8705e3145cae9536afc38a480e77f45a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pk-65dcc691430d345c80074d5c7e3be68ff623a88c56bfbe632d20314052cf8472.json
+++ b/openfisca_france/tests/json/f7pk-65dcc691430d345c80074d5c7e3be68ff623a88c56bfbe632d20314052cf8472.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pk-a8ce4e9ad83f795b8f3e6392830b25602f4fb8dd9cb7b5f004307d0b238c1ea0.json
+++ b/openfisca_france/tests/json/f7pk-a8ce4e9ad83f795b8f3e6392830b25602f4fb8dd9cb7b5f004307d0b238c1ea0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pk-ae4602f0efc541422dc1807ba84dbaa5611591f788aa31d618c9b6ca98151359.json
+++ b/openfisca_france/tests/json/f7pk-ae4602f0efc541422dc1807ba84dbaa5611591f788aa31d618c9b6ca98151359.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pk-ae8f20807c177198166cfa7372f6db5b677322d69bb82bd682cb9a967d68262b.json
+++ b/openfisca_france/tests/json/f7pk-ae8f20807c177198166cfa7372f6db5b677322d69bb82bd682cb9a967d68262b.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pk-dae46170efdf677300bd4a06580d469946cba4848e0e125ab786a1f48ac89f5f.json
+++ b/openfisca_france/tests/json/f7pk-dae46170efdf677300bd4a06580d469946cba4848e0e125ab786a1f48ac89f5f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pl-5c40b50421d965e569e158b82ff3dc854f18e65b78eea1f40e34a015ddf2bb31.json
+++ b/openfisca_france/tests/json/f7pl-5c40b50421d965e569e158b82ff3dc854f18e65b78eea1f40e34a015ddf2bb31.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pl-79e35437880f57a9c7dd8e1232afe56a611850696735a0cd53369ba7edc9098c.json
+++ b/openfisca_france/tests/json/f7pl-79e35437880f57a9c7dd8e1232afe56a611850696735a0cd53369ba7edc9098c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pl-9482a98887063ea74d499f2b4d58b1375fc437d297b3922fc677ca0aa5cbb486.json
+++ b/openfisca_france/tests/json/f7pl-9482a98887063ea74d499f2b4d58b1375fc437d297b3922fc677ca0aa5cbb486.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pl-c29f0efd30503942dca4860384c73466cbc41686493f92131cbd55ca9c23436f.json
+++ b/openfisca_france/tests/json/f7pl-c29f0efd30503942dca4860384c73466cbc41686493f92131cbd55ca9c23436f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pl-e5436b304e8b173239a1d9e48b0943aa4b55613e496e8688d71aa6f57a5b9bc3.json
+++ b/openfisca_france/tests/json/f7pl-e5436b304e8b173239a1d9e48b0943aa4b55613e496e8688d71aa6f57a5b9bc3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pl-e747cbb963e6050c40cbc5163dbfcc30c09c9267e4e3bd74e7faadcf126fee32.json
+++ b/openfisca_france/tests/json/f7pl-e747cbb963e6050c40cbc5163dbfcc30c09c9267e4e3bd74e7faadcf126fee32.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pm-0e60a3507832a63d6da07ea74636ed9d6cb7de9dc23525abf3d450a64300a873.json
+++ b/openfisca_france/tests/json/f7pm-0e60a3507832a63d6da07ea74636ed9d6cb7de9dc23525abf3d450a64300a873.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pm-23c0209843caedc3f5b99e4c5e6181acc55843e7adc27ea76833d427822dd727.json
+++ b/openfisca_france/tests/json/f7pm-23c0209843caedc3f5b99e4c5e6181acc55843e7adc27ea76833d427822dd727.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pm-28ef3efa22d25ee4d6318b17c70dd7034b8f09ab1866007f09f4b666a4860a6a.json
+++ b/openfisca_france/tests/json/f7pm-28ef3efa22d25ee4d6318b17c70dd7034b8f09ab1866007f09f4b666a4860a6a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pm-487db6975410415ad1595ebff85299ab047b2bf62c034996b9397330ef393a0a.json
+++ b/openfisca_france/tests/json/f7pm-487db6975410415ad1595ebff85299ab047b2bf62c034996b9397330ef393a0a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pm-50c0b07ceeba36c6afa148ebbfb263a7379fe670c6bbf2d50f3cfe33e0a0c648.json
+++ b/openfisca_france/tests/json/f7pm-50c0b07ceeba36c6afa148ebbfb263a7379fe670c6bbf2d50f3cfe33e0a0c648.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pm-637f062dbd9cca9c85beef244edfe2af8a9ef83d5acb8713a9ee3c723a23709b.json
+++ b/openfisca_france/tests/json/f7pm-637f062dbd9cca9c85beef244edfe2af8a9ef83d5acb8713a9ee3c723a23709b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pm-66f3e86dc0bb7a68e84f324680c8e643294bc70a35d6037bbdc9ee432bad2f32.json
+++ b/openfisca_france/tests/json/f7pm-66f3e86dc0bb7a68e84f324680c8e643294bc70a35d6037bbdc9ee432bad2f32.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pm-d1bb180c68a4528c4e6230b2c8dc463f77cf6c925463ada36fcf5ad2d2ce20f6.json
+++ b/openfisca_france/tests/json/f7pm-d1bb180c68a4528c4e6230b2c8dc463f77cf6c925463ada36fcf5ad2d2ce20f6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pm-d65ed0a9b948d37ded2bfac3b6ce182da308a06b29ddf7c2834259e2bb3b5033.json
+++ b/openfisca_france/tests/json/f7pm-d65ed0a9b948d37ded2bfac3b6ce182da308a06b29ddf7c2834259e2bb3b5033.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pn-2409571725bd61f4934ee52ec3c66d3ba439792ffa93cbfd14cbbf9fd1ac912b.json
+++ b/openfisca_france/tests/json/f7pn-2409571725bd61f4934ee52ec3c66d3ba439792ffa93cbfd14cbbf9fd1ac912b.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pn-463ccc469b815b81c4dec9e51a4a73a3388883832710bac71c0aebd307359b3b.json
+++ b/openfisca_france/tests/json/f7pn-463ccc469b815b81c4dec9e51a4a73a3388883832710bac71c0aebd307359b3b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pn-54e09bea20693ab719c5a352d0b06e2727a1a009b89eeedd479538d83c5eb00a.json
+++ b/openfisca_france/tests/json/f7pn-54e09bea20693ab719c5a352d0b06e2727a1a009b89eeedd479538d83c5eb00a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pn-8617c71de6404c5964cc619db5dc0a9ef1a105193120e125e0f78e6a2af1387d.json
+++ b/openfisca_france/tests/json/f7pn-8617c71de6404c5964cc619db5dc0a9ef1a105193120e125e0f78e6a2af1387d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pn-89e0a6e5073170b47c107407254b545876b48b0433b50dc2cc45291d3e504e17.json
+++ b/openfisca_france/tests/json/f7pn-89e0a6e5073170b47c107407254b545876b48b0433b50dc2cc45291d3e504e17.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pn-8cee072a92095b8b5703598db0dfa949c2b5dcbac7609bc98651b859756e738f.json
+++ b/openfisca_france/tests/json/f7pn-8cee072a92095b8b5703598db0dfa949c2b5dcbac7609bc98651b859756e738f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pn-a6612c35e748ded1f9cc3491d93698a74ab2d6ba7cebbee2fb1f28f5c57464d3.json
+++ b/openfisca_france/tests/json/f7pn-a6612c35e748ded1f9cc3491d93698a74ab2d6ba7cebbee2fb1f28f5c57464d3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pn-a74032fd002e6501a4deaaea05aaeb7e93ce5b7d8bb9044f752f048210546e56.json
+++ b/openfisca_france/tests/json/f7pn-a74032fd002e6501a4deaaea05aaeb7e93ce5b7d8bb9044f752f048210546e56.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pn-e41bc95a2425725fdfddca1b773330e5288701efd40d432c5aa7dcca8c8a64b5.json
+++ b/openfisca_france/tests/json/f7pn-e41bc95a2425725fdfddca1b773330e5288701efd40d432c5aa7dcca8c8a64b5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7po-27100ae2839d9e53af37f717dfa0c558bf7f6e24148c679fc4c49415a47966b9.json
+++ b/openfisca_france/tests/json/f7po-27100ae2839d9e53af37f717dfa0c558bf7f6e24148c679fc4c49415a47966b9.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7po-3aa188630cd2e5f0415c39484240c473fdff30f5a37e9b4a5bb4703d71a504c5.json
+++ b/openfisca_france/tests/json/f7po-3aa188630cd2e5f0415c39484240c473fdff30f5a37e9b4a5bb4703d71a504c5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7po-73f7f8f20a952651807c14fce008a8ea5616d51fc09c9a9d83a4e4e3f2ba2722.json
+++ b/openfisca_france/tests/json/f7po-73f7f8f20a952651807c14fce008a8ea5616d51fc09c9a9d83a4e4e3f2ba2722.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7po-75a314ba4f3a7fe64e46503daed36253a552415c7639f6bede5e8729280750b5.json
+++ b/openfisca_france/tests/json/f7po-75a314ba4f3a7fe64e46503daed36253a552415c7639f6bede5e8729280750b5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7po-7a77e8e9ec44a7cff1c4285f55a891871cfd241414e8877708686a1a482d4f2f.json
+++ b/openfisca_france/tests/json/f7po-7a77e8e9ec44a7cff1c4285f55a891871cfd241414e8877708686a1a482d4f2f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7po-97c991c935e0f95b129396a7f74ca456e68fe7e25b0c79dd9b1fc78c5b42ed94.json
+++ b/openfisca_france/tests/json/f7po-97c991c935e0f95b129396a7f74ca456e68fe7e25b0c79dd9b1fc78c5b42ed94.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7po-c07c44f0dc47bbc353ef2ba5fc699c9cf61ea37715e035ad07243faf49e60d08.json
+++ b/openfisca_france/tests/json/f7po-c07c44f0dc47bbc353ef2ba5fc699c9cf61ea37715e035ad07243faf49e60d08.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7po-c693364cecdbcc4573aad0d840fb48c21506a454978c36d4f24b208bbf6c751b.json
+++ b/openfisca_france/tests/json/f7po-c693364cecdbcc4573aad0d840fb48c21506a454978c36d4f24b208bbf6c751b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7po-d5d1b6eed875955b5bcbee8f15b76cd2d4653d84edca539bd451bc2ea47b13c7.json
+++ b/openfisca_france/tests/json/f7po-d5d1b6eed875955b5bcbee8f15b76cd2d4653d84edca539bd451bc2ea47b13c7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pp-0b713d403020532970d35293d827a69e568a37d88097c56aab1d4d03a81f207f.json
+++ b/openfisca_france/tests/json/f7pp-0b713d403020532970d35293d827a69e568a37d88097c56aab1d4d03a81f207f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pp-32844ba814eae361c0e412b33e050ebb736bd3118a30271045cdadadecfd9121.json
+++ b/openfisca_france/tests/json/f7pp-32844ba814eae361c0e412b33e050ebb736bd3118a30271045cdadadecfd9121.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pp-3ed3cced06b72299c5168106aabaa9f7858673d7bad4cbab03f5070b16ad74b6.json
+++ b/openfisca_france/tests/json/f7pp-3ed3cced06b72299c5168106aabaa9f7858673d7bad4cbab03f5070b16ad74b6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pp-49bd78c4b8178c2a9522ddfc66238db49fe43266cc18e01f493a5cf6c5163afe.json
+++ b/openfisca_france/tests/json/f7pp-49bd78c4b8178c2a9522ddfc66238db49fe43266cc18e01f493a5cf6c5163afe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pp-4f7d11d77462c58899ef696bf129c131ea7eeb4a96269ccd739223629a1ecb7f.json
+++ b/openfisca_france/tests/json/f7pp-4f7d11d77462c58899ef696bf129c131ea7eeb4a96269ccd739223629a1ecb7f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pp-51185117458a80097ebfee69a304decb0ae0997b69c5ba2c41f0477422e93ac8.json
+++ b/openfisca_france/tests/json/f7pp-51185117458a80097ebfee69a304decb0ae0997b69c5ba2c41f0477422e93ac8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pp-6083a6cd7738c12e65621d61a874b9ac5707b96ae03e365dbb2a963d11fab0e0.json
+++ b/openfisca_france/tests/json/f7pp-6083a6cd7738c12e65621d61a874b9ac5707b96ae03e365dbb2a963d11fab0e0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pp-67d7ac628ce0a8d893919d0bcc90ced5d3fe6cbf078c5baeedd5b6af95e7be3f.json
+++ b/openfisca_france/tests/json/f7pp-67d7ac628ce0a8d893919d0bcc90ced5d3fe6cbf078c5baeedd5b6af95e7be3f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pp-a26e79b8ac2f6e6a222ce4401687bf15a8fbda7891c1cfc34fd2a7d3787f0d82.json
+++ b/openfisca_france/tests/json/f7pp-a26e79b8ac2f6e6a222ce4401687bf15a8fbda7891c1cfc34fd2a7d3787f0d82.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pq-03b2cec17b19e133b39ddf85f8d12786b7eb1a877b3cb1b841c8a8414ae439c9.json
+++ b/openfisca_france/tests/json/f7pq-03b2cec17b19e133b39ddf85f8d12786b7eb1a877b3cb1b841c8a8414ae439c9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pq-226f3a752da5031ad5ffd61b4674efb043487cee43353f6489ead4b4280d2ce6.json
+++ b/openfisca_france/tests/json/f7pq-226f3a752da5031ad5ffd61b4674efb043487cee43353f6489ead4b4280d2ce6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pq-315e80d190eca0727385f8cca5b19089e5b2b4eaa05c94463f53353b7672bcae.json
+++ b/openfisca_france/tests/json/f7pq-315e80d190eca0727385f8cca5b19089e5b2b4eaa05c94463f53353b7672bcae.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pq-ab251812fc0a853def97263e787df8ca71a6e8d93111cae4a7b4e7a4e62940d0.json
+++ b/openfisca_france/tests/json/f7pq-ab251812fc0a853def97263e787df8ca71a6e8d93111cae4a7b4e7a4e62940d0.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pq-b91b18a5fca1803ae6d057a35115fa752935005fd61bab45ecb76134a311da17.json
+++ b/openfisca_france/tests/json/f7pq-b91b18a5fca1803ae6d057a35115fa752935005fd61bab45ecb76134a311da17.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pq-c49a5e894689dfb1a62459fb127bbc48239f16b4dcff194fa66c50f8bd9328bd.json
+++ b/openfisca_france/tests/json/f7pq-c49a5e894689dfb1a62459fb127bbc48239f16b4dcff194fa66c50f8bd9328bd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pq-cbe5420e6012a48e05615680ed5fee83eae9c4adc62c8a273d0ee3a53c3f1510.json
+++ b/openfisca_france/tests/json/f7pq-cbe5420e6012a48e05615680ed5fee83eae9c4adc62c8a273d0ee3a53c3f1510.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pq-da137261403893b438f0697f21ae438cd56ec28667acf6179140aa80cf3a9a04.json
+++ b/openfisca_france/tests/json/f7pq-da137261403893b438f0697f21ae438cd56ec28667acf6179140aa80cf3a9a04.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pq-fde767afd91eb20af75b1de3e61a347740ddb38378423b16fd01a8476104cfb3.json
+++ b/openfisca_france/tests/json/f7pq-fde767afd91eb20af75b1de3e61a347740ddb38378423b16fd01a8476104cfb3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pr-027f24a45df96b4c384115bff0971a443b846c1109595b691d291dc3dea892e4.json
+++ b/openfisca_france/tests/json/f7pr-027f24a45df96b4c384115bff0971a443b846c1109595b691d291dc3dea892e4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pr-13b10cce47fb3c076d8c699b1f18ccbf27f700627de460a25470f74bada477a0.json
+++ b/openfisca_france/tests/json/f7pr-13b10cce47fb3c076d8c699b1f18ccbf27f700627de460a25470f74bada477a0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pr-43dd513bcb0f0522be922dbfd9c466157632cc26ca6f45b40bd74f6232906318.json
+++ b/openfisca_france/tests/json/f7pr-43dd513bcb0f0522be922dbfd9c466157632cc26ca6f45b40bd74f6232906318.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pr-6e7421190e5e93edb58a7f11088692bd46f68d0485996d329923c0d297bbad3d.json
+++ b/openfisca_france/tests/json/f7pr-6e7421190e5e93edb58a7f11088692bd46f68d0485996d329923c0d297bbad3d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pr-9223df9ee4da9dcb073d62ae710a95c701d9abf1ca1809d51bddb02dce931ef7.json
+++ b/openfisca_france/tests/json/f7pr-9223df9ee4da9dcb073d62ae710a95c701d9abf1ca1809d51bddb02dce931ef7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pr-94cc6c3db7a11e3a28b52705a95764706b7c3ef17cdebfe3f5c33994b5193d8c.json
+++ b/openfisca_france/tests/json/f7pr-94cc6c3db7a11e3a28b52705a95764706b7c3ef17cdebfe3f5c33994b5193d8c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pr-e79d072b2afbb78fdc5b0dee273dd847bd5f98db9d433cbfa1572698911b2639.json
+++ b/openfisca_france/tests/json/f7pr-e79d072b2afbb78fdc5b0dee273dd847bd5f98db9d433cbfa1572698911b2639.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ps-05d528b99a7f281f48bf4e0684993780d6edee2149ab1ce4728eb908f0b82620.json
+++ b/openfisca_france/tests/json/f7ps-05d528b99a7f281f48bf4e0684993780d6edee2149ab1ce4728eb908f0b82620.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ps-2fa32cc1863a8e96f0d3c81088705b4f1f0ab90f48226a19fbeb6e6beb0742f7.json
+++ b/openfisca_france/tests/json/f7ps-2fa32cc1863a8e96f0d3c81088705b4f1f0ab90f48226a19fbeb6e6beb0742f7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ps-4d5804ede345c27be48793eee9528434c6f12b5dce82b90873b7170056036587.json
+++ b/openfisca_france/tests/json/f7ps-4d5804ede345c27be48793eee9528434c6f12b5dce82b90873b7170056036587.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ps-59c672991ab760cc1c9b8c41ecfeefe688566cdc49c766ab610c14c6d7f0b040.json
+++ b/openfisca_france/tests/json/f7ps-59c672991ab760cc1c9b8c41ecfeefe688566cdc49c766ab610c14c6d7f0b040.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ps-7ed320313796f2b9ffbeaabb5f0b39276e8289337820360becb9619c5f294714.json
+++ b/openfisca_france/tests/json/f7ps-7ed320313796f2b9ffbeaabb5f0b39276e8289337820360becb9619c5f294714.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ps-b5855f5b345bae41cc9e376949249d4818806b6249b47caf7b860b7701003928.json
+++ b/openfisca_france/tests/json/f7ps-b5855f5b345bae41cc9e376949249d4818806b6249b47caf7b860b7701003928.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ps-c62d58ef14bbbace6f5145ec78861279989a421f7e6aea1da8e249febd18d25d.json
+++ b/openfisca_france/tests/json/f7ps-c62d58ef14bbbace6f5145ec78861279989a421f7e6aea1da8e249febd18d25d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ps-c90afc890e76a8bed686de194492aa3c72c12df6e56fb55e851a49222b654311.json
+++ b/openfisca_france/tests/json/f7ps-c90afc890e76a8bed686de194492aa3c72c12df6e56fb55e851a49222b654311.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ps-dcb0d2a4cec4b04271351d8daf203a0d52ef67991456e83c59d15614e8d41044.json
+++ b/openfisca_france/tests/json/f7ps-dcb0d2a4cec4b04271351d8daf203a0d52ef67991456e83c59d15614e8d41044.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pt-0ec4d72b0dde56bfbcc722611dd7af11bae3eac0a80baf8e6463b1a25ac9cbfb.json
+++ b/openfisca_france/tests/json/f7pt-0ec4d72b0dde56bfbcc722611dd7af11bae3eac0a80baf8e6463b1a25ac9cbfb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pt-1e9b368a0e612ae0ae5a0a210a91cfeed33d5d91dba34459d35d0a300ebf116b.json
+++ b/openfisca_france/tests/json/f7pt-1e9b368a0e612ae0ae5a0a210a91cfeed33d5d91dba34459d35d0a300ebf116b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pt-291c4a25ab7b324816501ca7b9bb032dd614191c2e6400ebb3c429f657cd132a.json
+++ b/openfisca_france/tests/json/f7pt-291c4a25ab7b324816501ca7b9bb032dd614191c2e6400ebb3c429f657cd132a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pt-2be8441a58699f9be50a5112c7b67b908f00d70c15ffcd9b14e0b91704d6a3f3.json
+++ b/openfisca_france/tests/json/f7pt-2be8441a58699f9be50a5112c7b67b908f00d70c15ffcd9b14e0b91704d6a3f3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pt-60f21e325cb97f805c0158393d3e1ab5d265aee54ca2f9e8711799e7dd356bb2.json
+++ b/openfisca_france/tests/json/f7pt-60f21e325cb97f805c0158393d3e1ab5d265aee54ca2f9e8711799e7dd356bb2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pt-862e2e29e436730672347553fe8162af49eaca21083fb8e0914f0925c2c7274b.json
+++ b/openfisca_france/tests/json/f7pt-862e2e29e436730672347553fe8162af49eaca21083fb8e0914f0925c2c7274b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pt-cbc003b5208143b066bd1ba7aaebc57c803784bd4f108f82f240badc6be92806.json
+++ b/openfisca_france/tests/json/f7pt-cbc003b5208143b066bd1ba7aaebc57c803784bd4f108f82f240badc6be92806.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pt-ed4b1228d4385edd114ec0b5e01695e1a42f347a3ca9a2624e471b3f59b66724.json
+++ b/openfisca_france/tests/json/f7pt-ed4b1228d4385edd114ec0b5e01695e1a42f347a3ca9a2624e471b3f59b66724.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pt-fc05ce4d6d98016bb38377f67c29df0c3cfd9095e9a92ace5186e5a9606f401c.json
+++ b/openfisca_france/tests/json/f7pt-fc05ce4d6d98016bb38377f67c29df0c3cfd9095e9a92ace5186e5a9606f401c.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pu-0ced5ce53abb9fa1d1446995dc86bda781dee98272ca188f8bb9c933ae85e34a.json
+++ b/openfisca_france/tests/json/f7pu-0ced5ce53abb9fa1d1446995dc86bda781dee98272ca188f8bb9c933ae85e34a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pu-0cfe4e5de8935aa23c70c6ea5ba25a52cf646e516889238fdd227d5f75406c60.json
+++ b/openfisca_france/tests/json/f7pu-0cfe4e5de8935aa23c70c6ea5ba25a52cf646e516889238fdd227d5f75406c60.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pu-69683d69ca278f0ac97d3d6bead3c8a9bcb9c05d1c278f9b0977c4f57ff952d5.json
+++ b/openfisca_france/tests/json/f7pu-69683d69ca278f0ac97d3d6bead3c8a9bcb9c05d1c278f9b0977c4f57ff952d5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pu-8fb9fc39c01095f74c80e30d2d7d3c15e30b188926c1fe7e152eef358b488a73.json
+++ b/openfisca_france/tests/json/f7pu-8fb9fc39c01095f74c80e30d2d7d3c15e30b188926c1fe7e152eef358b488a73.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pu-a53d9381925901812e8597924e2829655e26382f76c96a32c64d4f091c4bfa5a.json
+++ b/openfisca_france/tests/json/f7pu-a53d9381925901812e8597924e2829655e26382f76c96a32c64d4f091c4bfa5a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pu-c218e64faeaeb2e6742355223ad1ab26a6346b36e76b10401ee9581d1cdffa66.json
+++ b/openfisca_france/tests/json/f7pu-c218e64faeaeb2e6742355223ad1ab26a6346b36e76b10401ee9581d1cdffa66.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pu-c553a3b9b63cafe247489601477757689b19e9392baa337106e2140fed08e310.json
+++ b/openfisca_france/tests/json/f7pu-c553a3b9b63cafe247489601477757689b19e9392baa337106e2140fed08e310.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pu-eafbc621a85e078c636148820aa0b195db247e417b9c974aef27abfa518a1845.json
+++ b/openfisca_france/tests/json/f7pu-eafbc621a85e078c636148820aa0b195db247e417b9c974aef27abfa518a1845.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pu-fd4cf2da7c12eaa0d742f59bff3a35538e28435dde59d7d183b645ac8813e3f4.json
+++ b/openfisca_france/tests/json/f7pu-fd4cf2da7c12eaa0d742f59bff3a35538e28435dde59d7d183b645ac8813e3f4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pv-0b06d31748c5df42bf355a48b6c0051e3741b73f6a0dfdb3736276d2d85a540a.json
+++ b/openfisca_france/tests/json/f7pv-0b06d31748c5df42bf355a48b6c0051e3741b73f6a0dfdb3736276d2d85a540a.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pv-202bac5558da205ef72f76bd5de937f68d0285a08bc888bebda4177d0baee2be.json
+++ b/openfisca_france/tests/json/f7pv-202bac5558da205ef72f76bd5de937f68d0285a08bc888bebda4177d0baee2be.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pv-525ba00200f4dd679280b870470b0c489288c422d3ed05dfbff48f04309ac5cb.json
+++ b/openfisca_france/tests/json/f7pv-525ba00200f4dd679280b870470b0c489288c422d3ed05dfbff48f04309ac5cb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pv-960795399dfe7f6e573535301803d7a4edaca6f2761947d4d51e4d66f174f375.json
+++ b/openfisca_france/tests/json/f7pv-960795399dfe7f6e573535301803d7a4edaca6f2761947d4d51e4d66f174f375.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pv-9b9977bef4e07af5db4976b6b4ccb5817923da7698b4c20b67cb82e9e06b91f6.json
+++ b/openfisca_france/tests/json/f7pv-9b9977bef4e07af5db4976b6b4ccb5817923da7698b4c20b67cb82e9e06b91f6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pv-bd1c1955c65151cffcc79c753456154bfeae94f5bcceb51da7bc6d0b910c0150.json
+++ b/openfisca_france/tests/json/f7pv-bd1c1955c65151cffcc79c753456154bfeae94f5bcceb51da7bc6d0b910c0150.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pv-c6cef6d584a064ec9f2ba61ab1e8dc198eee18efda31211e0eb4ce84db35a28e.json
+++ b/openfisca_france/tests/json/f7pv-c6cef6d584a064ec9f2ba61ab1e8dc198eee18efda31211e0eb4ce84db35a28e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pv-c96fd615d902c6a1faf36b7682ff5904bb3f1cd06dd709837bde8e62643ba2d2.json
+++ b/openfisca_france/tests/json/f7pv-c96fd615d902c6a1faf36b7682ff5904bb3f1cd06dd709837bde8e62643ba2d2.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pv-ecdb27813b85796de90a149669bd3ea90fd13ebc2168bd328b3c88e5e9c8d9fd.json
+++ b/openfisca_france/tests/json/f7pv-ecdb27813b85796de90a149669bd3ea90fd13ebc2168bd328b3c88e5e9c8d9fd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pw-12c7bf3db34d893ffaf063e027fbfd890fc9559067909c3c95489f6b4cc4289a.json
+++ b/openfisca_france/tests/json/f7pw-12c7bf3db34d893ffaf063e027fbfd890fc9559067909c3c95489f6b4cc4289a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pw-14ea2f6a46f17851f8b092a7a1bec21560cff90c10ee01ff455d0b1e77e065ec.json
+++ b/openfisca_france/tests/json/f7pw-14ea2f6a46f17851f8b092a7a1bec21560cff90c10ee01ff455d0b1e77e065ec.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pw-46f50aa8ccb678085b6579306c85588ac3a215730077283bd1d90e0d5a82bb31.json
+++ b/openfisca_france/tests/json/f7pw-46f50aa8ccb678085b6579306c85588ac3a215730077283bd1d90e0d5a82bb31.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pw-4959b8e74c98260d54dcf8dfc9613c08c3af036631341f95b52b901e0dd50f30.json
+++ b/openfisca_france/tests/json/f7pw-4959b8e74c98260d54dcf8dfc9613c08c3af036631341f95b52b901e0dd50f30.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pw-4dfa561373786bba27558fee28dc3c2a0323ad7b4b3505e337fcd521778f80df.json
+++ b/openfisca_france/tests/json/f7pw-4dfa561373786bba27558fee28dc3c2a0323ad7b4b3505e337fcd521778f80df.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pw-86f6fd9f616ebb44f61696fa7c51bb9a57bf816db25afbd7d254256790a32da8.json
+++ b/openfisca_france/tests/json/f7pw-86f6fd9f616ebb44f61696fa7c51bb9a57bf816db25afbd7d254256790a32da8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pw-bebce670596e3db184e1629a18b87917ad36cd3f42245567c9703113a84554ad.json
+++ b/openfisca_france/tests/json/f7pw-bebce670596e3db184e1629a18b87917ad36cd3f42245567c9703113a84554ad.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7px-2772f3e33b720296e282ecf96faddad79a50b3fc177dd7fd7f6b626032382506.json
+++ b/openfisca_france/tests/json/f7px-2772f3e33b720296e282ecf96faddad79a50b3fc177dd7fd7f6b626032382506.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7px-61ab59ec02a53863c6d408caac8ff0930b270793a060b5123e0efdbcfebbabbb.json
+++ b/openfisca_france/tests/json/f7px-61ab59ec02a53863c6d408caac8ff0930b270793a060b5123e0efdbcfebbabbb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7px-77a772a66c9b03474bd9747c6754de2222c2f5b3bb18cb9b9aa352fcb4997555.json
+++ b/openfisca_france/tests/json/f7px-77a772a66c9b03474bd9747c6754de2222c2f5b3bb18cb9b9aa352fcb4997555.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7px-968a768054ee0beb43c830e6f948eba3fd0645227e16fc3363e5862f9defa15d.json
+++ b/openfisca_france/tests/json/f7px-968a768054ee0beb43c830e6f948eba3fd0645227e16fc3363e5862f9defa15d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7px-9bedc564fc7e46149a0bbea6689561850108cfeeb3786c019582929b4ed89041.json
+++ b/openfisca_france/tests/json/f7px-9bedc564fc7e46149a0bbea6689561850108cfeeb3786c019582929b4ed89041.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7px-9c81d9f8ba4b438c9bdfda3d6071db737283891e04952e74a4e5225f5f069cc9.json
+++ b/openfisca_france/tests/json/f7px-9c81d9f8ba4b438c9bdfda3d6071db737283891e04952e74a4e5225f5f069cc9.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7px-c15dee13ba2d4bd613a2984ebb79cbf11c062c758b74ee5e54ba472709b86ca0.json
+++ b/openfisca_france/tests/json/f7px-c15dee13ba2d4bd613a2984ebb79cbf11c062c758b74ee5e54ba472709b86ca0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7px-e4b50c0a508369dd545b6afdd0c76fd23a654fb77e2f4357a91d5aa687175656.json
+++ b/openfisca_france/tests/json/f7px-e4b50c0a508369dd545b6afdd0c76fd23a654fb77e2f4357a91d5aa687175656.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7px-e73430e5359a7d8fab38bbc504fb5d62c8d03b54a9518dcacaa18e20fd5cea30.json
+++ b/openfisca_france/tests/json/f7px-e73430e5359a7d8fab38bbc504fb5d62c8d03b54a9518dcacaa18e20fd5cea30.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7py-115794656d0f8ccedb5fd7b123b257ed7a7241483843a83257c30fc7fe4d8c41.json
+++ b/openfisca_france/tests/json/f7py-115794656d0f8ccedb5fd7b123b257ed7a7241483843a83257c30fc7fe4d8c41.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7py-3f70ad779326bcd7fa60d45a68295e271d5de916ebe77dc550e1a2b527991c44.json
+++ b/openfisca_france/tests/json/f7py-3f70ad779326bcd7fa60d45a68295e271d5de916ebe77dc550e1a2b527991c44.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7py-57a4dab81c2c130686965477ac6a7b925f5b58bb49c0c240ab1ed48537245c64.json
+++ b/openfisca_france/tests/json/f7py-57a4dab81c2c130686965477ac6a7b925f5b58bb49c0c240ab1ed48537245c64.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7py-5f5465df8fa85122619b3087c1ae4c8ab19d8f8f2231785c0e82603cf54a9db4.json
+++ b/openfisca_france/tests/json/f7py-5f5465df8fa85122619b3087c1ae4c8ab19d8f8f2231785c0e82603cf54a9db4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7py-771afa815109cbbebe4899b8e04506741950f9a353276fe38eaca9a0bdb44d77.json
+++ b/openfisca_france/tests/json/f7py-771afa815109cbbebe4899b8e04506741950f9a353276fe38eaca9a0bdb44d77.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7py-8877d6e0ea14b43a1c0c7eec4b00c451b6dc995c0ed05f513ca342b8211ceca1.json
+++ b/openfisca_france/tests/json/f7py-8877d6e0ea14b43a1c0c7eec4b00c451b6dc995c0ed05f513ca342b8211ceca1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7py-9bee3f629a08f46d1c4ec3089fece73b16cda0ecef740457558af93de2d64083.json
+++ b/openfisca_france/tests/json/f7py-9bee3f629a08f46d1c4ec3089fece73b16cda0ecef740457558af93de2d64083.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7py-aa7181440958e775f87d560559b19d9b0ab2449f7428358bcc82b6b35e51f9fc.json
+++ b/openfisca_france/tests/json/f7py-aa7181440958e775f87d560559b19d9b0ab2449f7428358bcc82b6b35e51f9fc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7py-ce6e17f749afad9e84d6fe090886fd1e02d9401836d3004b1b7ee67514a84244.json
+++ b/openfisca_france/tests/json/f7py-ce6e17f749afad9e84d6fe090886fd1e02d9401836d3004b1b7ee67514a84244.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pz-0f83e5a4f83b28f5d846f7647003025dabd20705fc67667752edc65a6fa177b5.json
+++ b/openfisca_france/tests/json/f7pz-0f83e5a4f83b28f5d846f7647003025dabd20705fc67667752edc65a6fa177b5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pz-13e812a30c26866e96238cf6e008a6d37b596364d4e64dc32b182faee42f7edf.json
+++ b/openfisca_france/tests/json/f7pz-13e812a30c26866e96238cf6e008a6d37b596364d4e64dc32b182faee42f7edf.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pz-1dbb3915cb45c2c871e420df03b4195c3c3eb540889d3fac78426f5f894b7a0f.json
+++ b/openfisca_france/tests/json/f7pz-1dbb3915cb45c2c871e420df03b4195c3c3eb540889d3fac78426f5f894b7a0f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pz-24c30bb1774c87e6a7964873adc3cf16541795e8a2fc1c6a769ef5aa29e6e5cb.json
+++ b/openfisca_france/tests/json/f7pz-24c30bb1774c87e6a7964873adc3cf16541795e8a2fc1c6a769ef5aa29e6e5cb.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pz-60372aad96ea3e506a998ce3b4c6da5ec37af077787794cb68b2bfd884a73534.json
+++ b/openfisca_france/tests/json/f7pz-60372aad96ea3e506a998ce3b4c6da5ec37af077787794cb68b2bfd884a73534.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pz-68bc007d9fed79243dc8f599d2379f1ff2afdbfffebc7fc392ffc5ad3f6452cd.json
+++ b/openfisca_france/tests/json/f7pz-68bc007d9fed79243dc8f599d2379f1ff2afdbfffebc7fc392ffc5ad3f6452cd.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pz-7bc5fd780011b2573c72d4c309d9e1bdf8cdb35110e96df40e451fcc5a3c6c54.json
+++ b/openfisca_france/tests/json/f7pz-7bc5fd780011b2573c72d4c309d9e1bdf8cdb35110e96df40e451fcc5a3c6c54.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pz-9866b01917244d7b99fd9f80d8951bfe8b194bf144003839b4ca5548ba27072b.json
+++ b/openfisca_france/tests/json/f7pz-9866b01917244d7b99fd9f80d8951bfe8b194bf144003839b4ca5548ba27072b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7pz-d8d31f722a305c94bd375b7f6073e0b9298b5839ca1ee1ed7a79dc58c58ae80a.json
+++ b/openfisca_france/tests/json/f7pz-d8d31f722a305c94bd375b7f6073e0b9298b5839ca1ee1ed7a79dc58c58ae80a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qb-154fc916543f1063a854d867f4e2d244bee42afe36abc4e1243728ae034f43f7.json
+++ b/openfisca_france/tests/json/f7qb-154fc916543f1063a854d867f4e2d244bee42afe36abc4e1243728ae034f43f7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qb-36ce7bab2d7f55a1c8435018c0c8fcc2383e303c91fd65e30b6a9c196a7618e0.json
+++ b/openfisca_france/tests/json/f7qb-36ce7bab2d7f55a1c8435018c0c8fcc2383e303c91fd65e30b6a9c196a7618e0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qb-39fd8fae3d9335819968e13dbdc93821b513648c56aac920cc0e61375ed25e02.json
+++ b/openfisca_france/tests/json/f7qb-39fd8fae3d9335819968e13dbdc93821b513648c56aac920cc0e61375ed25e02.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qb-66a8820223bffd03383690693e768f116f3302b43762dc238643970dd923f68e.json
+++ b/openfisca_france/tests/json/f7qb-66a8820223bffd03383690693e768f116f3302b43762dc238643970dd923f68e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qb-80c4b5ea39c41c8bdb6140bdb4d2ccbff70f8c8b46c171b8552ed9a33bffa7c1.json
+++ b/openfisca_france/tests/json/f7qb-80c4b5ea39c41c8bdb6140bdb4d2ccbff70f8c8b46c171b8552ed9a33bffa7c1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qb-dd3f50fcabbfee72fdcb5bb7ed79dd3b74c30817807e5be03ac4362766742edc.json
+++ b/openfisca_france/tests/json/f7qb-dd3f50fcabbfee72fdcb5bb7ed79dd3b74c30817807e5be03ac4362766742edc.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qb-df9a8ffe5f4aa7c2245c70916b3781bf602b29f0172dfba49637315bb09cebca.json
+++ b/openfisca_france/tests/json/f7qb-df9a8ffe5f4aa7c2245c70916b3781bf602b29f0172dfba49637315bb09cebca.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qb-ea8dcf308fa644d480ef724b2ad8f71d8aae6c0f9491faf8e24851113db9a2af.json
+++ b/openfisca_france/tests/json/f7qb-ea8dcf308fa644d480ef724b2ad8f71d8aae6c0f9491faf8e24851113db9a2af.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qc-016a28f71f85e09956b78f77f9795359938d99e46a3258a864e15bb1fc1aa00c.json
+++ b/openfisca_france/tests/json/f7qc-016a28f71f85e09956b78f77f9795359938d99e46a3258a864e15bb1fc1aa00c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qc-31a0acc8cbad4a343e45f3c545d43cf0921a67f9a003f8bdf8e4f02d72ad4d4e.json
+++ b/openfisca_france/tests/json/f7qc-31a0acc8cbad4a343e45f3c545d43cf0921a67f9a003f8bdf8e4f02d72ad4d4e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qc-45d90c28ff8aa054483d0a2c18772a45f9467f5c48e95213b235b62ddb3b3b7a.json
+++ b/openfisca_france/tests/json/f7qc-45d90c28ff8aa054483d0a2c18772a45f9467f5c48e95213b235b62ddb3b3b7a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qc-581af307225032524e098726d083f9027383729cb0158aaedbb411dc312f0d23.json
+++ b/openfisca_france/tests/json/f7qc-581af307225032524e098726d083f9027383729cb0158aaedbb411dc312f0d23.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qc-5fe000f41258d365d91dd9bb7da727a33f682ef8b44865ea4656b7aef390da76.json
+++ b/openfisca_france/tests/json/f7qc-5fe000f41258d365d91dd9bb7da727a33f682ef8b44865ea4656b7aef390da76.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qc-719a9deb658dd22b37fb01635c3a4c429d0811e98dda0f2450efa49b3c0de77d.json
+++ b/openfisca_france/tests/json/f7qc-719a9deb658dd22b37fb01635c3a4c429d0811e98dda0f2450efa49b3c0de77d.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qc-b3718de9f0878c2e8a3e94a458f035d2f8c4d3486f08a7924c31d850de94187c.json
+++ b/openfisca_france/tests/json/f7qc-b3718de9f0878c2e8a3e94a458f035d2f8c4d3486f08a7924c31d850de94187c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qc-c83a1972b964a3ec8753342b9fdd15bb5d15f92936cb0c2e97873cf6c9d02798.json
+++ b/openfisca_france/tests/json/f7qc-c83a1972b964a3ec8753342b9fdd15bb5d15f92936cb0c2e97873cf6c9d02798.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qd-087fd26b4752fae0ef397f74cb0916dc0e693472f59267117970e103bbeed5ac.json
+++ b/openfisca_france/tests/json/f7qd-087fd26b4752fae0ef397f74cb0916dc0e693472f59267117970e103bbeed5ac.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qd-223e321779fbe3c07a6dfd190133bfc08b55face92ebe3d1590d8226dc65485c.json
+++ b/openfisca_france/tests/json/f7qd-223e321779fbe3c07a6dfd190133bfc08b55face92ebe3d1590d8226dc65485c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qd-23fee29a5a3b46ee14e5e5161249b64e900fbd1f25af7f3e6d73070adf27e73e.json
+++ b/openfisca_france/tests/json/f7qd-23fee29a5a3b46ee14e5e5161249b64e900fbd1f25af7f3e6d73070adf27e73e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qd-4277de99e81cc84360c5604e95e4c1f4bacec01c03fc49e08c0ff9dda5215402.json
+++ b/openfisca_france/tests/json/f7qd-4277de99e81cc84360c5604e95e4c1f4bacec01c03fc49e08c0ff9dda5215402.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qd-777dfa4b23052aaafa99500ede1b42858e5ed89a7bcf4432c3313fa3ec41899c.json
+++ b/openfisca_france/tests/json/f7qd-777dfa4b23052aaafa99500ede1b42858e5ed89a7bcf4432c3313fa3ec41899c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qd-b5a65d18f5f3d3e02964d16af14a1a4bbab2db0f4427c3d2ae0fc409a37d33d6.json
+++ b/openfisca_france/tests/json/f7qd-b5a65d18f5f3d3e02964d16af14a1a4bbab2db0f4427c3d2ae0fc409a37d33d6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qd-c571ce5f37fa8577f5f2dc1d37edfc1885add315618c3106ca8b9ea56a3b7588.json
+++ b/openfisca_france/tests/json/f7qd-c571ce5f37fa8577f5f2dc1d37edfc1885add315618c3106ca8b9ea56a3b7588.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qd-f7b81343b71cd1a11ddaf005d48125ac54515ea3016dc2b2a65bb94ce74d71db.json
+++ b/openfisca_france/tests/json/f7qd-f7b81343b71cd1a11ddaf005d48125ac54515ea3016dc2b2a65bb94ce74d71db.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qe-2701f36910f4b26c8e2d3e613ebf6e2fc452ff2754a04d4ea1fecbed878fad16.json
+++ b/openfisca_france/tests/json/f7qe-2701f36910f4b26c8e2d3e613ebf6e2fc452ff2754a04d4ea1fecbed878fad16.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qe-4faeaf4ba920bd72b311b6c00bf6f7d8dd502c480aca00fcb5426cb0812141a5.json
+++ b/openfisca_france/tests/json/f7qe-4faeaf4ba920bd72b311b6c00bf6f7d8dd502c480aca00fcb5426cb0812141a5.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qe-68e29497c4fae67b761c13c0feb2ede91d22403bb2b8ff2fcad4608b0f73a4f2.json
+++ b/openfisca_france/tests/json/f7qe-68e29497c4fae67b761c13c0feb2ede91d22403bb2b8ff2fcad4608b0f73a4f2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qe-77ab0370f96c657fce4371352a0b9eb1229b50d93a6e415c160c92823171981d.json
+++ b/openfisca_france/tests/json/f7qe-77ab0370f96c657fce4371352a0b9eb1229b50d93a6e415c160c92823171981d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qe-8bb58f351b7ee74d5af8c07dc290da6b3c78e7c3b93be227d0249e718a836208.json
+++ b/openfisca_france/tests/json/f7qe-8bb58f351b7ee74d5af8c07dc290da6b3c78e7c3b93be227d0249e718a836208.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qe-8decf9db7175b0bf6ce03ef84b0fce70aa5dfe132204ef46bed6be75b49cd786.json
+++ b/openfisca_france/tests/json/f7qe-8decf9db7175b0bf6ce03ef84b0fce70aa5dfe132204ef46bed6be75b49cd786.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qe-a41118eeb806d42ade647f7c44664690c24ca85c6ab8cfd8b26815c4450a5306.json
+++ b/openfisca_france/tests/json/f7qe-a41118eeb806d42ade647f7c44664690c24ca85c6ab8cfd8b26815c4450a5306.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qe-c7e6d0657b9058869a24c98f1f46305316de0cfa239720751bd11e5954315025.json
+++ b/openfisca_france/tests/json/f7qe-c7e6d0657b9058869a24c98f1f46305316de0cfa239720751bd11e5954315025.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qe-e5acd9da0f4a332055bd198eccbb9115a879f472b8d714ddc50467c84bb4650b.json
+++ b/openfisca_france/tests/json/f7qe-e5acd9da0f4a332055bd198eccbb9115a879f472b8d714ddc50467c84bb4650b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qf-20bce3c7a1f0d9ccb0a2bbe30457064972158590cac3e2ce498be3ada2285816.json
+++ b/openfisca_france/tests/json/f7qf-20bce3c7a1f0d9ccb0a2bbe30457064972158590cac3e2ce498be3ada2285816.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qf-232414a2a3ab7a08f8a460905ccb7d028a7149b0d6fd7029a4bc1bd401763c1f.json
+++ b/openfisca_france/tests/json/f7qf-232414a2a3ab7a08f8a460905ccb7d028a7149b0d6fd7029a4bc1bd401763c1f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qf-2698b6490ae056705e8efedc83cb57ccee5aaf855059afa7d8e728bfec5709b1.json
+++ b/openfisca_france/tests/json/f7qf-2698b6490ae056705e8efedc83cb57ccee5aaf855059afa7d8e728bfec5709b1.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qf-3027de6e72818b7983301332c24fcdc54cf9130c8711134ba4708f67add8e038.json
+++ b/openfisca_france/tests/json/f7qf-3027de6e72818b7983301332c24fcdc54cf9130c8711134ba4708f67add8e038.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qf-38f616138a87b581a7c52cddd45c00227324d69025cedf42d9dba70e292be8de.json
+++ b/openfisca_france/tests/json/f7qf-38f616138a87b581a7c52cddd45c00227324d69025cedf42d9dba70e292be8de.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qf-6a2cd4903788bf07d32228e953556a76a3067b788560ea5dc761de210ab2d42c.json
+++ b/openfisca_france/tests/json/f7qf-6a2cd4903788bf07d32228e953556a76a3067b788560ea5dc761de210ab2d42c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qf-6e7c158307a859db2046b9c764614451948fe3048b5e1caacd5f39d2cb982fc5.json
+++ b/openfisca_france/tests/json/f7qf-6e7c158307a859db2046b9c764614451948fe3048b5e1caacd5f39d2cb982fc5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qf-a6606c1bcc5cffbf78cf8e0cf1386067ee3d8bf50bf8e6857ea21dbb326e78a5.json
+++ b/openfisca_france/tests/json/f7qf-a6606c1bcc5cffbf78cf8e0cf1386067ee3d8bf50bf8e6857ea21dbb326e78a5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qf-b3ab40297dd6bdd1127d7578f8e82e1f2d081e456bb3510910572c4a666733e0.json
+++ b/openfisca_france/tests/json/f7qf-b3ab40297dd6bdd1127d7578f8e82e1f2d081e456bb3510910572c4a666733e0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qg-094d75d2581730c33ebb6490551745330167515bc26c48eadd4d3a642e15b26e.json
+++ b/openfisca_france/tests/json/f7qg-094d75d2581730c33ebb6490551745330167515bc26c48eadd4d3a642e15b26e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qg-14a0b5a7e4949bc32146fad1d5323d4bbd8f36808029178439f9e4cd7a190b99.json
+++ b/openfisca_france/tests/json/f7qg-14a0b5a7e4949bc32146fad1d5323d4bbd8f36808029178439f9e4cd7a190b99.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qg-233dc1c340773a39002c31489aad00160d999b6793cee979b6d800b3095033b8.json
+++ b/openfisca_france/tests/json/f7qg-233dc1c340773a39002c31489aad00160d999b6793cee979b6d800b3095033b8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qg-4343adf519ef318c7815a8e043d6d78f3e3246bfc36f4e5804a91707bcc09e85.json
+++ b/openfisca_france/tests/json/f7qg-4343adf519ef318c7815a8e043d6d78f3e3246bfc36f4e5804a91707bcc09e85.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qg-6129fd0cf790c167f0e9ce4c80e93c684df039071c22c0643661297eda0cf0f5.json
+++ b/openfisca_france/tests/json/f7qg-6129fd0cf790c167f0e9ce4c80e93c684df039071c22c0643661297eda0cf0f5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qg-6214b37214c9ef82939a2dbcd658ed320495c9352b87db2650ff47b616064f6c.json
+++ b/openfisca_france/tests/json/f7qg-6214b37214c9ef82939a2dbcd658ed320495c9352b87db2650ff47b616064f6c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qg-7f4451b41651163db06127ad2fb66a9bc3c0ae53dbb6117a616490f709670c05.json
+++ b/openfisca_france/tests/json/f7qg-7f4451b41651163db06127ad2fb66a9bc3c0ae53dbb6117a616490f709670c05.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qg-9a3bd0d0b09f225cc351f3ba485c20dc66744eda254b52b5e03ffb9bf8f9d4ce.json
+++ b/openfisca_france/tests/json/f7qg-9a3bd0d0b09f225cc351f3ba485c20dc66744eda254b52b5e03ffb9bf8f9d4ce.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qg-be43c3fe48efe0d353b020f071b0a96346297e49566d08ca096fb9b78e86d9eb.json
+++ b/openfisca_france/tests/json/f7qg-be43c3fe48efe0d353b020f071b0a96346297e49566d08ca096fb9b78e86d9eb.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qi-313005dc2b0a0353909766bc7b92dee89fec8e7deaa961ad32b15c60a2e736aa.json
+++ b/openfisca_france/tests/json/f7qi-313005dc2b0a0353909766bc7b92dee89fec8e7deaa961ad32b15c60a2e736aa.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qi-3af6239988bd267d934833a00e5873aeb78220f35a4395a2a4ed30aaf2a0cde8.json
+++ b/openfisca_france/tests/json/f7qi-3af6239988bd267d934833a00e5873aeb78220f35a4395a2a4ed30aaf2a0cde8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qi-7cf6cab8bdcf8e6fe90c13107468f09c025cedd3fcae2e40d476525639d72ac4.json
+++ b/openfisca_france/tests/json/f7qi-7cf6cab8bdcf8e6fe90c13107468f09c025cedd3fcae2e40d476525639d72ac4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qi-e63aa168e376c6e7600f4e0394816ef5a109ab21f2f75b5a6cac5033a72e84a8.json
+++ b/openfisca_france/tests/json/f7qi-e63aa168e376c6e7600f4e0394816ef5a109ab21f2f75b5a6cac5033a72e84a8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qi-ee123da66ec83e54227f51b27ad496de93735b1fbd6f2a1309e5dc27f08f4d7c.json
+++ b/openfisca_france/tests/json/f7qi-ee123da66ec83e54227f51b27ad496de93735b1fbd6f2a1309e5dc27f08f4d7c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ql-3b5a7b52d855e37e3c6eecc52f0da7ff83b527d002ecbb0ca08a4ce6b42f933c.json
+++ b/openfisca_france/tests/json/f7ql-3b5a7b52d855e37e3c6eecc52f0da7ff83b527d002ecbb0ca08a4ce6b42f933c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ql-44eb9a903d04f98b6f2b790c8c9cdd36dbc152f2bffbd466b5a19597634e52be.json
+++ b/openfisca_france/tests/json/f7ql-44eb9a903d04f98b6f2b790c8c9cdd36dbc152f2bffbd466b5a19597634e52be.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ql-7bb73bb919b6991f9a3a05b281612752a844118a633194e24f6bd2f7c42580e2.json
+++ b/openfisca_france/tests/json/f7ql-7bb73bb919b6991f9a3a05b281612752a844118a633194e24f6bd2f7c42580e2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ql-9d16adfc6a5bd9a9b63f7632e81839ee91ab1a2958087ff2230cdd5883532a00.json
+++ b/openfisca_france/tests/json/f7ql-9d16adfc6a5bd9a9b63f7632e81839ee91ab1a2958087ff2230cdd5883532a00.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ql-a570f93dc1f8558d631cbdbb3bf6f682eae90592a83e3e1066d16529c7e5df85.json
+++ b/openfisca_france/tests/json/f7ql-a570f93dc1f8558d631cbdbb3bf6f682eae90592a83e3e1066d16529c7e5df85.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ql-d7b25ad452c6418fb1c72cee909f77174e8265dedb731e9a93b588762ac6acc8.json
+++ b/openfisca_france/tests/json/f7ql-d7b25ad452c6418fb1c72cee909f77174e8265dedb731e9a93b588762ac6acc8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ql-ed5c02b1211c6e51a5818ad7e7fdcc845303a815c74c850bae56ad139a633615.json
+++ b/openfisca_france/tests/json/f7ql-ed5c02b1211c6e51a5818ad7e7fdcc845303a815c74c850bae56ad139a633615.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ql-fc01fc9fb065401e46af5d198a77f9046de9253caad137083d64d1ddce59a443.json
+++ b/openfisca_france/tests/json/f7ql-fc01fc9fb065401e46af5d198a77f9046de9253caad137083d64d1ddce59a443.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qm-13231e4ab715a45c86530c8404ac55d9b45fcd44b25d68910b1bbc5f8db4efde.json
+++ b/openfisca_france/tests/json/f7qm-13231e4ab715a45c86530c8404ac55d9b45fcd44b25d68910b1bbc5f8db4efde.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qm-1bb1a12e8f659ff8c9362af66771da31b1913cc20b1b88a35611eea43db5f0e0.json
+++ b/openfisca_france/tests/json/f7qm-1bb1a12e8f659ff8c9362af66771da31b1913cc20b1b88a35611eea43db5f0e0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qm-2b15d14b798b9a7eca2c878f008b599cc27614917fcdb3da121ebbe9d288134d.json
+++ b/openfisca_france/tests/json/f7qm-2b15d14b798b9a7eca2c878f008b599cc27614917fcdb3da121ebbe9d288134d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qm-57a8b7d2259035a3643f1f4f6d4fa954d78250a5f00bfff18fcf99d691d4a516.json
+++ b/openfisca_france/tests/json/f7qm-57a8b7d2259035a3643f1f4f6d4fa954d78250a5f00bfff18fcf99d691d4a516.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qm-632ebfe27b7b734e5cc71ba88003271b9656472f8eca0cb4e374c7dbf10f0732.json
+++ b/openfisca_france/tests/json/f7qm-632ebfe27b7b734e5cc71ba88003271b9656472f8eca0cb4e374c7dbf10f0732.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qm-68d76b49a29c69ade43080e111a946a53fafb608fb3afa79ca828bd099e063ae.json
+++ b/openfisca_france/tests/json/f7qm-68d76b49a29c69ade43080e111a946a53fafb608fb3afa79ca828bd099e063ae.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qm-b3a09fb10341d8837b9c08c5dc6022e0b0bd395477479c950f72b9e44e6b37fc.json
+++ b/openfisca_france/tests/json/f7qm-b3a09fb10341d8837b9c08c5dc6022e0b0bd395477479c950f72b9e44e6b37fc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qm-c27317b05838ccfff823bf3d19d1f12e1feb39cada234473f73f63082419229a.json
+++ b/openfisca_france/tests/json/f7qm-c27317b05838ccfff823bf3d19d1f12e1feb39cada234473f73f63082419229a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qo-0254fe37257c06c96484fcd6657cb2c00fed379f4ad08ed67bc1ac781713b660.json
+++ b/openfisca_france/tests/json/f7qo-0254fe37257c06c96484fcd6657cb2c00fed379f4ad08ed67bc1ac781713b660.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qo-0825bc0811312944d9f10eb66cfce301c1efee1238dcfd606edfaf634a2125bd.json
+++ b/openfisca_france/tests/json/f7qo-0825bc0811312944d9f10eb66cfce301c1efee1238dcfd606edfaf634a2125bd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qo-20576d058f207d98b204a64e94e1917f8e9604751b229b6331c4a3d51eab00c8.json
+++ b/openfisca_france/tests/json/f7qo-20576d058f207d98b204a64e94e1917f8e9604751b229b6331c4a3d51eab00c8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qo-3c5039bc6d1720316d6653e3cead4d088ac4d68c40b69a75e81cc6c028bf6a58.json
+++ b/openfisca_france/tests/json/f7qo-3c5039bc6d1720316d6653e3cead4d088ac4d68c40b69a75e81cc6c028bf6a58.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qo-7aab4ba21746c1e383125dedabeebf4b8d918796ae1bb5ce2756ac4b5b70e977.json
+++ b/openfisca_france/tests/json/f7qo-7aab4ba21746c1e383125dedabeebf4b8d918796ae1bb5ce2756ac4b5b70e977.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qo-977cd6f579de0753051d0d0259da01c7589104a7f53b459ce3f9f5e88f92f92d.json
+++ b/openfisca_france/tests/json/f7qo-977cd6f579de0753051d0d0259da01c7589104a7f53b459ce3f9f5e88f92f92d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qo-ac747e2e0c38c91fda5e553b8718f4ae48654c5c0a3347c95f18ae494c733154.json
+++ b/openfisca_france/tests/json/f7qo-ac747e2e0c38c91fda5e553b8718f4ae48654c5c0a3347c95f18ae494c733154.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qo-c2747cd469e1edf6914cff174fc971281efbe0332a9f8de941e4e920910c583f.json
+++ b/openfisca_france/tests/json/f7qo-c2747cd469e1edf6914cff174fc971281efbe0332a9f8de941e4e920910c583f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qo-eb788d131c2f7c60e0682125d9248331637b22c6172580f179da4dc0e5b528f8.json
+++ b/openfisca_france/tests/json/f7qo-eb788d131c2f7c60e0682125d9248331637b22c6172580f179da4dc0e5b528f8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qp-119392c5f2492c1af8267974629ccad6a8db05adcf728ab7c88eb98ab8e7ae08.json
+++ b/openfisca_france/tests/json/f7qp-119392c5f2492c1af8267974629ccad6a8db05adcf728ab7c88eb98ab8e7ae08.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qp-1d6bd2f76bf5bcf0c4068139f62f1b01672674c15e22c9f1353d44e3dfd5e0f2.json
+++ b/openfisca_france/tests/json/f7qp-1d6bd2f76bf5bcf0c4068139f62f1b01672674c15e22c9f1353d44e3dfd5e0f2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qp-3e7aba7fa9ab9c82018469762de741ea0cb7c05c3f839e87e9463cf3ee128202.json
+++ b/openfisca_france/tests/json/f7qp-3e7aba7fa9ab9c82018469762de741ea0cb7c05c3f839e87e9463cf3ee128202.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qp-63988b776969a553229a5f41142e469f68e8f5ba9fc144908d5908ebd0319bdd.json
+++ b/openfisca_france/tests/json/f7qp-63988b776969a553229a5f41142e469f68e8f5ba9fc144908d5908ebd0319bdd.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qp-75884a4f0e16b9870f01a8a324b1c4d06d9413c620c90a05275efabe2d5c7bbb.json
+++ b/openfisca_france/tests/json/f7qp-75884a4f0e16b9870f01a8a324b1c4d06d9413c620c90a05275efabe2d5c7bbb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qp-7e69adf59a0807f6bf50b269c78bf47ac7b4a902999e02ff6b379e6a6f3d7e89.json
+++ b/openfisca_france/tests/json/f7qp-7e69adf59a0807f6bf50b269c78bf47ac7b4a902999e02ff6b379e6a6f3d7e89.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qp-b6740635eb4a0925447e43740fdf6ea582bd6912b50acccb7c999530d512f513.json
+++ b/openfisca_france/tests/json/f7qp-b6740635eb4a0925447e43740fdf6ea582bd6912b50acccb7c999530d512f513.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qp-c295afc8d13ebf0b8b6c041b847358588db45a3715a26dc87d4309876bc3636b.json
+++ b/openfisca_france/tests/json/f7qp-c295afc8d13ebf0b8b6c041b847358588db45a3715a26dc87d4309876bc3636b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qp-ede50be351bb77a7a96a8067c9e0f25f7904c46bc292cbc7e4a6f07d8d89e24c.json
+++ b/openfisca_france/tests/json/f7qp-ede50be351bb77a7a96a8067c9e0f25f7904c46bc292cbc7e4a6f07d8d89e24c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qr-29b70a21d19af097fc559d11eac131067ee509a32b0371160405a622ea598eda.json
+++ b/openfisca_france/tests/json/f7qr-29b70a21d19af097fc559d11eac131067ee509a32b0371160405a622ea598eda.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qr-6b60f4fa9e933cfdd55aa094938832f403ec4375cbc897ce95fff57d70e3139b.json
+++ b/openfisca_france/tests/json/f7qr-6b60f4fa9e933cfdd55aa094938832f403ec4375cbc897ce95fff57d70e3139b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qr-9025ccb867162d18e14e8f7fc35cf4700a79f5640c69348243b2293a0b8ff117.json
+++ b/openfisca_france/tests/json/f7qr-9025ccb867162d18e14e8f7fc35cf4700a79f5640c69348243b2293a0b8ff117.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qr-963f8026de8c4f6c7819106ce52820134ba87ec382824df760b57a0aee125e9b.json
+++ b/openfisca_france/tests/json/f7qr-963f8026de8c4f6c7819106ce52820134ba87ec382824df760b57a0aee125e9b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qr-ca3f095938d19000af9536478a774d5022160b3c1b53e793c7a664df7cb223af.json
+++ b/openfisca_france/tests/json/f7qr-ca3f095938d19000af9536478a774d5022160b3c1b53e793c7a664df7cb223af.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qt-1648257fd22e82d45ddb1604f1a2a38027dd5b14834586c530b332abc25b9167.json
+++ b/openfisca_france/tests/json/f7qt-1648257fd22e82d45ddb1604f1a2a38027dd5b14834586c530b332abc25b9167.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qt-42310b4331214022ff655c479836a2d21b365abf188cb7ffd69d9e5483e01858.json
+++ b/openfisca_france/tests/json/f7qt-42310b4331214022ff655c479836a2d21b365abf188cb7ffd69d9e5483e01858.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qt-4b6eef825317f4357a2d9b425d494de3972e37fa2ee1de1835ae209042def878.json
+++ b/openfisca_france/tests/json/f7qt-4b6eef825317f4357a2d9b425d494de3972e37fa2ee1de1835ae209042def878.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qt-4e949ec889a1c77b4c121d602973dee52fe00d30e5ee3198584d7b6ac7914507.json
+++ b/openfisca_france/tests/json/f7qt-4e949ec889a1c77b4c121d602973dee52fe00d30e5ee3198584d7b6ac7914507.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qt-531e29a16346d0c855731b189faabb8d2b60f088406ab4ca9035d9b11c642137.json
+++ b/openfisca_france/tests/json/f7qt-531e29a16346d0c855731b189faabb8d2b60f088406ab4ca9035d9b11c642137.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qt-6c7bd2d2d6bfe9c4e75435b9bdf557126339bb925100c2ac9cbd8df3cdfd062c.json
+++ b/openfisca_france/tests/json/f7qt-6c7bd2d2d6bfe9c4e75435b9bdf557126339bb925100c2ac9cbd8df3cdfd062c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qt-c4376bc524b667c30f1922b177f734cef4ad44c784ba3adc28cf7b73d783a027.json
+++ b/openfisca_france/tests/json/f7qt-c4376bc524b667c30f1922b177f734cef4ad44c784ba3adc28cf7b73d783a027.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qt-f161492859622c75e90b0c36d397687fb020e8bfaa43e7ecb71cfe59f1bd352c.json
+++ b/openfisca_france/tests/json/f7qt-f161492859622c75e90b0c36d397687fb020e8bfaa43e7ecb71cfe59f1bd352c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qv-4e5a0910aec585eb5275a980d26935c31de9b901925521a706e32518687069e9.json
+++ b/openfisca_france/tests/json/f7qv-4e5a0910aec585eb5275a980d26935c31de9b901925521a706e32518687069e9.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qv-54701cee850e00dd6a282276debd90fc08fc9d0ef19ce2327071a7a896debff9.json
+++ b/openfisca_france/tests/json/f7qv-54701cee850e00dd6a282276debd90fc08fc9d0ef19ce2327071a7a896debff9.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qv-5a995493a99512ac8ced6b3701ea05636c3824a37e50aff628c14dc6462acda4.json
+++ b/openfisca_france/tests/json/f7qv-5a995493a99512ac8ced6b3701ea05636c3824a37e50aff628c14dc6462acda4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qv-61d5142e3d42c34ec1a7542d442debd1fc7442f60ab725f2dc9c28002bad6f7d.json
+++ b/openfisca_france/tests/json/f7qv-61d5142e3d42c34ec1a7542d442debd1fc7442f60ab725f2dc9c28002bad6f7d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qv-8264e98fc0163ce16a4939eb3eadbc46d11b6dda1c9adca8e73a969ff35365ab.json
+++ b/openfisca_france/tests/json/f7qv-8264e98fc0163ce16a4939eb3eadbc46d11b6dda1c9adca8e73a969ff35365ab.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qv-881d50d90152b7fbfdc47b5a76eca67469aee5f8c30ea0623ef38135e99ecf57.json
+++ b/openfisca_france/tests/json/f7qv-881d50d90152b7fbfdc47b5a76eca67469aee5f8c30ea0623ef38135e99ecf57.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qv-9b5aa576b91ae10ff82362bb7403ecef79f39e0d421d254a8f93440ea53f59ee.json
+++ b/openfisca_france/tests/json/f7qv-9b5aa576b91ae10ff82362bb7403ecef79f39e0d421d254a8f93440ea53f59ee.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qv-c469e37c755fe4e0ad703d8d65601070b93c65f879199596e2baaaacb64ba574.json
+++ b/openfisca_france/tests/json/f7qv-c469e37c755fe4e0ad703d8d65601070b93c65f879199596e2baaaacb64ba574.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qv-f38b2cb3532400066143ce3bbd341c15789c6198ab26ca7659f7eaca56878d7d.json
+++ b/openfisca_france/tests/json/f7qv-f38b2cb3532400066143ce3bbd341c15789c6198ab26ca7659f7eaca56878d7d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qz-006d85a91e910ca42c3a0f2848f2c1a6a159d12d9eccbe354cd2038d9103f0ed.json
+++ b/openfisca_france/tests/json/f7qz-006d85a91e910ca42c3a0f2848f2c1a6a159d12d9eccbe354cd2038d9103f0ed.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qz-029b53f7b3ca254afab4a283c1dfbef55d8c7e60d8960a41ff3fd01c5370e9b4.json
+++ b/openfisca_france/tests/json/f7qz-029b53f7b3ca254afab4a283c1dfbef55d8c7e60d8960a41ff3fd01c5370e9b4.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qz-0ea1627e49ff1935def6db521b803828b871fa86075a5f2ca600e9a943ca4dfc.json
+++ b/openfisca_france/tests/json/f7qz-0ea1627e49ff1935def6db521b803828b871fa86075a5f2ca600e9a943ca4dfc.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qz-33dd58685482ab173f470f1516f182ebbce2038eaaa5239533aad5aff4c8bb0c.json
+++ b/openfisca_france/tests/json/f7qz-33dd58685482ab173f470f1516f182ebbce2038eaaa5239533aad5aff4c8bb0c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qz-75ace68b639d4f5a556df75cee4d3cbb030d4869a0702e73217354e34d2abbbc.json
+++ b/openfisca_france/tests/json/f7qz-75ace68b639d4f5a556df75cee4d3cbb030d4869a0702e73217354e34d2abbbc.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qz-95fe593a01c1f94db674d8cf2c5d78673ce9ced0c5653cae3244eecb084affae.json
+++ b/openfisca_france/tests/json/f7qz-95fe593a01c1f94db674d8cf2c5d78673ce9ced0c5653cae3244eecb084affae.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qz-d474d28b43a7c4fea6cfd3813cad317ac114d2a253db32f38996a0624fa8b0cb.json
+++ b/openfisca_france/tests/json/f7qz-d474d28b43a7c4fea6cfd3813cad317ac114d2a253db32f38996a0624fa8b0cb.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qz-e5a0099fdaca6ed6ed9dceff4667a183d7bbfe96d49257e6b40abb8e69237217.json
+++ b/openfisca_france/tests/json/f7qz-e5a0099fdaca6ed6ed9dceff4667a183d7bbfe96d49257e6b40abb8e69237217.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7qz-eb09ae81eb0dc582783665dfda84b0213c41e7cdc560982ae9f8e72b0ac44017.json
+++ b/openfisca_france/tests/json/f7qz-eb09ae81eb0dc582783665dfda84b0213c41e7cdc560982ae9f8e72b0ac44017.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ra-7036179c010537ff845212500738f5ad4682ae335df7271dc0c32292025eb6e9.json
+++ b/openfisca_france/tests/json/f7ra-7036179c010537ff845212500738f5ad4682ae335df7271dc0c32292025eb6e9.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ra-9f056bbf512943af80bb32d988dbd70fccc7bacc4e60e77e7031a21689bd1c88.json
+++ b/openfisca_france/tests/json/f7ra-9f056bbf512943af80bb32d988dbd70fccc7bacc4e60e77e7031a21689bd1c88.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ra-a6256bf1070c09de689b700ee697211686f827a891f038792bdd230ed5379f46.json
+++ b/openfisca_france/tests/json/f7ra-a6256bf1070c09de689b700ee697211686f827a891f038792bdd230ed5379f46.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ra-b00a35998edd729402358198e3098ebfa6356ae225b1af84d107d90c17af5ca8.json
+++ b/openfisca_france/tests/json/f7ra-b00a35998edd729402358198e3098ebfa6356ae225b1af84d107d90c17af5ca8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ra-b9fd5568e271f3b50704fa76fd50459551193c5dc4db2ee53374a25276a4a496.json
+++ b/openfisca_france/tests/json/f7ra-b9fd5568e271f3b50704fa76fd50459551193c5dc4db2ee53374a25276a4a496.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ra-c82546e3ee3690dbae0edf4c9efe5e3e544a7d1dd8aaa821a14aeb2d23de3bfc.json
+++ b/openfisca_france/tests/json/f7ra-c82546e3ee3690dbae0edf4c9efe5e3e544a7d1dd8aaa821a14aeb2d23de3bfc.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ra-e660561765a985f2c63bf98d432b08d1b3b3431d71e438cce34db749e08c2629.json
+++ b/openfisca_france/tests/json/f7ra-e660561765a985f2c63bf98d432b08d1b3b3431d71e438cce34db749e08c2629.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ra-f7c2c70405d1737d41b7275e455641ce4419209a3e4aa6bfb158a35615926915.json
+++ b/openfisca_france/tests/json/f7ra-f7c2c70405d1737d41b7275e455641ce4419209a3e4aa6bfb158a35615926915.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ra-f961fc2e87e29ec08efbec5398c2e5c77a141ae16e01ef442ff9df84d1296d1f.json
+++ b/openfisca_france/tests/json/f7ra-f961fc2e87e29ec08efbec5398c2e5c77a141ae16e01ef442ff9df84d1296d1f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rb-106c07b1a30323530b45f715fe96c520c4c7ba898f03a6b15e68de25d887d3e6.json
+++ b/openfisca_france/tests/json/f7rb-106c07b1a30323530b45f715fe96c520c4c7ba898f03a6b15e68de25d887d3e6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rb-238bc29ec15985e7439b7c4643f1fc5dc789b442fc949733ec19c98e1c447f6a.json
+++ b/openfisca_france/tests/json/f7rb-238bc29ec15985e7439b7c4643f1fc5dc789b442fc949733ec19c98e1c447f6a.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rb-5f79d0c97d5043768b485a3b43699f4dd636c8e185633b604501dd908e22a9b3.json
+++ b/openfisca_france/tests/json/f7rb-5f79d0c97d5043768b485a3b43699f4dd636c8e185633b604501dd908e22a9b3.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rb-7520b1ed6ac385d2969fda09d587f91a2b62c32fd2be1327c952ee34e13f4b14.json
+++ b/openfisca_france/tests/json/f7rb-7520b1ed6ac385d2969fda09d587f91a2b62c32fd2be1327c952ee34e13f4b14.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rb-94fbd786fe4b867438bde00e2f7cf0c4ed2e940b7904274a9965556757005333.json
+++ b/openfisca_france/tests/json/f7rb-94fbd786fe4b867438bde00e2f7cf0c4ed2e940b7904274a9965556757005333.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rb-ac94d9db4f5b03839ca29bdcd2b649d17621af2415407aeee2f9738f9d448b51.json
+++ b/openfisca_france/tests/json/f7rb-ac94d9db4f5b03839ca29bdcd2b649d17621af2415407aeee2f9738f9d448b51.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rb-bf76a550f75644ee127a7a6b5987f49c60e59d54cb3aa775451180ea1a8cac45.json
+++ b/openfisca_france/tests/json/f7rb-bf76a550f75644ee127a7a6b5987f49c60e59d54cb3aa775451180ea1a8cac45.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rb-dc97c1d77b5b65787e3174e544814082f6ed3a02ab6d989c10cd563c5ebdae6d.json
+++ b/openfisca_france/tests/json/f7rb-dc97c1d77b5b65787e3174e544814082f6ed3a02ab6d989c10cd563c5ebdae6d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rb-f8d1d51d06780c10e310dcae558b662c1da5e251afc408edd4193d86d9fe476a.json
+++ b/openfisca_france/tests/json/f7rb-f8d1d51d06780c10e310dcae558b662c1da5e251afc408edd4193d86d9fe476a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rc-19b9e9416fe32202b03daa43cb997f0fe661dc03f28a23ed47c249eb109fa8c1.json
+++ b/openfisca_france/tests/json/f7rc-19b9e9416fe32202b03daa43cb997f0fe661dc03f28a23ed47c249eb109fa8c1.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rc-22049ceae7e17a140655205ba8c9b52f6a1311012549166b1ee543ef56b819ff.json
+++ b/openfisca_france/tests/json/f7rc-22049ceae7e17a140655205ba8c9b52f6a1311012549166b1ee543ef56b819ff.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rc-7471c1176d8e68c62f23f8e95f33e3e9ff0ee3f71137a833d725c891f0aaf52c.json
+++ b/openfisca_france/tests/json/f7rc-7471c1176d8e68c62f23f8e95f33e3e9ff0ee3f71137a833d725c891f0aaf52c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rc-9391add8368fa7a893c7becfa892d612119bb4474b3693f4864aacea2d65dee6.json
+++ b/openfisca_france/tests/json/f7rc-9391add8368fa7a893c7becfa892d612119bb4474b3693f4864aacea2d65dee6.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rc-a3723cda3aeba6f4cf1d2374be9be657f9836e9fdcb447d467ca00121a7e0ecf.json
+++ b/openfisca_france/tests/json/f7rc-a3723cda3aeba6f4cf1d2374be9be657f9836e9fdcb447d467ca00121a7e0ecf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rc-b5a6cc41479362de8f819e803f306f19d2ab437584310a98caa24a462462afbd.json
+++ b/openfisca_france/tests/json/f7rc-b5a6cc41479362de8f819e803f306f19d2ab437584310a98caa24a462462afbd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rc-c636040cce1c49c7615d02660a01abd9cd25e68c20ee1dfc58fa5fbbbca4ef1c.json
+++ b/openfisca_france/tests/json/f7rc-c636040cce1c49c7615d02660a01abd9cd25e68c20ee1dfc58fa5fbbbca4ef1c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rc-f1950a266638b7b6706f5c544d348d68721c47b96b5051230b321084b33fa174.json
+++ b/openfisca_france/tests/json/f7rc-f1950a266638b7b6706f5c544d348d68721c47b96b5051230b321084b33fa174.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rc-fa6fa8bad94691d6a3941b18512ff56a600573ffa260061465ae5fe50ecc06b3.json
+++ b/openfisca_france/tests/json/f7rc-fa6fa8bad94691d6a3941b18512ff56a600573ffa260061465ae5fe50ecc06b3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rd-1bce8b4ff5cfab98dc3b389b000c199ad18f27d314b808bdc2597c5bd7383da7.json
+++ b/openfisca_france/tests/json/f7rd-1bce8b4ff5cfab98dc3b389b000c199ad18f27d314b808bdc2597c5bd7383da7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rd-224f1a608098138265a11c18e2ee89b31c600cabac68f40c695d5d1d7399a723.json
+++ b/openfisca_france/tests/json/f7rd-224f1a608098138265a11c18e2ee89b31c600cabac68f40c695d5d1d7399a723.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rd-3bc6b63cfb9e13d0241a7dd52327f9bc7e3fe7e88cb4cce325208f2b4ba98dea.json
+++ b/openfisca_france/tests/json/f7rd-3bc6b63cfb9e13d0241a7dd52327f9bc7e3fe7e88cb4cce325208f2b4ba98dea.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rd-65d911b9908836078b569b0315b478f1e5703411d57ebc0ddeac66b7315eb619.json
+++ b/openfisca_france/tests/json/f7rd-65d911b9908836078b569b0315b478f1e5703411d57ebc0ddeac66b7315eb619.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rd-83c187a911fcdb120df3402570a77f34dd9498c889a8f2199f146a6bb972f3f7.json
+++ b/openfisca_france/tests/json/f7rd-83c187a911fcdb120df3402570a77f34dd9498c889a8f2199f146a6bb972f3f7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rd-9e21008542d8136bb0023e0ddeb41a213bf63f7ef311107f391909a5ac99b885.json
+++ b/openfisca_france/tests/json/f7rd-9e21008542d8136bb0023e0ddeb41a213bf63f7ef311107f391909a5ac99b885.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rd-aa8db2dab71b690a061f704500495ae49b79c5e301e5fac0388a621343b17c6e.json
+++ b/openfisca_france/tests/json/f7rd-aa8db2dab71b690a061f704500495ae49b79c5e301e5fac0388a621343b17c6e.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rd-bd922e7e42388a7761c967ddba73ec3a7c0b7345ee77afd10e0fcc51caac6a5c.json
+++ b/openfisca_france/tests/json/f7rd-bd922e7e42388a7761c967ddba73ec3a7c0b7345ee77afd10e0fcc51caac6a5c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rd-c734da5cc2ffebe3400a2555c339c6ccc08b62341f5d1665d038763a7e13db4f.json
+++ b/openfisca_france/tests/json/f7rd-c734da5cc2ffebe3400a2555c339c6ccc08b62341f5d1665d038763a7e13db4f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7re-07e65238fc3f0e36d2c0a8186cd8fd7ba0bcd4cbc1b49c75be367784c3d3b52e.json
+++ b/openfisca_france/tests/json/f7re-07e65238fc3f0e36d2c0a8186cd8fd7ba0bcd4cbc1b49c75be367784c3d3b52e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7re-1844e127fc3eb1d810c5e0386afbf212fc35b66712895d4bc0d894391d7e86ff.json
+++ b/openfisca_france/tests/json/f7re-1844e127fc3eb1d810c5e0386afbf212fc35b66712895d4bc0d894391d7e86ff.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7re-1e5c2fcf9bd2d6e841fe0ab947be205322f981dee18f18bfeea69d75b4cd6d23.json
+++ b/openfisca_france/tests/json/f7re-1e5c2fcf9bd2d6e841fe0ab947be205322f981dee18f18bfeea69d75b4cd6d23.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7re-2d544830dd6c39a377f8cca6d7307bab8789af248acdc470117efd15b95d053b.json
+++ b/openfisca_france/tests/json/f7re-2d544830dd6c39a377f8cca6d7307bab8789af248acdc470117efd15b95d053b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7re-5df063f4b383593a3af5d9593bca8dd14383ad78e27124e5055fe73dda0499a4.json
+++ b/openfisca_france/tests/json/f7re-5df063f4b383593a3af5d9593bca8dd14383ad78e27124e5055fe73dda0499a4.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7re-5f9683c377ae158a8013ccc029d0c5126b842f4ff259a720026cb27b2a769741.json
+++ b/openfisca_france/tests/json/f7re-5f9683c377ae158a8013ccc029d0c5126b842f4ff259a720026cb27b2a769741.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7re-8464e1c66a3ba11bef4caa1b0335d6b412ddd214835290c83ab8939c7b328582.json
+++ b/openfisca_france/tests/json/f7re-8464e1c66a3ba11bef4caa1b0335d6b412ddd214835290c83ab8939c7b328582.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7re-d24549e16ca0c3a330a9949b5fe2584a3f3e688dcfeeb8da03a8590a60be8998.json
+++ b/openfisca_france/tests/json/f7re-d24549e16ca0c3a330a9949b5fe2584a3f3e688dcfeeb8da03a8590a60be8998.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7re-d25cbe7c37f3506b95dbe9887a5224a71b5785c00dbebcee967627e2e628173c.json
+++ b/openfisca_france/tests/json/f7re-d25cbe7c37f3506b95dbe9887a5224a71b5785c00dbebcee967627e2e628173c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rf-0b01732cf298ddb154362da25927be7525cf078bdaaea12bc187b89a4040652c.json
+++ b/openfisca_france/tests/json/f7rf-0b01732cf298ddb154362da25927be7525cf078bdaaea12bc187b89a4040652c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rf-32e813a7f7a19e69affa92159fcc9a2571cc58b990609845d7db5241be86ccc4.json
+++ b/openfisca_france/tests/json/f7rf-32e813a7f7a19e69affa92159fcc9a2571cc58b990609845d7db5241be86ccc4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rf-47356b9a5b0f71505c80773146b53b27a79307872c74074f762a25596d97b1aa.json
+++ b/openfisca_france/tests/json/f7rf-47356b9a5b0f71505c80773146b53b27a79307872c74074f762a25596d97b1aa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rf-542c28551691e26ad4665e5458fcccdf27057b1821be7b63acd2d190129a6a45.json
+++ b/openfisca_france/tests/json/f7rf-542c28551691e26ad4665e5458fcccdf27057b1821be7b63acd2d190129a6a45.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rf-677ea1129fa20801a6911aa3256841884b78452c44aef24cc6285db03d30b64a.json
+++ b/openfisca_france/tests/json/f7rf-677ea1129fa20801a6911aa3256841884b78452c44aef24cc6285db03d30b64a.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rf-8487c1b2e4507d332b974c0fa48d85cc365305e77535407702a4b49b3d0237d5.json
+++ b/openfisca_france/tests/json/f7rf-8487c1b2e4507d332b974c0fa48d85cc365305e77535407702a4b49b3d0237d5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rf-8903ef3d0d955f4e3a11eb69e39daffa62598b495946e0b8a69a2fdaf304e054.json
+++ b/openfisca_france/tests/json/f7rf-8903ef3d0d955f4e3a11eb69e39daffa62598b495946e0b8a69a2fdaf304e054.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rf-8c5ef8c5fb647a2e7db3716937b3e7129d5c24b32846b4ca894b826f3001d570.json
+++ b/openfisca_france/tests/json/f7rf-8c5ef8c5fb647a2e7db3716937b3e7129d5c24b32846b4ca894b826f3001d570.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rf-dfa3ddd80128477d0c99d53585633b40fd5202fe73d4b034b6804da2d7b84561.json
+++ b/openfisca_france/tests/json/f7rf-dfa3ddd80128477d0c99d53585633b40fd5202fe73d4b034b6804da2d7b84561.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rg-0587f8f8b9644522e1ba3358721e72822f13c40922444e6bdea570d1ca20f930.json
+++ b/openfisca_france/tests/json/f7rg-0587f8f8b9644522e1ba3358721e72822f13c40922444e6bdea570d1ca20f930.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rg-43eba7ffe1e9af79ea5665216c5c822c3e448dd54b0d97cc8248ead357c8e267.json
+++ b/openfisca_france/tests/json/f7rg-43eba7ffe1e9af79ea5665216c5c822c3e448dd54b0d97cc8248ead357c8e267.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rg-4514a4f74040bf5cc6d5be685a3567880f849472b8502e40dc694118b0467964.json
+++ b/openfisca_france/tests/json/f7rg-4514a4f74040bf5cc6d5be685a3567880f849472b8502e40dc694118b0467964.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rg-57f8fecaddba93b1b63e94b1ade98a01fb07db57d57e60caeab4edd0ccd97ad4.json
+++ b/openfisca_france/tests/json/f7rg-57f8fecaddba93b1b63e94b1ade98a01fb07db57d57e60caeab4edd0ccd97ad4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rg-697c793fea32a579ecf08fac663f10eaa8e1c54af90ac39dd61e7eb4f1d1206f.json
+++ b/openfisca_france/tests/json/f7rg-697c793fea32a579ecf08fac663f10eaa8e1c54af90ac39dd61e7eb4f1d1206f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rg-8fc5f10ffb838dc863c04682ebf2a1a66220b3af7bc39696ed2f8b6161d7145d.json
+++ b/openfisca_france/tests/json/f7rg-8fc5f10ffb838dc863c04682ebf2a1a66220b3af7bc39696ed2f8b6161d7145d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rg-c9e85cdd909fc623083c5bb6a3a9c2218294d74703b690763f924ea7ce052112.json
+++ b/openfisca_france/tests/json/f7rg-c9e85cdd909fc623083c5bb6a3a9c2218294d74703b690763f924ea7ce052112.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rg-dee2430bc90512ba0d9ecb8ef82fb1613a37dcc5c77a308095a35728fada2cc7.json
+++ b/openfisca_france/tests/json/f7rg-dee2430bc90512ba0d9ecb8ef82fb1613a37dcc5c77a308095a35728fada2cc7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rg-f6c67bfc6b45b29d297eaafd52fe3d5b4be7c151e3c0aff661056537d7a39675.json
+++ b/openfisca_france/tests/json/f7rg-f6c67bfc6b45b29d297eaafd52fe3d5b4be7c151e3c0aff661056537d7a39675.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rh-1b8866edbf15a3f3fbd9cd3f25927cacc9af347adcd6a3eb762d91b92164b691.json
+++ b/openfisca_france/tests/json/f7rh-1b8866edbf15a3f3fbd9cd3f25927cacc9af347adcd6a3eb762d91b92164b691.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rh-200d7fdee0a0b188f66b67f349c1fb4f82444478355123d323f041d034be4d9c.json
+++ b/openfisca_france/tests/json/f7rh-200d7fdee0a0b188f66b67f349c1fb4f82444478355123d323f041d034be4d9c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rh-36bc3bffcd676d9a872e33dc0a4f8c869c63a47e551039c4910031eece866642.json
+++ b/openfisca_france/tests/json/f7rh-36bc3bffcd676d9a872e33dc0a4f8c869c63a47e551039c4910031eece866642.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rh-3abffcf6b4355551e1c3205fb01f96b2034d08bd7cfae1906a0f1971e0cbbc76.json
+++ b/openfisca_france/tests/json/f7rh-3abffcf6b4355551e1c3205fb01f96b2034d08bd7cfae1906a0f1971e0cbbc76.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rh-6acc17cf134d8e1a13be7924518a1156d097d9053ad003d8342753ea9f0a89d6.json
+++ b/openfisca_france/tests/json/f7rh-6acc17cf134d8e1a13be7924518a1156d097d9053ad003d8342753ea9f0a89d6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rh-9b64dfa62697a572dd1c48c73a4b8cad8642be7ef62d639f6993e57e8afa0581.json
+++ b/openfisca_france/tests/json/f7rh-9b64dfa62697a572dd1c48c73a4b8cad8642be7ef62d639f6993e57e8afa0581.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rh-d67767f24177239f7f0413a31314fb78f6e1b70bb9325f6824366217c00a5bf4.json
+++ b/openfisca_france/tests/json/f7rh-d67767f24177239f7f0413a31314fb78f6e1b70bb9325f6824366217c00a5bf4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rh-de887d2ebd8e76ab637df90338dac0875ac4f944c18989a921ed48264ca5cc3a.json
+++ b/openfisca_france/tests/json/f7rh-de887d2ebd8e76ab637df90338dac0875ac4f944c18989a921ed48264ca5cc3a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rh-f367c509f7e7322fe1e7737922f09e7256a42c3dc1ef78d1d2b638acaa4db1e2.json
+++ b/openfisca_france/tests/json/f7rh-f367c509f7e7322fe1e7737922f09e7256a42c3dc1ef78d1d2b638acaa4db1e2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ri-1c36045861b8b722e8090b84bfd8b2aa54c72e4fde142edb78cc357827ddcf44.json
+++ b/openfisca_france/tests/json/f7ri-1c36045861b8b722e8090b84bfd8b2aa54c72e4fde142edb78cc357827ddcf44.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ri-732ae9a873afc886e2c81eaee37b348baf39fa8b49a869652cf4aa1b50753b79.json
+++ b/openfisca_france/tests/json/f7ri-732ae9a873afc886e2c81eaee37b348baf39fa8b49a869652cf4aa1b50753b79.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ri-7ef0e529820fdb58ee9dd6742df178643db29b018b7860a3bc95fcaa9f67c41c.json
+++ b/openfisca_france/tests/json/f7ri-7ef0e529820fdb58ee9dd6742df178643db29b018b7860a3bc95fcaa9f67c41c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ri-acfc5674e485953fdedcce1e3a3d61ebf59378ecca7fac797ba4b20050075738.json
+++ b/openfisca_france/tests/json/f7ri-acfc5674e485953fdedcce1e3a3d61ebf59378ecca7fac797ba4b20050075738.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ri-d570874b91269258c64c9f7dbf2a8db4149a54099b6f1e442b5b9a9f382a280a.json
+++ b/openfisca_france/tests/json/f7ri-d570874b91269258c64c9f7dbf2a8db4149a54099b6f1e442b5b9a9f382a280a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ri-e48bcee53e10bcb9e8b0795b00893d48e4d8c38f3d283f285fd9728a005f2069.json
+++ b/openfisca_france/tests/json/f7ri-e48bcee53e10bcb9e8b0795b00893d48e4d8c38f3d283f285fd9728a005f2069.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ri-f0396e043af808b3f135860cab7e0ba3c46b60425723eabf1a707c5d4d5507a0.json
+++ b/openfisca_france/tests/json/f7ri-f0396e043af808b3f135860cab7e0ba3c46b60425723eabf1a707c5d4d5507a0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rj-00cd6bf9fd6872743eac2bbc23562a525f5a0dbfdd9091e43a1d9e54dce0c3c8.json
+++ b/openfisca_france/tests/json/f7rj-00cd6bf9fd6872743eac2bbc23562a525f5a0dbfdd9091e43a1d9e54dce0c3c8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rj-12f4ac6cd705aa1cda3b831726b5d6a83cf9a6bdb0d895941c8749b8441a8b8f.json
+++ b/openfisca_france/tests/json/f7rj-12f4ac6cd705aa1cda3b831726b5d6a83cf9a6bdb0d895941c8749b8441a8b8f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rj-271d8271f9d0d792cc44cb4064412af33b872c3926e467578fcc528a936ea94b.json
+++ b/openfisca_france/tests/json/f7rj-271d8271f9d0d792cc44cb4064412af33b872c3926e467578fcc528a936ea94b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rj-2846ca51de8e7c9d9607ea844d536d78a5c81012b18e70d5500fe128820db080.json
+++ b/openfisca_france/tests/json/f7rj-2846ca51de8e7c9d9607ea844d536d78a5c81012b18e70d5500fe128820db080.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rj-4e91272c791d809b3e94f801f8fe61ff1219bd11000e91e6b8a3e2947cb273cf.json
+++ b/openfisca_france/tests/json/f7rj-4e91272c791d809b3e94f801f8fe61ff1219bd11000e91e6b8a3e2947cb273cf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rj-5bec8e8885f4ffb185e126af64db1ea713fd88aab95901dd15c2df4eae41b22f.json
+++ b/openfisca_france/tests/json/f7rj-5bec8e8885f4ffb185e126af64db1ea713fd88aab95901dd15c2df4eae41b22f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rj-afa6adba2dec1c3f51fc16d7eb1de692241532dc793970a3d30e89cea4c3d488.json
+++ b/openfisca_france/tests/json/f7rj-afa6adba2dec1c3f51fc16d7eb1de692241532dc793970a3d30e89cea4c3d488.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rj-d2e9a1c2d45785d448574ea6655d186b7265bc34aad32c5ee93744c5999d1776.json
+++ b/openfisca_france/tests/json/f7rj-d2e9a1c2d45785d448574ea6655d186b7265bc34aad32c5ee93744c5999d1776.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rj-fe93b1719a8f138771b5a670ac373e5b95473191f37a229ade16a7bb7420371e.json
+++ b/openfisca_france/tests/json/f7rj-fe93b1719a8f138771b5a670ac373e5b95473191f37a229ade16a7bb7420371e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rk-2695985c2eaa83f2568d1a98425a6a022f2a9d891397222df4db2f50621ca15c.json
+++ b/openfisca_france/tests/json/f7rk-2695985c2eaa83f2568d1a98425a6a022f2a9d891397222df4db2f50621ca15c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rk-4b0801493efea6f790e12075f46652bf445860ac9caabcb730ca8cb9b26f5675.json
+++ b/openfisca_france/tests/json/f7rk-4b0801493efea6f790e12075f46652bf445860ac9caabcb730ca8cb9b26f5675.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rk-5cfb0d6f27d170f2bc74a476673cf37504c8687892ad96bf255d6e9dde7d7d1a.json
+++ b/openfisca_france/tests/json/f7rk-5cfb0d6f27d170f2bc74a476673cf37504c8687892ad96bf255d6e9dde7d7d1a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rk-6ca689242f1f5e45356752309d00419d920c6aab9286e4bd5131eb86fb7a6a7a.json
+++ b/openfisca_france/tests/json/f7rk-6ca689242f1f5e45356752309d00419d920c6aab9286e4bd5131eb86fb7a6a7a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rk-b8a7699b6ef38f6a1155bf7d2f36b888c84e30a0f94dd72020ad19eb169c5c45.json
+++ b/openfisca_france/tests/json/f7rk-b8a7699b6ef38f6a1155bf7d2f36b888c84e30a0f94dd72020ad19eb169c5c45.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rk-be4afd828826857e8ca0b0fe4f42cbe4b70393cf228fa9663401feb86c17a7d5.json
+++ b/openfisca_france/tests/json/f7rk-be4afd828826857e8ca0b0fe4f42cbe4b70393cf228fa9663401feb86c17a7d5.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rk-c8602f7c5506e8427b9a87e7f52e174a1b191feb7e7a2ee0118bd2389b7efc03.json
+++ b/openfisca_france/tests/json/f7rk-c8602f7c5506e8427b9a87e7f52e174a1b191feb7e7a2ee0118bd2389b7efc03.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rk-cb35b00c0519e8529bb908912f6e09f245e4d6374ccf959885280f595603239e.json
+++ b/openfisca_france/tests/json/f7rk-cb35b00c0519e8529bb908912f6e09f245e4d6374ccf959885280f595603239e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rk-cb72f4f72ce7841883e9244cf6511000a55fd9f93ca6c7b08121349a0c331d42.json
+++ b/openfisca_france/tests/json/f7rk-cb72f4f72ce7841883e9244cf6511000a55fd9f93ca6c7b08121349a0c331d42.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rl-35a16bc895c9371c1a889da33c1ebc7024e88c58b1689e969ed03e64078da458.json
+++ b/openfisca_france/tests/json/f7rl-35a16bc895c9371c1a889da33c1ebc7024e88c58b1689e969ed03e64078da458.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rl-4b65185c08d23aba8afc4dc5559774a7d49b12e7a0efc8c45879ed8f84e155af.json
+++ b/openfisca_france/tests/json/f7rl-4b65185c08d23aba8afc4dc5559774a7d49b12e7a0efc8c45879ed8f84e155af.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rl-70f6399e511199afc70942c4a7d6b26e73234ce85f8ea3de273d4eb011fcc066.json
+++ b/openfisca_france/tests/json/f7rl-70f6399e511199afc70942c4a7d6b26e73234ce85f8ea3de273d4eb011fcc066.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rl-99deaf1bd0c1dc6939432b130b9f884e651d852c658d9af00590da5fe2cd41aa.json
+++ b/openfisca_france/tests/json/f7rl-99deaf1bd0c1dc6939432b130b9f884e651d852c658d9af00590da5fe2cd41aa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rl-a4851aa7a7b5563dffc2e5868d351b39bdfdf00bb48e76aad3ac22bc1daa2a61.json
+++ b/openfisca_france/tests/json/f7rl-a4851aa7a7b5563dffc2e5868d351b39bdfdf00bb48e76aad3ac22bc1daa2a61.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rl-ae64a95a886c710f8bacd54de2c7d5ddba1f58b00eb571624238c50a2461f0be.json
+++ b/openfisca_france/tests/json/f7rl-ae64a95a886c710f8bacd54de2c7d5ddba1f58b00eb571624238c50a2461f0be.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rl-b8ab24238f864817058fdc31abdaa6d3f70326abe31756bf731d39558d91bcfb.json
+++ b/openfisca_france/tests/json/f7rl-b8ab24238f864817058fdc31abdaa6d3f70326abe31756bf731d39558d91bcfb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rl-cd2b310b527b76c527b9029231bbb1d698b8cc6c704f60ff47e636978d84a327.json
+++ b/openfisca_france/tests/json/f7rl-cd2b310b527b76c527b9029231bbb1d698b8cc6c704f60ff47e636978d84a327.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rl-fb5bab6310168c8a8a36c65883ecb8936aaeba3671c3281408a41ed0542bf8ea.json
+++ b/openfisca_france/tests/json/f7rl-fb5bab6310168c8a8a36c65883ecb8936aaeba3671c3281408a41ed0542bf8ea.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rm-011dbd7eb9c438dba5ee9370324060fa1fc12cdcb8a35ac51aa08afd10947b23.json
+++ b/openfisca_france/tests/json/f7rm-011dbd7eb9c438dba5ee9370324060fa1fc12cdcb8a35ac51aa08afd10947b23.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rm-13ca51922b36d17f8b782eed99ffd319b7aa3c17d7d2f84ebead3a213e484dab.json
+++ b/openfisca_france/tests/json/f7rm-13ca51922b36d17f8b782eed99ffd319b7aa3c17d7d2f84ebead3a213e484dab.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rm-1d731b045a7233ab0ed300d01cf6aeaffb9c1a3847e31bff8fae44a57f08a2cb.json
+++ b/openfisca_france/tests/json/f7rm-1d731b045a7233ab0ed300d01cf6aeaffb9c1a3847e31bff8fae44a57f08a2cb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rm-1ec2c5cc7f84c57c80f31e6b8c5c24122333126dd852412e3f3b8991299e6a77.json
+++ b/openfisca_france/tests/json/f7rm-1ec2c5cc7f84c57c80f31e6b8c5c24122333126dd852412e3f3b8991299e6a77.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rm-39b98b35cbd4eb87ec7ae8b82395a7c372c1e8a42310cdcd47e939e0c3f9730a.json
+++ b/openfisca_france/tests/json/f7rm-39b98b35cbd4eb87ec7ae8b82395a7c372c1e8a42310cdcd47e939e0c3f9730a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rm-acf436869bfdfdfd464e854b9c2d1d5a75ad204c8adce55a4d8e383c005cdac1.json
+++ b/openfisca_france/tests/json/f7rm-acf436869bfdfdfd464e854b9c2d1d5a75ad204c8adce55a4d8e383c005cdac1.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rm-b81ff3540c31e6e2da76474c641f8a40bd68263e7df96d3dfde57d279ebd3271.json
+++ b/openfisca_france/tests/json/f7rm-b81ff3540c31e6e2da76474c641f8a40bd68263e7df96d3dfde57d279ebd3271.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rm-cd5ecb26bd183d7c0b81e70325c35924f72fbb299b0251c3228fc40c0a4f3419.json
+++ b/openfisca_france/tests/json/f7rm-cd5ecb26bd183d7c0b81e70325c35924f72fbb299b0251c3228fc40c0a4f3419.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rm-e5e6df3179115a50df8406a15deef659168f1b0222b023eb61aa648455a24a04.json
+++ b/openfisca_france/tests/json/f7rm-e5e6df3179115a50df8406a15deef659168f1b0222b023eb61aa648455a24a04.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rn-1f31833fca3e689cad8640dd82871f3f1028787ec4f6a155b96ecf38945d54e5.json
+++ b/openfisca_france/tests/json/f7rn-1f31833fca3e689cad8640dd82871f3f1028787ec4f6a155b96ecf38945d54e5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rn-2d5e97204436f30e819dabd0b5323c9da61ec70310afc123c86ffd726814a2c0.json
+++ b/openfisca_france/tests/json/f7rn-2d5e97204436f30e819dabd0b5323c9da61ec70310afc123c86ffd726814a2c0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rn-5393091ea9d3b6a787bb9483fd0ddc9334d36fb7e29bb26fa3a19edf3daf2592.json
+++ b/openfisca_france/tests/json/f7rn-5393091ea9d3b6a787bb9483fd0ddc9334d36fb7e29bb26fa3a19edf3daf2592.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rn-5c6606ee302c2e6e738505d731d108a9e4f3d2ee6f4c8ea9a127d68129048fd6.json
+++ b/openfisca_france/tests/json/f7rn-5c6606ee302c2e6e738505d731d108a9e4f3d2ee6f4c8ea9a127d68129048fd6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rn-7e459d073488e66e07f0c9caa3997179a4388e1d2d497d16277008570c263e09.json
+++ b/openfisca_france/tests/json/f7rn-7e459d073488e66e07f0c9caa3997179a4388e1d2d497d16277008570c263e09.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rn-824b8a7d0f58912f997464b1ef8bf3894b6134ac960ea09d29aa0ade52bc2f13.json
+++ b/openfisca_france/tests/json/f7rn-824b8a7d0f58912f997464b1ef8bf3894b6134ac960ea09d29aa0ade52bc2f13.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rn-8bf5c29b7023749cf61bbf51f3de362165df96ef367afea099099c60e0f5066f.json
+++ b/openfisca_france/tests/json/f7rn-8bf5c29b7023749cf61bbf51f3de362165df96ef367afea099099c60e0f5066f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rn-c5715ee19150c83cda3b889d6b9cad398aba8f9ed58df1bfc8780dd2c4ba79ca.json
+++ b/openfisca_france/tests/json/f7rn-c5715ee19150c83cda3b889d6b9cad398aba8f9ed58df1bfc8780dd2c4ba79ca.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rn-e88a8311fdf144c96ba0d4bbf54c711b0d91c4bbf3f33f77bc0b839a33c634e3.json
+++ b/openfisca_france/tests/json/f7rn-e88a8311fdf144c96ba0d4bbf54c711b0d91c4bbf3f33f77bc0b839a33c634e3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ro-0d4efbfc59826538e4af7f263802279006b5f1e155c02ecf9e6fa1ec096a7e26.json
+++ b/openfisca_france/tests/json/f7ro-0d4efbfc59826538e4af7f263802279006b5f1e155c02ecf9e6fa1ec096a7e26.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ro-12c156ae44824d0c2acd6d4adc22716cca96abe99f9709ce28d56010351c93af.json
+++ b/openfisca_france/tests/json/f7ro-12c156ae44824d0c2acd6d4adc22716cca96abe99f9709ce28d56010351c93af.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ro-427856574bc90a7f9c5f713dd084ca6835ee0100fb41efb679ba61d131dbcb4f.json
+++ b/openfisca_france/tests/json/f7ro-427856574bc90a7f9c5f713dd084ca6835ee0100fb41efb679ba61d131dbcb4f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ro-51ecaef5d6b6d1e988b6cd9a5ab8f433a8df11f9283f2e1eb8c62f0742c1cf1e.json
+++ b/openfisca_france/tests/json/f7ro-51ecaef5d6b6d1e988b6cd9a5ab8f433a8df11f9283f2e1eb8c62f0742c1cf1e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ro-933cffc68c46072f505701eda2e55a2708200aa76f43579c3dac09a6f4322ff0.json
+++ b/openfisca_france/tests/json/f7ro-933cffc68c46072f505701eda2e55a2708200aa76f43579c3dac09a6f4322ff0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ro-b000f4c55ccc736742aa413391ba6232a7b62a6483a2a6c935d743a29ff756be.json
+++ b/openfisca_france/tests/json/f7ro-b000f4c55ccc736742aa413391ba6232a7b62a6483a2a6c935d743a29ff756be.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ro-e2ffc2b51237ff2afa82ef0fd54dabf0d3ba837a96ac3c0efa41b7f0d7546d06.json
+++ b/openfisca_france/tests/json/f7ro-e2ffc2b51237ff2afa82ef0fd54dabf0d3ba837a96ac3c0efa41b7f0d7546d06.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rp-3518b21843e987fb1bb14c706693bbffa0944d319eeced038390c1ac8329e165.json
+++ b/openfisca_france/tests/json/f7rp-3518b21843e987fb1bb14c706693bbffa0944d319eeced038390c1ac8329e165.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rp-3d402bc8430a3d77572cfd9b8fe6f54c66c28b903b3f9c1d57fb252f289d3ccc.json
+++ b/openfisca_france/tests/json/f7rp-3d402bc8430a3d77572cfd9b8fe6f54c66c28b903b3f9c1d57fb252f289d3ccc.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rp-5333c94fa1211a44bd83302f84f1290d9b04ab3b7b0c9b99a3e40352fba1c536.json
+++ b/openfisca_france/tests/json/f7rp-5333c94fa1211a44bd83302f84f1290d9b04ab3b7b0c9b99a3e40352fba1c536.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rp-84cf4f98e4da956fa831184ce42e7530439f5b1680099d87356d2d46a35baa24.json
+++ b/openfisca_france/tests/json/f7rp-84cf4f98e4da956fa831184ce42e7530439f5b1680099d87356d2d46a35baa24.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rp-8715bf0193358fc68b402cf9eced5aa5bbb4e9cbaa3ea2384d249b15b826dd09.json
+++ b/openfisca_france/tests/json/f7rp-8715bf0193358fc68b402cf9eced5aa5bbb4e9cbaa3ea2384d249b15b826dd09.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rp-8b1017e0c683c78ad180851ef50cdeb21f3da2ee5c35fa9da03da88f2ce90548.json
+++ b/openfisca_france/tests/json/f7rp-8b1017e0c683c78ad180851ef50cdeb21f3da2ee5c35fa9da03da88f2ce90548.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rp-939388338c0031d2819ebf03278aac5fffb8dae91ce09747d243b6c956067309.json
+++ b/openfisca_france/tests/json/f7rp-939388338c0031d2819ebf03278aac5fffb8dae91ce09747d243b6c956067309.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rp-b434a564045e327911185f0aea6715741a94a474f30765e19ddaf110f3b955e6.json
+++ b/openfisca_france/tests/json/f7rp-b434a564045e327911185f0aea6715741a94a474f30765e19ddaf110f3b955e6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rp-c25f340442685ed441c4e47da7a79ca9f4c547ce6dc36c9c6bb575e306b62ed4.json
+++ b/openfisca_france/tests/json/f7rp-c25f340442685ed441c4e47da7a79ca9f4c547ce6dc36c9c6bb575e306b62ed4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rq-000e660234294dc0f6ddf3486339138cec44a93c0f1ec86e61e30fcce43d0498.json
+++ b/openfisca_france/tests/json/f7rq-000e660234294dc0f6ddf3486339138cec44a93c0f1ec86e61e30fcce43d0498.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rq-0db37ed57ef8e04772f2273bde35e90cc2fe7752e9f7e6d5f7b86e62e19f9d75.json
+++ b/openfisca_france/tests/json/f7rq-0db37ed57ef8e04772f2273bde35e90cc2fe7752e9f7e6d5f7b86e62e19f9d75.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rq-1c118eaadf9138ecb38eb43f16cf9dda171707cc183bf3c524229b6cdc50117e.json
+++ b/openfisca_france/tests/json/f7rq-1c118eaadf9138ecb38eb43f16cf9dda171707cc183bf3c524229b6cdc50117e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rq-203d4c7b982db228c03e135fe25fc11aeaa7e33c2d6d73e0e1045d38f0032997.json
+++ b/openfisca_france/tests/json/f7rq-203d4c7b982db228c03e135fe25fc11aeaa7e33c2d6d73e0e1045d38f0032997.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rq-7853c4a1062905ee34ed4bff39bb4a260eb964b5ef5c8b8110c9c342b0992929.json
+++ b/openfisca_france/tests/json/f7rq-7853c4a1062905ee34ed4bff39bb4a260eb964b5ef5c8b8110c9c342b0992929.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rq-9b5540dcdd6ef6e4b1d0311c2fc527378e469a7ac255a8cca3f60c6826a506f0.json
+++ b/openfisca_france/tests/json/f7rq-9b5540dcdd6ef6e4b1d0311c2fc527378e469a7ac255a8cca3f60c6826a506f0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rq-c62ffe043da54d37f78379400c69388c9bdc2daef58361ac0d515307b8da54b0.json
+++ b/openfisca_france/tests/json/f7rq-c62ffe043da54d37f78379400c69388c9bdc2daef58361ac0d515307b8da54b0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rq-de37cd7bd178a8ffa3f3e857f40a225865ffed94a4a8aba6c87f459556aedcc3.json
+++ b/openfisca_france/tests/json/f7rq-de37cd7bd178a8ffa3f3e857f40a225865ffed94a4a8aba6c87f459556aedcc3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rq-f8445e7b3d863af1336dfeff8a3bb9c32bd520106159ab91eca1c4b35dadfc04.json
+++ b/openfisca_france/tests/json/f7rq-f8445e7b3d863af1336dfeff8a3bb9c32bd520106159ab91eca1c4b35dadfc04.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rr-353b8fddf91fc838ff93532e90b4fb37a6a76ccd93d8de16a31bb22b1028e9ef.json
+++ b/openfisca_france/tests/json/f7rr-353b8fddf91fc838ff93532e90b4fb37a6a76ccd93d8de16a31bb22b1028e9ef.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rr-7cef2cf4715fb57fc336316d91b0e6d7e78b1de7c61a7f48347d37d67c9aaba6.json
+++ b/openfisca_france/tests/json/f7rr-7cef2cf4715fb57fc336316d91b0e6d7e78b1de7c61a7f48347d37d67c9aaba6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rr-86385ac88bff1b8b6d028813ff49c9ad8f574e47034b5168f87abf8568a87139.json
+++ b/openfisca_france/tests/json/f7rr-86385ac88bff1b8b6d028813ff49c9ad8f574e47034b5168f87abf8568a87139.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rr-93ef17de04ffb0ba7255972c1ae74dd03a5157c4d56353b7ac18ab56c6a284db.json
+++ b/openfisca_france/tests/json/f7rr-93ef17de04ffb0ba7255972c1ae74dd03a5157c4d56353b7ac18ab56c6a284db.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rr-a4cf2306c715d72e2f8f7b75801062bc8b83e16ea34e46f0f30d0b5ad0f56495.json
+++ b/openfisca_france/tests/json/f7rr-a4cf2306c715d72e2f8f7b75801062bc8b83e16ea34e46f0f30d0b5ad0f56495.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rr-b400448a07e25c8169f86897e719a0b9d2864e5f112e39034da5c6bdf9881184.json
+++ b/openfisca_france/tests/json/f7rr-b400448a07e25c8169f86897e719a0b9d2864e5f112e39034da5c6bdf9881184.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rr-da414d16cee4ff9be04e28d2b97fbd2c42d1d51f21222b070ed161a45a899ad5.json
+++ b/openfisca_france/tests/json/f7rr-da414d16cee4ff9be04e28d2b97fbd2c42d1d51f21222b070ed161a45a899ad5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rr-de7ed8716ba79f3b3c45dee9a9c814c411161f87a2074d8261510bd52862e1ae.json
+++ b/openfisca_france/tests/json/f7rr-de7ed8716ba79f3b3c45dee9a9c814c411161f87a2074d8261510bd52862e1ae.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rr-e91f8ba4066e9772dea6edc5bba70a26a1849c419fb383acdf610f489eb12b78.json
+++ b/openfisca_france/tests/json/f7rr-e91f8ba4066e9772dea6edc5bba70a26a1849c419fb383acdf610f489eb12b78.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rs-157987d4f1323581dbf56e3826881a18c2e2d0fbe9aabf892783f0e2ecd20e0c.json
+++ b/openfisca_france/tests/json/f7rs-157987d4f1323581dbf56e3826881a18c2e2d0fbe9aabf892783f0e2ecd20e0c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rs-3d5060f4184071c180a9c5568c9bafc0991587f6bfd4d96c455e0418ed70be31.json
+++ b/openfisca_france/tests/json/f7rs-3d5060f4184071c180a9c5568c9bafc0991587f6bfd4d96c455e0418ed70be31.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rs-3d8483504a56a1508a6b80b43488df9ae1a1768c7ffbdaca92813cd5765fb979.json
+++ b/openfisca_france/tests/json/f7rs-3d8483504a56a1508a6b80b43488df9ae1a1768c7ffbdaca92813cd5765fb979.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rs-748a61726afffe0697923a1fdbccd226719c615312adb817dafe491818d96ff9.json
+++ b/openfisca_france/tests/json/f7rs-748a61726afffe0697923a1fdbccd226719c615312adb817dafe491818d96ff9.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rs-90c99db4f334c17a44929520b6b70396ba5ab907998f26b13d956a173169ce2c.json
+++ b/openfisca_france/tests/json/f7rs-90c99db4f334c17a44929520b6b70396ba5ab907998f26b13d956a173169ce2c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rs-a5125ea2b2415aee9b74660d494c7cab32092fdd0ad5d490e9ec335db4cb7de4.json
+++ b/openfisca_france/tests/json/f7rs-a5125ea2b2415aee9b74660d494c7cab32092fdd0ad5d490e9ec335db4cb7de4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rs-cd98c11fd08d4222d4474d5749a8a4054c9824067510b9d5163750676c2bdb90.json
+++ b/openfisca_france/tests/json/f7rs-cd98c11fd08d4222d4474d5749a8a4054c9824067510b9d5163750676c2bdb90.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rs-f918bba2197d93d1ab3ecf9fd6658ede7dd2c27d2ca48b13ab555c02d0b56a0d.json
+++ b/openfisca_france/tests/json/f7rs-f918bba2197d93d1ab3ecf9fd6658ede7dd2c27d2ca48b13ab555c02d0b56a0d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rs-fbb82f8055e06f043cb4c420110440b0cdd8cfa8e47fa32e789bf458586773c1.json
+++ b/openfisca_france/tests/json/f7rs-fbb82f8055e06f043cb4c420110440b0cdd8cfa8e47fa32e789bf458586773c1.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rt-0260825851c70dc7bb23b1bf85fa34b42d9fa434e47b8cabfbed1105943b354c.json
+++ b/openfisca_france/tests/json/f7rt-0260825851c70dc7bb23b1bf85fa34b42d9fa434e47b8cabfbed1105943b354c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rt-77d901cddc304b0bbba94cad9b181f6d38dc1ceb4335f87e8682bf4cb6b31708.json
+++ b/openfisca_france/tests/json/f7rt-77d901cddc304b0bbba94cad9b181f6d38dc1ceb4335f87e8682bf4cb6b31708.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rt-7a4eab612055ed2f731e049d78f01d9624ffde5f9681961c6a50e1b08e35eec7.json
+++ b/openfisca_france/tests/json/f7rt-7a4eab612055ed2f731e049d78f01d9624ffde5f9681961c6a50e1b08e35eec7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rt-922446f3814030e2116b1d4e44dfb55762460a426b20b71d1d1291526408cbf0.json
+++ b/openfisca_france/tests/json/f7rt-922446f3814030e2116b1d4e44dfb55762460a426b20b71d1d1291526408cbf0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rt-b3ce328d7990063fdcce413cfa3f20f6b0d92b5c4786f88ed59079967ca39a20.json
+++ b/openfisca_france/tests/json/f7rt-b3ce328d7990063fdcce413cfa3f20f6b0d92b5c4786f88ed59079967ca39a20.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rt-b893d4b40c00d1ce9825725a8657775e2df17b922e77a9206635bccbe228328c.json
+++ b/openfisca_france/tests/json/f7rt-b893d4b40c00d1ce9825725a8657775e2df17b922e77a9206635bccbe228328c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rt-f53504d50296086910a82865e6b0a992cd236dae43b8901abd9d1a88906de524.json
+++ b/openfisca_france/tests/json/f7rt-f53504d50296086910a82865e6b0a992cd236dae43b8901abd9d1a88906de524.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ru-1a4b811322413b52fdeeb5d221b2f2df9d2a721698d6d1dd5a32242df7886abb.json
+++ b/openfisca_france/tests/json/f7ru-1a4b811322413b52fdeeb5d221b2f2df9d2a721698d6d1dd5a32242df7886abb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ru-2fd49a9effb5a9e369d97039bfa005a1802af49e0126d7f7fada30ddbf0cb8ee.json
+++ b/openfisca_france/tests/json/f7ru-2fd49a9effb5a9e369d97039bfa005a1802af49e0126d7f7fada30ddbf0cb8ee.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ru-3c00add8f5670f474eed8128d7b6ec16c125d7f1951d587206e0458b8e7be621.json
+++ b/openfisca_france/tests/json/f7ru-3c00add8f5670f474eed8128d7b6ec16c125d7f1951d587206e0458b8e7be621.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ru-3d4e89adff6286c3b29511c0263db85f4991b490537fcf1fe879c1b7cc019d34.json
+++ b/openfisca_france/tests/json/f7ru-3d4e89adff6286c3b29511c0263db85f4991b490537fcf1fe879c1b7cc019d34.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ru-4652ea710452d20543bad216fd4506ce319e4161f61982d738a3251f54d3c8b8.json
+++ b/openfisca_france/tests/json/f7ru-4652ea710452d20543bad216fd4506ce319e4161f61982d738a3251f54d3c8b8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ru-9122de70553067b0b2351f1fe3a9c7b4368047b6aa28d413b43a2fdf642040aa.json
+++ b/openfisca_france/tests/json/f7ru-9122de70553067b0b2351f1fe3a9c7b4368047b6aa28d413b43a2fdf642040aa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ru-a95385255f3a5d8dce5a782deb32cf34ff12f50bcb0bd462063cfd02857ad46c.json
+++ b/openfisca_france/tests/json/f7ru-a95385255f3a5d8dce5a782deb32cf34ff12f50bcb0bd462063cfd02857ad46c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ru-ccadb6daed777a92579ad9bf100fb4afad8e77feec33e24433cb52fcf77aafff.json
+++ b/openfisca_france/tests/json/f7ru-ccadb6daed777a92579ad9bf100fb4afad8e77feec33e24433cb52fcf77aafff.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ru-df05c8b34ff8747c45ab89ddb59417e24184ecafd2adaad7d9d7093f4a1bbf0d.json
+++ b/openfisca_france/tests/json/f7ru-df05c8b34ff8747c45ab89ddb59417e24184ecafd2adaad7d9d7093f4a1bbf0d.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rv-0170d9b26f1096c67f20badfd21e057ea20380954b3a1df14c1b5e385f6bc59c.json
+++ b/openfisca_france/tests/json/f7rv-0170d9b26f1096c67f20badfd21e057ea20380954b3a1df14c1b5e385f6bc59c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rv-05a38bc0315c05475064eedaa53eb10634a35aea70f195c3e050f7de06dbd6c2.json
+++ b/openfisca_france/tests/json/f7rv-05a38bc0315c05475064eedaa53eb10634a35aea70f195c3e050f7de06dbd6c2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rv-1f75e787487ce01d38cbb10ee14389cb26d7e97d94938930e386f865f5d5ba1f.json
+++ b/openfisca_france/tests/json/f7rv-1f75e787487ce01d38cbb10ee14389cb26d7e97d94938930e386f865f5d5ba1f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rv-20fe292813dad1418ed55e4be3efdf90ce97b6c4309b176db8d7fa0c7b188590.json
+++ b/openfisca_france/tests/json/f7rv-20fe292813dad1418ed55e4be3efdf90ce97b6c4309b176db8d7fa0c7b188590.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rv-666d7a56708ce8eccd52b6dd996c9fb87e28955aa6f45828a83d9574e0375766.json
+++ b/openfisca_france/tests/json/f7rv-666d7a56708ce8eccd52b6dd996c9fb87e28955aa6f45828a83d9574e0375766.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rv-67429d4e226a7058d2c139355591966c7b4f62b2b2cf82106176f3a3cf068753.json
+++ b/openfisca_france/tests/json/f7rv-67429d4e226a7058d2c139355591966c7b4f62b2b2cf82106176f3a3cf068753.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rv-6d6bd54daf97c57ae5e7772cdc22420e22405367491dd91a36bed8a2b0b89c58.json
+++ b/openfisca_france/tests/json/f7rv-6d6bd54daf97c57ae5e7772cdc22420e22405367491dd91a36bed8a2b0b89c58.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rv-8fefe62feeef0233053e0fa773e7739344edc6f256238bf2cad316a2c2da1918.json
+++ b/openfisca_france/tests/json/f7rv-8fefe62feeef0233053e0fa773e7739344edc6f256238bf2cad316a2c2da1918.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rv-e89e7966f1a921a6a2160e05d03e6075106575671e196a59c821d12f26377501.json
+++ b/openfisca_france/tests/json/f7rv-e89e7966f1a921a6a2160e05d03e6075106575671e196a59c821d12f26377501.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rw-38275e7400c398c2088a400cb4de11e530106c2c0fa09c9a6c3e9000299eb714.json
+++ b/openfisca_france/tests/json/f7rw-38275e7400c398c2088a400cb4de11e530106c2c0fa09c9a6c3e9000299eb714.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rw-4b064a40ed29cd2030f3123134df280f8e67813672a9e7eea00c0d36bfaf39bf.json
+++ b/openfisca_france/tests/json/f7rw-4b064a40ed29cd2030f3123134df280f8e67813672a9e7eea00c0d36bfaf39bf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rw-5ecc9126a3224aeb28a65e220ff686aa685939efc73a42b7903c4f63a4df988c.json
+++ b/openfisca_france/tests/json/f7rw-5ecc9126a3224aeb28a65e220ff686aa685939efc73a42b7903c4f63a4df988c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rw-602b69bbaad5c49454ca4115f40ebbca563aa9acc26b209fde1cd3d8c4975855.json
+++ b/openfisca_france/tests/json/f7rw-602b69bbaad5c49454ca4115f40ebbca563aa9acc26b209fde1cd3d8c4975855.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rw-a126b7e8558b40139d947e6b1804c173d1886cc2d2b3ce0041d30e478077020f.json
+++ b/openfisca_france/tests/json/f7rw-a126b7e8558b40139d947e6b1804c173d1886cc2d2b3ce0041d30e478077020f.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rw-b16577eb1025f9d35991c2808a8582aed0c846ef2a13b63bd43cf346f780655e.json
+++ b/openfisca_france/tests/json/f7rw-b16577eb1025f9d35991c2808a8582aed0c846ef2a13b63bd43cf346f780655e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rw-d63a0d99eb69ace17926f1c44a447f4929ca429e304e472245694c07039e0eec.json
+++ b/openfisca_france/tests/json/f7rw-d63a0d99eb69ace17926f1c44a447f4929ca429e304e472245694c07039e0eec.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rw-dfe5f783cf3677248d023f4a792f44d97e3acb3b5ca60f3204330f0e8fee1a4f.json
+++ b/openfisca_france/tests/json/f7rw-dfe5f783cf3677248d023f4a792f44d97e3acb3b5ca60f3204330f0e8fee1a4f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rw-ff68f262698a9deb43b1e6727c204767da00fbb2988d3f4fdfe156dbd061f85e.json
+++ b/openfisca_france/tests/json/f7rw-ff68f262698a9deb43b1e6727c204767da00fbb2988d3f4fdfe156dbd061f85e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rx-0fff2fb2344a2d71e9430ed2bf1c2a84cc6badb5ffed15029f60a8468ab31868.json
+++ b/openfisca_france/tests/json/f7rx-0fff2fb2344a2d71e9430ed2bf1c2a84cc6badb5ffed15029f60a8468ab31868.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rx-289cfd5ac51c6e7e848c71894fc69e89e761b39a131932af582e4d226c2dc54e.json
+++ b/openfisca_france/tests/json/f7rx-289cfd5ac51c6e7e848c71894fc69e89e761b39a131932af582e4d226c2dc54e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rx-6c171ebf9cca8d15f6628023abcd800dee82a6b2773b09c10535e2d24fd95573.json
+++ b/openfisca_france/tests/json/f7rx-6c171ebf9cca8d15f6628023abcd800dee82a6b2773b09c10535e2d24fd95573.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rx-6eb14e2b22f1e55bc05c809ee7f9dad3e042b3d20500998cbf04ad3e9a86d3fa.json
+++ b/openfisca_france/tests/json/f7rx-6eb14e2b22f1e55bc05c809ee7f9dad3e042b3d20500998cbf04ad3e9a86d3fa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rx-a38ad1b3a7078b20100f9fcb0046e78018d3e81fb322509e9e1511356014313f.json
+++ b/openfisca_france/tests/json/f7rx-a38ad1b3a7078b20100f9fcb0046e78018d3e81fb322509e9e1511356014313f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rx-db8a407e30f61589b4a76579dac725e47c28ba111093484bcc8e4f5f3ff56844.json
+++ b/openfisca_france/tests/json/f7rx-db8a407e30f61589b4a76579dac725e47c28ba111093484bcc8e4f5f3ff56844.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rx-e4691756615a24e16d57753f28f875f0dc3baac0bf2008dc7aeb71038ae75a6b.json
+++ b/openfisca_france/tests/json/f7rx-e4691756615a24e16d57753f28f875f0dc3baac0bf2008dc7aeb71038ae75a6b.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rx-f479a00e6500c250dcf46151b58aef5360c0eb35a806ae48dc1f96f58226bd6e.json
+++ b/openfisca_france/tests/json/f7rx-f479a00e6500c250dcf46151b58aef5360c0eb35a806ae48dc1f96f58226bd6e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rx-f78fef868e88b85fa8ea51b6a4fe6dbf40db61cdee253ed9277f48c1235b1a01.json
+++ b/openfisca_france/tests/json/f7rx-f78fef868e88b85fa8ea51b6a4fe6dbf40db61cdee253ed9277f48c1235b1a01.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ry-11bf53f15e84b3d52bc2fc6bb5646aa64145214c367e24c8ed2068f894873304.json
+++ b/openfisca_france/tests/json/f7ry-11bf53f15e84b3d52bc2fc6bb5646aa64145214c367e24c8ed2068f894873304.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ry-27a9344735d7e05fb00d903571d9baad64a9cd11356b174d8e336ce1cf08216f.json
+++ b/openfisca_france/tests/json/f7ry-27a9344735d7e05fb00d903571d9baad64a9cd11356b174d8e336ce1cf08216f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ry-3c5db9dfe437a0392375ded0afc170ae8ead40d45c823c48fcdb3b25ee73e937.json
+++ b/openfisca_france/tests/json/f7ry-3c5db9dfe437a0392375ded0afc170ae8ead40d45c823c48fcdb3b25ee73e937.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ry-743e14ce4c60a9e6cd13fa5e792169ffe29b89a7e5c23a8b4888f821d0d03037.json
+++ b/openfisca_france/tests/json/f7ry-743e14ce4c60a9e6cd13fa5e792169ffe29b89a7e5c23a8b4888f821d0d03037.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ry-8a3ecead8c823d707ce7ea2f2e0250b47d58133668893391e9523f36535c3c03.json
+++ b/openfisca_france/tests/json/f7ry-8a3ecead8c823d707ce7ea2f2e0250b47d58133668893391e9523f36535c3c03.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ry-a2b86ade8ee1ecb988c8ce884bf3e185c5aac019f987b7bd144f2b96653fd823.json
+++ b/openfisca_france/tests/json/f7ry-a2b86ade8ee1ecb988c8ce884bf3e185c5aac019f987b7bd144f2b96653fd823.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ry-aab805b8c0158fa85445acd765eb3b0676203f91b5afe0a02bbb99576c04ff6e.json
+++ b/openfisca_france/tests/json/f7ry-aab805b8c0158fa85445acd765eb3b0676203f91b5afe0a02bbb99576c04ff6e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rz-0e7ee1d691b8ecb72a7b35196460837d939f9bdcf24c58a4e1edfbc2596d390f.json
+++ b/openfisca_france/tests/json/f7rz-0e7ee1d691b8ecb72a7b35196460837d939f9bdcf24c58a4e1edfbc2596d390f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rz-1cab973d4786ff4a8de2971f746c14b6db5a1d3aafb7e3f9f852e1bda1c7a925.json
+++ b/openfisca_france/tests/json/f7rz-1cab973d4786ff4a8de2971f746c14b6db5a1d3aafb7e3f9f852e1bda1c7a925.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rz-3642ffae9283b85eeecc23982dfce62f0292439574bb2a05885384e4ac6d6a63.json
+++ b/openfisca_france/tests/json/f7rz-3642ffae9283b85eeecc23982dfce62f0292439574bb2a05885384e4ac6d6a63.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rz-6c5167ba77cc45de6603b6ae566dbc8b7a0eb3ba70a2b1d9dbcba724946f9873.json
+++ b/openfisca_france/tests/json/f7rz-6c5167ba77cc45de6603b6ae566dbc8b7a0eb3ba70a2b1d9dbcba724946f9873.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rz-7a0066b3ccd0289703b3c7e8542b56f428720a9055d3a777eab7a13cef83216b.json
+++ b/openfisca_france/tests/json/f7rz-7a0066b3ccd0289703b3c7e8542b56f428720a9055d3a777eab7a13cef83216b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rz-bcf7c3ab5e504db03ae80f17175634a79a3d583588ce3a2788b02fb6f7be7b9c.json
+++ b/openfisca_france/tests/json/f7rz-bcf7c3ab5e504db03ae80f17175634a79a3d583588ce3a2788b02fb6f7be7b9c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rz-c1fdd593eae2930c32613878324f84a583c7a2b8ac7d4ea24466b368bba520f2.json
+++ b/openfisca_france/tests/json/f7rz-c1fdd593eae2930c32613878324f84a583c7a2b8ac7d4ea24466b368bba520f2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rz-d597be0fb3b2179d9198523ef7ba062b5c995a87802031e2dba3bbe14e6d3af9.json
+++ b/openfisca_france/tests/json/f7rz-d597be0fb3b2179d9198523ef7ba062b5c995a87802031e2dba3bbe14e6d3af9.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7rz-f54598ecc4ff676ef27397ed0e1b5a34d27cbea1bec74b3ee00760df3c150fe2.json
+++ b/openfisca_france/tests/json/f7rz-f54598ecc4ff676ef27397ed0e1b5a34d27cbea1bec74b3ee00760df3c150fe2.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sb-04df7b692e1747444207030cfd9067c6fc440c949a8902e64008aa7ff9e29287.json
+++ b/openfisca_france/tests/json/f7sb-04df7b692e1747444207030cfd9067c6fc440c949a8902e64008aa7ff9e29287.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sb-0a32f25464762a596cac19153150448adefbbcb8479f2e1f776e96cc5d1abf70.json
+++ b/openfisca_france/tests/json/f7sb-0a32f25464762a596cac19153150448adefbbcb8479f2e1f776e96cc5d1abf70.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sb-2c70e8a27be7d585cf74299cd2d14952cdbc6b9f416981960c922489733f1ad8.json
+++ b/openfisca_france/tests/json/f7sb-2c70e8a27be7d585cf74299cd2d14952cdbc6b9f416981960c922489733f1ad8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sb-46e356fd6f143d05c0ba96de19fb18edc1b48075d7c8770448ffdd110d68fc31.json
+++ b/openfisca_france/tests/json/f7sb-46e356fd6f143d05c0ba96de19fb18edc1b48075d7c8770448ffdd110d68fc31.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sf-03864a958931f7d19281b4255e714f72dca0c5639aa3bc3735abeb9ba49945ad.json
+++ b/openfisca_france/tests/json/f7sf-03864a958931f7d19281b4255e714f72dca0c5639aa3bc3735abeb9ba49945ad.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sf-06e780eb054d4736f657553130db09ad82cd2ab3754ff2d76514152b1b993a26.json
+++ b/openfisca_france/tests/json/f7sf-06e780eb054d4736f657553130db09ad82cd2ab3754ff2d76514152b1b993a26.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sf-40f54b06b2268599a19fda3cdd25a09462738835a96aae746ac60d2c0941e1e2.json
+++ b/openfisca_france/tests/json/f7sf-40f54b06b2268599a19fda3cdd25a09462738835a96aae746ac60d2c0941e1e2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sf-70d1e8f4aea6b3dea548d28974b3298c81353b2b6b52daefcc1d5af60053d664.json
+++ b/openfisca_france/tests/json/f7sf-70d1e8f4aea6b3dea548d28974b3298c81353b2b6b52daefcc1d5af60053d664.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sf-87e3c7f59e36e8b2d62f1832b37a685f1a48b0bbeb9e27ad7927e525ab7be60f.json
+++ b/openfisca_france/tests/json/f7sf-87e3c7f59e36e8b2d62f1832b37a685f1a48b0bbeb9e27ad7927e525ab7be60f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sf-8d304e947473c54d7cef53532303f63f04debe7e40417f4c396888d3f5cd8f73.json
+++ b/openfisca_france/tests/json/f7sf-8d304e947473c54d7cef53532303f63f04debe7e40417f4c396888d3f5cd8f73.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sf-b4fec36a2fa8064a2108cc1ac49f5612a3cf1e421a4f522ecb7257a51129dc76.json
+++ b/openfisca_france/tests/json/f7sf-b4fec36a2fa8064a2108cc1ac49f5612a3cf1e421a4f522ecb7257a51129dc76.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sf-d1debc74333ad257803d3de94377bbb8a3f6a84156f3a771f90c2f459c2238cb.json
+++ b/openfisca_france/tests/json/f7sf-d1debc74333ad257803d3de94377bbb8a3f6a84156f3a771f90c2f459c2238cb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sf-d7350873156aa660b0b874752a38d465fff9db664cee47e9120de24fd87dbd03.json
+++ b/openfisca_france/tests/json/f7sf-d7350873156aa660b0b874752a38d465fff9db664cee47e9120de24fd87dbd03.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sh-0fe098ab1f911bd849a3e8ec32684274a75d8ed3d27e27c10f815da2406e68fc.json
+++ b/openfisca_france/tests/json/f7sh-0fe098ab1f911bd849a3e8ec32684274a75d8ed3d27e27c10f815da2406e68fc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sh-c8011ac3b0b97ccaf5ab55ed84fab72bcf61837d47d1651fbb1540b9e6963b71.json
+++ b/openfisca_france/tests/json/f7sh-c8011ac3b0b97ccaf5ab55ed84fab72bcf61837d47d1651fbb1540b9e6963b71.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sh-d481540b97e4c8d404e0a41ef79fb7960860e1cc643c3eb7ded426d010c1d5f4.json
+++ b/openfisca_france/tests/json/f7sh-d481540b97e4c8d404e0a41ef79fb7960860e1cc643c3eb7ded426d010c1d5f4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sh-df779e53dbb9cdf7940e268bcc0998a284275f11320119719dca8a526adebb10.json
+++ b/openfisca_france/tests/json/f7sh-df779e53dbb9cdf7940e268bcc0998a284275f11320119719dca8a526adebb10.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sh-f3c861c441242bcd4f0ba68945374c6ee9fad80fe189223778a0697e09ad3e88.json
+++ b/openfisca_france/tests/json/f7sh-f3c861c441242bcd4f0ba68945374c6ee9fad80fe189223778a0697e09ad3e88.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7si-074c3d8545a9778f36aa220d0c816b4f4f684bc3e006252dab0b3926a8730816.json
+++ b/openfisca_france/tests/json/f7si-074c3d8545a9778f36aa220d0c816b4f4f684bc3e006252dab0b3926a8730816.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7si-14f30a94900fd3fcb0079365363d3a82354a4be263d73e8a2eda2c20962f9e27.json
+++ b/openfisca_france/tests/json/f7si-14f30a94900fd3fcb0079365363d3a82354a4be263d73e8a2eda2c20962f9e27.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7si-23c83272376fb752ef4a036fa9a29f0a59f516c07ec11c8304a3884352f6541c.json
+++ b/openfisca_france/tests/json/f7si-23c83272376fb752ef4a036fa9a29f0a59f516c07ec11c8304a3884352f6541c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7si-5d1b12afbd5682dca66fe1857650c28949f996e26ea8419041e8c7c9f4752f90.json
+++ b/openfisca_france/tests/json/f7si-5d1b12afbd5682dca66fe1857650c28949f996e26ea8419041e8c7c9f4752f90.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7si-624fe665b50d01ab8ef22289139eac8f8506b527d931d088a2cbff953fc87b61.json
+++ b/openfisca_france/tests/json/f7si-624fe665b50d01ab8ef22289139eac8f8506b527d931d088a2cbff953fc87b61.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7si-833b78b975c7dc28e61f1a21017c5c0b02bb24d5d1c85cb129530e6cb7455cef.json
+++ b/openfisca_france/tests/json/f7si-833b78b975c7dc28e61f1a21017c5c0b02bb24d5d1c85cb129530e6cb7455cef.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7si-9ea58add5d9f67fe3e1309d7535b8ad6772c5fb63d4bfedf14dce94545710da8.json
+++ b/openfisca_france/tests/json/f7si-9ea58add5d9f67fe3e1309d7535b8ad6772c5fb63d4bfedf14dce94545710da8.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7si-e1b04ebeb21fbdb35df692472c24df58d9b4931def732c5315694c1d5fa65d35.json
+++ b/openfisca_france/tests/json/f7si-e1b04ebeb21fbdb35df692472c24df58d9b4931def732c5315694c1d5fa65d35.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7si-f5da70a233f6681fe0eeadc108092f7f3e021c1815f4a476bffd13406e821ad0.json
+++ b/openfisca_france/tests/json/f7si-f5da70a233f6681fe0eeadc108092f7f3e021c1815f4a476bffd13406e821ad0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sj-1650a2692313fb8556fa0addc9238419e8a8b52f54cacd3490cfebb1098414b7.json
+++ b/openfisca_france/tests/json/f7sj-1650a2692313fb8556fa0addc9238419e8a8b52f54cacd3490cfebb1098414b7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sj-37db85b2bffaafd919fccd27f1163914ecb8c8b8ff705c1cf5b4cd0a9271b48b.json
+++ b/openfisca_france/tests/json/f7sj-37db85b2bffaafd919fccd27f1163914ecb8c8b8ff705c1cf5b4cd0a9271b48b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sj-38b295563db3d9dcfdf24435ef523cb0aa4995539f69c2eab6e1a04edc3f222d.json
+++ b/openfisca_france/tests/json/f7sj-38b295563db3d9dcfdf24435ef523cb0aa4995539f69c2eab6e1a04edc3f222d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sj-4aa7b14a7dbb88e04b487b45db1156885b082350ec2f8f0372a7ae20b6dd6a8f.json
+++ b/openfisca_france/tests/json/f7sj-4aa7b14a7dbb88e04b487b45db1156885b082350ec2f8f0372a7ae20b6dd6a8f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sj-599b2ad8dac5897c4d69b1f84b2209f7e63e3e250e6438d8fe236293906d69df.json
+++ b/openfisca_france/tests/json/f7sj-599b2ad8dac5897c4d69b1f84b2209f7e63e3e250e6438d8fe236293906d69df.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sj-7c013ff7c2817f48760bf4af3a20b4ffbd30926a29efc065cdc275c130459153.json
+++ b/openfisca_france/tests/json/f7sj-7c013ff7c2817f48760bf4af3a20b4ffbd30926a29efc065cdc275c130459153.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sj-f8c375782eab970df06f3eb8ca820385f37f1f5344d8e0044c681fe8997cbe37.json
+++ b/openfisca_france/tests/json/f7sj-f8c375782eab970df06f3eb8ca820385f37f1f5344d8e0044c681fe8997cbe37.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sk-2b6dedc4fb3009f482256465aa40740a409cb6d562994ff07c4a1d71ab76d76c.json
+++ b/openfisca_france/tests/json/f7sk-2b6dedc4fb3009f482256465aa40740a409cb6d562994ff07c4a1d71ab76d76c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sk-631743bad24e5d8d1194e4703abd282ec829d4a24225d9d098f25d8fba9bffb1.json
+++ b/openfisca_france/tests/json/f7sk-631743bad24e5d8d1194e4703abd282ec829d4a24225d9d098f25d8fba9bffb1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sk-7b04bc4dcdeb977070a1a3c369dff058424caeb931d0dfd1d04473c23d5aa59c.json
+++ b/openfisca_france/tests/json/f7sk-7b04bc4dcdeb977070a1a3c369dff058424caeb931d0dfd1d04473c23d5aa59c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sk-a4007df1bea9c2de34b0eca8b93a3b752f98b0d183644515fcacc1395242d2ec.json
+++ b/openfisca_france/tests/json/f7sk-a4007df1bea9c2de34b0eca8b93a3b752f98b0d183644515fcacc1395242d2ec.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sk-adaeb031b20363c4033b7290c05863f752571aa903e8ff3813620a17ed3c7500.json
+++ b/openfisca_france/tests/json/f7sk-adaeb031b20363c4033b7290c05863f752571aa903e8ff3813620a17ed3c7500.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sk-e5f3b4f5f70b3ac06c1841bdcb974a3e2189267f4c09650160d310810623679a.json
+++ b/openfisca_france/tests/json/f7sk-e5f3b4f5f70b3ac06c1841bdcb974a3e2189267f4c09650160d310810623679a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sk-fda8d01396eb55e1894ce63fb8aad9adebf2780a8868d47d50c3562d7dd73b15.json
+++ b/openfisca_france/tests/json/f7sk-fda8d01396eb55e1894ce63fb8aad9adebf2780a8868d47d50c3562d7dd73b15.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sl-0f860e2ee326849ad09b321d52f16aa164e7a2cea70eff2c8c770172dc98200f.json
+++ b/openfisca_france/tests/json/f7sl-0f860e2ee326849ad09b321d52f16aa164e7a2cea70eff2c8c770172dc98200f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sl-41bd8f2aa58e41d599f196ebf36b730795657468d9e8ccd906836e01b79aefb2.json
+++ b/openfisca_france/tests/json/f7sl-41bd8f2aa58e41d599f196ebf36b730795657468d9e8ccd906836e01b79aefb2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sl-456b5728fc9d2e5770adbdef0b3304e83c335a93f1ed2fc8c2b32829c0d44c18.json
+++ b/openfisca_france/tests/json/f7sl-456b5728fc9d2e5770adbdef0b3304e83c335a93f1ed2fc8c2b32829c0d44c18.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sl-aa15d84281c7e7cf3dd9587e4d520f168a1c60b85b330410aca74bd891a4a88f.json
+++ b/openfisca_france/tests/json/f7sl-aa15d84281c7e7cf3dd9587e4d520f168a1c60b85b330410aca74bd891a4a88f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sl-b7f3174aa9a332d88f818c057e2a2847ee8ae4c69bb4aab9ec48929065ae69ff.json
+++ b/openfisca_france/tests/json/f7sl-b7f3174aa9a332d88f818c057e2a2847ee8ae4c69bb4aab9ec48929065ae69ff.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sl-de365d2f7e3b53460e429d6411cd9e432c5277557d52e719df59de14daec7f83.json
+++ b/openfisca_france/tests/json/f7sl-de365d2f7e3b53460e429d6411cd9e432c5277557d52e719df59de14daec7f83.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sl-de55d95524af9a10d6cf7042ef92f2aa8d7ee423c9528629cbc31e7974f47626.json
+++ b/openfisca_france/tests/json/f7sl-de55d95524af9a10d6cf7042ef92f2aa8d7ee423c9528629cbc31e7974f47626.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sm-163577c5b1e58854a0168b532bbe48eed8ffe74e7c11e2e7cd98f77341a740b5.json
+++ b/openfisca_france/tests/json/f7sm-163577c5b1e58854a0168b532bbe48eed8ffe74e7c11e2e7cd98f77341a740b5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sm-19180748ec58612a9667c50d77bc4025c27eb4195429b3bc6cc46da656c37181.json
+++ b/openfisca_france/tests/json/f7sm-19180748ec58612a9667c50d77bc4025c27eb4195429b3bc6cc46da656c37181.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sm-28ce0847677a4970cf2b79e19aa3b6ef05dc6ed8bd1e039735f5eaf1e239e39f.json
+++ b/openfisca_france/tests/json/f7sm-28ce0847677a4970cf2b79e19aa3b6ef05dc6ed8bd1e039735f5eaf1e239e39f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sm-292a32daaae3576c4bc1a9d70f5a38f5f299e92ef4881f4eb64b2191dde41918.json
+++ b/openfisca_france/tests/json/f7sm-292a32daaae3576c4bc1a9d70f5a38f5f299e92ef4881f4eb64b2191dde41918.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sm-63ca1d620cee0d3822e7da5c92ed5613e18a37cdb33f0817745ba2011827f886.json
+++ b/openfisca_france/tests/json/f7sm-63ca1d620cee0d3822e7da5c92ed5613e18a37cdb33f0817745ba2011827f886.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sm-a1ea2a3de4b1d15fa794fd5f12f42557b5681b9f25474f966ab44b5e9cf6f15b.json
+++ b/openfisca_france/tests/json/f7sm-a1ea2a3de4b1d15fa794fd5f12f42557b5681b9f25474f966ab44b5e9cf6f15b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sm-c5410f45f376bd08039db21a06d3849a08908ba201c7c9e08f0073ca929cbf4c.json
+++ b/openfisca_france/tests/json/f7sm-c5410f45f376bd08039db21a06d3849a08908ba201c7c9e08f0073ca929cbf4c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sm-d43b52080b7651225c36ada42579c8b19107282a9404d38a91b35e302a92a3ad.json
+++ b/openfisca_france/tests/json/f7sm-d43b52080b7651225c36ada42579c8b19107282a9404d38a91b35e302a92a3ad.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sm-f77f94c6396dd54a3956bbbfcbe23861c6db19cc2acb8aa879dbd0fe63775adb.json
+++ b/openfisca_france/tests/json/f7sm-f77f94c6396dd54a3956bbbfcbe23861c6db19cc2acb8aa879dbd0fe63775adb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7so-0ef9fc9d3909ec42b3c2c142f64972e9cb229fc97d8085166be98fcc1fcacac0.json
+++ b/openfisca_france/tests/json/f7so-0ef9fc9d3909ec42b3c2c142f64972e9cb229fc97d8085166be98fcc1fcacac0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7so-4dde36c309c168f1ce312bc99c1ea5743372d317ea099c0d4de40d5695ca895b.json
+++ b/openfisca_france/tests/json/f7so-4dde36c309c168f1ce312bc99c1ea5743372d317ea099c0d4de40d5695ca895b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7so-6133862a7a2ed350878fd6ccf854be1c0f91ee9b0723f9304b6de08f56c91cd3.json
+++ b/openfisca_france/tests/json/f7so-6133862a7a2ed350878fd6ccf854be1c0f91ee9b0723f9304b6de08f56c91cd3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7so-73994eb5dcd8742a8b73a17fb087c7cf4a07ffc79079e199980a7d497a22c8a9.json
+++ b/openfisca_france/tests/json/f7so-73994eb5dcd8742a8b73a17fb087c7cf4a07ffc79079e199980a7d497a22c8a9.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7so-8f2a362e809f5392bc7a4d046b061773ad6804b024e9cf322b253cb8ba5ac4c4.json
+++ b/openfisca_france/tests/json/f7so-8f2a362e809f5392bc7a4d046b061773ad6804b024e9cf322b253cb8ba5ac4c4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7so-b653d4cf64a83f622a30146fa29825fbac28e131e3ea3b658f982dfdeffdc85d.json
+++ b/openfisca_france/tests/json/f7so-b653d4cf64a83f622a30146fa29825fbac28e131e3ea3b658f982dfdeffdc85d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7so-c082fb8a9706a2fbaf39e14b54ff2f9745d5180cb89bf40e6ca7c2be0ff08b6a.json
+++ b/openfisca_france/tests/json/f7so-c082fb8a9706a2fbaf39e14b54ff2f9745d5180cb89bf40e6ca7c2be0ff08b6a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7so-c768635154434366ebcc9e302194efd6648603fd7a17055e42c68e07897229e7.json
+++ b/openfisca_france/tests/json/f7so-c768635154434366ebcc9e302194efd6648603fd7a17055e42c68e07897229e7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7so-ec7146f7871572a99d6d5c7a496c29d440c9393c8082effe10d641513a29b700.json
+++ b/openfisca_france/tests/json/f7so-ec7146f7871572a99d6d5c7a496c29d440c9393c8082effe10d641513a29b700.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sp-22665e4b5afc91ceca0c14015a1ebf4b4705ef334ffb13426ad8262c7b3b76bc.json
+++ b/openfisca_france/tests/json/f7sp-22665e4b5afc91ceca0c14015a1ebf4b4705ef334ffb13426ad8262c7b3b76bc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sp-2593669d8e51dfa243c8efc465c87ecd8cc936d869540c82c71def420653fcc5.json
+++ b/openfisca_france/tests/json/f7sp-2593669d8e51dfa243c8efc465c87ecd8cc936d869540c82c71def420653fcc5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sp-4f3fc319e2635c36a7546f73308ba6217c3bad6b39e381c43913bd79965dca33.json
+++ b/openfisca_france/tests/json/f7sp-4f3fc319e2635c36a7546f73308ba6217c3bad6b39e381c43913bd79965dca33.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sp-67637a61fbbea8b33a192f35977445a1c63aa5aea9a9186181dd842fa41fe1cb.json
+++ b/openfisca_france/tests/json/f7sp-67637a61fbbea8b33a192f35977445a1c63aa5aea9a9186181dd842fa41fe1cb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sp-9af88089926b0a3712a818309a73fc5a84a3fce074f2c661dd9a7989710f79db.json
+++ b/openfisca_france/tests/json/f7sp-9af88089926b0a3712a818309a73fc5a84a3fce074f2c661dd9a7989710f79db.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sp-d0576e34d1b149adca0ec19caabcaf3eabfdfd3e410c23381a90ad3e98b7266a.json
+++ b/openfisca_france/tests/json/f7sp-d0576e34d1b149adca0ec19caabcaf3eabfdfd3e410c23381a90ad3e98b7266a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sp-ec4c6a345728956484d1aa5cef5ef6254290c59d97c751ce76476f26e00f0458.json
+++ b/openfisca_france/tests/json/f7sp-ec4c6a345728956484d1aa5cef5ef6254290c59d97c751ce76476f26e00f0458.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sp-f636b81f353dba7223871bb3f0ff29c848c2732d7797472bb0991e906231c5d6.json
+++ b/openfisca_france/tests/json/f7sp-f636b81f353dba7223871bb3f0ff29c848c2732d7797472bb0991e906231c5d6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sp-f8b3ea2dd2a3e31cd46605effdb8c5b080d95d2ee79ebec9c70b5a4b35643909.json
+++ b/openfisca_france/tests/json/f7sp-f8b3ea2dd2a3e31cd46605effdb8c5b080d95d2ee79ebec9c70b5a4b35643909.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sq-848bfd28e9b842a2e50847a65c0d5432c05fd1fd65b5e238f62f720972c581be.json
+++ b/openfisca_france/tests/json/f7sq-848bfd28e9b842a2e50847a65c0d5432c05fd1fd65b5e238f62f720972c581be.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sq-8f332197327741d30f1fb529be07e4c7594ea6fae4f0e17e841ee918a01d3573.json
+++ b/openfisca_france/tests/json/f7sq-8f332197327741d30f1fb529be07e4c7594ea6fae4f0e17e841ee918a01d3573.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sq-9027114647d602e775ca2165a780ebf3ee2fd304054cd1c0e0895e2c52894d39.json
+++ b/openfisca_france/tests/json/f7sq-9027114647d602e775ca2165a780ebf3ee2fd304054cd1c0e0895e2c52894d39.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sq-9f31536e3529064ff8cd413dc6afbbd152d0bc8eaf58bf029b18c41d254bb090.json
+++ b/openfisca_france/tests/json/f7sq-9f31536e3529064ff8cd413dc6afbbd152d0bc8eaf58bf029b18c41d254bb090.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sq-a1a4b07a0c3c72d6bd37ccf423652e62c0b2056f593b64ff0d3c99d694e0aa48.json
+++ b/openfisca_france/tests/json/f7sq-a1a4b07a0c3c72d6bd37ccf423652e62c0b2056f593b64ff0d3c99d694e0aa48.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sq-cd4008b2c4aecf756eb553912480dbcac628838b3d655339bb2a8d7212956269.json
+++ b/openfisca_france/tests/json/f7sq-cd4008b2c4aecf756eb553912480dbcac628838b3d655339bb2a8d7212956269.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sq-e0d1425ed1ef3f4f764a4f2dea71d9a4312f9cd28754c6c20ca20b46e9ee73fa.json
+++ b/openfisca_france/tests/json/f7sq-e0d1425ed1ef3f4f764a4f2dea71d9a4312f9cd28754c6c20ca20b46e9ee73fa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sq-e7b24bfc12dbd202acf3a2b113cf2477d74f2360b98583bb2168d86f9aa87dbe.json
+++ b/openfisca_france/tests/json/f7sq-e7b24bfc12dbd202acf3a2b113cf2477d74f2360b98583bb2168d86f9aa87dbe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sq-ef70f24fb3c1a4114a640595c392e50546f6e1853d7b9641944589341ae0ff01.json
+++ b/openfisca_france/tests/json/f7sq-ef70f24fb3c1a4114a640595c392e50546f6e1853d7b9641944589341ae0ff01.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sr-30b006139eda5531ccf977e6579cdc5dafba2902104017b7bbcf5118e6c19a7d.json
+++ b/openfisca_france/tests/json/f7sr-30b006139eda5531ccf977e6579cdc5dafba2902104017b7bbcf5118e6c19a7d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sr-52dd06c615f242425a169ea48d256c527fbea1f2f870f85a0755fe5bb20da9d3.json
+++ b/openfisca_france/tests/json/f7sr-52dd06c615f242425a169ea48d256c527fbea1f2f870f85a0755fe5bb20da9d3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sr-5d3ad6f7654bd7124d1a1713dea813707bd2e508a76586b34b9e47a695a3b119.json
+++ b/openfisca_france/tests/json/f7sr-5d3ad6f7654bd7124d1a1713dea813707bd2e508a76586b34b9e47a695a3b119.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sr-b9372f52a53a4ed8d8723b4f3eff49f52e48057efa2107b4da0d466e0a6ca8e1.json
+++ b/openfisca_france/tests/json/f7sr-b9372f52a53a4ed8d8723b4f3eff49f52e48057efa2107b4da0d466e0a6ca8e1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sr-b9a13163c9e343717d9e6933745c1b98ce2760b100d36fdb11876167bdc0a476.json
+++ b/openfisca_france/tests/json/f7sr-b9a13163c9e343717d9e6933745c1b98ce2760b100d36fdb11876167bdc0a476.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sr-d1653af6d3fda76cb820e9ec1bd01c090a9f7ea4fcc529d62b9982eae413fdc2.json
+++ b/openfisca_france/tests/json/f7sr-d1653af6d3fda76cb820e9ec1bd01c090a9f7ea4fcc529d62b9982eae413fdc2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sr-db73f8dff65ca851d7744337e621516b168b93f6c70220ff115864ee7828769b.json
+++ b/openfisca_france/tests/json/f7sr-db73f8dff65ca851d7744337e621516b168b93f6c70220ff115864ee7828769b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sr-e71827a04a9e10c3a4da8db93777b8cb25a269e122d13a6664ea5824ed69bd75.json
+++ b/openfisca_france/tests/json/f7sr-e71827a04a9e10c3a4da8db93777b8cb25a269e122d13a6664ea5824ed69bd75.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sr-eb98b639f754a547ffe6f9d6d16d2f71827844962e9b4d7288d2923976338b1a.json
+++ b/openfisca_france/tests/json/f7sr-eb98b639f754a547ffe6f9d6d16d2f71827844962e9b4d7288d2923976338b1a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ss-1f9ce00ea1af8a4c129eedfc9e3d16bec9ed128c07d2a2b29b245cb09a118091.json
+++ b/openfisca_france/tests/json/f7ss-1f9ce00ea1af8a4c129eedfc9e3d16bec9ed128c07d2a2b29b245cb09a118091.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ss-20fb2f7a3439b85c3e109846f9e0872622a20ae2d8edf9db9c9ff3740208ec0a.json
+++ b/openfisca_france/tests/json/f7ss-20fb2f7a3439b85c3e109846f9e0872622a20ae2d8edf9db9c9ff3740208ec0a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ss-32c9481a56a0363362203488d3c51884270a086421b1ef6f5a55cf3d6169fb8c.json
+++ b/openfisca_france/tests/json/f7ss-32c9481a56a0363362203488d3c51884270a086421b1ef6f5a55cf3d6169fb8c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ss-3c78de335a76a1d0e572f3d9d15bd38ee6b95756d10643ed0d06e107206e7b94.json
+++ b/openfisca_france/tests/json/f7ss-3c78de335a76a1d0e572f3d9d15bd38ee6b95756d10643ed0d06e107206e7b94.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ss-5e730c6461b1e90321a7d5208eb48946ceab37bccf7a85c5e4c5cf4b22fc1ec8.json
+++ b/openfisca_france/tests/json/f7ss-5e730c6461b1e90321a7d5208eb48946ceab37bccf7a85c5e4c5cf4b22fc1ec8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ss-aa2e3d4f0f7c0481237322ab50ccf59a68b76e0adbd7726689b9ee8466c16c73.json
+++ b/openfisca_france/tests/json/f7ss-aa2e3d4f0f7c0481237322ab50ccf59a68b76e0adbd7726689b9ee8466c16c73.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ss-e347475381d9ed47bf94c5b10d1450514812203b4ced627b210df3a7ecd98bde.json
+++ b/openfisca_france/tests/json/f7ss-e347475381d9ed47bf94c5b10d1450514812203b4ced627b210df3a7ecd98bde.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ss-f8b51abbe0f1610aba0fb41574d41d150701e07d1d477173132d2e2544b914fe.json
+++ b/openfisca_france/tests/json/f7ss-f8b51abbe0f1610aba0fb41574d41d150701e07d1d477173132d2e2544b914fe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ss-fa4c74ebf3b68322711709892b592f9039653a6e134c42fc0067b4e65707a748.json
+++ b/openfisca_france/tests/json/f7ss-fa4c74ebf3b68322711709892b592f9039653a6e134c42fc0067b4e65707a748.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7st-0df5dfe9dc0b9d074f706b026f6fa4500087493ac8086b40beffca6e657f9f70.json
+++ b/openfisca_france/tests/json/f7st-0df5dfe9dc0b9d074f706b026f6fa4500087493ac8086b40beffca6e657f9f70.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7st-118055998a4e297bc1ae0d27004d2370f69b17c161044e5a2ec23bf061389995.json
+++ b/openfisca_france/tests/json/f7st-118055998a4e297bc1ae0d27004d2370f69b17c161044e5a2ec23bf061389995.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7st-11caaa830b854924b3d4fab192151226715048e2944e1c4af14d650b971fd655.json
+++ b/openfisca_france/tests/json/f7st-11caaa830b854924b3d4fab192151226715048e2944e1c4af14d650b971fd655.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7st-2cf692a4e99f2406c4a570f05b553e760b78794b722cb70085c76b67fd145b61.json
+++ b/openfisca_france/tests/json/f7st-2cf692a4e99f2406c4a570f05b553e760b78794b722cb70085c76b67fd145b61.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7st-36f0ba7dc2c176cf269022693b3939464c8c4865754cddcc924ef795739f9ded.json
+++ b/openfisca_france/tests/json/f7st-36f0ba7dc2c176cf269022693b3939464c8c4865754cddcc924ef795739f9ded.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7st-6237c728d9bac22c0325ed570033df4139856d1c3c85dff3956cdd13d4939a7f.json
+++ b/openfisca_france/tests/json/f7st-6237c728d9bac22c0325ed570033df4139856d1c3c85dff3956cdd13d4939a7f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7st-7d8cc06fd5015ab85c9acebb22e95411abf603b1d59739e6c627012057d2dd76.json
+++ b/openfisca_france/tests/json/f7st-7d8cc06fd5015ab85c9acebb22e95411abf603b1d59739e6c627012057d2dd76.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7st-c09242680c137f090f67d320e39b69e93816ab9aacf95eb2ac362e97d99a082a.json
+++ b/openfisca_france/tests/json/f7st-c09242680c137f090f67d320e39b69e93816ab9aacf95eb2ac362e97d99a082a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7st-f43e10ffd4354705405d22ad71eea51eda96a0ce1b63bad421ce9a6b92b6d318.json
+++ b/openfisca_france/tests/json/f7st-f43e10ffd4354705405d22ad71eea51eda96a0ce1b63bad421ce9a6b92b6d318.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7su-1231ffc52a9a668d8802b311bf0625c4f7a83692e081ae78261cae6ad97a0ece.json
+++ b/openfisca_france/tests/json/f7su-1231ffc52a9a668d8802b311bf0625c4f7a83692e081ae78261cae6ad97a0ece.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7su-32a10ed8c0697316f4e3aa8db350184187cb313b18313cefc1171d26b3669271.json
+++ b/openfisca_france/tests/json/f7su-32a10ed8c0697316f4e3aa8db350184187cb313b18313cefc1171d26b3669271.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7su-371cb2d5cf6ea83ef0c4953210203674b54f2964361c09b725872b3995cd4c89.json
+++ b/openfisca_france/tests/json/f7su-371cb2d5cf6ea83ef0c4953210203674b54f2964361c09b725872b3995cd4c89.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7su-55a44108d05ca99ab6b2eecfe7a48b9553e71d9fc45fec25a604ec5a67213354.json
+++ b/openfisca_france/tests/json/f7su-55a44108d05ca99ab6b2eecfe7a48b9553e71d9fc45fec25a604ec5a67213354.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7su-5db1e4f66d4adc22e06c5d861812d1c315fc58fc4f2ee0ce7a14626e28634209.json
+++ b/openfisca_france/tests/json/f7su-5db1e4f66d4adc22e06c5d861812d1c315fc58fc4f2ee0ce7a14626e28634209.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7su-6980181591b43479dcc215b49ea8512203f8a824247c50469fe031dbdbd77eb8.json
+++ b/openfisca_france/tests/json/f7su-6980181591b43479dcc215b49ea8512203f8a824247c50469fe031dbdbd77eb8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7su-7a8a09a7ed2e78decf6a6339163899232fdb4302e6bad41aace5269d15154552.json
+++ b/openfisca_france/tests/json/f7su-7a8a09a7ed2e78decf6a6339163899232fdb4302e6bad41aace5269d15154552.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7su-952c4dd5f91c37d966d8e3d7f130491d41b03ef81059e049678ce298fc2ae516.json
+++ b/openfisca_france/tests/json/f7su-952c4dd5f91c37d966d8e3d7f130491d41b03ef81059e049678ce298fc2ae516.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7su-fde59484ea04cf4a1861ae716733228039f2f63ca00c834e822b333ff393b7db.json
+++ b/openfisca_france/tests/json/f7su-fde59484ea04cf4a1861ae716733228039f2f63ca00c834e822b333ff393b7db.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sv-3a924e35e71d1e330e59ea572f498a659ec270778258a461ce4d3cccd12c8faf.json
+++ b/openfisca_france/tests/json/f7sv-3a924e35e71d1e330e59ea572f498a659ec270778258a461ce4d3cccd12c8faf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sv-49ab2bb338f50cd66e00d14e6e8400181b58489cc321a5569667bbaf3de7301f.json
+++ b/openfisca_france/tests/json/f7sv-49ab2bb338f50cd66e00d14e6e8400181b58489cc321a5569667bbaf3de7301f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sv-751f469f4cdecc14f8af0d08d89589c7ec6a52e702963e82f253681a1296be9b.json
+++ b/openfisca_france/tests/json/f7sv-751f469f4cdecc14f8af0d08d89589c7ec6a52e702963e82f253681a1296be9b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sv-82966ad798911c3bec2be768c6fe6648107e81594822ce74d23463c8244d7ff6.json
+++ b/openfisca_france/tests/json/f7sv-82966ad798911c3bec2be768c6fe6648107e81594822ce74d23463c8244d7ff6.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sv-873170497443b6ced95d424207fc0ede4348bf83eae54c05020fcb1841b4c3ca.json
+++ b/openfisca_france/tests/json/f7sv-873170497443b6ced95d424207fc0ede4348bf83eae54c05020fcb1841b4c3ca.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sv-d1ba2a892f3556ff6cfbb7fca460f1039a9c99a3e76ccbca553dff4a6e5c1cd6.json
+++ b/openfisca_france/tests/json/f7sv-d1ba2a892f3556ff6cfbb7fca460f1039a9c99a3e76ccbca553dff4a6e5c1cd6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sv-e62d918d6f4c575209f9e303e79cc23de70da8b06db90927043cdb13ca1f1390.json
+++ b/openfisca_france/tests/json/f7sv-e62d918d6f4c575209f9e303e79cc23de70da8b06db90927043cdb13ca1f1390.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sv-ee268f286225a73719f86afe369262c05d66e7d19b4d033df5693de19fe78fbc.json
+++ b/openfisca_france/tests/json/f7sv-ee268f286225a73719f86afe369262c05d66e7d19b4d033df5693de19fe78fbc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sv-fe171361b4872f75ed806ed51722c71ac0ff39d104f9cbb91612cb6e313bff78.json
+++ b/openfisca_france/tests/json/f7sv-fe171361b4872f75ed806ed51722c71ac0ff39d104f9cbb91612cb6e313bff78.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sw-2d9e9c44f53643d80bbb93659790d2ac9972e7daf0f585e78ff6c9e6e105a165.json
+++ b/openfisca_france/tests/json/f7sw-2d9e9c44f53643d80bbb93659790d2ac9972e7daf0f585e78ff6c9e6e105a165.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sw-4ae8c17ec8009b9f1458edf5a5df71f49a5452e1ac6e23afa512313222ef5b34.json
+++ b/openfisca_france/tests/json/f7sw-4ae8c17ec8009b9f1458edf5a5df71f49a5452e1ac6e23afa512313222ef5b34.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sw-7f8d75366a6b06ab368ab6991242c84ab4af2d823c69789dd4eafaeb7fc6cd93.json
+++ b/openfisca_france/tests/json/f7sw-7f8d75366a6b06ab368ab6991242c84ab4af2d823c69789dd4eafaeb7fc6cd93.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sw-814c767ebc5a7f8a5e796d16d79dc83fc55c866519a8cc82422f45c3f27e7246.json
+++ b/openfisca_france/tests/json/f7sw-814c767ebc5a7f8a5e796d16d79dc83fc55c866519a8cc82422f45c3f27e7246.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sw-90f201a1819cfd9fef3b1a0527a8ab29872010af861410aa4ab641393380aedb.json
+++ b/openfisca_france/tests/json/f7sw-90f201a1819cfd9fef3b1a0527a8ab29872010af861410aa4ab641393380aedb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sw-98c624e250ef855a8dd9d16aea093d5e2827432e9124532b44ac42892ad09e8a.json
+++ b/openfisca_france/tests/json/f7sw-98c624e250ef855a8dd9d16aea093d5e2827432e9124532b44ac42892ad09e8a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sw-cb53312d65f7245e5f05c70deb7d2f796326c83b7c6172bb64164bf097132c21.json
+++ b/openfisca_france/tests/json/f7sw-cb53312d65f7245e5f05c70deb7d2f796326c83b7c6172bb64164bf097132c21.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sw-d6570c945c350011a198ac5ea6125e913c00e0429909201af91f2e6defd484b9.json
+++ b/openfisca_france/tests/json/f7sw-d6570c945c350011a198ac5ea6125e913c00e0429909201af91f2e6defd484b9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sw-dd1e2883636ee8f2babe1dbe848d5f12f7b417e41ab18ffe6c03cffe44692dc0.json
+++ b/openfisca_france/tests/json/f7sw-dd1e2883636ee8f2babe1dbe848d5f12f7b417e41ab18ffe6c03cffe44692dc0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sx-286875e70e7947af50b9bae3de79df077110d40d31bb06f4b88def23f0c18c1a.json
+++ b/openfisca_france/tests/json/f7sx-286875e70e7947af50b9bae3de79df077110d40d31bb06f4b88def23f0c18c1a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sx-400d823995ae45800bc35ebe74e318f0ba125a7d94eee6f1de22e78ee84605e2.json
+++ b/openfisca_france/tests/json/f7sx-400d823995ae45800bc35ebe74e318f0ba125a7d94eee6f1de22e78ee84605e2.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sx-758af192b85f1a71f9cc1b9b2991c3e6371c815028c286a93a846a453f26eb63.json
+++ b/openfisca_france/tests/json/f7sx-758af192b85f1a71f9cc1b9b2991c3e6371c815028c286a93a846a453f26eb63.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sx-8f51632aa93a078c04abdd5c8696ad531383541f32dd192914ffe36790d49e1e.json
+++ b/openfisca_france/tests/json/f7sx-8f51632aa93a078c04abdd5c8696ad531383541f32dd192914ffe36790d49e1e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sx-98b7494e1c4730d8d0dbefdab813717bc22f586c13ff678c9aae31979d6a92cd.json
+++ b/openfisca_france/tests/json/f7sx-98b7494e1c4730d8d0dbefdab813717bc22f586c13ff678c9aae31979d6a92cd.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sx-9e859cd3f4b8311900e7c4a0177ade9afb51290e43abdfd89460f73574ce8fb5.json
+++ b/openfisca_france/tests/json/f7sx-9e859cd3f4b8311900e7c4a0177ade9afb51290e43abdfd89460f73574ce8fb5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sx-cf16e16f1c4c4665de4a56b4c149a7287b1c5b9e273ad503172b9283afbdc35f.json
+++ b/openfisca_france/tests/json/f7sx-cf16e16f1c4c4665de4a56b4c149a7287b1c5b9e273ad503172b9283afbdc35f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sx-d87eaeae85d751d6febd83bd94d583f6e8fdfb0cf840d013347eee5ec8cb7ead.json
+++ b/openfisca_france/tests/json/f7sx-d87eaeae85d751d6febd83bd94d583f6e8fdfb0cf840d013347eee5ec8cb7ead.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sx-e19a0daf066cde80ebdfa4cffacf497424fe8c6d3f589b784e90dbcd91ea540f.json
+++ b/openfisca_france/tests/json/f7sx-e19a0daf066cde80ebdfa4cffacf497424fe8c6d3f589b784e90dbcd91ea540f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sy-01e1c8370cc2999f1c7269d43c06842bc1b5d6c9e655f714b908dcf527a990ef.json
+++ b/openfisca_france/tests/json/f7sy-01e1c8370cc2999f1c7269d43c06842bc1b5d6c9e655f714b908dcf527a990ef.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sy-1f3a767ed1117083147e9c2027ea149bdd1d0aee29c9cf509d2d471f6dff65a9.json
+++ b/openfisca_france/tests/json/f7sy-1f3a767ed1117083147e9c2027ea149bdd1d0aee29c9cf509d2d471f6dff65a9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sy-6d016a609b1b56b7fbdc48d50aa1f60261b487e7f8124de0339cdd48d7535bba.json
+++ b/openfisca_france/tests/json/f7sy-6d016a609b1b56b7fbdc48d50aa1f60261b487e7f8124de0339cdd48d7535bba.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sy-af6119d8937300bbe79cde7c52101fb29deef56e15b472a3f959b5b34de75ee4.json
+++ b/openfisca_france/tests/json/f7sy-af6119d8937300bbe79cde7c52101fb29deef56e15b472a3f959b5b34de75ee4.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sy-b7ef70775c3885b033ce5e12b1e5f4e6651689ef47e42f6ca9daf7aa1b588b8d.json
+++ b/openfisca_france/tests/json/f7sy-b7ef70775c3885b033ce5e12b1e5f4e6651689ef47e42f6ca9daf7aa1b588b8d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sy-d2779684774130ce6f58976f30b6bbc3a3d31eec9a6ccb2d6b30946d8555dc64.json
+++ b/openfisca_france/tests/json/f7sy-d2779684774130ce6f58976f30b6bbc3a3d31eec9a6ccb2d6b30946d8555dc64.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sy-db998d1c2b10733ffc3966d4ab3278c0690a24c8bd40bcf98d24223c7ba9a0a0.json
+++ b/openfisca_france/tests/json/f7sy-db998d1c2b10733ffc3966d4ab3278c0690a24c8bd40bcf98d24223c7ba9a0a0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sy-e277424d2dfcdc7e3b75b4167410a24477dcc4596dbf92dde41e1f84fed2b782.json
+++ b/openfisca_france/tests/json/f7sy-e277424d2dfcdc7e3b75b4167410a24477dcc4596dbf92dde41e1f84fed2b782.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sy-ea204a975372d9e2e4dfcc8289f80cbde4f17c1766641abc5e4596b9e78aa076.json
+++ b/openfisca_france/tests/json/f7sy-ea204a975372d9e2e4dfcc8289f80cbde4f17c1766641abc5e4596b9e78aa076.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sz-11ab651450c959bc0090949b2988873bcdc1d863219aa8b97c8e0d16656df3fd.json
+++ b/openfisca_france/tests/json/f7sz-11ab651450c959bc0090949b2988873bcdc1d863219aa8b97c8e0d16656df3fd.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sz-1752e4cf91165c77e29d4f7c4fe0043b21b840702dc732d3f73a40a72babc62a.json
+++ b/openfisca_france/tests/json/f7sz-1752e4cf91165c77e29d4f7c4fe0043b21b840702dc732d3f73a40a72babc62a.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sz-1b340667450e6964b7242d5cd75de1b3818948788c0f74422f15cf8446e8ba4b.json
+++ b/openfisca_france/tests/json/f7sz-1b340667450e6964b7242d5cd75de1b3818948788c0f74422f15cf8446e8ba4b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sz-27aec35b1bdb09e54cfc5c429f76ebae6f28e05e8cac33c738fb5b9a32c844b9.json
+++ b/openfisca_france/tests/json/f7sz-27aec35b1bdb09e54cfc5c429f76ebae6f28e05e8cac33c738fb5b9a32c844b9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sz-96782fdb548fcb1232a66bfb3696c76e51610ab8d6225382bf7553ec97e60fae.json
+++ b/openfisca_france/tests/json/f7sz-96782fdb548fcb1232a66bfb3696c76e51610ab8d6225382bf7553ec97e60fae.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sz-994d63aaebe5042e44ec283691a64ffc694903ccf69df1401dae185131b2adf2.json
+++ b/openfisca_france/tests/json/f7sz-994d63aaebe5042e44ec283691a64ffc694903ccf69df1401dae185131b2adf2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sz-ad43b56e3ee04017c2ac8a51d861d0a703fe344d165c44dbfb430752cc4ec696.json
+++ b/openfisca_france/tests/json/f7sz-ad43b56e3ee04017c2ac8a51d861d0a703fe344d165c44dbfb430752cc4ec696.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sz-bba4be5355b0a9b08f958fbb6856d49992b61305b2ba725311e7f32bac3131a8.json
+++ b/openfisca_france/tests/json/f7sz-bba4be5355b0a9b08f958fbb6856d49992b61305b2ba725311e7f32bac3131a8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7sz-dd0e3739fa8e307c2fca1bd51e89443fb056cfc5286bba9e8caaa02817948c40.json
+++ b/openfisca_france/tests/json/f7sz-dd0e3739fa8e307c2fca1bd51e89443fb056cfc5286bba9e8caaa02817948c40.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7td-6e4cc8093bb303f4883168b58d8d953ee7e9985936ddf14d821d380d696f2695.json
+++ b/openfisca_france/tests/json/f7td-6e4cc8093bb303f4883168b58d8d953ee7e9985936ddf14d821d380d696f2695.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7td-97e6ba983261558260620d012ce7f9c8a2a1f3728539ac6f23623ef8371463b3.json
+++ b/openfisca_france/tests/json/f7td-97e6ba983261558260620d012ce7f9c8a2a1f3728539ac6f23623ef8371463b3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7td-e9d7debf5cef0a9ad6a8650e79b7875204274e919e0096f329cef4c695d19f9c.json
+++ b/openfisca_france/tests/json/f7td-e9d7debf5cef0a9ad6a8650e79b7875204274e919e0096f329cef4c695d19f9c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7te-320bbbc671d3196edfcdc7ce57677371ecfc3f8c448ba50d84a4e48283d4d997.json
+++ b/openfisca_france/tests/json/f7te-320bbbc671d3196edfcdc7ce57677371ecfc3f8c448ba50d84a4e48283d4d997.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7te-4005ab4586850b998a4f124b67b7ea3398a12afcfac7bdef3698c150352dce94.json
+++ b/openfisca_france/tests/json/f7te-4005ab4586850b998a4f124b67b7ea3398a12afcfac7bdef3698c150352dce94.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7te-6f2b8376402b9342b19fef17f8eb26b688e7dcd6b0b0f12282cab5fc32425c83.json
+++ b/openfisca_france/tests/json/f7te-6f2b8376402b9342b19fef17f8eb26b688e7dcd6b0b0f12282cab5fc32425c83.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7te-85cdafa5edd2e50167e1db15a1a0aa62fe201310a8c79dc9cc71488d08105c20.json
+++ b/openfisca_france/tests/json/f7te-85cdafa5edd2e50167e1db15a1a0aa62fe201310a8c79dc9cc71488d08105c20.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7te-b5a80723d2758d6d1a10abe449be8cae23444e539a5e765ed829819ca56e5617.json
+++ b/openfisca_france/tests/json/f7te-b5a80723d2758d6d1a10abe449be8cae23444e539a5e765ed829819ca56e5617.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7te-befd03f04149fe3b1f75c4a34d2489481e99b077183c45ed92c8f12c5032c387.json
+++ b/openfisca_france/tests/json/f7te-befd03f04149fe3b1f75c4a34d2489481e99b077183c45ed92c8f12c5032c387.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7te-cefee9d1a99c1dee1a4707f61e45dd63b5d6f1cb506c403e78c7f3657801b582.json
+++ b/openfisca_france/tests/json/f7te-cefee9d1a99c1dee1a4707f61e45dd63b5d6f1cb506c403e78c7f3657801b582.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7te-d74e351dcabce4603959944572354883c1951f2f22189712a204fec36a95192e.json
+++ b/openfisca_france/tests/json/f7te-d74e351dcabce4603959944572354883c1951f2f22189712a204fec36a95192e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7te-e0b91af5dda8c46985f7191848ef29431b4889552b27a72fb851c59345c0f709.json
+++ b/openfisca_france/tests/json/f7te-e0b91af5dda8c46985f7191848ef29431b4889552b27a72fb851c59345c0f709.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tf-1fedb3803896229c66ce6d1642636387b7a1022b641dd67d1f4b0c2effb823d7.json
+++ b/openfisca_france/tests/json/f7tf-1fedb3803896229c66ce6d1642636387b7a1022b641dd67d1f4b0c2effb823d7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tf-209d2de90f0536bec276bad53e4625145c5ab9536db4e36eb05e07d1ffbe9f67.json
+++ b/openfisca_france/tests/json/f7tf-209d2de90f0536bec276bad53e4625145c5ab9536db4e36eb05e07d1ffbe9f67.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tf-2233549ec526e3fdcc73af7e56854f267c3564154ee4402c284448f81475aa2d.json
+++ b/openfisca_france/tests/json/f7tf-2233549ec526e3fdcc73af7e56854f267c3564154ee4402c284448f81475aa2d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tf-22745c35cbe1dd8fa348b95b83b681a5f30b834c93dc5cc4b0ff9733b2b37830.json
+++ b/openfisca_france/tests/json/f7tf-22745c35cbe1dd8fa348b95b83b681a5f30b834c93dc5cc4b0ff9733b2b37830.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tf-3f88f71b0261d710bd3630d0cb44844e045b00051828ec42455af2cd4fd35f76.json
+++ b/openfisca_france/tests/json/f7tf-3f88f71b0261d710bd3630d0cb44844e045b00051828ec42455af2cd4fd35f76.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tf-65507d04c4a529012ca24a83a60728aad443aaf31931068d3e481c5382ea1db7.json
+++ b/openfisca_france/tests/json/f7tf-65507d04c4a529012ca24a83a60728aad443aaf31931068d3e481c5382ea1db7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tf-6d6b65765680d326339ee1faf60abe7e20087c27520d84b6fdeff844f4f7a6b1.json
+++ b/openfisca_france/tests/json/f7tf-6d6b65765680d326339ee1faf60abe7e20087c27520d84b6fdeff844f4f7a6b1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tf-955a2050a578789482056702928385ea5ab085c520940944b88571237a268a16.json
+++ b/openfisca_france/tests/json/f7tf-955a2050a578789482056702928385ea5ab085c520940944b88571237a268a16.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tf-a1699a873047c417baddc7ab7e776b62962e951a489f5784459993b0b5d646c3.json
+++ b/openfisca_france/tests/json/f7tf-a1699a873047c417baddc7ab7e776b62962e951a489f5784459993b0b5d646c3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tg-021734ffe7828ef3af74d70963def1d9e6c7224a91c9e277fb6110f319efdb1f.json
+++ b/openfisca_france/tests/json/f7tg-021734ffe7828ef3af74d70963def1d9e6c7224a91c9e277fb6110f319efdb1f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tg-3058e462aebb1c49db7697fda0f15adfa939a924460a66d309d1a83f3d56c2e4.json
+++ b/openfisca_france/tests/json/f7tg-3058e462aebb1c49db7697fda0f15adfa939a924460a66d309d1a83f3d56c2e4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tg-6c07adb7827b8da6069d3d8004b8cfcc1a9cd07a365ccb9a4aebc9f33e8d69da.json
+++ b/openfisca_france/tests/json/f7tg-6c07adb7827b8da6069d3d8004b8cfcc1a9cd07a365ccb9a4aebc9f33e8d69da.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tg-8cb5cfc848f601fc5cb10799ef3df68fba080a847a7a77c040ee5af7f3b89809.json
+++ b/openfisca_france/tests/json/f7tg-8cb5cfc848f601fc5cb10799ef3df68fba080a847a7a77c040ee5af7f3b89809.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tg-8fedad0be4ac180da64da3e892406b424bc009416bf1f7d28803e5b20307da8a.json
+++ b/openfisca_france/tests/json/f7tg-8fedad0be4ac180da64da3e892406b424bc009416bf1f7d28803e5b20307da8a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tg-c324918743801a4cd7465c7343b3c275d4dc1d9ead785b8b1049ff7e719bcc51.json
+++ b/openfisca_france/tests/json/f7tg-c324918743801a4cd7465c7343b3c275d4dc1d9ead785b8b1049ff7e719bcc51.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tg-ccb454da29c8d8247c5e762eddd9f3fc9f6dc687402706d75c5032c104d9f416.json
+++ b/openfisca_france/tests/json/f7tg-ccb454da29c8d8247c5e762eddd9f3fc9f6dc687402706d75c5032c104d9f416.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tg-d22d9079d9303cee089775c9833ddb90af78d85c2d0a00885757f7f385ad3ed5.json
+++ b/openfisca_france/tests/json/f7tg-d22d9079d9303cee089775c9833ddb90af78d85c2d0a00885757f7f385ad3ed5.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tg-fbad4cdf6d3772c4b7b5706d6386fda38a5befe902b68b4b6decf19ab9fbbe09.json
+++ b/openfisca_france/tests/json/f7tg-fbad4cdf6d3772c4b7b5706d6386fda38a5befe902b68b4b6decf19ab9fbbe09.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7th-0c2ade6aaad7566c7e0b8101b6d2332d9d615cf2a9e6d839faa69b223cd2317f.json
+++ b/openfisca_france/tests/json/f7th-0c2ade6aaad7566c7e0b8101b6d2332d9d615cf2a9e6d839faa69b223cd2317f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7th-21c2357672460a81920688f89e247dfa7d5af2ab5430a0e21947316c57c8e8d3.json
+++ b/openfisca_france/tests/json/f7th-21c2357672460a81920688f89e247dfa7d5af2ab5430a0e21947316c57c8e8d3.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7th-5ca6e4d757f1a02874cf80679dcdd214ebf9eeda2703d6ed8999cce89c7fae11.json
+++ b/openfisca_france/tests/json/f7th-5ca6e4d757f1a02874cf80679dcdd214ebf9eeda2703d6ed8999cce89c7fae11.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7th-80480ae6363dc71c57bb2e9032938472daf7397500f8226dddf38a68b25ad2ee.json
+++ b/openfisca_france/tests/json/f7th-80480ae6363dc71c57bb2e9032938472daf7397500f8226dddf38a68b25ad2ee.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7th-9a85f715453e8d1fa2f682d083a2aaccb604ba74171c865268530dbfeeb9e6d9.json
+++ b/openfisca_france/tests/json/f7th-9a85f715453e8d1fa2f682d083a2aaccb604ba74171c865268530dbfeeb9e6d9.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7th-9f8051cecffaa56265a48d34d665e4bf0fff424ea174922f9e004b6eab333537.json
+++ b/openfisca_france/tests/json/f7th-9f8051cecffaa56265a48d34d665e4bf0fff424ea174922f9e004b6eab333537.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7th-bec8c18e6018faa28c1b3c3efb2965855132bc95dc08076174fb65a969bc47ac.json
+++ b/openfisca_france/tests/json/f7th-bec8c18e6018faa28c1b3c3efb2965855132bc95dc08076174fb65a969bc47ac.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7th-c4669652fcb29724f131b877650b7a1b5c710a9338ebbfa8e1b2b165943b1c04.json
+++ b/openfisca_france/tests/json/f7th-c4669652fcb29724f131b877650b7a1b5c710a9338ebbfa8e1b2b165943b1c04.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7th-da31dc0fd2e705660eeb101176cc656431c8c3e1d1475eb07f364688afb1d18c.json
+++ b/openfisca_france/tests/json/f7th-da31dc0fd2e705660eeb101176cc656431c8c3e1d1475eb07f364688afb1d18c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tt-00a0b50e6c7ef9741f049a58e7cb4f9933c5c9b37c1d2fdd90c389bd7e97caf4.json
+++ b/openfisca_france/tests/json/f7tt-00a0b50e6c7ef9741f049a58e7cb4f9933c5c9b37c1d2fdd90c389bd7e97caf4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tt-01aff33427a1fe855399858e50cf12f4b9a0e79e72b36d5804f351cdf492accc.json
+++ b/openfisca_france/tests/json/f7tt-01aff33427a1fe855399858e50cf12f4b9a0e79e72b36d5804f351cdf492accc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tt-2c21f0d188d3179549954802a087aeabea15a2e2196b2b4a9b30a4eb716334ac.json
+++ b/openfisca_france/tests/json/f7tt-2c21f0d188d3179549954802a087aeabea15a2e2196b2b4a9b30a4eb716334ac.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tt-2ef9192ec935764ecb8ede87d12d719e8e8f641bbe70eb262da23830a2f89be7.json
+++ b/openfisca_france/tests/json/f7tt-2ef9192ec935764ecb8ede87d12d719e8e8f641bbe70eb262da23830a2f89be7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tt-5567acf6407539dfac2eb1f5c8d4fb71b2555931156fcbacc35634b029e08869.json
+++ b/openfisca_france/tests/json/f7tt-5567acf6407539dfac2eb1f5c8d4fb71b2555931156fcbacc35634b029e08869.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tt-aaedf8adb79f0655416cc295d3599ae5d38fef96f3252ce165e8e97b56272b38.json
+++ b/openfisca_france/tests/json/f7tt-aaedf8adb79f0655416cc295d3599ae5d38fef96f3252ce165e8e97b56272b38.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tt-b43bd8c77b79b66065c2d1f5992dd531fac416ae9fd23ab14e8c0e6864bdd080.json
+++ b/openfisca_france/tests/json/f7tt-b43bd8c77b79b66065c2d1f5992dd531fac416ae9fd23ab14e8c0e6864bdd080.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tt-daa98d3bec2285e64dcae81b2d31e4761a08161776332c621b5406c8090d277c.json
+++ b/openfisca_france/tests/json/f7tt-daa98d3bec2285e64dcae81b2d31e4761a08161776332c621b5406c8090d277c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tt-dd2813ca32dc4d7d413feeefc39771d453ab8707a654853faed1b4a276839776.json
+++ b/openfisca_france/tests/json/f7tt-dd2813ca32dc4d7d413feeefc39771d453ab8707a654853faed1b4a276839776.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tu-031eb224c9a0ab5ff3daf27543b600189705c2f12ec4e7dea37cf1c8f793f477.json
+++ b/openfisca_france/tests/json/f7tu-031eb224c9a0ab5ff3daf27543b600189705c2f12ec4e7dea37cf1c8f793f477.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tu-19a5e788ebc456b2c57a6c849fbef55df434e4e4b5c7e0612cf95885b3cc60ca.json
+++ b/openfisca_france/tests/json/f7tu-19a5e788ebc456b2c57a6c849fbef55df434e4e4b5c7e0612cf95885b3cc60ca.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tu-6720742996767dfd84695449c181d4ed0c934940bb67dca9eece862605cf9234.json
+++ b/openfisca_france/tests/json/f7tu-6720742996767dfd84695449c181d4ed0c934940bb67dca9eece862605cf9234.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tu-6f2ce1143712e8ba7330548c5e680fb2f097d915a8b9cc6b1cb701ef7793f0ce.json
+++ b/openfisca_france/tests/json/f7tu-6f2ce1143712e8ba7330548c5e680fb2f097d915a8b9cc6b1cb701ef7793f0ce.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tu-6f6345242dfff30a512af5aaacf8b545338d73fc0d5a5bd74375680db05838b5.json
+++ b/openfisca_france/tests/json/f7tu-6f6345242dfff30a512af5aaacf8b545338d73fc0d5a5bd74375680db05838b5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tu-8b024e291f1c4a552318ba42d719c1f1e65643fd01adc1dbd1744ffedc5d8698.json
+++ b/openfisca_france/tests/json/f7tu-8b024e291f1c4a552318ba42d719c1f1e65643fd01adc1dbd1744ffedc5d8698.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tu-9e2ef84b6f7d0c70ff929c6d376e3e92640b6026c7cc164e696f7ae2a28fdeb5.json
+++ b/openfisca_france/tests/json/f7tu-9e2ef84b6f7d0c70ff929c6d376e3e92640b6026c7cc164e696f7ae2a28fdeb5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tu-b6e215f9598af3eed47091e0b4a92128f6f31f4690b07b3e579627f0ac888a91.json
+++ b/openfisca_france/tests/json/f7tu-b6e215f9598af3eed47091e0b4a92128f6f31f4690b07b3e579627f0ac888a91.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tu-d8c24131b2e90d15ea1f5ec2337514d3b8494540a88803608d272416e4e1933c.json
+++ b/openfisca_france/tests/json/f7tu-d8c24131b2e90d15ea1f5ec2337514d3b8494540a88803608d272416e4e1933c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tv-195a869b0717a486dd81b88339686dc2bc1ce4743176575f66154ad7538009d6.json
+++ b/openfisca_france/tests/json/f7tv-195a869b0717a486dd81b88339686dc2bc1ce4743176575f66154ad7538009d6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tv-20bb0a3098df430250c396c54ab3f2cc45f4e1a6b436d1cd6866c8522d03ba13.json
+++ b/openfisca_france/tests/json/f7tv-20bb0a3098df430250c396c54ab3f2cc45f4e1a6b436d1cd6866c8522d03ba13.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tv-46e3e278c9591ad70c3e210ca4acc0a6584b5ca534c02220a671594b46d8881f.json
+++ b/openfisca_france/tests/json/f7tv-46e3e278c9591ad70c3e210ca4acc0a6584b5ca534c02220a671594b46d8881f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tv-5c5fefa610c7b52772fb5cebf03ab97fee3eb9c3de6b2d6281e576a135523cfd.json
+++ b/openfisca_france/tests/json/f7tv-5c5fefa610c7b52772fb5cebf03ab97fee3eb9c3de6b2d6281e576a135523cfd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tv-5dd057e408ee8a784454a3c70365156791011e532d5cc372152762d8c016d29e.json
+++ b/openfisca_france/tests/json/f7tv-5dd057e408ee8a784454a3c70365156791011e532d5cc372152762d8c016d29e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tv-7b10c7541c03d2c976383e6a7ccef16736034c5d76da28da9ca594003307c0ec.json
+++ b/openfisca_france/tests/json/f7tv-7b10c7541c03d2c976383e6a7ccef16736034c5d76da28da9ca594003307c0ec.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tv-ac860cb41080651f94c556ca221d845e3c44e448d552c5bb95ebcb57bdd8a560.json
+++ b/openfisca_france/tests/json/f7tv-ac860cb41080651f94c556ca221d845e3c44e448d552c5bb95ebcb57bdd8a560.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tv-b76e8b593eb102766c959df3a84ac929554f73edeb8f37901286f9142f458496.json
+++ b/openfisca_france/tests/json/f7tv-b76e8b593eb102766c959df3a84ac929554f73edeb8f37901286f9142f458496.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tv-f8df66a4476e7f43df8dfb18dc32be373d72b229f1583801bb6b01105f2b8a67.json
+++ b/openfisca_france/tests/json/f7tv-f8df66a4476e7f43df8dfb18dc32be373d72b229f1583801bb6b01105f2b8a67.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tw-22b65d5f159f3aa60c85f60e00bbf5614e0c918f72496ce6ce53bab11a6c2ffb.json
+++ b/openfisca_france/tests/json/f7tw-22b65d5f159f3aa60c85f60e00bbf5614e0c918f72496ce6ce53bab11a6c2ffb.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tw-2fec15501c9f0c78f47f16d3ccc9d923f414f38e33ef290758120e6cfbe09878.json
+++ b/openfisca_france/tests/json/f7tw-2fec15501c9f0c78f47f16d3ccc9d923f414f38e33ef290758120e6cfbe09878.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tw-44de5ee4b625cc371e4458207350caf55ae18c451f10474b6512c61b7c1ae063.json
+++ b/openfisca_france/tests/json/f7tw-44de5ee4b625cc371e4458207350caf55ae18c451f10474b6512c61b7c1ae063.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tw-6ce4c6878f46e2f342a70ae211a36689f5f94285119f8b0eaec945ca8c745c88.json
+++ b/openfisca_france/tests/json/f7tw-6ce4c6878f46e2f342a70ae211a36689f5f94285119f8b0eaec945ca8c745c88.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tw-87c4bf8bc7cc5d6dfe6955118e5052c935abca492d98bdcec9009d8b06002dfc.json
+++ b/openfisca_france/tests/json/f7tw-87c4bf8bc7cc5d6dfe6955118e5052c935abca492d98bdcec9009d8b06002dfc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tw-8bdaca77c8d09290f25b05f82d78ab72d05bfc493430c3c6daf85a8f616a6e4b.json
+++ b/openfisca_france/tests/json/f7tw-8bdaca77c8d09290f25b05f82d78ab72d05bfc493430c3c6daf85a8f616a6e4b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tw-94e8494aca69db564979d284233142df088375404c1fd7eb98991a8382e69cf6.json
+++ b/openfisca_france/tests/json/f7tw-94e8494aca69db564979d284233142df088375404c1fd7eb98991a8382e69cf6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tw-9a99d5a80f919856297fda52e76a8301e0a02fc3c5416b8791e7997be9e49b51.json
+++ b/openfisca_france/tests/json/f7tw-9a99d5a80f919856297fda52e76a8301e0a02fc3c5416b8791e7997be9e49b51.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tw-ba508c9ea23831c4933614e33ae7833db83f80f5457ec6ef85505faf64730d9d.json
+++ b/openfisca_france/tests/json/f7tw-ba508c9ea23831c4933614e33ae7833db83f80f5457ec6ef85505faf64730d9d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tx-075bac79abcbbcddbbeecd164e9e8f3b3408be3268a090c7e97049bea0656d96.json
+++ b/openfisca_france/tests/json/f7tx-075bac79abcbbcddbbeecd164e9e8f3b3408be3268a090c7e97049bea0656d96.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tx-9e060133428266c411b001ff36785500d144b5be5ccb0007dc8f120166ed8a29.json
+++ b/openfisca_france/tests/json/f7tx-9e060133428266c411b001ff36785500d144b5be5ccb0007dc8f120166ed8a29.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tx-afafd17bc4c57439c5c32b1522bfb571f360485ade114483a0a8c29f629dd7f3.json
+++ b/openfisca_france/tests/json/f7tx-afafd17bc4c57439c5c32b1522bfb571f360485ade114483a0a8c29f629dd7f3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tx-b21819da4870064733cc32b22d10171365c49b9f44474fd3dc4961f131c70eac.json
+++ b/openfisca_france/tests/json/f7tx-b21819da4870064733cc32b22d10171365c49b9f44474fd3dc4961f131c70eac.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tx-b6da1e0f5588aac5717cb25dd005d914a9551e4b444ed9599aea34f53f0c7e0a.json
+++ b/openfisca_france/tests/json/f7tx-b6da1e0f5588aac5717cb25dd005d914a9551e4b444ed9599aea34f53f0c7e0a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tx-b98f6c409019b99b51f13af7665e9187cfce0fad1a438e1b8a354401116e6e6d.json
+++ b/openfisca_france/tests/json/f7tx-b98f6c409019b99b51f13af7665e9187cfce0fad1a438e1b8a354401116e6e6d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tx-bbd0a6e040b34e0175fb987099fc2edace703c64cfec272b12f56e485908fabf.json
+++ b/openfisca_france/tests/json/f7tx-bbd0a6e040b34e0175fb987099fc2edace703c64cfec272b12f56e485908fabf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tx-d4cb45e2eba83503641349b078931c11343ae149cf8eadf19193f3e0884ecf70.json
+++ b/openfisca_france/tests/json/f7tx-d4cb45e2eba83503641349b078931c11343ae149cf8eadf19193f3e0884ecf70.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7tx-f17534a54526b92053e1f3c9df72a774a776f2971b62a20d4134649aeef6cfbc.json
+++ b/openfisca_france/tests/json/f7tx-f17534a54526b92053e1f3c9df72a774a776f2971b62a20d4134649aeef6cfbc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ty-5035bf8beac8cb2b21c8aa9bfac9da80051c142f8ee5736bbab5b897c2b8649a.json
+++ b/openfisca_france/tests/json/f7ty-5035bf8beac8cb2b21c8aa9bfac9da80051c142f8ee5736bbab5b897c2b8649a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ty-559010d84d234b5d9867e26c35857fc1c2b46db6d3112e14c9c6e47dc47972b3.json
+++ b/openfisca_france/tests/json/f7ty-559010d84d234b5d9867e26c35857fc1c2b46db6d3112e14c9c6e47dc47972b3.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ty-79d53f39ab975ccec4927be0fa3da778151b1f309c5cc8d305bfcc2509c7afd4.json
+++ b/openfisca_france/tests/json/f7ty-79d53f39ab975ccec4927be0fa3da778151b1f309c5cc8d305bfcc2509c7afd4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ty-860cb5b60347ad48cabdd589032d221b896f27e6a3ca692c7c7f0667eb9123f4.json
+++ b/openfisca_france/tests/json/f7ty-860cb5b60347ad48cabdd589032d221b896f27e6a3ca692c7c7f0667eb9123f4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ty-986c955cf0cae5b970fa83e6b70f62ba816bbb5fd13420ee2a9a2fea374d6da1.json
+++ b/openfisca_france/tests/json/f7ty-986c955cf0cae5b970fa83e6b70f62ba816bbb5fd13420ee2a9a2fea374d6da1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ty-9feb564c72c2353adecf25af5943addcdf196caf9bccb72841929c01fb88f2ae.json
+++ b/openfisca_france/tests/json/f7ty-9feb564c72c2353adecf25af5943addcdf196caf9bccb72841929c01fb88f2ae.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ty-b7e7ee0d43c3e7b5a913ac780ea6e6dbdcd81ec31209d3ecc9b1ae3944dae0bb.json
+++ b/openfisca_france/tests/json/f7ty-b7e7ee0d43c3e7b5a913ac780ea6e6dbdcd81ec31209d3ecc9b1ae3944dae0bb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ty-d3cbffd0f4a5e5be0aef6f9cc347a1436f1d539a38ea5ee22a4c52c3847d3c4a.json
+++ b/openfisca_france/tests/json/f7ty-d3cbffd0f4a5e5be0aef6f9cc347a1436f1d539a38ea5ee22a4c52c3847d3c4a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ty-f03e6a3d983f1d65473cb89de3d08d119553bf886e3f29e6ca17a60bc2a46031.json
+++ b/openfisca_france/tests/json/f7ty-f03e6a3d983f1d65473cb89de3d08d119553bf886e3f29e6ca17a60bc2a46031.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ua-039528b6f71843c9aefef587d2b6ec0425c88b90cdade7e00e11cafb1de2c293.json
+++ b/openfisca_france/tests/json/f7ua-039528b6f71843c9aefef587d2b6ec0425c88b90cdade7e00e11cafb1de2c293.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ua-171c771da4943865ad2d81a3e41c63dd70acd2a3c25e91812aa6c588181e4116.json
+++ b/openfisca_france/tests/json/f7ua-171c771da4943865ad2d81a3e41c63dd70acd2a3c25e91812aa6c588181e4116.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ua-49238e5eeb0fc88d3e3b8925d27ab1831c427c47c6638603cc6ca48ec7e76370.json
+++ b/openfisca_france/tests/json/f7ua-49238e5eeb0fc88d3e3b8925d27ab1831c427c47c6638603cc6ca48ec7e76370.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ua-4d1e1a1eec524098bfb4beb176d9e9c31b412c18feafe705d89402d987168191.json
+++ b/openfisca_france/tests/json/f7ua-4d1e1a1eec524098bfb4beb176d9e9c31b412c18feafe705d89402d987168191.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ua-736f162f6853a3c79797557fa76f88b4b7fd7c9a206d37e56756c8988d07348f.json
+++ b/openfisca_france/tests/json/f7ua-736f162f6853a3c79797557fa76f88b4b7fd7c9a206d37e56756c8988d07348f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ua-998fcd92c763fe921fa3115334b83d6ba4dc051e26dbd6588499b29c739224ef.json
+++ b/openfisca_france/tests/json/f7ua-998fcd92c763fe921fa3115334b83d6ba4dc051e26dbd6588499b29c739224ef.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ua-c1627e2f4bc3a1190d4b4e6a0dbdfca957da67813e1a998d95d2dbe68ba9714a.json
+++ b/openfisca_france/tests/json/f7ua-c1627e2f4bc3a1190d4b4e6a0dbdfca957da67813e1a998d95d2dbe68ba9714a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ua-ca7edc950ceb507e0f1691ddcc554b5f2b0eed9ed6e20459d7a995d5411cc546.json
+++ b/openfisca_france/tests/json/f7ua-ca7edc950ceb507e0f1691ddcc554b5f2b0eed9ed6e20459d7a995d5411cc546.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ua-f9e6db3bc0aacf677b4814591ef87b18d40d91516fbbab9d06a112d6c91d7b3f.json
+++ b/openfisca_france/tests/json/f7ua-f9e6db3bc0aacf677b4814591ef87b18d40d91516fbbab9d06a112d6c91d7b3f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ub-223597b605929f3a26bce8f60af3a1f6343fa60ab0f1298d64fd15fc5c68ff12.json
+++ b/openfisca_france/tests/json/f7ub-223597b605929f3a26bce8f60af3a1f6343fa60ab0f1298d64fd15fc5c68ff12.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ub-7468a4726f90abb22bace767fa4c924904c8b0a78dc1560245990d5a139e22e0.json
+++ b/openfisca_france/tests/json/f7ub-7468a4726f90abb22bace767fa4c924904c8b0a78dc1560245990d5a139e22e0.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ub-7a2b5858ffc02ec3aecd9c79bc335f92502408d110b77c86a364b9efda02d355.json
+++ b/openfisca_france/tests/json/f7ub-7a2b5858ffc02ec3aecd9c79bc335f92502408d110b77c86a364b9efda02d355.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ub-829c2ce0200451d8e06dd71ed5ccc49f7e12abcfde292cc02ef00145339aeecb.json
+++ b/openfisca_france/tests/json/f7ub-829c2ce0200451d8e06dd71ed5ccc49f7e12abcfde292cc02ef00145339aeecb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ub-83da4ba0190a78aa02d6ba6494db562c1362743e47b22a1a491d29ea48d1a514.json
+++ b/openfisca_france/tests/json/f7ub-83da4ba0190a78aa02d6ba6494db562c1362743e47b22a1a491d29ea48d1a514.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ub-9dddc2bb789c139390f5233a27ae57229ef9522d80aaab7c86d8822bfdb31318.json
+++ b/openfisca_france/tests/json/f7ub-9dddc2bb789c139390f5233a27ae57229ef9522d80aaab7c86d8822bfdb31318.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ub-ad2e75018bccfcb0e0c180dc39d0978bd015d3381114c36f30632369dbe961d1.json
+++ b/openfisca_france/tests/json/f7ub-ad2e75018bccfcb0e0c180dc39d0978bd015d3381114c36f30632369dbe961d1.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ub-b4f87398c85b08656bf897d1640a1047b8a5471ed365612e8e05851126f150de.json
+++ b/openfisca_france/tests/json/f7ub-b4f87398c85b08656bf897d1640a1047b8a5471ed365612e8e05851126f150de.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ub-c95f72a4e8dff455fcfb4871c8eebd819db0dacbf347705ebcb8d04441e98f58.json
+++ b/openfisca_france/tests/json/f7ub-c95f72a4e8dff455fcfb4871c8eebd819db0dacbf347705ebcb8d04441e98f58.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uc-0b53e2d690a6fcfb3c4b93dfcdea644d65b7f92ec98153c359c323f63f44b600.json
+++ b/openfisca_france/tests/json/f7uc-0b53e2d690a6fcfb3c4b93dfcdea644d65b7f92ec98153c359c323f63f44b600.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uc-1c0d853f2c76c15fe0e05bdfacb982b8c83c1b934910ee7cd7792e11d109b68a.json
+++ b/openfisca_france/tests/json/f7uc-1c0d853f2c76c15fe0e05bdfacb982b8c83c1b934910ee7cd7792e11d109b68a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uc-35c7432986a2ca49282d2b502a03db98d720d29221f126aa79403bbc700ec8ed.json
+++ b/openfisca_france/tests/json/f7uc-35c7432986a2ca49282d2b502a03db98d720d29221f126aa79403bbc700ec8ed.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uc-6e4b33443523e8ed06c735e70bcaab7d25a08a16ef30d3e68c9ec66842dca1ca.json
+++ b/openfisca_france/tests/json/f7uc-6e4b33443523e8ed06c735e70bcaab7d25a08a16ef30d3e68c9ec66842dca1ca.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uc-7ba48fee4cda2a40c6e68a7c6515d4b10d70f6d69a72ad5a2e92db376d0b7d23.json
+++ b/openfisca_france/tests/json/f7uc-7ba48fee4cda2a40c6e68a7c6515d4b10d70f6d69a72ad5a2e92db376d0b7d23.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uc-7ba98de897c67a4ce90fa3b2d9fbad3f83003a2439ea71903d668946392e7969.json
+++ b/openfisca_france/tests/json/f7uc-7ba98de897c67a4ce90fa3b2d9fbad3f83003a2439ea71903d668946392e7969.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uc-99a6dd855d65f682968fbbc19835cb542f60950f981533e2f282ade2b788555c.json
+++ b/openfisca_france/tests/json/f7uc-99a6dd855d65f682968fbbc19835cb542f60950f981533e2f282ade2b788555c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uc-aa535bb0fc9ccf465f26b1fbad6464fb65e217e898491bcf0ac512bb59288dff.json
+++ b/openfisca_france/tests/json/f7uc-aa535bb0fc9ccf465f26b1fbad6464fb65e217e898491bcf0ac512bb59288dff.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uc-cf0b0a074fbe4563a3583325805482c0ce7318cf958a388a9e4c497c1e86b5ea.json
+++ b/openfisca_france/tests/json/f7uc-cf0b0a074fbe4563a3583325805482c0ce7318cf958a388a9e4c497c1e86b5ea.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ud-2e9c888f652fc6d33d977f9eb2d1c40d544f93ceba223792b9777ff4f5ef5cca.json
+++ b/openfisca_france/tests/json/f7ud-2e9c888f652fc6d33d977f9eb2d1c40d544f93ceba223792b9777ff4f5ef5cca.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ud-4e0baec59c8942ee68f7fb1b6dbb7accefa04d9bddd9883edf75e47729233d55.json
+++ b/openfisca_france/tests/json/f7ud-4e0baec59c8942ee68f7fb1b6dbb7accefa04d9bddd9883edf75e47729233d55.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ud-980aa8234ded07e25fd64e05fbdb942c213fc3ca16309d5149b227438f24ae7c.json
+++ b/openfisca_france/tests/json/f7ud-980aa8234ded07e25fd64e05fbdb942c213fc3ca16309d5149b227438f24ae7c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ud-cd20e6f81b9feb6c6bc59849be529e8e5b26f4e7647902398a2ad5bd3b50efe4.json
+++ b/openfisca_france/tests/json/f7ud-cd20e6f81b9feb6c6bc59849be529e8e5b26f4e7647902398a2ad5bd3b50efe4.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ud-da62dc9c7ead67454a163fe24099a61218f4b7b3cfadba9f58036217617c5f41.json
+++ b/openfisca_france/tests/json/f7ud-da62dc9c7ead67454a163fe24099a61218f4b7b3cfadba9f58036217617c5f41.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ud-e948696b60887ef6d4bc572f45ef0bef6557bdf96f10bd809e1d793618d7d143.json
+++ b/openfisca_france/tests/json/f7ud-e948696b60887ef6d4bc572f45ef0bef6557bdf96f10bd809e1d793618d7d143.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ud-e9fa0fde95b334f76531814b443aea626eb59e4a4ca281a2121df1e35c36e760.json
+++ b/openfisca_france/tests/json/f7ud-e9fa0fde95b334f76531814b443aea626eb59e4a4ca281a2121df1e35c36e760.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ud-ee799c48d5a3b16ac8d421bbd27d6ca920f5c75c7bdd7157dfa2f854dc1defea.json
+++ b/openfisca_france/tests/json/f7ud-ee799c48d5a3b16ac8d421bbd27d6ca920f5c75c7bdd7157dfa2f854dc1defea.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ud-f8e9babcc9117ea6b60dbcbf37ddaa707d5b221471abe638a09501bb4b030aa1.json
+++ b/openfisca_france/tests/json/f7ud-f8e9babcc9117ea6b60dbcbf37ddaa707d5b221471abe638a09501bb4b030aa1.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uf-1a17174f669c21f6abe7a33750bd05602169500f20a46f3145818b99045eaef3.json
+++ b/openfisca_france/tests/json/f7uf-1a17174f669c21f6abe7a33750bd05602169500f20a46f3145818b99045eaef3.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uf-319ad60057d6c84aa6335f9b12aebd312aa80fe0e7be8544f2db313a132b3bb5.json
+++ b/openfisca_france/tests/json/f7uf-319ad60057d6c84aa6335f9b12aebd312aa80fe0e7be8544f2db313a132b3bb5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uf-356959c65cfcb9ceeb45252d5e36b5e17f0de60c3d79ea3cc9c4ec871277d40a.json
+++ b/openfisca_france/tests/json/f7uf-356959c65cfcb9ceeb45252d5e36b5e17f0de60c3d79ea3cc9c4ec871277d40a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uf-4a1c54e47d67d5d8335aafc9a6b1fb0c8b0768c72eea32d299eb8918449e5f76.json
+++ b/openfisca_france/tests/json/f7uf-4a1c54e47d67d5d8335aafc9a6b1fb0c8b0768c72eea32d299eb8918449e5f76.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uf-5ea98f738095528d6d25a5627e1d43dd16407ea308ddcaac3fd9c6767191b279.json
+++ b/openfisca_france/tests/json/f7uf-5ea98f738095528d6d25a5627e1d43dd16407ea308ddcaac3fd9c6767191b279.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uf-6b72a5acaea6e615323cf132095266f7342d0b53d11d7d79b183c4dbe10444fe.json
+++ b/openfisca_france/tests/json/f7uf-6b72a5acaea6e615323cf132095266f7342d0b53d11d7d79b183c4dbe10444fe.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uf-a563ccfa0427632d7a704ff717c051495b18a93273324861e5bb22ef89df77a4.json
+++ b/openfisca_france/tests/json/f7uf-a563ccfa0427632d7a704ff717c051495b18a93273324861e5bb22ef89df77a4.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uf-adefd298c799d1bf4f54538194a8c2835b071fa6516b8cfb6a14fe23425162fc.json
+++ b/openfisca_france/tests/json/f7uf-adefd298c799d1bf4f54538194a8c2835b071fa6516b8cfb6a14fe23425162fc.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uf-c7fc62eeba69ac831c88d3081c018035f682e9aa710e44018f42a952f906b3d7.json
+++ b/openfisca_france/tests/json/f7uf-c7fc62eeba69ac831c88d3081c018035f682e9aa710e44018f42a952f906b3d7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uh-22f703838b2cce6083d9b4e74a6d388552a05938314753d569470708ce42ba74.json
+++ b/openfisca_france/tests/json/f7uh-22f703838b2cce6083d9b4e74a6d388552a05938314753d569470708ce42ba74.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uh-556979828f49ea2272c12474141bb4c345903441f641376552b1297d0828b1e5.json
+++ b/openfisca_france/tests/json/f7uh-556979828f49ea2272c12474141bb4c345903441f641376552b1297d0828b1e5.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uh-5a6f3b00f4a3d6f3bcf780c8288acb6c622b37b02a66c01c24a9b2f2542c2af3.json
+++ b/openfisca_france/tests/json/f7uh-5a6f3b00f4a3d6f3bcf780c8288acb6c622b37b02a66c01c24a9b2f2542c2af3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uh-5de6408a77d0a5ac662b43a0726218bbed382b5aa12bd068713ac5a4dd83a530.json
+++ b/openfisca_france/tests/json/f7uh-5de6408a77d0a5ac662b43a0726218bbed382b5aa12bd068713ac5a4dd83a530.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uh-6b4a57fa7bfa5ba9383b0bbd201fc647400529e213d16584bd350975712e7a70.json
+++ b/openfisca_france/tests/json/f7uh-6b4a57fa7bfa5ba9383b0bbd201fc647400529e213d16584bd350975712e7a70.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uh-a883ee77b2da86dfb26c9831e8e60068e821c8997e3e5058e542885e84a61342.json
+++ b/openfisca_france/tests/json/f7uh-a883ee77b2da86dfb26c9831e8e60068e821c8997e3e5058e542885e84a61342.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uh-b0205a593c5757bf7de7065345a8c3e709a22a3314e136af770b92941af69cf8.json
+++ b/openfisca_france/tests/json/f7uh-b0205a593c5757bf7de7065345a8c3e709a22a3314e136af770b92941af69cf8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uh-b03bc5ef6513b072c226b62790f52427ba5be649fc2349faa0086a9f400fd0f0.json
+++ b/openfisca_france/tests/json/f7uh-b03bc5ef6513b072c226b62790f52427ba5be649fc2349faa0086a9f400fd0f0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uh-d45f19af4732fe75255cd60318bffb4f15488975407fbd94db0d5ef6d9cc3bcd.json
+++ b/openfisca_france/tests/json/f7uh-d45f19af4732fe75255cd60318bffb4f15488975407fbd94db0d5ef6d9cc3bcd.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ui-2b0c14254c306ba6f63ec8a5df7a5fa90d7858faded190d0bfc05d42133ef7f9.json
+++ b/openfisca_france/tests/json/f7ui-2b0c14254c306ba6f63ec8a5df7a5fa90d7858faded190d0bfc05d42133ef7f9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ui-603bf762eb3e644ec7ed33d6bf6a361397f6c0596acc2899d29da02a64ea417b.json
+++ b/openfisca_france/tests/json/f7ui-603bf762eb3e644ec7ed33d6bf6a361397f6c0596acc2899d29da02a64ea417b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ui-8bfeaceffa2897d63bc22803ab8a5da601ca01113dd2ec2435836c6c5361df9d.json
+++ b/openfisca_france/tests/json/f7ui-8bfeaceffa2897d63bc22803ab8a5da601ca01113dd2ec2435836c6c5361df9d.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ui-8d8d4d931964750916a072ea4dcce5ea3386c26961bd0fa224cf393d6deb1d47.json
+++ b/openfisca_france/tests/json/f7ui-8d8d4d931964750916a072ea4dcce5ea3386c26961bd0fa224cf393d6deb1d47.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ui-9435bdf9c95a60e986dbe9894549036bbed0267faca802f976cb29affa2391f7.json
+++ b/openfisca_france/tests/json/f7ui-9435bdf9c95a60e986dbe9894549036bbed0267faca802f976cb29affa2391f7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ui-96df754bf6e7e944aa1f0ba6b7c6d8ffeddd04cdfdc3941ffb7770e934486864.json
+++ b/openfisca_france/tests/json/f7ui-96df754bf6e7e944aa1f0ba6b7c6d8ffeddd04cdfdc3941ffb7770e934486864.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ui-bd04e1cc5ce0aaeec22117e7de7c8da57bb3167642ba53866a22b514a3805dc5.json
+++ b/openfisca_france/tests/json/f7ui-bd04e1cc5ce0aaeec22117e7de7c8da57bb3167642ba53866a22b514a3805dc5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ui-c731c2e9fd5a687b188a2381684a95990c373899525349526ba87e638507a4dc.json
+++ b/openfisca_france/tests/json/f7ui-c731c2e9fd5a687b188a2381684a95990c373899525349526ba87e638507a4dc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ui-fc50d34b97506d3eb2d6eabe149aedc600ddb54b03ca55a48c96e17a407f0d15.json
+++ b/openfisca_france/tests/json/f7ui-fc50d34b97506d3eb2d6eabe149aedc600ddb54b03ca55a48c96e17a407f0d15.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uj-2ae07eef6ec9dfa8a07953c6371f833ac0e276e61b4e79efcd85331a476ac736.json
+++ b/openfisca_france/tests/json/f7uj-2ae07eef6ec9dfa8a07953c6371f833ac0e276e61b4e79efcd85331a476ac736.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uj-330080a7c24062eab17bc3f92c0551264b442f55b47dbfd7fe6b8fd0b5e1b9ca.json
+++ b/openfisca_france/tests/json/f7uj-330080a7c24062eab17bc3f92c0551264b442f55b47dbfd7fe6b8fd0b5e1b9ca.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uj-38a3f99f9c6c2f7889f38dab63cde2e880d37e42d7a3e1ff2357bb2e68af966d.json
+++ b/openfisca_france/tests/json/f7uj-38a3f99f9c6c2f7889f38dab63cde2e880d37e42d7a3e1ff2357bb2e68af966d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uj-a16f67d4e5a5c5bd8e1da3ec94413b569ed796ef9e57cce4445b6caf45b20683.json
+++ b/openfisca_france/tests/json/f7uj-a16f67d4e5a5c5bd8e1da3ec94413b569ed796ef9e57cce4445b6caf45b20683.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uj-a7ea7b0484fd9954c0bc5c6daee10e0ea5ee04c4d3fa9ed24827882531774049.json
+++ b/openfisca_france/tests/json/f7uj-a7ea7b0484fd9954c0bc5c6daee10e0ea5ee04c4d3fa9ed24827882531774049.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uj-bc048280ad6ab97c5c84c49fef37022fa0307b5a0d8235e8c5bc23ff30f2ed5b.json
+++ b/openfisca_france/tests/json/f7uj-bc048280ad6ab97c5c84c49fef37022fa0307b5a0d8235e8c5bc23ff30f2ed5b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uj-c27431b0b009363cb2ce6f9eed63bdef36f92ac331aaf9ebf28021ef9f0f345f.json
+++ b/openfisca_france/tests/json/f7uj-c27431b0b009363cb2ce6f9eed63bdef36f92ac331aaf9ebf28021ef9f0f345f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uj-c7ebf32bd1a2f949973bcca42f8b0fe78cc6b56ec81e7be95e5a48a3cbe94132.json
+++ b/openfisca_france/tests/json/f7uj-c7ebf32bd1a2f949973bcca42f8b0fe78cc6b56ec81e7be95e5a48a3cbe94132.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uj-d25e743b428dda01b62fdae7aa1a0081890a90dee6cce57669ad050f55da6ca4.json
+++ b/openfisca_france/tests/json/f7uj-d25e743b428dda01b62fdae7aa1a0081890a90dee6cce57669ad050f55da6ca4.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uk-901a296634f0e8ac640fc6b910089b7b4a6b5c80c05bb71d5c94734d9f13de9e.json
+++ b/openfisca_france/tests/json/f7uk-901a296634f0e8ac640fc6b910089b7b4a6b5c80c05bb71d5c94734d9f13de9e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ul-3d53aa5f9a57ee6b36ed37c4fcf634d97fd565f32d43f970aa3b40be9dc76013.json
+++ b/openfisca_france/tests/json/f7ul-3d53aa5f9a57ee6b36ed37c4fcf634d97fd565f32d43f970aa3b40be9dc76013.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ul-47b8cebdf1a84c552eba0920e84319814c234a6c0cb5abae2a4708b565394f69.json
+++ b/openfisca_france/tests/json/f7ul-47b8cebdf1a84c552eba0920e84319814c234a6c0cb5abae2a4708b565394f69.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ul-4f0fa68627d7cfb33a0ab6e6a563f9cfc4b16a3ff8b59239e7d808477cf8a6c9.json
+++ b/openfisca_france/tests/json/f7ul-4f0fa68627d7cfb33a0ab6e6a563f9cfc4b16a3ff8b59239e7d808477cf8a6c9.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ul-73fdbeb712bcf045ac91d1da1a502841817be8a76e3c46acee3f749f8cf54de1.json
+++ b/openfisca_france/tests/json/f7ul-73fdbeb712bcf045ac91d1da1a502841817be8a76e3c46acee3f749f8cf54de1.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ul-d6eabad14aa703da474344dfebd55c20a2df1a8d13c39c0723991cb82082d432.json
+++ b/openfisca_france/tests/json/f7ul-d6eabad14aa703da474344dfebd55c20a2df1a8d13c39c0723991cb82082d432.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7um-12461b7d6ee92af3c469a5fbb4c562b576aa18508819f42989fe3959316b782f.json
+++ b/openfisca_france/tests/json/f7um-12461b7d6ee92af3c469a5fbb4c562b576aa18508819f42989fe3959316b782f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7un-09841f060e913a633259ddd1c3be635b303fbec7ca61046e880b0cf1e3f48436.json
+++ b/openfisca_france/tests/json/f7un-09841f060e913a633259ddd1c3be635b303fbec7ca61046e880b0cf1e3f48436.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7un-0c462b92e42cebe3d55d1fdb48e6935c5b139c44f9f87c06d0f4ac0718b67b57.json
+++ b/openfisca_france/tests/json/f7un-0c462b92e42cebe3d55d1fdb48e6935c5b139c44f9f87c06d0f4ac0718b67b57.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7un-489f3d4945dc523c1daf000e007f3e72881d523e04ab6f437b2fc0dc367037e2.json
+++ b/openfisca_france/tests/json/f7un-489f3d4945dc523c1daf000e007f3e72881d523e04ab6f437b2fc0dc367037e2.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7un-618d0d33cf20829bff1a6786848e98345de51e55596e6722a6128d0aa07bf50e.json
+++ b/openfisca_france/tests/json/f7un-618d0d33cf20829bff1a6786848e98345de51e55596e6722a6128d0aa07bf50e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7un-72152619c1d51a3fe25db9f9de35612b53734b14c8ddd54e2925b939397116ad.json
+++ b/openfisca_france/tests/json/f7un-72152619c1d51a3fe25db9f9de35612b53734b14c8ddd54e2925b939397116ad.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7un-9f78d6f496b84a90d482c1c05cc5ae40064a10ab6149e5dc487c2f877710333a.json
+++ b/openfisca_france/tests/json/f7un-9f78d6f496b84a90d482c1c05cc5ae40064a10ab6149e5dc487c2f877710333a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7un-b2a66e89155f1331832b2e9d8226dace054909c3239c2ce5b58b0adea2ddacb5.json
+++ b/openfisca_france/tests/json/f7un-b2a66e89155f1331832b2e9d8226dace054909c3239c2ce5b58b0adea2ddacb5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7un-da2dda9f2e73cd119eee48bc8c496d9f0c87bc117371f8501586b406ead38bc6.json
+++ b/openfisca_france/tests/json/f7un-da2dda9f2e73cd119eee48bc8c496d9f0c87bc117371f8501586b406ead38bc6.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7un-e510f21f90333cb418029b69e31628f0c5be334e82f5f71d6b31a39808508434.json
+++ b/openfisca_france/tests/json/f7un-e510f21f90333cb418029b69e31628f0c5be334e82f5f71d6b31a39808508434.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ur-0647e27922a090865d3b7d84787a6cebb35acfe9e19b6712aa79ef58f1e3cff1.json
+++ b/openfisca_france/tests/json/f7ur-0647e27922a090865d3b7d84787a6cebb35acfe9e19b6712aa79ef58f1e3cff1.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ur-1348764f6accdadb845d86af3d033c144bc052dac7629f0303e86be16934c9b3.json
+++ b/openfisca_france/tests/json/f7ur-1348764f6accdadb845d86af3d033c144bc052dac7629f0303e86be16934c9b3.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ur-13fa6a177659e817df4eb28128ba634b96592dd52c62231e8898d0cfe0ce74ca.json
+++ b/openfisca_france/tests/json/f7ur-13fa6a177659e817df4eb28128ba634b96592dd52c62231e8898d0cfe0ce74ca.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ur-4de25935eadd028470374619b3d66b8d05ef176c017cc9a0a6f1da83505caf7b.json
+++ b/openfisca_france/tests/json/f7ur-4de25935eadd028470374619b3d66b8d05ef176c017cc9a0a6f1da83505caf7b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ur-637e444328b88270c9159a64f4dd09f6434b4f184040e929927d6016da5c1a5f.json
+++ b/openfisca_france/tests/json/f7ur-637e444328b88270c9159a64f4dd09f6434b4f184040e929927d6016da5c1a5f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ur-6b8de47384312b1366e8a49f6d29ffacd478c347558b5ea878f03f6e121405b6.json
+++ b/openfisca_france/tests/json/f7ur-6b8de47384312b1366e8a49f6d29ffacd478c347558b5ea878f03f6e121405b6.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ur-74e30d3072befd7c5ef224842004808bb99b01df8593cbdd75533866396f0405.json
+++ b/openfisca_france/tests/json/f7ur-74e30d3072befd7c5ef224842004808bb99b01df8593cbdd75533866396f0405.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ur-9363f08c1a40806b304c556cb0e9dea9c5d420a541d906dfa9d40405c5eb530d.json
+++ b/openfisca_france/tests/json/f7ur-9363f08c1a40806b304c556cb0e9dea9c5d420a541d906dfa9d40405c5eb530d.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ur-f6d084d2fee1cbda80269b735f92f8ec7b02d8f489a80bd76209eab9d48fc45d.json
+++ b/openfisca_france/tests/json/f7ur-f6d084d2fee1cbda80269b735f92f8ec7b02d8f489a80bd76209eab9d48fc45d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uu-2197648ef06913ef0e257f1b9386ea4dfb3c05dee5f2c11ed09bf14e26f05e71.json
+++ b/openfisca_france/tests/json/f7uu-2197648ef06913ef0e257f1b9386ea4dfb3c05dee5f2c11ed09bf14e26f05e71.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uu-64a13f353be4774f56a3ed0ef67bc54780ef6ec7e3c92a8404b2b03a7e4b6744.json
+++ b/openfisca_france/tests/json/f7uu-64a13f353be4774f56a3ed0ef67bc54780ef6ec7e3c92a8404b2b03a7e4b6744.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uu-726060b90e451fcf90395db33a39d31da15a681bb3f4d425a7f3803e46abdcb4.json
+++ b/openfisca_france/tests/json/f7uu-726060b90e451fcf90395db33a39d31da15a681bb3f4d425a7f3803e46abdcb4.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uu-7920e0ad1c301a1c043cb66e3d0e66979c841c6c42bce9ee50b4e9fdabe56ed1.json
+++ b/openfisca_france/tests/json/f7uu-7920e0ad1c301a1c043cb66e3d0e66979c841c6c42bce9ee50b4e9fdabe56ed1.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uu-8d234041aead04ed6eeacb3058f1db21d9086fb781bc7f60bb1107bdb667c529.json
+++ b/openfisca_france/tests/json/f7uu-8d234041aead04ed6eeacb3058f1db21d9086fb781bc7f60bb1107bdb667c529.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uu-c2ec76e13ee22f70e770ac11ed191ec99351a84c246988eac44fa003647c3a69.json
+++ b/openfisca_france/tests/json/f7uu-c2ec76e13ee22f70e770ac11ed191ec99351a84c246988eac44fa003647c3a69.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uu-cf637ef912f312b0a3b5b21ebfa7bdf06dae5332d0dfeab5bb021fb35b2e40b1.json
+++ b/openfisca_france/tests/json/f7uu-cf637ef912f312b0a3b5b21ebfa7bdf06dae5332d0dfeab5bb021fb35b2e40b1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uu-d14f14679970548f12e03551f3ca63b966dc5cd3e7865390884eba7a4b30f728.json
+++ b/openfisca_france/tests/json/f7uu-d14f14679970548f12e03551f3ca63b966dc5cd3e7865390884eba7a4b30f728.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uu-d2cee12ae70f178124ebe31733cf92ab2944e1ee2c8a470aeeddf9b502d14062.json
+++ b/openfisca_france/tests/json/f7uu-d2cee12ae70f178124ebe31733cf92ab2944e1ee2c8a470aeeddf9b502d14062.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uv-036cd82ef4355420200400d0c79d5d6ca18ac2bb76202b689653f8160cbd485a.json
+++ b/openfisca_france/tests/json/f7uv-036cd82ef4355420200400d0c79d5d6ca18ac2bb76202b689653f8160cbd485a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uv-1225118b2973b08291fe1faed0599544c8bb5259acea0745d39f03ab2297a1aa.json
+++ b/openfisca_france/tests/json/f7uv-1225118b2973b08291fe1faed0599544c8bb5259acea0745d39f03ab2297a1aa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uv-26272f3f0347cf1703066a76078278428985f32e1a7d33393933f641ec944bdb.json
+++ b/openfisca_france/tests/json/f7uv-26272f3f0347cf1703066a76078278428985f32e1a7d33393933f641ec944bdb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uv-32f4f2c6b2f86c3367c7c131a86d3d7fb381b79bd6d9625e2348a973ac10f882.json
+++ b/openfisca_france/tests/json/f7uv-32f4f2c6b2f86c3367c7c131a86d3d7fb381b79bd6d9625e2348a973ac10f882.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uv-419127e03e5d248fe9d148aa5d8b0cdfa25fd10b3a1d7f2ba3a279c7051eb672.json
+++ b/openfisca_france/tests/json/f7uv-419127e03e5d248fe9d148aa5d8b0cdfa25fd10b3a1d7f2ba3a279c7051eb672.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uv-46c2e971c87211f567afc8a15f7f250d1fa10c79757647a8310faa051188b47d.json
+++ b/openfisca_france/tests/json/f7uv-46c2e971c87211f567afc8a15f7f250d1fa10c79757647a8310faa051188b47d.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uv-77caca2cc8570ca527e598372b5120461046af6b7464a45fa2752ebb87f625db.json
+++ b/openfisca_france/tests/json/f7uv-77caca2cc8570ca527e598372b5120461046af6b7464a45fa2752ebb87f625db.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uv-abe85f07e556be8cd704757cb1b6b7715577501409270a1912999e7c7e4f0135.json
+++ b/openfisca_france/tests/json/f7uv-abe85f07e556be8cd704757cb1b6b7715577501409270a1912999e7c7e4f0135.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uv-eda4f8137a899afa57f7ffcaeeb648e742b9e9c0b2b1384995a95c5f09720c7d.json
+++ b/openfisca_france/tests/json/f7uv-eda4f8137a899afa57f7ffcaeeb648e742b9e9c0b2b1384995a95c5f09720c7d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uw-2951c1a54ffd02bb494584d940824add36d98b3b2da312223f6bc1d1b8bb3d27.json
+++ b/openfisca_france/tests/json/f7uw-2951c1a54ffd02bb494584d940824add36d98b3b2da312223f6bc1d1b8bb3d27.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uw-2bc2c5b7468a360a7641b895c40ac8d12167f824650cdc2fd7a61cfc8adb2b8c.json
+++ b/openfisca_france/tests/json/f7uw-2bc2c5b7468a360a7641b895c40ac8d12167f824650cdc2fd7a61cfc8adb2b8c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uw-3498a9cf7040ffc91f36631f02fb6368727f5fb88453f205c9787ceb50c4fa6b.json
+++ b/openfisca_france/tests/json/f7uw-3498a9cf7040ffc91f36631f02fb6368727f5fb88453f205c9787ceb50c4fa6b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uw-3ba83542da97cd1b005f0833a88c2f44faa3b5dfe6229f2990d82bd0739014f7.json
+++ b/openfisca_france/tests/json/f7uw-3ba83542da97cd1b005f0833a88c2f44faa3b5dfe6229f2990d82bd0739014f7.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uw-480eba007f007b8b97791dd885345df81c366cada4c0941045d636fe63d8a935.json
+++ b/openfisca_france/tests/json/f7uw-480eba007f007b8b97791dd885345df81c366cada4c0941045d636fe63d8a935.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uw-89cd98cdbdc8ef23ccd5414bd5d50c0a665a1b666de8ed9eeb3591237e3b599e.json
+++ b/openfisca_france/tests/json/f7uw-89cd98cdbdc8ef23ccd5414bd5d50c0a665a1b666de8ed9eeb3591237e3b599e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uw-d573ac9af4e265376817d04007135b96337ef9cef6992b290c37cae6333c051b.json
+++ b/openfisca_france/tests/json/f7uw-d573ac9af4e265376817d04007135b96337ef9cef6992b290c37cae6333c051b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uw-e193e0a9ccd39ea4f6d529c334ba9c1ccbed19ccfd793592d530e996e2aa5f2a.json
+++ b/openfisca_france/tests/json/f7uw-e193e0a9ccd39ea4f6d529c334ba9c1ccbed19ccfd793592d530e996e2aa5f2a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uw-e79f235e3147e9023e504d22d55373306907634cff091b2685c73ae4c2653014.json
+++ b/openfisca_france/tests/json/f7uw-e79f235e3147e9023e504d22d55373306907634cff091b2685c73ae4c2653014.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ux-17c92cb1551de96cc3be44230ab31a01134e5e60e884a0d1711d64259569b23d.json
+++ b/openfisca_france/tests/json/f7ux-17c92cb1551de96cc3be44230ab31a01134e5e60e884a0d1711d64259569b23d.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ux-1f3bfad86f6097d928c4c51d1836dd658e4392fa38d7c1d4adf5fdca365e49a1.json
+++ b/openfisca_france/tests/json/f7ux-1f3bfad86f6097d928c4c51d1836dd658e4392fa38d7c1d4adf5fdca365e49a1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ux-3ddbefe9272d12c92a67f00e185dd5613f99f248b76a418320c9cdbcd1ff7710.json
+++ b/openfisca_france/tests/json/f7ux-3ddbefe9272d12c92a67f00e185dd5613f99f248b76a418320c9cdbcd1ff7710.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ux-3fe8e6d0144b560de01dcc8ab17385a6f2ed1f3ce167e2fbc1079e280db713e2.json
+++ b/openfisca_france/tests/json/f7ux-3fe8e6d0144b560de01dcc8ab17385a6f2ed1f3ce167e2fbc1079e280db713e2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ux-b21c60bac50197b89c0b05340bc7aae53f687d8cc0337425d0bb955ab3227cb2.json
+++ b/openfisca_france/tests/json/f7ux-b21c60bac50197b89c0b05340bc7aae53f687d8cc0337425d0bb955ab3227cb2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ux-b67db05605ce98568df30c112795ecadd8ed021bf9d50694310ccfe16a92ee61.json
+++ b/openfisca_france/tests/json/f7ux-b67db05605ce98568df30c112795ecadd8ed021bf9d50694310ccfe16a92ee61.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ux-c2a35631797d94d58e4d50ac1c51b31cc40544abf9b540b1835f46f193648813.json
+++ b/openfisca_france/tests/json/f7ux-c2a35631797d94d58e4d50ac1c51b31cc40544abf9b540b1835f46f193648813.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ux-d5e98d06e6399466ba1f8a86f6dc88b2f8aa7463000c1a51ddf762975cbad8ee.json
+++ b/openfisca_france/tests/json/f7ux-d5e98d06e6399466ba1f8a86f6dc88b2f8aa7463000c1a51ddf762975cbad8ee.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7ux-ffd069c0446adbdb58d4067dd0f4fffab107ab710437aa0696cc7a4ee58a3e21.json
+++ b/openfisca_france/tests/json/f7ux-ffd069c0446adbdb58d4067dd0f4fffab107ab710437aa0696cc7a4ee58a3e21.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uy-00ba4e0a38655594c1bf8f1e128116531dd0e253aa46124a6f7380d64c488c85.json
+++ b/openfisca_france/tests/json/f7uy-00ba4e0a38655594c1bf8f1e128116531dd0e253aa46124a6f7380d64c488c85.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uy-061239bb6ea514f93addb13ab62c4697e992ec21853d6dfbd25ac8fc0153d0e2.json
+++ b/openfisca_france/tests/json/f7uy-061239bb6ea514f93addb13ab62c4697e992ec21853d6dfbd25ac8fc0153d0e2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uy-4b1c30b541cae2140ad2bc317284c7ab8402138fd50225b936d10532a80d3afb.json
+++ b/openfisca_france/tests/json/f7uy-4b1c30b541cae2140ad2bc317284c7ab8402138fd50225b936d10532a80d3afb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uy-5523e8649f71fd9406c7041fa748b712cbc95f28fd1fd52b74694417a7de5fa0.json
+++ b/openfisca_france/tests/json/f7uy-5523e8649f71fd9406c7041fa748b712cbc95f28fd1fd52b74694417a7de5fa0.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uy-7b4a1e46ad1e677c1af34c343a7f98caf9727016ce8fb6b204c1ad552b54f9b5.json
+++ b/openfisca_france/tests/json/f7uy-7b4a1e46ad1e677c1af34c343a7f98caf9727016ce8fb6b204c1ad552b54f9b5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uy-8f245abadcd222060ad2822dbbff0d3e443c7b7dc7ce1c0b03472307aa856495.json
+++ b/openfisca_france/tests/json/f7uy-8f245abadcd222060ad2822dbbff0d3e443c7b7dc7ce1c0b03472307aa856495.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uy-9f2349a57c73c292edcd06d160d38d2618c0d03e5abb1a27b78cb95cb2c66e0d.json
+++ b/openfisca_france/tests/json/f7uy-9f2349a57c73c292edcd06d160d38d2618c0d03e5abb1a27b78cb95cb2c66e0d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uy-c14bc52ae88f097c25a05390e6783d8cce7f1b1b5d41eff94b2f6221cce8a3c7.json
+++ b/openfisca_france/tests/json/f7uy-c14bc52ae88f097c25a05390e6783d8cce7f1b1b5d41eff94b2f6221cce8a3c7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uy-da80dd25654039c4e696d35ba85059db672f239aa3836ba288c9afc4b60cfcf7.json
+++ b/openfisca_france/tests/json/f7uy-da80dd25654039c4e696d35ba85059db672f239aa3836ba288c9afc4b60cfcf7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uz-19a946039053db9edf656d781549dd8199ee2b4df647e3771701d35c65df0a27.json
+++ b/openfisca_france/tests/json/f7uz-19a946039053db9edf656d781549dd8199ee2b4df647e3771701d35c65df0a27.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uz-1f5e30978905d9b4c19cccda929f5ed951470b722924747532f2bd29942e6187.json
+++ b/openfisca_france/tests/json/f7uz-1f5e30978905d9b4c19cccda929f5ed951470b722924747532f2bd29942e6187.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uz-3f0d1c2b99ae3263b0d5ab0239d312472f16131a0b2ee3285806430fc127906c.json
+++ b/openfisca_france/tests/json/f7uz-3f0d1c2b99ae3263b0d5ab0239d312472f16131a0b2ee3285806430fc127906c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uz-6f29bacc32601b2b66c061974eefb92971ecd4f4f61afa36f5a08a7cf3fd264e.json
+++ b/openfisca_france/tests/json/f7uz-6f29bacc32601b2b66c061974eefb92971ecd4f4f61afa36f5a08a7cf3fd264e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uz-da54dc00f3db47eed664ec6c2a2fbd88cddc47ffca35acf96a373cfb1641eefe.json
+++ b/openfisca_france/tests/json/f7uz-da54dc00f3db47eed664ec6c2a2fbd88cddc47ffca35acf96a373cfb1641eefe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uz-dc29f168bb66f5f9472ebe099efc2df8312c98128957aa6424f76b4f925343ea.json
+++ b/openfisca_france/tests/json/f7uz-dc29f168bb66f5f9472ebe099efc2df8312c98128957aa6424f76b4f925343ea.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uz-df17f1e7622044bcfa188de6e10d0f7ee7b6e8bcc97bd5e487dccbdff63f85f0.json
+++ b/openfisca_france/tests/json/f7uz-df17f1e7622044bcfa188de6e10d0f7ee7b6e8bcc97bd5e487dccbdff63f85f0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uz-ecd108aaab3173c7645b8d68c6ade15f6bbb621209dc7cd0bf1ec0c9c074efa0.json
+++ b/openfisca_france/tests/json/f7uz-ecd108aaab3173c7645b8d68c6ade15f6bbb621209dc7cd0bf1ec0c9c074efa0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7uz-f0b38e9882dbc9f35e78a09fb67bf5eead9ad19804cae77d473eb5ba1b6d59bd.json
+++ b/openfisca_france/tests/json/f7uz-f0b38e9882dbc9f35e78a09fb67bf5eead9ad19804cae77d473eb5ba1b6d59bd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vc-093e6415122ed04ad49790e348f585d16d6cddfa020747f4c0ab31bd48f805bf.json
+++ b/openfisca_france/tests/json/f7vc-093e6415122ed04ad49790e348f585d16d6cddfa020747f4c0ab31bd48f805bf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vc-23d576780f916b1ae6a9b4f115ecbef6c3655016a674a3442fb681ab802c9b6a.json
+++ b/openfisca_france/tests/json/f7vc-23d576780f916b1ae6a9b4f115ecbef6c3655016a674a3442fb681ab802c9b6a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vc-63f8de98249830549f30ac58933b1a0c91bd061753180b827b783a342a82ad63.json
+++ b/openfisca_france/tests/json/f7vc-63f8de98249830549f30ac58933b1a0c91bd061753180b827b783a342a82ad63.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vc-6e704d23af241e1b53c88b8ad8469c16233e9b49fe4c47ab338b38fa262e0a29.json
+++ b/openfisca_france/tests/json/f7vc-6e704d23af241e1b53c88b8ad8469c16233e9b49fe4c47ab338b38fa262e0a29.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vc-817c48418b636655e5857fe6aa8bd25876df5e4db9a858b25ce169b16c37204d.json
+++ b/openfisca_france/tests/json/f7vc-817c48418b636655e5857fe6aa8bd25876df5e4db9a858b25ce169b16c37204d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vc-aee58609ab26ab0dd1767acd673da919ba16dedb9f514a97a9c6260bd47ec060.json
+++ b/openfisca_france/tests/json/f7vc-aee58609ab26ab0dd1767acd673da919ba16dedb9f514a97a9c6260bd47ec060.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vc-e7c7d89d7a3a549cc2b37a5b03624f01acc414519bfb9f20472841179a26c400.json
+++ b/openfisca_france/tests/json/f7vc-e7c7d89d7a3a549cc2b37a5b03624f01acc414519bfb9f20472841179a26c400.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vo-8cb6d8c56d7a7640e28f2831684162f72816f1788e42e82e23be73ce7a4e0ee7.json
+++ b/openfisca_france/tests/json/f7vo-8cb6d8c56d7a7640e28f2831684162f72816f1788e42e82e23be73ce7a4e0ee7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vt-225cac2c1ac324890aadfa23148daeea8e419e1b7b75f920fc4a8f756130f15f.json
+++ b/openfisca_france/tests/json/f7vt-225cac2c1ac324890aadfa23148daeea8e419e1b7b75f920fc4a8f756130f15f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vt-258ef05ec2fabaaa8b3f98680b689a0ab0a9007c7518fea7dcd3121c2da35dcf.json
+++ b/openfisca_france/tests/json/f7vt-258ef05ec2fabaaa8b3f98680b689a0ab0a9007c7518fea7dcd3121c2da35dcf.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vt-3185756452aab1488cbda9e1428dd1ee84f12d44c61d661093bc6f7f74f81dc1.json
+++ b/openfisca_france/tests/json/f7vt-3185756452aab1488cbda9e1428dd1ee84f12d44c61d661093bc6f7f74f81dc1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vt-7eaa465b02a7b6cd4bd9c48f6a93139c6b4fa083554e040e2926724b9e6dc5bb.json
+++ b/openfisca_france/tests/json/f7vt-7eaa465b02a7b6cd4bd9c48f6a93139c6b4fa083554e040e2926724b9e6dc5bb.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vt-85001a05507e5db10bff94a55ea145b0525caccbf61999e44477fc029b983d4b.json
+++ b/openfisca_france/tests/json/f7vt-85001a05507e5db10bff94a55ea145b0525caccbf61999e44477fc029b983d4b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vt-88ef67a0501c04d88aa6b8317a52cd7f9369c6b51d9d53fe4cc03cdc3f0d2cbd.json
+++ b/openfisca_france/tests/json/f7vt-88ef67a0501c04d88aa6b8317a52cd7f9369c6b51d9d53fe4cc03cdc3f0d2cbd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vt-b0decb6378e4f24a712bac76982dcfc45155a0b9c59908ba0fb35d3928811241.json
+++ b/openfisca_france/tests/json/f7vt-b0decb6378e4f24a712bac76982dcfc45155a0b9c59908ba0fb35d3928811241.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vt-cebd7eec34ff5eea5505e313344bb1ba9b51ade8bc069cbba59d465ec70541f6.json
+++ b/openfisca_france/tests/json/f7vt-cebd7eec34ff5eea5505e313344bb1ba9b51ade8bc069cbba59d465ec70541f6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vt-fcdfb8d8aab18d740c7ea435d4663cc807d43369d96de3da99c398f646b7b0e1.json
+++ b/openfisca_france/tests/json/f7vt-fcdfb8d8aab18d740c7ea435d4663cc807d43369d96de3da99c398f646b7b0e1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vu-0385e8d36be19fac77634a609243af5a5298b1128251032dc400c41c08c1d700.json
+++ b/openfisca_france/tests/json/f7vu-0385e8d36be19fac77634a609243af5a5298b1128251032dc400c41c08c1d700.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vu-3915b4a04216fd82f11c018b7f4943b9ec769864b0c29294556f3d1a2d8d7e91.json
+++ b/openfisca_france/tests/json/f7vu-3915b4a04216fd82f11c018b7f4943b9ec769864b0c29294556f3d1a2d8d7e91.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vu-5f92ad94ae3817c0c140c9e7aaeb19cd81446c3886f10c65f72323c4905357ed.json
+++ b/openfisca_france/tests/json/f7vu-5f92ad94ae3817c0c140c9e7aaeb19cd81446c3886f10c65f72323c4905357ed.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vu-77d894e903c673f90faf83f2554351d66245523ac649c56577e7a6aa2267189b.json
+++ b/openfisca_france/tests/json/f7vu-77d894e903c673f90faf83f2554351d66245523ac649c56577e7a6aa2267189b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vu-9a4fd3413313e42b9abd108c5c89c71d083e2a79e30e537cf28659ed9bd52747.json
+++ b/openfisca_france/tests/json/f7vu-9a4fd3413313e42b9abd108c5c89c71d083e2a79e30e537cf28659ed9bd52747.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vu-a3c496c042c519b15158211c482daa7e87cc21c2357a1b53d5dcebfcee8288fb.json
+++ b/openfisca_france/tests/json/f7vu-a3c496c042c519b15158211c482daa7e87cc21c2357a1b53d5dcebfcee8288fb.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vu-c3d74aea0dc8ef8f7713ac4bd7affe16c9579838d3b8f22e637f593b6058fe68.json
+++ b/openfisca_france/tests/json/f7vu-c3d74aea0dc8ef8f7713ac4bd7affe16c9579838d3b8f22e637f593b6058fe68.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vu-e6da9505bca5c30811eb974c06b8c6ad618c32546c0b207bb555861304d3d9dd.json
+++ b/openfisca_france/tests/json/f7vu-e6da9505bca5c30811eb974c06b8c6ad618c32546c0b207bb555861304d3d9dd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vu-f9c296f4c43c767a143e9346912e8c2a42cb77b3596d77796d15862d0034368a.json
+++ b/openfisca_france/tests/json/f7vu-f9c296f4c43c767a143e9346912e8c2a42cb77b3596d77796d15862d0034368a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vw-09abb1197dab0da885e7a8674a7c9b073f36e31b86a559cd6970595973c93f24.json
+++ b/openfisca_france/tests/json/f7vw-09abb1197dab0da885e7a8674a7c9b073f36e31b86a559cd6970595973c93f24.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vw-30eb59f8b2782ae566e01a7155a763056c17fb8c969266cee701dcf291976149.json
+++ b/openfisca_france/tests/json/f7vw-30eb59f8b2782ae566e01a7155a763056c17fb8c969266cee701dcf291976149.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vw-39df4581a5a53a7ba5859ddda7f414413cc1137ce5dd970952f742819890a0d9.json
+++ b/openfisca_france/tests/json/f7vw-39df4581a5a53a7ba5859ddda7f414413cc1137ce5dd970952f742819890a0d9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vw-4599603b4ecdcdb9ff479ebdb87108bdcf99588bd6c34868ff09b7770983090c.json
+++ b/openfisca_france/tests/json/f7vw-4599603b4ecdcdb9ff479ebdb87108bdcf99588bd6c34868ff09b7770983090c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vw-62f8ae989cd23c88f55b8ff0c4c4b1f600a0aa964902d3820e341fb1cc89bf9b.json
+++ b/openfisca_france/tests/json/f7vw-62f8ae989cd23c88f55b8ff0c4c4b1f600a0aa964902d3820e341fb1cc89bf9b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vw-63d63baaff195a824641e6ce3b957417984480f70ab3c213443b981443822a63.json
+++ b/openfisca_france/tests/json/f7vw-63d63baaff195a824641e6ce3b957417984480f70ab3c213443b981443822a63.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vw-6af20be15fc10494748d19bd2467227865a09d592f4cbcc6e0c6585395284c07.json
+++ b/openfisca_france/tests/json/f7vw-6af20be15fc10494748d19bd2467227865a09d592f4cbcc6e0c6585395284c07.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vw-8be36684bc1b5aab7edf1bc7c358199cea9f1c1fe6a7d32fd364755a0c6c5a77.json
+++ b/openfisca_france/tests/json/f7vw-8be36684bc1b5aab7edf1bc7c358199cea9f1c1fe6a7d32fd364755a0c6c5a77.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vw-a5a8068c4c64ec6d5a682c15b5ca8da4ca4d19a487b3cbaff2d9892df6dc184d.json
+++ b/openfisca_france/tests/json/f7vw-a5a8068c4c64ec6d5a682c15b5ca8da4ca4d19a487b3cbaff2d9892df6dc184d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vx-08f341fd606e276098fe610df0d5e7312ba3aec0503384e9b13b33f61163159f.json
+++ b/openfisca_france/tests/json/f7vx-08f341fd606e276098fe610df0d5e7312ba3aec0503384e9b13b33f61163159f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vx-83bb01cf4f9642e5b027d1f57e5b185e8d33beafb99088fb16fddade3d0e0417.json
+++ b/openfisca_france/tests/json/f7vx-83bb01cf4f9642e5b027d1f57e5b185e8d33beafb99088fb16fddade3d0e0417.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vx-85687883cb1e14faf7891b50211eca8ccec6e8cd5741d18b74555a93f3e62af3.json
+++ b/openfisca_france/tests/json/f7vx-85687883cb1e14faf7891b50211eca8ccec6e8cd5741d18b74555a93f3e62af3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vx-86632a18110e2a487a1269b3f18a2b4ab0fde7a5d4c9de9b34ba53833ec1e416.json
+++ b/openfisca_france/tests/json/f7vx-86632a18110e2a487a1269b3f18a2b4ab0fde7a5d4c9de9b34ba53833ec1e416.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vx-b7c1b580572dba74b8512444927d21a1155838afcf57f6e2c308cc496266edf8.json
+++ b/openfisca_france/tests/json/f7vx-b7c1b580572dba74b8512444927d21a1155838afcf57f6e2c308cc496266edf8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vx-baaca8f6721b301a01dd62f9945546041e74a5c158c8273efe76d56bca809bdd.json
+++ b/openfisca_france/tests/json/f7vx-baaca8f6721b301a01dd62f9945546041e74a5c158c8273efe76d56bca809bdd.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vx-d7b0574983e26cae51a45bbdba6d6e38173c195f49d81811cb7272a9110aad25.json
+++ b/openfisca_france/tests/json/f7vx-d7b0574983e26cae51a45bbdba6d6e38173c195f49d81811cb7272a9110aad25.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vx-e61b117d6f508ac3a8657d7ef873af84b4fced5acd0c2cffc3abf5550a449eee.json
+++ b/openfisca_france/tests/json/f7vx-e61b117d6f508ac3a8657d7ef873af84b4fced5acd0c2cffc3abf5550a449eee.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vx-f20ac3d3907ad7f39f9e24a34940b15ebc533215b0f437817ff8ecf4d808d682.json
+++ b/openfisca_france/tests/json/f7vx-f20ac3d3907ad7f39f9e24a34940b15ebc533215b0f437817ff8ecf4d808d682.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vy-2411ae30a2a0441d582b08a3c8fd6dbcdb6ce810e7ab8ec198aa48f589266746.json
+++ b/openfisca_france/tests/json/f7vy-2411ae30a2a0441d582b08a3c8fd6dbcdb6ce810e7ab8ec198aa48f589266746.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vy-729febfbb15d5ee06050069d79446b8948bfd9c094de59e221264cd831bed954.json
+++ b/openfisca_france/tests/json/f7vy-729febfbb15d5ee06050069d79446b8948bfd9c094de59e221264cd831bed954.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vy-882d796ed58a3421802b408a22ee14f585da046147439b8ab49771934dc40261.json
+++ b/openfisca_france/tests/json/f7vy-882d796ed58a3421802b408a22ee14f585da046147439b8ab49771934dc40261.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vy-962066f9e8613a0b48db45f1639da5ec8c7be3a9b9da13345006188ddfcab266.json
+++ b/openfisca_france/tests/json/f7vy-962066f9e8613a0b48db45f1639da5ec8c7be3a9b9da13345006188ddfcab266.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vy-9779f43d2a83da15291b2a900229bb43ccbb054520585bb57e04ac2adc23cd0f.json
+++ b/openfisca_france/tests/json/f7vy-9779f43d2a83da15291b2a900229bb43ccbb054520585bb57e04ac2adc23cd0f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vy-9dd574535bf63d071dd7677f637e8530517d3ebe4e38fd58b4aceff88951e035.json
+++ b/openfisca_france/tests/json/f7vy-9dd574535bf63d071dd7677f637e8530517d3ebe4e38fd58b4aceff88951e035.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vy-a9aff134cf224ae22eb311c3ef545050135db8a860c134b14ae7c2a4afb900d9.json
+++ b/openfisca_france/tests/json/f7vy-a9aff134cf224ae22eb311c3ef545050135db8a860c134b14ae7c2a4afb900d9.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vy-e2966cae2bfeb68c06dae9c6c028a5ea786ffe6af140eabd9518e22952781af9.json
+++ b/openfisca_france/tests/json/f7vy-e2966cae2bfeb68c06dae9c6c028a5ea786ffe6af140eabd9518e22952781af9.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vy-ee6d462a5bfad23e7d1ed707b1050c5e822ddb933914e970eb2a82040cdb072c.json
+++ b/openfisca_france/tests/json/f7vy-ee6d462a5bfad23e7d1ed707b1050c5e822ddb933914e970eb2a82040cdb072c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vz-1b2380ecd6ce7c7b50f873b11c3fcfedc92220ab7737990d7fb3ad7c3f39c17b.json
+++ b/openfisca_france/tests/json/f7vz-1b2380ecd6ce7c7b50f873b11c3fcfedc92220ab7737990d7fb3ad7c3f39c17b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vz-330222d5f897f29fcf175e91ee2bc1510924ceb9e75b8df3296997219dfc0728.json
+++ b/openfisca_france/tests/json/f7vz-330222d5f897f29fcf175e91ee2bc1510924ceb9e75b8df3296997219dfc0728.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vz-3d360a3c9e411cafebb59f817f2c0ac990713dd481b44407deb884983463c6b7.json
+++ b/openfisca_france/tests/json/f7vz-3d360a3c9e411cafebb59f817f2c0ac990713dd481b44407deb884983463c6b7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vz-5398dc637b33c58672436f61675f1e583817e4778887b22f02da041f1a19849d.json
+++ b/openfisca_france/tests/json/f7vz-5398dc637b33c58672436f61675f1e583817e4778887b22f02da041f1a19849d.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vz-a3fa69f2565eb42a9d2775178df367b0bc422c041ec6cda1f1adf6b2edb2898c.json
+++ b/openfisca_france/tests/json/f7vz-a3fa69f2565eb42a9d2775178df367b0bc422c041ec6cda1f1adf6b2edb2898c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vz-aece94b5f42402fd9fa5a098b8a713276b49d9ab03b0fd41c4c6cbf383868e32.json
+++ b/openfisca_france/tests/json/f7vz-aece94b5f42402fd9fa5a098b8a713276b49d9ab03b0fd41c4c6cbf383868e32.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vz-c3b39f1b74a4d1455b5d4fcbccb77a8d267caa6e41b970ad26dfa44925e20cec.json
+++ b/openfisca_france/tests/json/f7vz-c3b39f1b74a4d1455b5d4fcbccb77a8d267caa6e41b970ad26dfa44925e20cec.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vz-cb3045c59f0122c7d34f9413d44c2b6d3dc856f8fd2ea29744624bdfb0f8d50c.json
+++ b/openfisca_france/tests/json/f7vz-cb3045c59f0122c7d34f9413d44c2b6d3dc856f8fd2ea29744624bdfb0f8d50c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7vz-f3ef167488cd60c0befd88b2173a4e69b66e66c8da1aad8d0a4c03e388ea78a7.json
+++ b/openfisca_france/tests/json/f7vz-f3ef167488cd60c0befd88b2173a4e69b66e66c8da1aad8d0a4c03e388ea78a7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wc-451b6f800d7bd3045a4bf21ecb6b00649995b75777dd0561199d2bc8c21a3ce9.json
+++ b/openfisca_france/tests/json/f7wc-451b6f800d7bd3045a4bf21ecb6b00649995b75777dd0561199d2bc8c21a3ce9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wc-611f4899c9604a342f7753f249fbaf7874512283efae6ca7139985a1647a346e.json
+++ b/openfisca_france/tests/json/f7wc-611f4899c9604a342f7753f249fbaf7874512283efae6ca7139985a1647a346e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wc-6b393047194a9e5e13f2374067330a75528e08bb9ba658e902091e8c7a6fa1e7.json
+++ b/openfisca_france/tests/json/f7wc-6b393047194a9e5e13f2374067330a75528e08bb9ba658e902091e8c7a6fa1e7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wc-6f91bb0be138c600a54bba14f47875b8d7c4b5384f1b62033343f469aaae3275.json
+++ b/openfisca_france/tests/json/f7wc-6f91bb0be138c600a54bba14f47875b8d7c4b5384f1b62033343f469aaae3275.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wc-aef759274ab574342c053bb5a0e0f9a7e9a7e1e70deef9984e6d2aa535908204.json
+++ b/openfisca_france/tests/json/f7wc-aef759274ab574342c053bb5a0e0f9a7e9a7e1e70deef9984e6d2aa535908204.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wc-c4fb57fbe7b549b5e904169a86bb2ac9f78a5a03d122cdabe4792ac00b301cbe.json
+++ b/openfisca_france/tests/json/f7wc-c4fb57fbe7b549b5e904169a86bb2ac9f78a5a03d122cdabe4792ac00b301cbe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wc-f1298d32d9bf086c212b6bba4b752d1b186e59545b6f1cf0d7e0faa6002c570a.json
+++ b/openfisca_france/tests/json/f7wc-f1298d32d9bf086c212b6bba4b752d1b186e59545b6f1cf0d7e0faa6002c570a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wf-512ad6a4bbb92ca319487f0f765f7940a07c02f0465bc6d8441063860e813820.json
+++ b/openfisca_france/tests/json/f7wf-512ad6a4bbb92ca319487f0f765f7940a07c02f0465bc6d8441063860e813820.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wf-63a55fa3e55b4e24050755c7c10c2123717fb5d6f731237d2f2f6068a93e658b.json
+++ b/openfisca_france/tests/json/f7wf-63a55fa3e55b4e24050755c7c10c2123717fb5d6f731237d2f2f6068a93e658b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wf-74ccf29e77488c6ce7c94b7ca30df19b6e7ed78e23ee99754d3c36990b571f91.json
+++ b/openfisca_france/tests/json/f7wf-74ccf29e77488c6ce7c94b7ca30df19b6e7ed78e23ee99754d3c36990b571f91.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wf-89188555748d9061d07a02555c37d2cc3b44f4d1d1539afc205694a2713658c6.json
+++ b/openfisca_france/tests/json/f7wf-89188555748d9061d07a02555c37d2cc3b44f4d1d1539afc205694a2713658c6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wf-c5d46f0cfaf98642d3e267cb17c18df2fa8605cb9a9c3080f758460b8de5d238.json
+++ b/openfisca_france/tests/json/f7wf-c5d46f0cfaf98642d3e267cb17c18df2fa8605cb9a9c3080f758460b8de5d238.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wf-cd24cc2fd3ad6b391213ce0ff7a43d17cfa9a5149b856523ea2f0f4aef5e1cb1.json
+++ b/openfisca_france/tests/json/f7wf-cd24cc2fd3ad6b391213ce0ff7a43d17cfa9a5149b856523ea2f0f4aef5e1cb1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wf-f74fac91d773ba434b1e5ef42edbfa2db64ede1ca515ad253d6c82f0f06a9323.json
+++ b/openfisca_france/tests/json/f7wf-f74fac91d773ba434b1e5ef42edbfa2db64ede1ca515ad253d6c82f0f06a9323.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wg-0f19d4c6bb1e35b65bca2157d33da7034efefbac0b80d8b4caca341600e680a2.json
+++ b/openfisca_france/tests/json/f7wg-0f19d4c6bb1e35b65bca2157d33da7034efefbac0b80d8b4caca341600e680a2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wg-1fd97d5774da680624e3af1ffb94f2b58175b0cebbdb0d1ad4da6b732ee31f0e.json
+++ b/openfisca_france/tests/json/f7wg-1fd97d5774da680624e3af1ffb94f2b58175b0cebbdb0d1ad4da6b732ee31f0e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wg-34e48e7552b17ee2e33582b80b3559aad3f7dcdb732827062338611083d74714.json
+++ b/openfisca_france/tests/json/f7wg-34e48e7552b17ee2e33582b80b3559aad3f7dcdb732827062338611083d74714.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wg-558152c07ee9e278053a617aed28b91ac6e5824cc1262d8b82becd2acb169075.json
+++ b/openfisca_france/tests/json/f7wg-558152c07ee9e278053a617aed28b91ac6e5824cc1262d8b82becd2acb169075.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wg-63ad90f2289f52ab4b5d2e08744470c2730f26c70102679740a1ca6cc8552233.json
+++ b/openfisca_france/tests/json/f7wg-63ad90f2289f52ab4b5d2e08744470c2730f26c70102679740a1ca6cc8552233.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wg-86a24010ce3f693b8e30163d5b4f49b924a5266828c9d8843984be00669e26dd.json
+++ b/openfisca_france/tests/json/f7wg-86a24010ce3f693b8e30163d5b4f49b924a5266828c9d8843984be00669e26dd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wi-03194ba3716bd00bc805609759afbfad61ed592bf7d49ad51afae31d5f51912a.json
+++ b/openfisca_france/tests/json/f7wi-03194ba3716bd00bc805609759afbfad61ed592bf7d49ad51afae31d5f51912a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wi-0f362edc1b255bad822a9d5c7b91aa7c2e4a490ddd71734b49be9a938ceaef10.json
+++ b/openfisca_france/tests/json/f7wi-0f362edc1b255bad822a9d5c7b91aa7c2e4a490ddd71734b49be9a938ceaef10.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wi-28ff7f44d5c3c055911a9b36e517d64a6372dc9b08667622a606c699d6d56409.json
+++ b/openfisca_france/tests/json/f7wi-28ff7f44d5c3c055911a9b36e517d64a6372dc9b08667622a606c699d6d56409.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wi-693452a9c0c0bc940168dca513dadc86d5f348c2e1f373ec5febd98e562f7b53.json
+++ b/openfisca_france/tests/json/f7wi-693452a9c0c0bc940168dca513dadc86d5f348c2e1f373ec5febd98e562f7b53.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wi-924fdcbc529f513fbfed05860764d939bcb93029d494782d04442a05e038921f.json
+++ b/openfisca_france/tests/json/f7wi-924fdcbc529f513fbfed05860764d939bcb93029d494782d04442a05e038921f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wi-93d4bbd138408a6911d1fa798540e96663437f0bbeb38ba1ff9326d704ce77ec.json
+++ b/openfisca_france/tests/json/f7wi-93d4bbd138408a6911d1fa798540e96663437f0bbeb38ba1ff9326d704ce77ec.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wi-9cdd4b3116486b38291d7c340a40661fccee45433840bc7c93fd2bfba573a1a9.json
+++ b/openfisca_france/tests/json/f7wi-9cdd4b3116486b38291d7c340a40661fccee45433840bc7c93fd2bfba573a1a9.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wi-e3a55eacf28c3827626803bfc1a4dba713690b614b35dee2ce44892237833a09.json
+++ b/openfisca_france/tests/json/f7wi-e3a55eacf28c3827626803bfc1a4dba713690b614b35dee2ce44892237833a09.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wi-eff5b345da70dd23d12c939a680a706e583c5c2010f1a9fed64785ccaa7f476f.json
+++ b/openfisca_france/tests/json/f7wi-eff5b345da70dd23d12c939a680a706e583c5c2010f1a9fed64785ccaa7f476f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wj-3cba176a6d34f7ecff3109b3cdb3077abf6a837824bfbd27cbd29c926c560394.json
+++ b/openfisca_france/tests/json/f7wj-3cba176a6d34f7ecff3109b3cdb3077abf6a837824bfbd27cbd29c926c560394.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wj-454ae9096ed53ce1bdd69e7f6bb65bbc33fc892d9d22efe5742d5ea7d21ab028.json
+++ b/openfisca_france/tests/json/f7wj-454ae9096ed53ce1bdd69e7f6bb65bbc33fc892d9d22efe5742d5ea7d21ab028.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wj-4611b639d00bf8b3b889edbab259c7bf4828a2a68a525a67fc7570f95fa398e0.json
+++ b/openfisca_france/tests/json/f7wj-4611b639d00bf8b3b889edbab259c7bf4828a2a68a525a67fc7570f95fa398e0.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wj-60ec6caf893947cbd1ba0264c2c804664ffda201272553482b6ba00471142d44.json
+++ b/openfisca_france/tests/json/f7wj-60ec6caf893947cbd1ba0264c2c804664ffda201272553482b6ba00471142d44.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wj-898661d164f6565de6ba9e55e7756be80705e5d562400ab5e435ea6afc2c19b3.json
+++ b/openfisca_france/tests/json/f7wj-898661d164f6565de6ba9e55e7756be80705e5d562400ab5e435ea6afc2c19b3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wj-b2d86ae2188d37df973cead3914c0c1dac8eef5e3e465eb4eddcc9dc85c6cd13.json
+++ b/openfisca_france/tests/json/f7wj-b2d86ae2188d37df973cead3914c0c1dac8eef5e3e465eb4eddcc9dc85c6cd13.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wj-c0246f5c60e985e76a6d35762cbd808a63686111628c19101bbde66d177f120a.json
+++ b/openfisca_france/tests/json/f7wj-c0246f5c60e985e76a6d35762cbd808a63686111628c19101bbde66d177f120a.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wj-c18891c9a73dbef7621addd594cb7250a2c5bf99749eb39d468aac8074d13b97.json
+++ b/openfisca_france/tests/json/f7wj-c18891c9a73dbef7621addd594cb7250a2c5bf99749eb39d468aac8074d13b97.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wj-ee532cebd5c585b822d8aba92f502a8c5a8bb514d3367e5e87038f02db3e8770.json
+++ b/openfisca_france/tests/json/f7wj-ee532cebd5c585b822d8aba92f502a8c5a8bb514d3367e5e87038f02db3e8770.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wl-309bbb9379f32c81d1ef5a4ebbb9674188dd8cc9e1a399babaece136eab325ed.json
+++ b/openfisca_france/tests/json/f7wl-309bbb9379f32c81d1ef5a4ebbb9674188dd8cc9e1a399babaece136eab325ed.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wl-349d68550d701323952f49406df8c63e7c0f59b2b66ed22fee29d32c318fc11f.json
+++ b/openfisca_france/tests/json/f7wl-349d68550d701323952f49406df8c63e7c0f59b2b66ed22fee29d32c318fc11f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wl-4738e406f3d904eb56d7f03bba5da9150f6fd57ae2dcfb728654b291be1b8f8d.json
+++ b/openfisca_france/tests/json/f7wl-4738e406f3d904eb56d7f03bba5da9150f6fd57ae2dcfb728654b291be1b8f8d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wl-506effa8784cf9f524a5fbdb39d06fc5723af3812f223cce094aafda5fa8a8b3.json
+++ b/openfisca_france/tests/json/f7wl-506effa8784cf9f524a5fbdb39d06fc5723af3812f223cce094aafda5fa8a8b3.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wl-65d5ce209277302982edcc693af1755503ced754868a7e6ddbdb3e2ba1dc1920.json
+++ b/openfisca_france/tests/json/f7wl-65d5ce209277302982edcc693af1755503ced754868a7e6ddbdb3e2ba1dc1920.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wl-a5a62e7ce85884a9508b7dc4316c0f92bb682efa256f2fc9a4e67a70be7df3ad.json
+++ b/openfisca_france/tests/json/f7wl-a5a62e7ce85884a9508b7dc4316c0f92bb682efa256f2fc9a4e67a70be7df3ad.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wl-b345d27f9fb9dc0f3189de3150f4f26c76e49b19acf56e616007d982a4dae57d.json
+++ b/openfisca_france/tests/json/f7wl-b345d27f9fb9dc0f3189de3150f4f26c76e49b19acf56e616007d982a4dae57d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wl-b9ef37d3437d6184be5dc0b919171ba8020db196f3a84e33a191fea4fe9de1fb.json
+++ b/openfisca_france/tests/json/f7wl-b9ef37d3437d6184be5dc0b919171ba8020db196f3a84e33a191fea4fe9de1fb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wl-e6403063ef07c2b1f0643ddf71040475e8008adf0e6f003f8c3996813d9a411d.json
+++ b/openfisca_france/tests/json/f7wl-e6403063ef07c2b1f0643ddf71040475e8008adf0e6f003f8c3996813d9a411d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wp-0de109b905613ce28c98ed444fa14b696e9ba0f39e6879f6b45d6847bded3c69.json
+++ b/openfisca_france/tests/json/f7wp-0de109b905613ce28c98ed444fa14b696e9ba0f39e6879f6b45d6847bded3c69.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wp-430ea58e49c99e3e5680e0c31e18fd047ea85ef1789b659f0115d89bd98b7ee4.json
+++ b/openfisca_france/tests/json/f7wp-430ea58e49c99e3e5680e0c31e18fd047ea85ef1789b659f0115d89bd98b7ee4.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wp-659a3e6d165ff9d3ed64fc2461eb1ea395e091d6b61a9c06d1e435d94199189d.json
+++ b/openfisca_france/tests/json/f7wp-659a3e6d165ff9d3ed64fc2461eb1ea395e091d6b61a9c06d1e435d94199189d.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wp-6791d1c939bbce81293acbe12b9c77699d36ee7f29cd6935886cf29609590b32.json
+++ b/openfisca_france/tests/json/f7wp-6791d1c939bbce81293acbe12b9c77699d36ee7f29cd6935886cf29609590b32.json
@@ -109,7 +109,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wp-8e2825e2dade7a6a9812e8a1faf22c0548338825cd822ab0fa149be8884d4370.json
+++ b/openfisca_france/tests/json/f7wp-8e2825e2dade7a6a9812e8a1faf22c0548338825cd822ab0fa149be8884d4370.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wp-bc62fadeef556b5787fa9398c564ac7c581bf9df30b8cf7d4581c04cdff54c3a.json
+++ b/openfisca_france/tests/json/f7wp-bc62fadeef556b5787fa9398c564ac7c581bf9df30b8cf7d4581c04cdff54c3a.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wp-d1dc375ae76e8dffc72e7d04e1f7793e1efd2ce48f1d4b362715ac35385b5051.json
+++ b/openfisca_france/tests/json/f7wp-d1dc375ae76e8dffc72e7d04e1f7793e1efd2ce48f1d4b362715ac35385b5051.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wp-d51ff0b1f242cbce22535c13fc3dea9d3829e16875173081226d1795d1124e4d.json
+++ b/openfisca_france/tests/json/f7wp-d51ff0b1f242cbce22535c13fc3dea9d3829e16875173081226d1795d1124e4d.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wp-fcf9a9f38a1e4168ad16c6945337407d2f08ab3a3e0fc684beb3ce3855efb73f.json
+++ b/openfisca_france/tests/json/f7wp-fcf9a9f38a1e4168ad16c6945337407d2f08ab3a3e0fc684beb3ce3855efb73f.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wr-030f5da342a2b2414961edecab03b0850ac8400e7a3c333132d3752a9066cb10.json
+++ b/openfisca_france/tests/json/f7wr-030f5da342a2b2414961edecab03b0850ac8400e7a3c333132d3752a9066cb10.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wr-034337726a7dc636434dff24de110434cb4a8ccf40be94b9a7961c2ff9d7bb63.json
+++ b/openfisca_france/tests/json/f7wr-034337726a7dc636434dff24de110434cb4a8ccf40be94b9a7961c2ff9d7bb63.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wr-064f1965ab33715a38856859067402342a64138bc49f68ffdc5e82937771207f.json
+++ b/openfisca_france/tests/json/f7wr-064f1965ab33715a38856859067402342a64138bc49f68ffdc5e82937771207f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wr-1fba8fdb0ca86e8c7c8a0bd4a466cff97fc27447b2c107a6f9e31b972189ffa0.json
+++ b/openfisca_france/tests/json/f7wr-1fba8fdb0ca86e8c7c8a0bd4a466cff97fc27447b2c107a6f9e31b972189ffa0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wr-37db47010b016dcca1edd4fce8dd6d2cd5cbe55680d3d2c62f7151faa8afbe5d.json
+++ b/openfisca_france/tests/json/f7wr-37db47010b016dcca1edd4fce8dd6d2cd5cbe55680d3d2c62f7151faa8afbe5d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wr-71bcbf8e09b832d0010de7aef42a5b7b93bafa3c06571de77de3c9675f43bef5.json
+++ b/openfisca_france/tests/json/f7wr-71bcbf8e09b832d0010de7aef42a5b7b93bafa3c06571de77de3c9675f43bef5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wr-8e09a7859c2f6a1335ec53c7a39993565900dfd134c414332b01e1c8054a2e58.json
+++ b/openfisca_france/tests/json/f7wr-8e09a7859c2f6a1335ec53c7a39993565900dfd134c414332b01e1c8054a2e58.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wr-a6d967622253e60ea18e249cda0e33d7bea4181275124d7a8988911a12ba9ce2.json
+++ b/openfisca_france/tests/json/f7wr-a6d967622253e60ea18e249cda0e33d7bea4181275124d7a8988911a12ba9ce2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7wr-d60212dfd80df164d4c2b5365c3b029498cb96d7b768669694d4ea366e11de77.json
+++ b/openfisca_france/tests/json/f7wr-d60212dfd80df164d4c2b5365c3b029498cb96d7b768669694d4ea366e11de77.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xa-05e375caa8cc5a8807d91f26681e9a8657f71172525b1d986c3427de4ef0ed9d.json
+++ b/openfisca_france/tests/json/f7xa-05e375caa8cc5a8807d91f26681e9a8657f71172525b1d986c3427de4ef0ed9d.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xa-20cea48e3b13543d0ab9dfff7365b2cb3baed1db4f904c76dc9b98e549ba84cc.json
+++ b/openfisca_france/tests/json/f7xa-20cea48e3b13543d0ab9dfff7365b2cb3baed1db4f904c76dc9b98e549ba84cc.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xa-5d6398e0d5f33016b88db1d3ab39fea06261c9e2cf5bcf28908cc5bd7878af3c.json
+++ b/openfisca_france/tests/json/f7xa-5d6398e0d5f33016b88db1d3ab39fea06261c9e2cf5bcf28908cc5bd7878af3c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xa-8bd9bab5a999366c07a1f4ee6cace2a175ef8647ce0dfcc5438f5a2e5fd35465.json
+++ b/openfisca_france/tests/json/f7xa-8bd9bab5a999366c07a1f4ee6cace2a175ef8647ce0dfcc5438f5a2e5fd35465.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xa-9b2effc21732a2b9e39552f2d934d87d6b1cc2f834e8cf9562cd5839538c23b9.json
+++ b/openfisca_france/tests/json/f7xa-9b2effc21732a2b9e39552f2d934d87d6b1cc2f834e8cf9562cd5839538c23b9.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xa-9b7d059d5b35a4688af27f66264a6196c215ca49d4c9ec65a1ccd06e0cbfc496.json
+++ b/openfisca_france/tests/json/f7xa-9b7d059d5b35a4688af27f66264a6196c215ca49d4c9ec65a1ccd06e0cbfc496.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xa-cccb7c31c14139e22eee372763b78f8e84c5e07a5d8bd3fb40ebafc6ed435c45.json
+++ b/openfisca_france/tests/json/f7xa-cccb7c31c14139e22eee372763b78f8e84c5e07a5d8bd3fb40ebafc6ed435c45.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xa-d5367b91d3f2401a228e3a6d22a91b3bf1f9d9d3abedca9a079251b84ad0956a.json
+++ b/openfisca_france/tests/json/f7xa-d5367b91d3f2401a228e3a6d22a91b3bf1f9d9d3abedca9a079251b84ad0956a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xa-de8ae6bbd7931d7ada5ab02b5e5470db006b9d7ca6145a9c4318e23265924b26.json
+++ b/openfisca_france/tests/json/f7xa-de8ae6bbd7931d7ada5ab02b5e5470db006b9d7ca6145a9c4318e23265924b26.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xb-30ed37de2ec637626ad8b8d9c0ef3c0293e44325e07abfa39c2184c8df001106.json
+++ b/openfisca_france/tests/json/f7xb-30ed37de2ec637626ad8b8d9c0ef3c0293e44325e07abfa39c2184c8df001106.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xb-33f830443faceacfe58133979db92c33d339a9230f6b3e31636b4ef355d69ca6.json
+++ b/openfisca_france/tests/json/f7xb-33f830443faceacfe58133979db92c33d339a9230f6b3e31636b4ef355d69ca6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xb-4f1b2fb891efef7e01950ab718c2f88d77c35b74c0fd06af0120f49d629add91.json
+++ b/openfisca_france/tests/json/f7xb-4f1b2fb891efef7e01950ab718c2f88d77c35b74c0fd06af0120f49d629add91.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xb-a1036eb1ed0dd072b1bafd29b5f0287ee47e503857423b912a3b0fc191d211d8.json
+++ b/openfisca_france/tests/json/f7xb-a1036eb1ed0dd072b1bafd29b5f0287ee47e503857423b912a3b0fc191d211d8.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xb-a4f6c0c746b263f4c5d533bc745b10abfb107a4e2999f3620667537b4414b40b.json
+++ b/openfisca_france/tests/json/f7xb-a4f6c0c746b263f4c5d533bc745b10abfb107a4e2999f3620667537b4414b40b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xb-ae6bdf7587b0bebd18f52272d09d6e50cae825de30e152fa7fb2ffd88ac23a0c.json
+++ b/openfisca_france/tests/json/f7xb-ae6bdf7587b0bebd18f52272d09d6e50cae825de30e152fa7fb2ffd88ac23a0c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xb-b3058e364349c50bad2b6378aea22d22cf1fa6df73de50c7f008542aa850d306.json
+++ b/openfisca_france/tests/json/f7xb-b3058e364349c50bad2b6378aea22d22cf1fa6df73de50c7f008542aa850d306.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xb-ce7d1e28d3151623e864df0b87bd0f13ed41dd5870a05e05078b951370cd5176.json
+++ b/openfisca_france/tests/json/f7xb-ce7d1e28d3151623e864df0b87bd0f13ed41dd5870a05e05078b951370cd5176.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xb-e3d66e88092a31f86471c37d20ee1e85dc4df7e3ae752bd8a15b983a32eeede8.json
+++ b/openfisca_france/tests/json/f7xb-e3d66e88092a31f86471c37d20ee1e85dc4df7e3ae752bd8a15b983a32eeede8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xc-188108bf90f20075ff1e6a39a8d7784eb57a043d6037a45aa71666fb0f812954.json
+++ b/openfisca_france/tests/json/f7xc-188108bf90f20075ff1e6a39a8d7784eb57a043d6037a45aa71666fb0f812954.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xc-33b1e0c0f9d73930a2d0b6d478f57beae60474c7fead474543c4f2ff4b603b76.json
+++ b/openfisca_france/tests/json/f7xc-33b1e0c0f9d73930a2d0b6d478f57beae60474c7fead474543c4f2ff4b603b76.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xc-4b9917f2c6a618d73e625c8326a121223ab978f90eadf87e148f20857090745c.json
+++ b/openfisca_france/tests/json/f7xc-4b9917f2c6a618d73e625c8326a121223ab978f90eadf87e148f20857090745c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xc-6ae677e5f61c42f9f6920816d56f0026b083f16add856320e49e47086e37aafc.json
+++ b/openfisca_france/tests/json/f7xc-6ae677e5f61c42f9f6920816d56f0026b083f16add856320e49e47086e37aafc.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xc-6e33b2b3206602e25197823accaa9fac652d3a2f6a66eadbb4233ebca4034f65.json
+++ b/openfisca_france/tests/json/f7xc-6e33b2b3206602e25197823accaa9fac652d3a2f6a66eadbb4233ebca4034f65.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xc-7bd7df413e25bd1186f8a31b697e81f348c3bf330ca5d9efb2bbb7cab5bd7853.json
+++ b/openfisca_france/tests/json/f7xc-7bd7df413e25bd1186f8a31b697e81f348c3bf330ca5d9efb2bbb7cab5bd7853.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xc-94194030e64ae3a7405d92a142610b33255abf5a70d5acbaaa355b3278f51963.json
+++ b/openfisca_france/tests/json/f7xc-94194030e64ae3a7405d92a142610b33255abf5a70d5acbaaa355b3278f51963.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xc-d0024c87ea2feda1126ebf110e9bbe88d6357948a4fa9e6d1154f793f5d85c84.json
+++ b/openfisca_france/tests/json/f7xc-d0024c87ea2feda1126ebf110e9bbe88d6357948a4fa9e6d1154f793f5d85c84.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xc-dba448d0a8e2083c1d94539216af54da2cf83c16a71e33fdc0bad0433766971d.json
+++ b/openfisca_france/tests/json/f7xc-dba448d0a8e2083c1d94539216af54da2cf83c16a71e33fdc0bad0433766971d.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xd-0ac5d770d011357447df52185e2bce92b9679540f7e401775329aceb45e8681b.json
+++ b/openfisca_france/tests/json/f7xd-0ac5d770d011357447df52185e2bce92b9679540f7e401775329aceb45e8681b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xd-48d56d632ed08c1d12476279daf563d424356567834debda4e614121a8b94fc9.json
+++ b/openfisca_france/tests/json/f7xd-48d56d632ed08c1d12476279daf563d424356567834debda4e614121a8b94fc9.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xd-b6ab24d0f1ed2cdc96587246d8b8223d088e7761f3479258e0859c87fa35a4b7.json
+++ b/openfisca_france/tests/json/f7xd-b6ab24d0f1ed2cdc96587246d8b8223d088e7761f3479258e0859c87fa35a4b7.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xd-d310e85ec5fbe0285af998427073d1198f15f6b9064adcdf013f48017f1ec357.json
+++ b/openfisca_france/tests/json/f7xd-d310e85ec5fbe0285af998427073d1198f15f6b9064adcdf013f48017f1ec357.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xe-6b5d888ebe5a921971d644c63f93f6779acb16e3f127b9dd153deb228a4fecc4.json
+++ b/openfisca_france/tests/json/f7xe-6b5d888ebe5a921971d644c63f93f6779acb16e3f127b9dd153deb228a4fecc4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xe-90cafb8bd7b06d7d9298098da3bad261b964ed3f8ee303fc5b4577d9fc068513.json
+++ b/openfisca_france/tests/json/f7xe-90cafb8bd7b06d7d9298098da3bad261b964ed3f8ee303fc5b4577d9fc068513.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xe-b2bb893d15cd34d6e7800b562d9c7d39ee496ab14a2c5e882709dd7262339787.json
+++ b/openfisca_france/tests/json/f7xe-b2bb893d15cd34d6e7800b562d9c7d39ee496ab14a2c5e882709dd7262339787.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xe-f354be9fbebdaaf9fbf3c1cb0c577e6eb0c811c4119a1e2c5ed0b7ec89e587da.json
+++ b/openfisca_france/tests/json/f7xe-f354be9fbebdaaf9fbf3c1cb0c577e6eb0c811c4119a1e2c5ed0b7ec89e587da.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xf-19143a689f4474f9a4a7c59c6e7438cb2600a28c4b8110c9edc5c5c5d513f463.json
+++ b/openfisca_france/tests/json/f7xf-19143a689f4474f9a4a7c59c6e7438cb2600a28c4b8110c9edc5c5c5d513f463.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xf-51ae56fadfcf438cca7f42e9582fd9b0097eecb75a03c3740e3647666bbe345f.json
+++ b/openfisca_france/tests/json/f7xf-51ae56fadfcf438cca7f42e9582fd9b0097eecb75a03c3740e3647666bbe345f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xf-654bd2d1fa3804dc5c22fad3c16e64c808d7618d4b7693b79885b20277184213.json
+++ b/openfisca_france/tests/json/f7xf-654bd2d1fa3804dc5c22fad3c16e64c808d7618d4b7693b79885b20277184213.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xf-6ae9059aa0a8a787c3b44655696d8fe6a62c6f32738534dfa0769103750ea988.json
+++ b/openfisca_france/tests/json/f7xf-6ae9059aa0a8a787c3b44655696d8fe6a62c6f32738534dfa0769103750ea988.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xf-79a3f20a63c2074b304e8302f7572d7150bb5d88b941eea428b8b419ee287995.json
+++ b/openfisca_france/tests/json/f7xf-79a3f20a63c2074b304e8302f7572d7150bb5d88b941eea428b8b419ee287995.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xf-84bb2cd437dc6c7ed3f7f563e78532b990d59da93c9b1fbc881b269e5142d1b9.json
+++ b/openfisca_france/tests/json/f7xf-84bb2cd437dc6c7ed3f7f563e78532b990d59da93c9b1fbc881b269e5142d1b9.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xf-a84f7230c3291092fd1453892be72d5e8a3b0778196953504ad1d062e8b0a180.json
+++ b/openfisca_france/tests/json/f7xf-a84f7230c3291092fd1453892be72d5e8a3b0778196953504ad1d062e8b0a180.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xf-b6d4c6b154f8c51badf31fdda93be6618ce2be80269b29e6f35287eb17600ef8.json
+++ b/openfisca_france/tests/json/f7xf-b6d4c6b154f8c51badf31fdda93be6618ce2be80269b29e6f35287eb17600ef8.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xf-dcae4d691f1268185b4de6d8e7d563ee2600c588e75e0806328cbf8124c30bab.json
+++ b/openfisca_france/tests/json/f7xf-dcae4d691f1268185b4de6d8e7d563ee2600c588e75e0806328cbf8124c30bab.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xg-08138e9a0be85d81456752d3353a8a6ba53a12b0eb79c32d6d0c89b150d5699e.json
+++ b/openfisca_france/tests/json/f7xg-08138e9a0be85d81456752d3353a8a6ba53a12b0eb79c32d6d0c89b150d5699e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xg-08cddf63ac56ef182ecce6b878a5ba3f5f837cc9437a94cae8cdc25b9fefea28.json
+++ b/openfisca_france/tests/json/f7xg-08cddf63ac56ef182ecce6b878a5ba3f5f837cc9437a94cae8cdc25b9fefea28.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xg-241a400fa8a7bab1794aea59d568bde6abcdf801b9ea73428bf161e3d773bd22.json
+++ b/openfisca_france/tests/json/f7xg-241a400fa8a7bab1794aea59d568bde6abcdf801b9ea73428bf161e3d773bd22.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xg-296f28db4be6f63377a6ecd2f18d9fc9f0723edcfc26b8dedddaca5ada20c5b0.json
+++ b/openfisca_france/tests/json/f7xg-296f28db4be6f63377a6ecd2f18d9fc9f0723edcfc26b8dedddaca5ada20c5b0.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xg-3925647b3a13fd740130bb87be0faa63f18ee42d7c9e549c879258caaafb3c4f.json
+++ b/openfisca_france/tests/json/f7xg-3925647b3a13fd740130bb87be0faa63f18ee42d7c9e549c879258caaafb3c4f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xg-68da2374ea2f535efcd9235f5c8b89f1686dde4f47bf975682b17765216f11d8.json
+++ b/openfisca_france/tests/json/f7xg-68da2374ea2f535efcd9235f5c8b89f1686dde4f47bf975682b17765216f11d8.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xg-6eed6dbf95bef04d7239f7f9b0fd10884bee31be89d4c14a4442f5169ecb2900.json
+++ b/openfisca_france/tests/json/f7xg-6eed6dbf95bef04d7239f7f9b0fd10884bee31be89d4c14a4442f5169ecb2900.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xg-9c0d1acc8e760cff45645cebaed7ed30384b259230a6071ec08889adf8f9dd5b.json
+++ b/openfisca_france/tests/json/f7xg-9c0d1acc8e760cff45645cebaed7ed30384b259230a6071ec08889adf8f9dd5b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xg-d96932c39e17b9b13f02c9448cbf34790570b9ba9cf40c770f77f0073ab93300.json
+++ b/openfisca_france/tests/json/f7xg-d96932c39e17b9b13f02c9448cbf34790570b9ba9cf40c770f77f0073ab93300.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xh-337c38985e00e60b70302d2de4ca7234450d12b633722cfe3f2247520620232e.json
+++ b/openfisca_france/tests/json/f7xh-337c38985e00e60b70302d2de4ca7234450d12b633722cfe3f2247520620232e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xh-34f90aa6c3e77030851657cf75d2d087412739d1e5723dac5c5ec6dbf78c4f48.json
+++ b/openfisca_france/tests/json/f7xh-34f90aa6c3e77030851657cf75d2d087412739d1e5723dac5c5ec6dbf78c4f48.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xh-35c82c270fd8256f2530b94391d0593ac67a581f5cf94d07955498de83cfe2b1.json
+++ b/openfisca_france/tests/json/f7xh-35c82c270fd8256f2530b94391d0593ac67a581f5cf94d07955498de83cfe2b1.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xh-6c62253d58e120e942e91c13ce9622e2424f845a880e6bdd8839f352c2d3bf6a.json
+++ b/openfisca_france/tests/json/f7xh-6c62253d58e120e942e91c13ce9622e2424f845a880e6bdd8839f352c2d3bf6a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xh-7ffdddf6377b859c1c8a9c1fa54404141b6948bf78c7dfa8b8141321f732c1bd.json
+++ b/openfisca_france/tests/json/f7xh-7ffdddf6377b859c1c8a9c1fa54404141b6948bf78c7dfa8b8141321f732c1bd.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xh-9180e5fdbdb046f4142c478cf482a55791765e8709deeff2b7ea38e53ed2548c.json
+++ b/openfisca_france/tests/json/f7xh-9180e5fdbdb046f4142c478cf482a55791765e8709deeff2b7ea38e53ed2548c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xh-e14ef69acf63a81d783b5655134a2567e72437a23399b00be751ee848027a9a7.json
+++ b/openfisca_france/tests/json/f7xh-e14ef69acf63a81d783b5655134a2567e72437a23399b00be751ee848027a9a7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xh-ed0f0c2ddc3507448dcc48d28f108dd5cd84c4ccc1bace32491d98486bab96f3.json
+++ b/openfisca_france/tests/json/f7xh-ed0f0c2ddc3507448dcc48d28f108dd5cd84c4ccc1bace32491d98486bab96f3.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xh-f343b6cdfabdb6344fce82c392a31101dab1226c8b6154e02c2a03e0b5abd0bb.json
+++ b/openfisca_france/tests/json/f7xh-f343b6cdfabdb6344fce82c392a31101dab1226c8b6154e02c2a03e0b5abd0bb.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xi-11e679f7c7ad1f417db50ce4a684638be660d11a5a97b4c5894595808e087940.json
+++ b/openfisca_france/tests/json/f7xi-11e679f7c7ad1f417db50ce4a684638be660d11a5a97b4c5894595808e087940.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xi-47fed0fc262b725e180426ada8ddf8e9089387621f746854153efa74f3052ca5.json
+++ b/openfisca_france/tests/json/f7xi-47fed0fc262b725e180426ada8ddf8e9089387621f746854153efa74f3052ca5.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xi-5ce631a0aa95c95cc3086cd2395fe14fd5f9d0e2e690b4991492b898ac2faa55.json
+++ b/openfisca_france/tests/json/f7xi-5ce631a0aa95c95cc3086cd2395fe14fd5f9d0e2e690b4991492b898ac2faa55.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xi-74e5d4bf0f38d575be3aabfca7d62771f1c9b37c70da96bb0bfd6dab8194188d.json
+++ b/openfisca_france/tests/json/f7xi-74e5d4bf0f38d575be3aabfca7d62771f1c9b37c70da96bb0bfd6dab8194188d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xi-7a4eccc7e674dc9a92b1eb7a6813b03be3e4aec4eb75abcdb78b78588f128a4f.json
+++ b/openfisca_france/tests/json/f7xi-7a4eccc7e674dc9a92b1eb7a6813b03be3e4aec4eb75abcdb78b78588f128a4f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xi-7ec58f40aa4232a903d8d1e31e48b42db387cb48670318689436e9390b507b85.json
+++ b/openfisca_france/tests/json/f7xi-7ec58f40aa4232a903d8d1e31e48b42db387cb48670318689436e9390b507b85.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xi-ad1301901033fbcb77676bf126b10feb2c79bc5665b330317d15031cf6a7704d.json
+++ b/openfisca_france/tests/json/f7xi-ad1301901033fbcb77676bf126b10feb2c79bc5665b330317d15031cf6a7704d.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xi-ce5ea998ce00461d7a8eff2c4cdaa41886cf2ffb16eab55d0b8b0f86a6c0cbf2.json
+++ b/openfisca_france/tests/json/f7xi-ce5ea998ce00461d7a8eff2c4cdaa41886cf2ffb16eab55d0b8b0f86a6c0cbf2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xi-e8c89c58506a4b249148f59fb9fc72c6be479a6f31a94f34c57f84e4e8ed704e.json
+++ b/openfisca_france/tests/json/f7xi-e8c89c58506a4b249148f59fb9fc72c6be479a6f31a94f34c57f84e4e8ed704e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xj-04668a7339669008cfeedb5afc89bb023562524f468178519394f8f9255951de.json
+++ b/openfisca_france/tests/json/f7xj-04668a7339669008cfeedb5afc89bb023562524f468178519394f8f9255951de.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xj-125f85dd3d3049772cca8998c56649c514d90d554c0e12a51b5dfdfd2427ca35.json
+++ b/openfisca_france/tests/json/f7xj-125f85dd3d3049772cca8998c56649c514d90d554c0e12a51b5dfdfd2427ca35.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xj-2fcfaaecaf9f79e30ff29b8a63a78aa4b7dc8f5dff46552dd82c30c9f57ca3c1.json
+++ b/openfisca_france/tests/json/f7xj-2fcfaaecaf9f79e30ff29b8a63a78aa4b7dc8f5dff46552dd82c30c9f57ca3c1.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xj-58525eb1b40c19b442cdd337bca963aa59349e21c1586dfabfe35ef50fd914ce.json
+++ b/openfisca_france/tests/json/f7xj-58525eb1b40c19b442cdd337bca963aa59349e21c1586dfabfe35ef50fd914ce.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xj-6f66c7b3efa1a09dade49e0157286673f5dec4b71630cf4759e9e9c9695d795d.json
+++ b/openfisca_france/tests/json/f7xj-6f66c7b3efa1a09dade49e0157286673f5dec4b71630cf4759e9e9c9695d795d.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xj-828a2e18d2d79f8abba5957970d815a6953ab1e6e4b21d60ff48106b6e332586.json
+++ b/openfisca_france/tests/json/f7xj-828a2e18d2d79f8abba5957970d815a6953ab1e6e4b21d60ff48106b6e332586.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xj-c8fa98b79fbbe05dee9968f745047fd11e52eea37f81b981da85b0cb2940d458.json
+++ b/openfisca_france/tests/json/f7xj-c8fa98b79fbbe05dee9968f745047fd11e52eea37f81b981da85b0cb2940d458.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xj-d58d864dce31d82e28996483aa372efc4aa9b0ab1b2878ec5003b3bed8e13526.json
+++ b/openfisca_france/tests/json/f7xj-d58d864dce31d82e28996483aa372efc4aa9b0ab1b2878ec5003b3bed8e13526.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xj-e00b651f33444aa12813c3c543c1b5fa5b83dea9ad887215a103949a3ba2ac66.json
+++ b/openfisca_france/tests/json/f7xj-e00b651f33444aa12813c3c543c1b5fa5b83dea9ad887215a103949a3ba2ac66.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xk-068c873f8a1a1bb97a86cb3c5ef4fb671ca39284bbb5112215b887aca7512f64.json
+++ b/openfisca_france/tests/json/f7xk-068c873f8a1a1bb97a86cb3c5ef4fb671ca39284bbb5112215b887aca7512f64.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xk-0bb7c89354f04f4876280e4bd50faa7738fe2e12a713387accfa508935e93925.json
+++ b/openfisca_france/tests/json/f7xk-0bb7c89354f04f4876280e4bd50faa7738fe2e12a713387accfa508935e93925.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xk-0eb6dd172c5103b4adc4b2ae17e5457c6ffb0e8371cbbf13fb64cfcf361061fe.json
+++ b/openfisca_france/tests/json/f7xk-0eb6dd172c5103b4adc4b2ae17e5457c6ffb0e8371cbbf13fb64cfcf361061fe.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xk-23ce072177fe8a5a174806674fc49fa8d040a258fb923ab0fa8ba391864d1df6.json
+++ b/openfisca_france/tests/json/f7xk-23ce072177fe8a5a174806674fc49fa8d040a258fb923ab0fa8ba391864d1df6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xk-a93887de40fa2a24ed50c7d33c9ba59f4fe31ad8c823db6b296e979e8a112384.json
+++ b/openfisca_france/tests/json/f7xk-a93887de40fa2a24ed50c7d33c9ba59f4fe31ad8c823db6b296e979e8a112384.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xk-bdf49a8f9e33540afc973b85729930062a7ce4e13a05082aab5fa13ec8dc61bd.json
+++ b/openfisca_france/tests/json/f7xk-bdf49a8f9e33540afc973b85729930062a7ce4e13a05082aab5fa13ec8dc61bd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xk-d8e35251537b51fd63277403b8c53917532b01a12b0934aaa0d9c5ea7130a221.json
+++ b/openfisca_france/tests/json/f7xk-d8e35251537b51fd63277403b8c53917532b01a12b0934aaa0d9c5ea7130a221.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xk-ef532e66970fd9bc0e64e315781de3f6631c9f53d588e649c50052786f2aec19.json
+++ b/openfisca_france/tests/json/f7xk-ef532e66970fd9bc0e64e315781de3f6631c9f53d588e649c50052786f2aec19.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xk-efc939f927c162ca0d1ac0aa6e9623700979e1f674f79decf2096ed62f63c00d.json
+++ b/openfisca_france/tests/json/f7xk-efc939f927c162ca0d1ac0aa6e9623700979e1f674f79decf2096ed62f63c00d.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xl-22df3c317f68db7458ba7367dddee2cc2dffc75d8b37ba6fa4c9d5ad50713492.json
+++ b/openfisca_france/tests/json/f7xl-22df3c317f68db7458ba7367dddee2cc2dffc75d8b37ba6fa4c9d5ad50713492.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xl-3604bf51f2cabb496c7c732ec962e6b1d92bac9c31a809235e929f9a1efec63f.json
+++ b/openfisca_france/tests/json/f7xl-3604bf51f2cabb496c7c732ec962e6b1d92bac9c31a809235e929f9a1efec63f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xl-6a89925fed8d1ae55af2282b7cd57fcdc95a30a385e65593ee36af11007f0b47.json
+++ b/openfisca_france/tests/json/f7xl-6a89925fed8d1ae55af2282b7cd57fcdc95a30a385e65593ee36af11007f0b47.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xl-6ce244aa89896ebdd42bae4727aa53f29fc0520c5a4a7c3dbbbaf04636ba1867.json
+++ b/openfisca_france/tests/json/f7xl-6ce244aa89896ebdd42bae4727aa53f29fc0520c5a4a7c3dbbbaf04636ba1867.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xl-7818ad2547712121c33e90826ac83ee176c2fb8b45b81aab972aec77f2a43dd7.json
+++ b/openfisca_france/tests/json/f7xl-7818ad2547712121c33e90826ac83ee176c2fb8b45b81aab972aec77f2a43dd7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xl-9ce0c5c2086fec90d7b13fa650196e3301e51a785ff72ab2d3ae66148efe57cd.json
+++ b/openfisca_france/tests/json/f7xl-9ce0c5c2086fec90d7b13fa650196e3301e51a785ff72ab2d3ae66148efe57cd.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xl-bc9da7ae8f4b86cf095d1742b2465e054f99f921a32d882bfaf842839e81dc93.json
+++ b/openfisca_france/tests/json/f7xl-bc9da7ae8f4b86cf095d1742b2465e054f99f921a32d882bfaf842839e81dc93.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xl-c66ae27f0c26b42bfd9f4505ded7a38b06c8b8ed44f2922eddaa37e39e060c54.json
+++ b/openfisca_france/tests/json/f7xl-c66ae27f0c26b42bfd9f4505ded7a38b06c8b8ed44f2922eddaa37e39e060c54.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xl-ff55e1985de19bc231fce1bcac8a12d0c928354087d27d96664eb936b5c0a331.json
+++ b/openfisca_france/tests/json/f7xl-ff55e1985de19bc231fce1bcac8a12d0c928354087d27d96664eb936b5c0a331.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xm-361619f8b2c8c8504d35bb2954c48be41dc0e40ed78cdea45401ec33598cb6e7.json
+++ b/openfisca_france/tests/json/f7xm-361619f8b2c8c8504d35bb2954c48be41dc0e40ed78cdea45401ec33598cb6e7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xm-56e65cbaa6ca3f27cdb03897758aa62727324be41c72b7326227f2262622aa1b.json
+++ b/openfisca_france/tests/json/f7xm-56e65cbaa6ca3f27cdb03897758aa62727324be41c72b7326227f2262622aa1b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xm-5b0966ae5c64737a87c538563f00ef51a646d731615632b4d4923433295e4f81.json
+++ b/openfisca_france/tests/json/f7xm-5b0966ae5c64737a87c538563f00ef51a646d731615632b4d4923433295e4f81.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xm-8a15a950c0be3712b2bbb8f30d3de0b429c7529af10ba9b93450faaae7fbf421.json
+++ b/openfisca_france/tests/json/f7xm-8a15a950c0be3712b2bbb8f30d3de0b429c7529af10ba9b93450faaae7fbf421.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xm-ac2f413fa69e6e15f8945a0c2fb197ed111390959d2251bb24c6328455366b34.json
+++ b/openfisca_france/tests/json/f7xm-ac2f413fa69e6e15f8945a0c2fb197ed111390959d2251bb24c6328455366b34.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xm-b267d9445ff13dc8e146a6c5c7ccbf240155548df1de4245827b18fb8231865a.json
+++ b/openfisca_france/tests/json/f7xm-b267d9445ff13dc8e146a6c5c7ccbf240155548df1de4245827b18fb8231865a.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xm-c07dfd17989bde75fc16a356fbda938d87fbd7e27ecc881d946ae6196bb260ec.json
+++ b/openfisca_france/tests/json/f7xm-c07dfd17989bde75fc16a356fbda938d87fbd7e27ecc881d946ae6196bb260ec.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xm-e584cdede09f6661c6d9613342fcbea8e89d186e9150dc2b87aedbbcc28a37ea.json
+++ b/openfisca_france/tests/json/f7xm-e584cdede09f6661c6d9613342fcbea8e89d186e9150dc2b87aedbbcc28a37ea.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xm-e5d270d4487525a70231cc841f410339f6440b0311d599e0662627c5176bdc55.json
+++ b/openfisca_france/tests/json/f7xm-e5d270d4487525a70231cc841f410339f6440b0311d599e0662627c5176bdc55.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xn-16092990fb01a25b27b57c679a3066a06b5060ec348fb8fc23fdc1488ec42b61.json
+++ b/openfisca_france/tests/json/f7xn-16092990fb01a25b27b57c679a3066a06b5060ec348fb8fc23fdc1488ec42b61.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xn-4d4bd0dca2669c20376008aeaf829ee4993e6495806dcdfb5eb8e3559372b522.json
+++ b/openfisca_france/tests/json/f7xn-4d4bd0dca2669c20376008aeaf829ee4993e6495806dcdfb5eb8e3559372b522.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xn-72a1b07a4d1dd92d78055cd014577fe5a47b4bcd22f504bae15dd169dfd65ceb.json
+++ b/openfisca_france/tests/json/f7xn-72a1b07a4d1dd92d78055cd014577fe5a47b4bcd22f504bae15dd169dfd65ceb.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xn-79831657bc1055e2998c6e6ecbffb96d18f86f70b917dc764aaebe71533615b9.json
+++ b/openfisca_france/tests/json/f7xn-79831657bc1055e2998c6e6ecbffb96d18f86f70b917dc764aaebe71533615b9.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xn-c25e4cb5337ac53904f1196bb78242ad6d924da9c124b6211a52d255ddbac80a.json
+++ b/openfisca_france/tests/json/f7xn-c25e4cb5337ac53904f1196bb78242ad6d924da9c124b6211a52d255ddbac80a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xn-c5edba853dd02c336f4537a40deacf848f01aef92251316261c73b3df8277aae.json
+++ b/openfisca_france/tests/json/f7xn-c5edba853dd02c336f4537a40deacf848f01aef92251316261c73b3df8277aae.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xn-e9e146d4c57b740d21ace18f5646611e13c37f86a22266ed70ea3197daa3aace.json
+++ b/openfisca_france/tests/json/f7xn-e9e146d4c57b740d21ace18f5646611e13c37f86a22266ed70ea3197daa3aace.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xn-f288db57611bb2529fa48a3a15865431c7a4150c16474c43f387e91e7e11a3a1.json
+++ b/openfisca_france/tests/json/f7xn-f288db57611bb2529fa48a3a15865431c7a4150c16474c43f387e91e7e11a3a1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xn-ff9dbe5fb1cbe7e884ee8f76f05e54c546c163be2b72e3c7679bede1663a4466.json
+++ b/openfisca_france/tests/json/f7xn-ff9dbe5fb1cbe7e884ee8f76f05e54c546c163be2b72e3c7679bede1663a4466.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xo-185e34685ff6513b9eac41e3b03b2c7275813712198cd7934ff5efc1eb0a5360.json
+++ b/openfisca_france/tests/json/f7xo-185e34685ff6513b9eac41e3b03b2c7275813712198cd7934ff5efc1eb0a5360.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xo-259b335497d82195ac77aa4d8909f7411fbab0a922795e295ed64029b177db41.json
+++ b/openfisca_france/tests/json/f7xo-259b335497d82195ac77aa4d8909f7411fbab0a922795e295ed64029b177db41.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xo-344c9a0dc96006ff654e3ae81aab930635a20ed6b6907ac2c0739b1ff9aa09ed.json
+++ b/openfisca_france/tests/json/f7xo-344c9a0dc96006ff654e3ae81aab930635a20ed6b6907ac2c0739b1ff9aa09ed.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xo-4167b633d36ab0b6f39e7275628b2189139674b346b3ee51612ccd6a8347929c.json
+++ b/openfisca_france/tests/json/f7xo-4167b633d36ab0b6f39e7275628b2189139674b346b3ee51612ccd6a8347929c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xo-51e336726243769d3a950e862d48190d99666c905a9ef90956fe84119573e140.json
+++ b/openfisca_france/tests/json/f7xo-51e336726243769d3a950e862d48190d99666c905a9ef90956fe84119573e140.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xo-68bb47a9fa73123b0f27b488a8c834c2577bc80130b51fc20f4b6a55c8a129eb.json
+++ b/openfisca_france/tests/json/f7xo-68bb47a9fa73123b0f27b488a8c834c2577bc80130b51fc20f4b6a55c8a129eb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xo-b57e7bfb7cd8421236d5d234f6587ffd6029bbdf6764d2e96c4a9990abd70c3c.json
+++ b/openfisca_france/tests/json/f7xo-b57e7bfb7cd8421236d5d234f6587ffd6029bbdf6764d2e96c4a9990abd70c3c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xo-cb69db1a6e9e63381c1a315bb0e075c598b89c4974452d9b3fbcefd57ccef803.json
+++ b/openfisca_france/tests/json/f7xo-cb69db1a6e9e63381c1a315bb0e075c598b89c4974452d9b3fbcefd57ccef803.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xo-e6c72bd6c5aeab45c2d6190de36282483a896290de505412339008864aa1f5f7.json
+++ b/openfisca_france/tests/json/f7xo-e6c72bd6c5aeab45c2d6190de36282483a896290de505412339008864aa1f5f7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xp-1a1b80fe26a06fe4432294f9266cf51ba1992ed7fe7fc033672897ffab025ae9.json
+++ b/openfisca_france/tests/json/f7xp-1a1b80fe26a06fe4432294f9266cf51ba1992ed7fe7fc033672897ffab025ae9.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xp-1be0b555f5749457dd3fb6bb8dbdac4b52a4f024c15215d9e5f943dc6093c0b6.json
+++ b/openfisca_france/tests/json/f7xp-1be0b555f5749457dd3fb6bb8dbdac4b52a4f024c15215d9e5f943dc6093c0b6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xp-34d73a067145c5d30a474b7b93cf0f52de795e530422ab4e7f17c78abafa56e1.json
+++ b/openfisca_france/tests/json/f7xp-34d73a067145c5d30a474b7b93cf0f52de795e530422ab4e7f17c78abafa56e1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xp-84d9ffaa2bcb1c7cabef23c47b967473465e4fd7794c27173ecd68ca0b7009c1.json
+++ b/openfisca_france/tests/json/f7xp-84d9ffaa2bcb1c7cabef23c47b967473465e4fd7794c27173ecd68ca0b7009c1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xp-b577d66218b766da55a4e00ec7595a0d176706f3c753ac4219a336bc9635e97a.json
+++ b/openfisca_france/tests/json/f7xp-b577d66218b766da55a4e00ec7595a0d176706f3c753ac4219a336bc9635e97a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xp-bc464eb30702445dc5a6f07652e6ecb0ea0a73aa03497fab744d7ce60fcffef5.json
+++ b/openfisca_france/tests/json/f7xp-bc464eb30702445dc5a6f07652e6ecb0ea0a73aa03497fab744d7ce60fcffef5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xp-c225ffd4f6b1af6084e6f0ade306c9fa9fc7fc03033ef54b700c4ee9381d14c4.json
+++ b/openfisca_france/tests/json/f7xp-c225ffd4f6b1af6084e6f0ade306c9fa9fc7fc03033ef54b700c4ee9381d14c4.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xp-c6dc3a0562ca8b2355aa1dfa52c23668d254e6302af637b6810abe0d209fb288.json
+++ b/openfisca_france/tests/json/f7xp-c6dc3a0562ca8b2355aa1dfa52c23668d254e6302af637b6810abe0d209fb288.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xp-f44705cc0811a826d8e2d5429a4a6576e62ed22e5523038c4c3396d662693cbd.json
+++ b/openfisca_france/tests/json/f7xp-f44705cc0811a826d8e2d5429a4a6576e62ed22e5523038c4c3396d662693cbd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xq-1a66f9539771241190132e1554fda6127726508c62b2c55cca569b15ce96e4da.json
+++ b/openfisca_france/tests/json/f7xq-1a66f9539771241190132e1554fda6127726508c62b2c55cca569b15ce96e4da.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xq-3b617a8d9e0ae950b650732ddee774621010e25fa66f40a73569753d79b27420.json
+++ b/openfisca_france/tests/json/f7xq-3b617a8d9e0ae950b650732ddee774621010e25fa66f40a73569753d79b27420.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xq-45fa6f233cdbb31664166503dc76db2d695258324d4e02be3d78746bb8074667.json
+++ b/openfisca_france/tests/json/f7xq-45fa6f233cdbb31664166503dc76db2d695258324d4e02be3d78746bb8074667.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xq-819fa1089c04c07ebc1dceccba9a43ad49cf00d0af78ca39fb63cfb1e3875ec2.json
+++ b/openfisca_france/tests/json/f7xq-819fa1089c04c07ebc1dceccba9a43ad49cf00d0af78ca39fb63cfb1e3875ec2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xq-8e496fab803fa6610cc922d51a1f4c859a5feb6f1eade2630f62f588d2c8e2aa.json
+++ b/openfisca_france/tests/json/f7xq-8e496fab803fa6610cc922d51a1f4c859a5feb6f1eade2630f62f588d2c8e2aa.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xq-a7bdd31b7ea87cd87eef97fb97981a322115baa34df37a8dfda23ac0f99d7754.json
+++ b/openfisca_france/tests/json/f7xq-a7bdd31b7ea87cd87eef97fb97981a322115baa34df37a8dfda23ac0f99d7754.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xq-b082537369aa072867ba3579e70c56189b38be1f5ff2cb3952b055b84bb13d27.json
+++ b/openfisca_france/tests/json/f7xq-b082537369aa072867ba3579e70c56189b38be1f5ff2cb3952b055b84bb13d27.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xq-b8978173fbbe383d047e083028c118870be808301883b60eab1dd5434da8ffeb.json
+++ b/openfisca_france/tests/json/f7xq-b8978173fbbe383d047e083028c118870be808301883b60eab1dd5434da8ffeb.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xq-defc83800eca8e2c02b33f28d13c972d36cabaa030f144b65aeb4a2f71504173.json
+++ b/openfisca_france/tests/json/f7xq-defc83800eca8e2c02b33f28d13c972d36cabaa030f144b65aeb4a2f71504173.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xr-3a701f3b9f2a40ef2e5039590a4e65619d4bc8be0e50e81828464bf39fd54be6.json
+++ b/openfisca_france/tests/json/f7xr-3a701f3b9f2a40ef2e5039590a4e65619d4bc8be0e50e81828464bf39fd54be6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xr-425e2eaf89e13ffef3dd4056fc0af46b0d7bacf97250998529018ac58b19fe54.json
+++ b/openfisca_france/tests/json/f7xr-425e2eaf89e13ffef3dd4056fc0af46b0d7bacf97250998529018ac58b19fe54.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xr-70a7c6f8c9fac38ca1c80c839e3aeb26b95c7d26ceb9bd210d7ed2b0b59c40ab.json
+++ b/openfisca_france/tests/json/f7xr-70a7c6f8c9fac38ca1c80c839e3aeb26b95c7d26ceb9bd210d7ed2b0b59c40ab.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xr-82782f07d938b7417766c5b14288a32f6bab33ef07eb6b2ca042c450e9dfbe96.json
+++ b/openfisca_france/tests/json/f7xr-82782f07d938b7417766c5b14288a32f6bab33ef07eb6b2ca042c450e9dfbe96.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xr-84cffe113241fa4b0d6ec1117867de57e9f12e34f6be3d03d27a3ecc4a3a6414.json
+++ b/openfisca_france/tests/json/f7xr-84cffe113241fa4b0d6ec1117867de57e9f12e34f6be3d03d27a3ecc4a3a6414.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xr-b8335fd5489f9b3c39990bde2b0ccfb2969f408e761d1715fbfbd3d601f5d37e.json
+++ b/openfisca_france/tests/json/f7xr-b8335fd5489f9b3c39990bde2b0ccfb2969f408e761d1715fbfbd3d601f5d37e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xr-d1c9130fcb3f1e8f3f77d0b7eea0e5749a751a6b8fbfb10140874b3867c3a9de.json
+++ b/openfisca_france/tests/json/f7xr-d1c9130fcb3f1e8f3f77d0b7eea0e5749a751a6b8fbfb10140874b3867c3a9de.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xr-f46d1d1b909007dd18f0e0943de557188a09f29db4cce0442da4e016da2c053b.json
+++ b/openfisca_france/tests/json/f7xr-f46d1d1b909007dd18f0e0943de557188a09f29db4cce0442da4e016da2c053b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xr-f8d1c1035a8e15c16e2870d6c7d71ec4a2e85b0c825d17143e62bfccc0e6ef87.json
+++ b/openfisca_france/tests/json/f7xr-f8d1c1035a8e15c16e2870d6c7d71ec4a2e85b0c825d17143e62bfccc0e6ef87.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xs-2f99c47f881ac010edb775b8dd668e2aab104790fde2723b1e362e1dfabb5af3.json
+++ b/openfisca_france/tests/json/f7xs-2f99c47f881ac010edb775b8dd668e2aab104790fde2723b1e362e1dfabb5af3.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xs-5dd43197204b9333ebfcac70eda13b503ab17c6ab3ee8c503875782ea9a5f884.json
+++ b/openfisca_france/tests/json/f7xs-5dd43197204b9333ebfcac70eda13b503ab17c6ab3ee8c503875782ea9a5f884.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xs-727b7605fd80e9c49605b8161ef3dc7e4fa887e06e391b2a00ffbaaa698ce7e7.json
+++ b/openfisca_france/tests/json/f7xs-727b7605fd80e9c49605b8161ef3dc7e4fa887e06e391b2a00ffbaaa698ce7e7.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xs-740f8d1c428567513cc0462bd789e3a2954e24432ca396a3c830e84e1638a8c9.json
+++ b/openfisca_france/tests/json/f7xs-740f8d1c428567513cc0462bd789e3a2954e24432ca396a3c830e84e1638a8c9.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xs-b59b1b2249a9c78426755e939a88612caa5225b0500fe26cd1ffa1ffedff057f.json
+++ b/openfisca_france/tests/json/f7xs-b59b1b2249a9c78426755e939a88612caa5225b0500fe26cd1ffa1ffedff057f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xs-ca82d966e07d3e27848cf933c47e63bc4776ffc24e5ea121e827c2a25469dce9.json
+++ b/openfisca_france/tests/json/f7xs-ca82d966e07d3e27848cf933c47e63bc4776ffc24e5ea121e827c2a25469dce9.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xs-d699b58c1c1ac6437f9392222ff50e087c89863df9f1b91db5fc952fe8f781c5.json
+++ b/openfisca_france/tests/json/f7xs-d699b58c1c1ac6437f9392222ff50e087c89863df9f1b91db5fc952fe8f781c5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xs-d913b23c67873ad1599a85a152860f8a965422a3c682d2e127412e02569adeee.json
+++ b/openfisca_france/tests/json/f7xs-d913b23c67873ad1599a85a152860f8a965422a3c682d2e127412e02569adeee.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xs-e49244af13f01cd18bb99f230ce49d7533ec214d2d5ec6d09fc3fc42409cae45.json
+++ b/openfisca_france/tests/json/f7xs-e49244af13f01cd18bb99f230ce49d7533ec214d2d5ec6d09fc3fc42409cae45.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xt-3ea98cca6fe9fae92d4b7583090457124023b505a57d9e7a69d3eacc4f668c88.json
+++ b/openfisca_france/tests/json/f7xt-3ea98cca6fe9fae92d4b7583090457124023b505a57d9e7a69d3eacc4f668c88.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xt-4d06d7b23ad743e1ae9080274d8a3cb925ed998603f6d4b36a143273c2f16da4.json
+++ b/openfisca_france/tests/json/f7xt-4d06d7b23ad743e1ae9080274d8a3cb925ed998603f6d4b36a143273c2f16da4.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xt-52bd52f4e4673137d7a6ee062e041c24d610cc8c276482dc79a9aaebf421d468.json
+++ b/openfisca_france/tests/json/f7xt-52bd52f4e4673137d7a6ee062e041c24d610cc8c276482dc79a9aaebf421d468.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xt-53eff9fe03f1e8d8c9d50c0f8f8e41a999a654600af871fa5d9e31ec70ff59a3.json
+++ b/openfisca_france/tests/json/f7xt-53eff9fe03f1e8d8c9d50c0f8f8e41a999a654600af871fa5d9e31ec70ff59a3.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xt-d6867daaf4b0d0dc65f1662a47b3ca26f51f1c2f908f5d246533738f31c5daa0.json
+++ b/openfisca_france/tests/json/f7xt-d6867daaf4b0d0dc65f1662a47b3ca26f51f1c2f908f5d246533738f31c5daa0.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xt-d8f0b1364cd0ee086d83f76455ef6559493cef483559527c803f953a957d8b3b.json
+++ b/openfisca_france/tests/json/f7xt-d8f0b1364cd0ee086d83f76455ef6559493cef483559527c803f953a957d8b3b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xt-e0c78757a6dd3e5bdba3ed7be1c57dcfd3ac3a87fae8b3eeff3642bc29bd2b6b.json
+++ b/openfisca_france/tests/json/f7xt-e0c78757a6dd3e5bdba3ed7be1c57dcfd3ac3a87fae8b3eeff3642bc29bd2b6b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xt-e245890e3160bb08d0937fd437a23f7fe6a8eca5243b49572e3884f6a5afbb33.json
+++ b/openfisca_france/tests/json/f7xt-e245890e3160bb08d0937fd437a23f7fe6a8eca5243b49572e3884f6a5afbb33.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xt-eb3cb449854d58752180b72f8ab032e70e3b26994ee5ef135bcf9bef71d00969.json
+++ b/openfisca_france/tests/json/f7xt-eb3cb449854d58752180b72f8ab032e70e3b26994ee5ef135bcf9bef71d00969.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xu-028a6c1c01f21ba19f85ee8fa5ad9f3ad4ffc6ac74ce5d393861202d4a88b6a3.json
+++ b/openfisca_france/tests/json/f7xu-028a6c1c01f21ba19f85ee8fa5ad9f3ad4ffc6ac74ce5d393861202d4a88b6a3.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xu-10a527af453010119cd62cf5bf79908b1c0603a5ea9490c445552e1744cc0c4f.json
+++ b/openfisca_france/tests/json/f7xu-10a527af453010119cd62cf5bf79908b1c0603a5ea9490c445552e1744cc0c4f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xu-377639835bc0be64c128a0fb53dec9251e53f9808ea6098a6c3563782d620964.json
+++ b/openfisca_france/tests/json/f7xu-377639835bc0be64c128a0fb53dec9251e53f9808ea6098a6c3563782d620964.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xu-4bac77b37f50397c798a5c6d5aeeb0237cc40af7236d3002f41dc51777dc91cd.json
+++ b/openfisca_france/tests/json/f7xu-4bac77b37f50397c798a5c6d5aeeb0237cc40af7236d3002f41dc51777dc91cd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xu-6864541ded15edc602a20600038fb27684b0d4c0e5c9910ee63bb5996af1c867.json
+++ b/openfisca_france/tests/json/f7xu-6864541ded15edc602a20600038fb27684b0d4c0e5c9910ee63bb5996af1c867.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xu-8b4bde11158583dda816a2aedf1f015c91b39ab537d64fab3554bad5713dadad.json
+++ b/openfisca_france/tests/json/f7xu-8b4bde11158583dda816a2aedf1f015c91b39ab537d64fab3554bad5713dadad.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xu-ad3455c37da3b4890260cba881ba1a298c3cf4691df83a46fa30a53c76f9e201.json
+++ b/openfisca_france/tests/json/f7xu-ad3455c37da3b4890260cba881ba1a298c3cf4691df83a46fa30a53c76f9e201.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xu-b04c5f09b497a97ca6a97583c916d30caf68e299d2d3ee7e5eedf9b0044d8f52.json
+++ b/openfisca_france/tests/json/f7xu-b04c5f09b497a97ca6a97583c916d30caf68e299d2d3ee7e5eedf9b0044d8f52.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xu-c234ad196ed311da3b9849858b6a0cccc964ae2c899c93b5fc9a6fb4deccac76.json
+++ b/openfisca_france/tests/json/f7xu-c234ad196ed311da3b9849858b6a0cccc964ae2c899c93b5fc9a6fb4deccac76.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xv-08dcf358e3beda1bf7d58545147a92955931c887d04b1152ac20aa3709cb7729.json
+++ b/openfisca_france/tests/json/f7xv-08dcf358e3beda1bf7d58545147a92955931c887d04b1152ac20aa3709cb7729.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xv-55596f488dfc29ec617a3de9dc15195f69c9f0dff5f0111f46e5d30554bc7b86.json
+++ b/openfisca_france/tests/json/f7xv-55596f488dfc29ec617a3de9dc15195f69c9f0dff5f0111f46e5d30554bc7b86.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xv-5bcf2a0d75c66d6ea9fe9a3439e9e6c94d54fc37d35df94775f085e92afbf96a.json
+++ b/openfisca_france/tests/json/f7xv-5bcf2a0d75c66d6ea9fe9a3439e9e6c94d54fc37d35df94775f085e92afbf96a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xv-6187e3bcea2092d483583726e8ff13f1eda67c4c622ad3bd4fe90b579a307997.json
+++ b/openfisca_france/tests/json/f7xv-6187e3bcea2092d483583726e8ff13f1eda67c4c622ad3bd4fe90b579a307997.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xv-62e7c2b51e25db4223c1b94c4233d56e37a5ce1d6f5b6a3f56e589174ffea4d0.json
+++ b/openfisca_france/tests/json/f7xv-62e7c2b51e25db4223c1b94c4233d56e37a5ce1d6f5b6a3f56e589174ffea4d0.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xv-7aef872e511dac39c4a6a078c2a7bbd2b44d8b7171a790337acd4e6dffa30319.json
+++ b/openfisca_france/tests/json/f7xv-7aef872e511dac39c4a6a078c2a7bbd2b44d8b7171a790337acd4e6dffa30319.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xv-9969b8a6a570b39e38cd52af821556489e5f7269410d86a3059ab72f1a4ff7f1.json
+++ b/openfisca_france/tests/json/f7xv-9969b8a6a570b39e38cd52af821556489e5f7269410d86a3059ab72f1a4ff7f1.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xv-ceeb4f7d189cf4a357098d3f25e018860a47489c2e93f290ab2469e1e650dd95.json
+++ b/openfisca_france/tests/json/f7xv-ceeb4f7d189cf4a357098d3f25e018860a47489c2e93f290ab2469e1e650dd95.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xv-e7e216ce34ce49fee445f842210bdac60af64c2124cdb72b4e01f772abdf777f.json
+++ b/openfisca_france/tests/json/f7xv-e7e216ce34ce49fee445f842210bdac60af64c2124cdb72b4e01f772abdf777f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xw-289bd8ad8ef8f206e0da22e4dff3b6c1e8691fac70cf7dd3dc89d5a3b69f9e57.json
+++ b/openfisca_france/tests/json/f7xw-289bd8ad8ef8f206e0da22e4dff3b6c1e8691fac70cf7dd3dc89d5a3b69f9e57.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xw-57971ea323637c45bff011c32b31120416284ac89659e249a9bfa467ecddc0e8.json
+++ b/openfisca_france/tests/json/f7xw-57971ea323637c45bff011c32b31120416284ac89659e249a9bfa467ecddc0e8.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xw-73dc3f0dee615ddf61f769f39f7b92cdbfd81ac8d6844cf7b48e136fe3234c5b.json
+++ b/openfisca_france/tests/json/f7xw-73dc3f0dee615ddf61f769f39f7b92cdbfd81ac8d6844cf7b48e136fe3234c5b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xw-7a68cdfd461c7d54190b7d422b33d4640255c39846cd2b29091f7405c4a3e605.json
+++ b/openfisca_france/tests/json/f7xw-7a68cdfd461c7d54190b7d422b33d4640255c39846cd2b29091f7405c4a3e605.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xw-890a2d3b2acc943299714747cc05adc365bf2e754aadc163ae85d0c984984a5f.json
+++ b/openfisca_france/tests/json/f7xw-890a2d3b2acc943299714747cc05adc365bf2e754aadc163ae85d0c984984a5f.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xw-92369a842c4f5569a511fbd7d6145e9ae3f7db02c978a839080165c5b897900a.json
+++ b/openfisca_france/tests/json/f7xw-92369a842c4f5569a511fbd7d6145e9ae3f7db02c978a839080165c5b897900a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xw-c7d1588918fe062eebd9416d42805e2704b5a957d6ff90dadbf8bb1e52875ebe.json
+++ b/openfisca_france/tests/json/f7xw-c7d1588918fe062eebd9416d42805e2704b5a957d6ff90dadbf8bb1e52875ebe.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xw-e4b8e951606a2c597c737da94d0bfec751c7c81a7108c3c9807d955616d449e6.json
+++ b/openfisca_france/tests/json/f7xw-e4b8e951606a2c597c737da94d0bfec751c7c81a7108c3c9807d955616d449e6.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xw-f76caeb035dc8ef71582354ab920d43b063c2c012130bc5d9a79b18b920a933b.json
+++ b/openfisca_france/tests/json/f7xw-f76caeb035dc8ef71582354ab920d43b063c2c012130bc5d9a79b18b920a933b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xx-20e075b9fc9905801d4baa76cd5a1812e91278d38037ca2e4318ddba517beb70.json
+++ b/openfisca_france/tests/json/f7xx-20e075b9fc9905801d4baa76cd5a1812e91278d38037ca2e4318ddba517beb70.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xx-39bbc338ed844a225e71105a0402a533c2b22e4410608fd7b53d2fa584d630be.json
+++ b/openfisca_france/tests/json/f7xx-39bbc338ed844a225e71105a0402a533c2b22e4410608fd7b53d2fa584d630be.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xx-3ef8b464052499dd28b139802c55d3c1c490e0ff37635b7039b82648073ffba3.json
+++ b/openfisca_france/tests/json/f7xx-3ef8b464052499dd28b139802c55d3c1c490e0ff37635b7039b82648073ffba3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xx-447322fa8b0346d937c84cdfb09d9b62d52cfd1bb67543f12356b63445ebc96e.json
+++ b/openfisca_france/tests/json/f7xx-447322fa8b0346d937c84cdfb09d9b62d52cfd1bb67543f12356b63445ebc96e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xx-50b011002fef913b4a2f262f0dbae016cff928d12df4b49f8464babe2aa9759c.json
+++ b/openfisca_france/tests/json/f7xx-50b011002fef913b4a2f262f0dbae016cff928d12df4b49f8464babe2aa9759c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xx-6fba043090dc8ac733870f9d52339fa822d9f31a0d856f57b380ae156fb4e10c.json
+++ b/openfisca_france/tests/json/f7xx-6fba043090dc8ac733870f9d52339fa822d9f31a0d856f57b380ae156fb4e10c.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xx-b720f4f66571212c4d8a921684bb72058b67d29a481de75f16ce6aca3a2294d6.json
+++ b/openfisca_france/tests/json/f7xx-b720f4f66571212c4d8a921684bb72058b67d29a481de75f16ce6aca3a2294d6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xx-dc48e9d3d148d3a5d3b2cf27915e4aa04b75de53c886d6943318bbd345f51dc0.json
+++ b/openfisca_france/tests/json/f7xx-dc48e9d3d148d3a5d3b2cf27915e4aa04b75de53c886d6943318bbd345f51dc0.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xx-e293397f29f9c9c3c20fddcf1b6adc2dab9043bbad2586a1965363d668842b6e.json
+++ b/openfisca_france/tests/json/f7xx-e293397f29f9c9c3c20fddcf1b6adc2dab9043bbad2586a1965363d668842b6e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xz-27a93e26c6d49592c4601d0cfe724d76552b2da89883412adf4b26ba729f5aef.json
+++ b/openfisca_france/tests/json/f7xz-27a93e26c6d49592c4601d0cfe724d76552b2da89883412adf4b26ba729f5aef.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xz-29fff3357ab9fe36ef87ed2f42bb323c5ff13bc35b301be6110d8cd2cd8ae294.json
+++ b/openfisca_france/tests/json/f7xz-29fff3357ab9fe36ef87ed2f42bb323c5ff13bc35b301be6110d8cd2cd8ae294.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xz-444684fcdd1b6d74511c0dbdc108bc995b4c3576cb8b16ceeaa4549dc54d2264.json
+++ b/openfisca_france/tests/json/f7xz-444684fcdd1b6d74511c0dbdc108bc995b4c3576cb8b16ceeaa4549dc54d2264.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xz-7af2ada5fca15ae4da44ddfc9119d268cf9f73231ec17e4fda9fbb37b5906a78.json
+++ b/openfisca_france/tests/json/f7xz-7af2ada5fca15ae4da44ddfc9119d268cf9f73231ec17e4fda9fbb37b5906a78.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xz-8098c13bc75378f204ceb80a149180ef6278bab2d8ea6d03bf56faae417fcae9.json
+++ b/openfisca_france/tests/json/f7xz-8098c13bc75378f204ceb80a149180ef6278bab2d8ea6d03bf56faae417fcae9.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xz-9ebc78f5294600056f717af7bbed856f5f01c2bc8f7e03493d337c46ad0678be.json
+++ b/openfisca_france/tests/json/f7xz-9ebc78f5294600056f717af7bbed856f5f01c2bc8f7e03493d337c46ad0678be.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xz-9ec4eb670acb3da78a6ed1b32c4b0bbbc47bc8ef8d138c3c10aaa9af4484f8dd.json
+++ b/openfisca_france/tests/json/f7xz-9ec4eb670acb3da78a6ed1b32c4b0bbbc47bc8ef8d138c3c10aaa9af4484f8dd.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xz-b6c2170f69ef3de50842625a5abfca9cc463b150d2bf6dd000e5858648b9a96a.json
+++ b/openfisca_france/tests/json/f7xz-b6c2170f69ef3de50842625a5abfca9cc463b150d2bf6dd000e5858648b9a96a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f7xz-fa3a19ca9b48f2fd75421bf4c5ee1b199cf367b8e08d2c0b071183e3be0c006a.json
+++ b/openfisca_france/tests/json/f7xz-fa3a19ca9b48f2fd75421bf4c5ee1b199cf367b8e08d2c0b071183e3be0c006a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ta-1fe6ba3b96ef21f09a188fdd83e0d746f02e26d5006aee91777ee93e74827aef.json
+++ b/openfisca_france/tests/json/f8ta-1fe6ba3b96ef21f09a188fdd83e0d746f02e26d5006aee91777ee93e74827aef.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ta-47bfdbfa2ac544fbbec02e402a0894ad7d405f96ee7018979aa2196fd046f08b.json
+++ b/openfisca_france/tests/json/f8ta-47bfdbfa2ac544fbbec02e402a0894ad7d405f96ee7018979aa2196fd046f08b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ta-4c5a11f7db5d5fe4dcd66c2a3d679d485ce5d418d201c354aa72625f2f105476.json
+++ b/openfisca_france/tests/json/f8ta-4c5a11f7db5d5fe4dcd66c2a3d679d485ce5d418d201c354aa72625f2f105476.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ta-6d0681074a955cc509367430ad6403d4710e20d33e150420f6742bceac127cb2.json
+++ b/openfisca_france/tests/json/f8ta-6d0681074a955cc509367430ad6403d4710e20d33e150420f6742bceac127cb2.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ta-a1c978d446000ec290be5b75f98da34d302ddf7c27460630bca8c9fbb53c147f.json
+++ b/openfisca_france/tests/json/f8ta-a1c978d446000ec290be5b75f98da34d302ddf7c27460630bca8c9fbb53c147f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ta-a21591bf71d18edcc7660610a350b106bb697ff935648e3158ba28e2684c9e02.json
+++ b/openfisca_france/tests/json/f8ta-a21591bf71d18edcc7660610a350b106bb697ff935648e3158ba28e2684c9e02.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ta-b2846573d0bceee18c995a1e5dcaf73deb97030d0f75398a134fab2db73b0abe.json
+++ b/openfisca_france/tests/json/f8ta-b2846573d0bceee18c995a1e5dcaf73deb97030d0f75398a134fab2db73b0abe.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ta-da88ecdc13ff05fe22fb1fd5181b31da88e5d84d5871e047844b8735f72de265.json
+++ b/openfisca_france/tests/json/f8ta-da88ecdc13ff05fe22fb1fd5181b31da88e5d84d5871e047844b8735f72de265.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ta-f7cfb93f38b4f449e02420923bd7428e981ab816ae575d358c147aad76ac21c5.json
+++ b/openfisca_france/tests/json/f8ta-f7cfb93f38b4f449e02420923bd7428e981ab816ae575d358c147aad76ac21c5.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tf-2837c3abcef12ef200540638a34af2841b2fcdced0355cde597e4a021b0a7d90.json
+++ b/openfisca_france/tests/json/f8tf-2837c3abcef12ef200540638a34af2841b2fcdced0355cde597e4a021b0a7d90.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tf-3f208ac69fbc73d876d5ad96570c58ad680af8d7b6a92ba430390ebd087476b8.json
+++ b/openfisca_france/tests/json/f8tf-3f208ac69fbc73d876d5ad96570c58ad680af8d7b6a92ba430390ebd087476b8.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tf-4296d0be59d82a5361a356450d0d7be3cfb187b6d2140b28004f49812697953d.json
+++ b/openfisca_france/tests/json/f8tf-4296d0be59d82a5361a356450d0d7be3cfb187b6d2140b28004f49812697953d.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tf-6e1f874d8f95c58372af78f2389e00f1693232b3a01610440c6a7f2fc625ee43.json
+++ b/openfisca_france/tests/json/f8tf-6e1f874d8f95c58372af78f2389e00f1693232b3a01610440c6a7f2fc625ee43.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tf-74d7fb29b463a81103978c6629a89d3fc8df69fd2c0b808f312a86654be6229b.json
+++ b/openfisca_france/tests/json/f8tf-74d7fb29b463a81103978c6629a89d3fc8df69fd2c0b808f312a86654be6229b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tf-d426185f0dddffb8a2a84e1a5a4e8b0530fd237a97e1eeb8af1124232bb7f770.json
+++ b/openfisca_france/tests/json/f8tf-d426185f0dddffb8a2a84e1a5a4e8b0530fd237a97e1eeb8af1124232bb7f770.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tf-d79fa519c50a645da8b53d929450af4403de4d994c47df4826158deba68dae57.json
+++ b/openfisca_france/tests/json/f8tf-d79fa519c50a645da8b53d929450af4403de4d994c47df4826158deba68dae57.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tf-e3cce234492bfb1333ed30ecab6bbbe61501c02052823436139ab67fb9bdf167.json
+++ b/openfisca_france/tests/json/f8tf-e3cce234492bfb1333ed30ecab6bbbe61501c02052823436139ab67fb9bdf167.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tf-f9254c2d9d0bb2dc765c3f4118da2b772378d103a46b0f4e7f81cf62fd7b5473.json
+++ b/openfisca_france/tests/json/f8tf-f9254c2d9d0bb2dc765c3f4118da2b772378d103a46b0f4e7f81cf62fd7b5473.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8th-03861d980861f9aff774cac744a7eb32eed4ad87a0cb86bed0cae0a4fa72e48e.json
+++ b/openfisca_france/tests/json/f8th-03861d980861f9aff774cac744a7eb32eed4ad87a0cb86bed0cae0a4fa72e48e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8th-0d6788a2ca1eb766128dfc43ee32a066bf99139ca9a3d30a65bed22598f1ec6c.json
+++ b/openfisca_france/tests/json/f8th-0d6788a2ca1eb766128dfc43ee32a066bf99139ca9a3d30a65bed22598f1ec6c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8th-2e8b5ae9b5e4fbec646b0057bfbf6bb6734370b0dbd3e8aad0d396e31d788c34.json
+++ b/openfisca_france/tests/json/f8th-2e8b5ae9b5e4fbec646b0057bfbf6bb6734370b0dbd3e8aad0d396e31d788c34.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8th-3c5dccf348c77ab6330a80afbe795ee8bac346425725e1cbac9df48f8590b2de.json
+++ b/openfisca_france/tests/json/f8th-3c5dccf348c77ab6330a80afbe795ee8bac346425725e1cbac9df48f8590b2de.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8th-5142f898e711aab8670cd83b9a15b78906221c4599f962df916e3a4749a0279b.json
+++ b/openfisca_france/tests/json/f8th-5142f898e711aab8670cd83b9a15b78906221c4599f962df916e3a4749a0279b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8th-6e51129f6bfb2336ec1ef8c252739184f89c54ef44f6aa93b6082eb9171c3d8c.json
+++ b/openfisca_france/tests/json/f8th-6e51129f6bfb2336ec1ef8c252739184f89c54ef44f6aa93b6082eb9171c3d8c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8th-956e77cd0dd8858e0914da60918ea37e3632e55f2dc1cf636327ec7b00aff8c2.json
+++ b/openfisca_france/tests/json/f8th-956e77cd0dd8858e0914da60918ea37e3632e55f2dc1cf636327ec7b00aff8c2.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8th-e385dfa4b7d5dbf2059b71154e28fd1dbff0847f29e14bd39919f725c55df594.json
+++ b/openfisca_france/tests/json/f8th-e385dfa4b7d5dbf2059b71154e28fd1dbff0847f29e14bd39919f725c55df594.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8th-e804c55b0fe0c870fdcbc689ed8fdc1237e500d150f2aebd4d6c2c660fa4950b.json
+++ b/openfisca_france/tests/json/f8th-e804c55b0fe0c870fdcbc689ed8fdc1237e500d150f2aebd4d6c2c660fa4950b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8to-145ba76b3ab619f8f55cbcc84084d93306b542e90b1ad8bcdd0a69c0f06bd3e8.json
+++ b/openfisca_france/tests/json/f8to-145ba76b3ab619f8f55cbcc84084d93306b542e90b1ad8bcdd0a69c0f06bd3e8.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8to-3098bf7e5a0da0ffc7465b7ecebfeac7d56822ac83432f42fa7e047c12171125.json
+++ b/openfisca_france/tests/json/f8to-3098bf7e5a0da0ffc7465b7ecebfeac7d56822ac83432f42fa7e047c12171125.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8to-57dd2269df96cbebb0e1bb960fe0e9008cf1ab403a98b506201aa278093394df.json
+++ b/openfisca_france/tests/json/f8to-57dd2269df96cbebb0e1bb960fe0e9008cf1ab403a98b506201aa278093394df.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8to-5c94796bc5f4d6c032e776cadc8a98c02a4d247d1119a034a561dc5777f9af9e.json
+++ b/openfisca_france/tests/json/f8to-5c94796bc5f4d6c032e776cadc8a98c02a4d247d1119a034a561dc5777f9af9e.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8to-a9782b4e3b554f2ed347fea8ea2de02852eccd4d31170cf0b7a911f0786ea504.json
+++ b/openfisca_france/tests/json/f8to-a9782b4e3b554f2ed347fea8ea2de02852eccd4d31170cf0b7a911f0786ea504.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8to-c17c605595bcda8bc597cca001bc1f95cf292c28d059154e89172fbc7aa9a57a.json
+++ b/openfisca_france/tests/json/f8to-c17c605595bcda8bc597cca001bc1f95cf292c28d059154e89172fbc7aa9a57a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8to-d0546c8fe49612e389e890c6de65e8a254f38124d3ce8b34b6805d9edb754a5b.json
+++ b/openfisca_france/tests/json/f8to-d0546c8fe49612e389e890c6de65e8a254f38124d3ce8b34b6805d9edb754a5b.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8to-d675ed3e1db6145e822d84634dac7df1aa5e3d6da0623858ff5108660722dbf2.json
+++ b/openfisca_france/tests/json/f8to-d675ed3e1db6145e822d84634dac7df1aa5e3d6da0623858ff5108660722dbf2.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8to-f64bed9d00b31917d62c4bc410dac758abcbe438b1f8cab3c31fce7a106dbea5.json
+++ b/openfisca_france/tests/json/f8to-f64bed9d00b31917d62c4bc410dac758abcbe438b1f8cab3c31fce7a106dbea5.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tp-0024479acda1f893620845c67ce8bbc4069dde1af2d87320f1f5d7a9ea7e09a6.json
+++ b/openfisca_france/tests/json/f8tp-0024479acda1f893620845c67ce8bbc4069dde1af2d87320f1f5d7a9ea7e09a6.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tp-2444f3111961a049585cae97c8e0c566ce6544175b96c33d2cd6503388af88d7.json
+++ b/openfisca_france/tests/json/f8tp-2444f3111961a049585cae97c8e0c566ce6544175b96c33d2cd6503388af88d7.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tp-30ea87f3a449b2148c950815c4976f7f3d890461e89d7d74212d087a2944ab19.json
+++ b/openfisca_france/tests/json/f8tp-30ea87f3a449b2148c950815c4976f7f3d890461e89d7d74212d087a2944ab19.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tp-4babb7086e613f018545927d1a34542d570997184a47cedb7494306d1270bd2b.json
+++ b/openfisca_france/tests/json/f8tp-4babb7086e613f018545927d1a34542d570997184a47cedb7494306d1270bd2b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tp-71d0846bd8308187f807e264243275f87c7409a8ed57ee8d0ff7c9a161488eb2.json
+++ b/openfisca_france/tests/json/f8tp-71d0846bd8308187f807e264243275f87c7409a8ed57ee8d0ff7c9a161488eb2.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tp-c4f39634a248e959ba95319e904c3f472e20a63065c19f1f74c0f45de1d22278.json
+++ b/openfisca_france/tests/json/f8tp-c4f39634a248e959ba95319e904c3f472e20a63065c19f1f74c0f45de1d22278.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tp-c9239dc30949b7e3814322a0ad5f9a94df680aed82634042c0f5d7c80c6258de.json
+++ b/openfisca_france/tests/json/f8tp-c9239dc30949b7e3814322a0ad5f9a94df680aed82634042c0f5d7c80c6258de.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tp-d2377b942e8bf3c223def02dcf830eda23fe52ffe7802d5410e0bc9a0ffe09fb.json
+++ b/openfisca_france/tests/json/f8tp-d2377b942e8bf3c223def02dcf830eda23fe52ffe7802d5410e0bc9a0ffe09fb.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8tp-fbbf4b1d9685fe0f5b12a40a1584cc944c1487b38aae8be537a9906a7aa01021.json
+++ b/openfisca_france/tests/json/f8tp-fbbf4b1d9685fe0f5b12a40a1584cc944c1487b38aae8be537a9906a7aa01021.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ts-542d21fd1f584d06535f13b348a33725e9cb36bb6c01f15a69de979ae3f69918.json
+++ b/openfisca_france/tests/json/f8ts-542d21fd1f584d06535f13b348a33725e9cb36bb6c01f15a69de979ae3f69918.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ts-a278b6dc0638ea532ed07c597954cc26c4ff0cc476a071b975c8b96d8e4370ef.json
+++ b/openfisca_france/tests/json/f8ts-a278b6dc0638ea532ed07c597954cc26c4ff0cc476a071b975c8b96d8e4370ef.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ts-a6eb89a598110d1b98aaf48b43cf30acbcc9ca911722ad1566973356e054d3cb.json
+++ b/openfisca_france/tests/json/f8ts-a6eb89a598110d1b98aaf48b43cf30acbcc9ca911722ad1566973356e054d3cb.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ts-b701b38a2256fe362ab5bb9a6eb282021b37a59f2c076dca910f4ae1714c2016.json
+++ b/openfisca_france/tests/json/f8ts-b701b38a2256fe362ab5bb9a6eb282021b37a59f2c076dca910f4ae1714c2016.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ts-c1d3f3b9b7f78aff32cdf188bcade92790e13e2cde335f1e440966742babc89d.json
+++ b/openfisca_france/tests/json/f8ts-c1d3f3b9b7f78aff32cdf188bcade92790e13e2cde335f1e440966742babc89d.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ts-dcb9469293e1899a44e68e535d209c9b7f5d8e31a72c50171a74550172c2ae4a.json
+++ b/openfisca_france/tests/json/f8ts-dcb9469293e1899a44e68e535d209c9b7f5d8e31a72c50171a74550172c2ae4a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ts-fcdef63e5c01a7a2ed67ef51f1136592d5af5eb41200157f74ec62d5a0bf5602.json
+++ b/openfisca_france/tests/json/f8ts-fcdef63e5c01a7a2ed67ef51f1136592d5af5eb41200157f74ec62d5a0bf5602.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8uw-3a262819dfcc6cf111df4b37e63108309b6885d1b820ce4a22758857c4b32b02.json
+++ b/openfisca_france/tests/json/f8uw-3a262819dfcc6cf111df4b37e63108309b6885d1b820ce4a22758857c4b32b02.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8uw-4a9754371f4485c9770de22820a6465a77ae1d1f5ce6e240b3ff14864cbd7da0.json
+++ b/openfisca_france/tests/json/f8uw-4a9754371f4485c9770de22820a6465a77ae1d1f5ce6e240b3ff14864cbd7da0.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8uw-93c0f8a613bc07558e3dbcc0dc07004178a11e4dc6e4acc7a01b03116aa2f45f.json
+++ b/openfisca_france/tests/json/f8uw-93c0f8a613bc07558e3dbcc0dc07004178a11e4dc6e4acc7a01b03116aa2f45f.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8uw-aecf1322e707c595460acb53f8a2cb99751910242aa6d8b0dcaadfffcf59cc45.json
+++ b/openfisca_france/tests/json/f8uw-aecf1322e707c595460acb53f8a2cb99751910242aa6d8b0dcaadfffcf59cc45.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8uw-b57b5d082620ef8096c15c5a1729f429f30e0a5bec5124da78cbee9f67472c68.json
+++ b/openfisca_france/tests/json/f8uw-b57b5d082620ef8096c15c5a1729f429f30e0a5bec5124da78cbee9f67472c68.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8uw-bf41e62f4247919a0e38cab06d2bdbb8ac35ad6c40a48a6f3ab4bb319bc151a3.json
+++ b/openfisca_france/tests/json/f8uw-bf41e62f4247919a0e38cab06d2bdbb8ac35ad6c40a48a6f3ab4bb319bc151a3.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8uw-cb42893a5e068c912711b93ca319050bf7656a19fd122960600b60d824b1b994.json
+++ b/openfisca_france/tests/json/f8uw-cb42893a5e068c912711b93ca319050bf7656a19fd122960600b60d824b1b994.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8uw-f24cbd2e19b8877582ba1581ca32006ff6c8c701cc0f714859c878003fdee3d5.json
+++ b/openfisca_france/tests/json/f8uw-f24cbd2e19b8877582ba1581ca32006ff6c8c701cc0f714859c878003fdee3d5.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8uy-250939e32945ac2b5797bba854e296826239cbdadd6f92ca2ae46b956eb760ab.json
+++ b/openfisca_france/tests/json/f8uy-250939e32945ac2b5797bba854e296826239cbdadd6f92ca2ae46b956eb760ab.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8uy-5c60e997d8ea2c608dec750535ae72078c0dc252b3348cfbc136ef57bbb1be4e.json
+++ b/openfisca_france/tests/json/f8uy-5c60e997d8ea2c608dec750535ae72078c0dc252b3348cfbc136ef57bbb1be4e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8uy-a82d90ed5ee8e07dddc5614ed1354b7ce8f7954cea77d77baa98f643be2d49c1.json
+++ b/openfisca_france/tests/json/f8uy-a82d90ed5ee8e07dddc5614ed1354b7ce8f7954cea77d77baa98f643be2d49c1.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8uy-a9a5065fbe8501e601d31b9aee489a12c494839299be13de2c7ef5a9d10172de.json
+++ b/openfisca_france/tests/json/f8uy-a9a5065fbe8501e601d31b9aee489a12c494839299be13de2c7ef5a9d10172de.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8wd-3fa33c091103e00f1ef5c34823a99429b085b9d52d71f04c9b1d6fcc5a2b6053.json
+++ b/openfisca_france/tests/json/f8wd-3fa33c091103e00f1ef5c34823a99429b085b9d52d71f04c9b1d6fcc5a2b6053.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8ws-7dd0d8e0c76017c906658780bf9305c63c656b612a468d160d260fbf75958fd8.json
+++ b/openfisca_france/tests/json/f8ws-7dd0d8e0c76017c906658780bf9305c63c656b612a468d160d260fbf75958fd8.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8wt-9cd380cbc2f1fc9c82d390e6c4571d61fb60dc489d7a24f78003c803c4a7ba76.json
+++ b/openfisca_france/tests/json/f8wt-9cd380cbc2f1fc9c82d390e6c4571d61fb60dc489d7a24f78003c803c4a7ba76.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8wu-6eb48d3d02a021ac2bdd25bb0609cd107902fc72e901b9aa469550401759f888.json
+++ b/openfisca_france/tests/json/f8wu-6eb48d3d02a021ac2bdd25bb0609cd107902fc72e901b9aa469550401759f888.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8wv-097f4c487b3aa8f8ef4e3b4b4f5e626269f7da8318cc243b8be29a11807118ab.json
+++ b/openfisca_france/tests/json/f8wv-097f4c487b3aa8f8ef4e3b4b4f5e626269f7da8318cc243b8be29a11807118ab.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8wv-fa6a2c239cb0a98f1609d62a99c1b60770a906de771026b0c7d9c31a4a2776be.json
+++ b/openfisca_france/tests/json/f8wv-fa6a2c239cb0a98f1609d62a99c1b60770a906de771026b0c7d9c31a4a2776be.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8wx-0798311362ebe6fffb01faba1375676d755ce8c5f8b148a001dba1a42e699472.json
+++ b/openfisca_france/tests/json/f8wx-0798311362ebe6fffb01faba1375676d755ce8c5f8b148a001dba1a42e699472.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/f8wx-ae59c8698b84814a83ffd37653fd5e49c3f8ecd580849de16ce1ab038f14ce57.json
+++ b/openfisca_france/tests/json/f8wx-ae59c8698b84814a83ffd37653fd5e49c3f8ecd580849de16ce1ab038f14ce57.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhoz-07552097e6ceb4c08da4cb919ce1d44babe49e0943ad8cf5a836b881b8913055.json
+++ b/openfisca_france/tests/json/fhoz-07552097e6ceb4c08da4cb919ce1d44babe49e0943ad8cf5a836b881b8913055.json
@@ -104,7 +104,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsa-f56906eb552d01e0a54cd784ed7a8be8ebcd3623d4dcafc4a04628330d13c57b.json
+++ b/openfisca_france/tests/json/fhsa-f56906eb552d01e0a54cd784ed7a8be8ebcd3623d4dcafc4a04628330d13c57b.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsa-ffbf63f62d637813cbe43dfa37ede9dd600274b33ea242795a3750595bdb4a5c.json
+++ b/openfisca_france/tests/json/fhsa-ffbf63f62d637813cbe43dfa37ede9dd600274b33ea242795a3750595bdb4a5c.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsb-89299fe699bb246124dc1ed6e8bc6e42eff91233cd4dd223807846772f4479dc.json
+++ b/openfisca_france/tests/json/fhsb-89299fe699bb246124dc1ed6e8bc6e42eff91233cd4dd223807846772f4479dc.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsc-0341842f462cf13c0d54b3f2596685ac48f8e2b2d4952c06b2a2ced9ba8a5f57.json
+++ b/openfisca_france/tests/json/fhsc-0341842f462cf13c0d54b3f2596685ac48f8e2b2d4952c06b2a2ced9ba8a5f57.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsd-c5e2a94050282b884d80330a2a2b6159f59e6b97728579a14090ba56cc9abe61.json
+++ b/openfisca_france/tests/json/fhsd-c5e2a94050282b884d80330a2a2b6159f59e6b97728579a14090ba56cc9abe61.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsf-54f7f8b011efe3960610de5a896d8dbd37d195e5e11208cbd4bab06aa2822538.json
+++ b/openfisca_france/tests/json/fhsf-54f7f8b011efe3960610de5a896d8dbd37d195e5e11208cbd4bab06aa2822538.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsg-1f4169f745f6a24b909ef065c762f22074dad827248f02140e255acddbe32533.json
+++ b/openfisca_france/tests/json/fhsg-1f4169f745f6a24b909ef065c762f22074dad827248f02140e255acddbe32533.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsh-64331c25f50970ce5bb959e8e6747f17077bff16d8c34c5391337547e5f14f80.json
+++ b/openfisca_france/tests/json/fhsh-64331c25f50970ce5bb959e8e6747f17077bff16d8c34c5391337547e5f14f80.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsi-a84f3f1bf1d4b4f946cf59444e79198ea22a7702396aa412b4b62363a6d19b81.json
+++ b/openfisca_france/tests/json/fhsi-a84f3f1bf1d4b4f946cf59444e79198ea22a7702396aa412b4b62363a6d19b81.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsk-09e6aca923b24ca581cbc327a2861744913014ec4e1c872d7d40790ce80cd40f.json
+++ b/openfisca_france/tests/json/fhsk-09e6aca923b24ca581cbc327a2861744913014ec4e1c872d7d40790ce80cd40f.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsl-bc623079e9c8014f77189c4453b18426239295ca23fe058b37934b906186b136.json
+++ b/openfisca_france/tests/json/fhsl-bc623079e9c8014f77189c4453b18426239295ca23fe058b37934b906186b136.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsm-940f852149dcf0eb64ff0a97268be7c0b793fc0989f7223db30eb7287029c12b.json
+++ b/openfisca_france/tests/json/fhsm-940f852149dcf0eb64ff0a97268be7c0b793fc0989f7223db30eb7287029c12b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsn-f5f4de84e0e05f02026d6ac2b3101143f7876deedc1c03f754700e8406d6e936.json
+++ b/openfisca_france/tests/json/fhsn-f5f4de84e0e05f02026d6ac2b3101143f7876deedc1c03f754700e8406d6e936.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsp-27f1dd2d34ab718bdfe57f1e783c4ee5e6c30a36e9a1af8b75ebe427455e84db.json
+++ b/openfisca_france/tests/json/fhsp-27f1dd2d34ab718bdfe57f1e783c4ee5e6c30a36e9a1af8b75ebe427455e84db.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsq-e0d336b6f284132f5ca1308db800eeb3e1bdd19135ee26734e2151329a702ee1.json
+++ b/openfisca_france/tests/json/fhsq-e0d336b6f284132f5ca1308db800eeb3e1bdd19135ee26734e2151329a702ee1.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsr-32ec79e5746c7115cc4547cbb7351bfcbd8f673ecf59ece42a969fd829b5d578.json
+++ b/openfisca_france/tests/json/fhsr-32ec79e5746c7115cc4547cbb7351bfcbd8f673ecf59ece42a969fd829b5d578.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhss-85d32bce998bdbc4743ccf7f56b36a20d3185cfc750f680600afba5d8d0d508c.json
+++ b/openfisca_france/tests/json/fhss-85d32bce998bdbc4743ccf7f56b36a20d3185cfc750f680600afba5d8d0d508c.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsu-b232c250a38a776ff5b4b733d1765637b47443309280e361631ff9e8dd226d71.json
+++ b/openfisca_france/tests/json/fhsu-b232c250a38a776ff5b4b733d1765637b47443309280e361631ff9e8dd226d71.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsv-a37276195f4abafac6c472cbd10d039d4e176b595b3aced37069891d1c8a8a20.json
+++ b/openfisca_france/tests/json/fhsv-a37276195f4abafac6c472cbd10d039d4e176b595b3aced37069891d1c8a8a20.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsw-061ba125756e9c66106c7d458bb80bb42b97f30c584d2087699599b5bc207e91.json
+++ b/openfisca_france/tests/json/fhsw-061ba125756e9c66106c7d458bb80bb42b97f30c584d2087699599b5bc207e91.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsx-2f9c2294768fdc8da32deb9f778c7b1272d0abb4d2e50e00b4ed22831cd0479f.json
+++ b/openfisca_france/tests/json/fhsx-2f9c2294768fdc8da32deb9f778c7b1272d0abb4d2e50e00b4ed22831cd0479f.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsy-33d91b85bea96f8a37d97988174a28eafc07603b75786544d916d939d3851e34.json
+++ b/openfisca_france/tests/json/fhsy-33d91b85bea96f8a37d97988174a28eafc07603b75786544d916d939d3851e34.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhsz-21954c6c9973df733d9ed60c613fae0b607aae96e9556039fdf93a0a5aaaf29e.json
+++ b/openfisca_france/tests/json/fhsz-21954c6c9973df733d9ed60c613fae0b607aae96e9556039fdf93a0a5aaaf29e.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhta-de245c2c5088ed3f5703517ff0e08850fde15731883ee249f16ce01d83f41d54.json
+++ b/openfisca_france/tests/json/fhta-de245c2c5088ed3f5703517ff0e08850fde15731883ee249f16ce01d83f41d54.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhtb-e8a64fe7e7e4303f551994d9605fbd80da864cb90632a68341f7f6780e9f468b.json
+++ b/openfisca_france/tests/json/fhtb-e8a64fe7e7e4303f551994d9605fbd80da864cb90632a68341f7f6780e9f468b.json
@@ -99,7 +99,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/fhtc-8bfe0e363dcf9c2f8e8eb8d37b5cabdb0c5a35165251f86050a597440e59389d.json
+++ b/openfisca_france/tests/json/fhtc-8bfe0e363dcf9c2f8e8eb8d37b5cabdb0c5a35165251f86050a597440e59389d.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
 
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_exon-09b961202ec0d41e189722de5161280701b2c180cf4b99eef6af224d446f5e77.json
+++ b/openfisca_france/tests/json/frag_exon-09b961202ec0d41e189722de5161280701b2c180cf4b99eef6af224d446f5e77.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "frag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_exon-13db57473e698e65ae3216eeb90cd36fdc11eb1f8366c0f9ea07982b63b7b073.json
+++ b/openfisca_france/tests/json/frag_exon-13db57473e698e65ae3216eeb90cd36fdc11eb1f8366c0f9ea07982b63b7b073.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_exon-20606a7dabb56d5fb218e604b90070b4cef1b9fa400b5084f80720fbfc2374b6.json
+++ b/openfisca_france/tests/json/frag_exon-20606a7dabb56d5fb218e604b90070b4cef1b9fa400b5084f80720fbfc2374b6.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_exon-32fee2781ccdc0303840f9bc76f2b7b8c4dbfb4f0bf7fb5b737a6cd419dcdb14.json
+++ b/openfisca_france/tests/json/frag_exon-32fee2781ccdc0303840f9bc76f2b7b8c4dbfb4f0bf7fb5b737a6cd419dcdb14.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_exon-3a4526626512e14e87c136fab9c6cb312599a139a46b2ea50af66624f21f890c.json
+++ b/openfisca_france/tests/json/frag_exon-3a4526626512e14e87c136fab9c6cb312599a139a46b2ea50af66624f21f890c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_exon-7424a18235bca93916d4540cfce91a9c7412ecc8919ee6da6f362702433c04f2.json
+++ b/openfisca_france/tests/json/frag_exon-7424a18235bca93916d4540cfce91a9c7412ecc8919ee6da6f362702433c04f2.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_exon-8725cc56dee7eec2c2dc7884b82469911f68159a8c03bea8e1608905a6300ea0.json
+++ b/openfisca_france/tests/json/frag_exon-8725cc56dee7eec2c2dc7884b82469911f68159a8c03bea8e1608905a6300ea0.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_exon-8d0217c235eaeb20d6e23fe539b3c2b65abaff657ef7713267c9333b7db6dc01.json
+++ b/openfisca_france/tests/json/frag_exon-8d0217c235eaeb20d6e23fe539b3c2b65abaff657ef7713267c9333b7db6dc01.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_exon-a84d966ec5cbde4d6bc2a4303b5618f258a03fc8d3251dbae55807a3c90113c8.json
+++ b/openfisca_france/tests/json/frag_exon-a84d966ec5cbde4d6bc2a4303b5618f258a03fc8d3251dbae55807a3c90113c8.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "frag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_impo-0205da05348505a505b850e43d8b6428173468280182cadc8c6baa5ddcb49dcb.json
+++ b/openfisca_france/tests/json/frag_impo-0205da05348505a505b850e43d8b6428173468280182cadc8c6baa5ddcb49dcb.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_impo-0e104650481e5a72672c386693ddcbe043592a258cba2dc804f91759d5484f96.json
+++ b/openfisca_france/tests/json/frag_impo-0e104650481e5a72672c386693ddcbe043592a258cba2dc804f91759d5484f96.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_impo-2543b40cd1d300b9a87b13c3b61092043112b06288e38bb61e54d4d70d5e69d2.json
+++ b/openfisca_france/tests/json/frag_impo-2543b40cd1d300b9a87b13c3b61092043112b06288e38bb61e54d4d70d5e69d2.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_impo-6f5565a78c9de3f6ca7dfd3a953473ec0a372600f0d09c024415d4201503233d.json
+++ b/openfisca_france/tests/json/frag_impo-6f5565a78c9de3f6ca7dfd3a953473ec0a372600f0d09c024415d4201503233d.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "frag_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_impo-791a00eae8721f6300f5750557cbba8bbb6eca9ab6b6c55c1b3b9cda845f6e43.json
+++ b/openfisca_france/tests/json/frag_impo-791a00eae8721f6300f5750557cbba8bbb6eca9ab6b6c55c1b3b9cda845f6e43.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_impo-aadc9cbac77fc0f6fb25826cac5325cdab0520c5d1bd0bb33aa95f952bf87c5c.json
+++ b/openfisca_france/tests/json/frag_impo-aadc9cbac77fc0f6fb25826cac5325cdab0520c5d1bd0bb33aa95f952bf87c5c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_impo-c541f2509a662ad0baf4d9888a5f800630d16c482fd684d67344ef9dd0802f67.json
+++ b/openfisca_france/tests/json/frag_impo-c541f2509a662ad0baf4d9888a5f800630d16c482fd684d67344ef9dd0802f67.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "frag_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_impo-dda06ae63ccd53f8dafdd4c72caea8e9accd285a31e9570129731904dcbb1609.json
+++ b/openfisca_france/tests/json/frag_impo-dda06ae63ccd53f8dafdd4c72caea8e9accd285a31e9570129731904dcbb1609.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_impo-e21be5d96ae9e7b1562f1acc57bdc8252ae72f9e1d943166bd6ece346b71e7a2.json
+++ b/openfisca_france/tests/json/frag_impo-e21be5d96ae9e7b1562f1acc57bdc8252ae72f9e1d943166bd6ece346b71e7a2.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvce-24cc0022b357b2b28800b67c5da1bacad3b07ffd456d3bae5b29aa6e1cdbbae2.json
+++ b/openfisca_france/tests/json/frag_pvce-24cc0022b357b2b28800b67c5da1bacad3b07ffd456d3bae5b29aa6e1cdbbae2.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvce-3c58ee8d32394c6749241b8bf57256ef97959f37184a1fb749536d779acad031.json
+++ b/openfisca_france/tests/json/frag_pvce-3c58ee8d32394c6749241b8bf57256ef97959f37184a1fb749536d779acad031.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvce-4d0ec6bcdfa3c2d2244c4961eea3ba9ab22916467d71a54b62ecce88e0bcde56.json
+++ b/openfisca_france/tests/json/frag_pvce-4d0ec6bcdfa3c2d2244c4961eea3ba9ab22916467d71a54b62ecce88e0bcde56.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvce-66e885430a1013fbe00a16d5dad86229ef4887c435557be604cf5429aa526736.json
+++ b/openfisca_france/tests/json/frag_pvce-66e885430a1013fbe00a16d5dad86229ef4887c435557be604cf5429aa526736.json
@@ -118,7 +118,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvce-a409b336b8efb9869ef46a6b24c711599bc991a090644c68db8d29cebc2984ab.json
+++ b/openfisca_france/tests/json/frag_pvce-a409b336b8efb9869ef46a6b24c711599bc991a090644c68db8d29cebc2984ab.json
@@ -128,7 +128,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvce-befc7a367410381965e1faaa11c3c3680b5ee4aa002ed89cfe9764b632ce4419.json
+++ b/openfisca_france/tests/json/frag_pvce-befc7a367410381965e1faaa11c3c3680b5ee4aa002ed89cfe9764b632ce4419.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvce-ca2add29d2a83cbdd13ea901cbe1449737faebc3a21f2a2412bf516a059ae3fe.json
+++ b/openfisca_france/tests/json/frag_pvce-ca2add29d2a83cbdd13ea901cbe1449737faebc3a21f2a2412bf516a059ae3fe.json
@@ -123,7 +123,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvce-e68723db5665a147014176cd88beb9aa76412beb168ab7117726e9179cd8b391.json
+++ b/openfisca_france/tests/json/frag_pvce-e68723db5665a147014176cd88beb9aa76412beb168ab7117726e9179cd8b391.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvce-f18314e25f579efb6d520822ab30cbdc463d5b3499d8207309304bb75ebd5872.json
+++ b/openfisca_france/tests/json/frag_pvce-f18314e25f579efb6d520822ab30cbdc463d5b3499d8207309304bb75ebd5872.json
@@ -128,7 +128,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvct-0ac8448e7803a089a7b2af9aab8e0ca3d901a9bdaa39836e23d56af8e769ade5.json
+++ b/openfisca_france/tests/json/frag_pvct-0ac8448e7803a089a7b2af9aab8e0ca3d901a9bdaa39836e23d56af8e769ade5.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvct-156524515eb48393bbb3564f632f7cc04c443f1f5ce783c73182cb413452f215.json
+++ b/openfisca_france/tests/json/frag_pvct-156524515eb48393bbb3564f632f7cc04c443f1f5ce783c73182cb413452f215.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvct-5ea5c3de135079478871496a09253001c8d5c372b2ad10000320b20b863ab864.json
+++ b/openfisca_france/tests/json/frag_pvct-5ea5c3de135079478871496a09253001c8d5c372b2ad10000320b20b863ab864.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvct-7c6eea50d44fb84a4400e422da42832f43aa76d469b92b5886370c06344993ea.json
+++ b/openfisca_france/tests/json/frag_pvct-7c6eea50d44fb84a4400e422da42832f43aa76d469b92b5886370c06344993ea.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvct-9237d597f6710c87a56bee8ddef8ae878ea32e9f898e04c9d7270a8a59acf952.json
+++ b/openfisca_france/tests/json/frag_pvct-9237d597f6710c87a56bee8ddef8ae878ea32e9f898e04c9d7270a8a59acf952.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvct-a839f0e9d7511ac6c531886db957722088aee0ca6ad6c46d1d0bfb4671bcdcee.json
+++ b/openfisca_france/tests/json/frag_pvct-a839f0e9d7511ac6c531886db957722088aee0ca6ad6c46d1d0bfb4671bcdcee.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvct-c7ad963db6ca8332c7f8e7080b6f91cc1bafb1b8b4cb109348a200e1ea77b70d.json
+++ b/openfisca_france/tests/json/frag_pvct-c7ad963db6ca8332c7f8e7080b6f91cc1bafb1b8b4cb109348a200e1ea77b70d.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvct-cc852111b47ad4b4405d15e7f453d107402317fc844897b088dce825d3a14549.json
+++ b/openfisca_france/tests/json/frag_pvct-cc852111b47ad4b4405d15e7f453d107402317fc844897b088dce825d3a14549.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/frag_pvct-fadf00fc1fc901cf721c8c8062bc115ac92d9bfe389a614a6f54bbdd61144291.json
+++ b/openfisca_france/tests/json/frag_pvct-fadf00fc1fc901cf721c8c8062bc115ac92d9bfe389a614a6f54bbdd61144291.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "frag_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_exon-07497c3bb5d108ca03ac200fc16a82c6afff8be347ce609bdd2e50e351a5568d.json
+++ b/openfisca_france/tests/json/macc_exon-07497c3bb5d108ca03ac200fc16a82c6afff8be347ce609bdd2e50e351a5568d.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_exon-0ce9fe588e02004615c6bbb99610bc19302c5a734e9eddf076ce8cabb6bcbf60.json
+++ b/openfisca_france/tests/json/macc_exon-0ce9fe588e02004615c6bbb99610bc19302c5a734e9eddf076ce8cabb6bcbf60.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_exon-2954df4837729c919e1b04291d38f1a4219bf2e9044130fef16dac1cb33057ca.json
+++ b/openfisca_france/tests/json/macc_exon-2954df4837729c919e1b04291d38f1a4219bf2e9044130fef16dac1cb33057ca.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_exon-31e1629f930d1c40d58e7cbf4814f7c7f35a9194aaa0e55516161589bdedf4d7.json
+++ b/openfisca_france/tests/json/macc_exon-31e1629f930d1c40d58e7cbf4814f7c7f35a9194aaa0e55516161589bdedf4d7.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "macc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_exon-436e0f9d3b956f3c5434ed848d72a5dccb9bea72212d5fbce193c962546cecbc.json
+++ b/openfisca_france/tests/json/macc_exon-436e0f9d3b956f3c5434ed848d72a5dccb9bea72212d5fbce193c962546cecbc.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_exon-83c9c6c676941eee2367e678c1fb184ad96f346cf401898c0f745df8a80ae51a.json
+++ b/openfisca_france/tests/json/macc_exon-83c9c6c676941eee2367e678c1fb184ad96f346cf401898c0f745df8a80ae51a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_exon-b342406f608d7f9fb04524cb07c608996f3393dd3000e7797314749d3813ce8e.json
+++ b/openfisca_france/tests/json/macc_exon-b342406f608d7f9fb04524cb07c608996f3393dd3000e7797314749d3813ce8e.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "macc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_exon-dd14699ab09188575800f3f44a810177818cd8754584e9152b0ee9b14111cdc6.json
+++ b/openfisca_france/tests/json/macc_exon-dd14699ab09188575800f3f44a810177818cd8754584e9152b0ee9b14111cdc6.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_exon-f14f242aa583ce576d5f71b1f2b34f3d6dc8ebbce829532adc603d31a8220e8a.json
+++ b/openfisca_france/tests/json/macc_exon-f14f242aa583ce576d5f71b1f2b34f3d6dc8ebbce829532adc603d31a8220e8a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_imps-1303f7835badcfd8278be9a857c6114c9f4ea1c7fa0f9c7d5116baa28fc3bf01.json
+++ b/openfisca_france/tests/json/macc_imps-1303f7835badcfd8278be9a857c6114c9f4ea1c7fa0f9c7d5116baa28fc3bf01.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_imps-36cb2eab4b859e71d605975ccdc49652302d3e12de3fba6b0c4776e71e1b2782.json
+++ b/openfisca_france/tests/json/macc_imps-36cb2eab4b859e71d605975ccdc49652302d3e12de3fba6b0c4776e71e1b2782.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_imps-3a9d9e75058808e176163fb92c17e43a37809bb7e1971e56aa4ca8d0f1b9ba11.json
+++ b/openfisca_france/tests/json/macc_imps-3a9d9e75058808e176163fb92c17e43a37809bb7e1971e56aa4ca8d0f1b9ba11.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_imps-3aa3aa75105ac99cd5768ee7d0d1cf4773ca0e95ba47d609b1b83bc7255e5684.json
+++ b/openfisca_france/tests/json/macc_imps-3aa3aa75105ac99cd5768ee7d0d1cf4773ca0e95ba47d609b1b83bc7255e5684.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "macc_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_imps-4c1dbceba92caa17ab347b0dd381e25b9d06a6bf72896c286eff4cefe3b99227.json
+++ b/openfisca_france/tests/json/macc_imps-4c1dbceba92caa17ab347b0dd381e25b9d06a6bf72896c286eff4cefe3b99227.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_imps-560624c4e3f175fd8ba2c7ee0cb6f97ba31fd918aba3949c608cc4e368f9332b.json
+++ b/openfisca_france/tests/json/macc_imps-560624c4e3f175fd8ba2c7ee0cb6f97ba31fd918aba3949c608cc4e368f9332b.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_imps-8c2e7366b658fcb1250fc3b46fa11288445a72d5e490a005e987eef724cac066.json
+++ b/openfisca_france/tests/json/macc_imps-8c2e7366b658fcb1250fc3b46fa11288445a72d5e490a005e987eef724cac066.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_imps-caed1cf9454fd94a89e82a6ca0039420af2e3414e9c5a7e9e7a3f1f0d7e8cc32.json
+++ b/openfisca_france/tests/json/macc_imps-caed1cf9454fd94a89e82a6ca0039420af2e3414e9c5a7e9e7a3f1f0d7e8cc32.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "macc_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_imps-e5526e445dd7658f2bf53ef09cc407276f1166b737a0564655969f5cfc4ce7ca.json
+++ b/openfisca_france/tests/json/macc_imps-e5526e445dd7658f2bf53ef09cc407276f1166b737a0564655969f5cfc4ce7ca.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_impv-03a05c68af2d15a2aa020eb3dbf6c036613e0d7a56b4f523b5656d39076b16c9.json
+++ b/openfisca_france/tests/json/macc_impv-03a05c68af2d15a2aa020eb3dbf6c036613e0d7a56b4f523b5656d39076b16c9.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_impv-368abc73134f903162e8f74c3ed7ec80f340e8aa484c780febde762549f56a69.json
+++ b/openfisca_france/tests/json/macc_impv-368abc73134f903162e8f74c3ed7ec80f340e8aa484c780febde762549f56a69.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_impv-6392c391927625f1b685b74f613e01908c025550b6a3684f1bf90b223b526481.json
+++ b/openfisca_france/tests/json/macc_impv-6392c391927625f1b685b74f613e01908c025550b6a3684f1bf90b223b526481.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_impv-6d4e8b10457d2b47e24c352e1984ce945fe54dbe4f5e8a49f003f04ddb3a1f5c.json
+++ b/openfisca_france/tests/json/macc_impv-6d4e8b10457d2b47e24c352e1984ce945fe54dbe4f5e8a49f003f04ddb3a1f5c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_impv-82433a7b6f22ac990bfc87e3e459ff79d1ae60ce844b84c7d9928fca70d1fdf7.json
+++ b/openfisca_france/tests/json/macc_impv-82433a7b6f22ac990bfc87e3e459ff79d1ae60ce844b84c7d9928fca70d1fdf7.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "macc_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_impv-8bf57208796059ab98b119e0c96c9fd9049a8e99cc94c9210fe44b5ea800de51.json
+++ b/openfisca_france/tests/json/macc_impv-8bf57208796059ab98b119e0c96c9fd9049a8e99cc94c9210fe44b5ea800de51.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_impv-a929a4499f5f74c4d85497825827f1ee14c8c80c21d2f63f2731a0fba60573d5.json
+++ b/openfisca_france/tests/json/macc_impv-a929a4499f5f74c4d85497825827f1ee14c8c80c21d2f63f2731a0fba60573d5.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_impv-fbd15cff1fc928a9dc08c48ad8dad269a8176a25458378cc3412cc4c3908eda4.json
+++ b/openfisca_france/tests/json/macc_impv-fbd15cff1fc928a9dc08c48ad8dad269a8176a25458378cc3412cc4c3908eda4.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "macc_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_impv-ff90b60ac9bfa316b9ed097da2cef2067a3fe8e94572cfd83d0cd133d25d6eb8.json
+++ b/openfisca_france/tests/json/macc_impv-ff90b60ac9bfa316b9ed097da2cef2067a3fe8e94572cfd83d0cd133d25d6eb8.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvct-0c34e53eac665045ff694ed7ffe42bd54891180bf8dd52449d2f6d37dbe792c5.json
+++ b/openfisca_france/tests/json/macc_mvct-0c34e53eac665045ff694ed7ffe42bd54891180bf8dd52449d2f6d37dbe792c5.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvct-1827d824e81ad269250ee51501063cd725aea5ba5ced05ee4199176db2067730.json
+++ b/openfisca_france/tests/json/macc_mvct-1827d824e81ad269250ee51501063cd725aea5ba5ced05ee4199176db2067730.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvct-2bbd72bb10328dfea23bce21459995efabfec98d82933b7b107820d196f462c4.json
+++ b/openfisca_france/tests/json/macc_mvct-2bbd72bb10328dfea23bce21459995efabfec98d82933b7b107820d196f462c4.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvct-3ad92cad9087908ee5506bcb3f376df3b4dbe55b31548416fc32a186be9fc022.json
+++ b/openfisca_france/tests/json/macc_mvct-3ad92cad9087908ee5506bcb3f376df3b4dbe55b31548416fc32a186be9fc022.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvct-41e10f7b10839fd9b3eb150ea77c80d53f0090d304c339ffce400c21a7afa09d.json
+++ b/openfisca_france/tests/json/macc_mvct-41e10f7b10839fd9b3eb150ea77c80d53f0090d304c339ffce400c21a7afa09d.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvct-5ff8a3b95a7b9c4ceda363bf53565ea29b3831ea3a339e331e56abe713d6b79f.json
+++ b/openfisca_france/tests/json/macc_mvct-5ff8a3b95a7b9c4ceda363bf53565ea29b3831ea3a339e331e56abe713d6b79f.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvct-ca0a2c89c90ff5b8c26d5e13e526437355c234bff9aab0000ada02079af25d4d.json
+++ b/openfisca_france/tests/json/macc_mvct-ca0a2c89c90ff5b8c26d5e13e526437355c234bff9aab0000ada02079af25d4d.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvct-d7e9d20d533ad644c72b76fb44ac972b93c24e164bff27ce89dfac66853c6212.json
+++ b/openfisca_france/tests/json/macc_mvct-d7e9d20d533ad644c72b76fb44ac972b93c24e164bff27ce89dfac66853c6212.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvct-faff0bc1fb12d64f08bd9a867cd9e68b2692e38cbe8cfd90f8673ca50271044e.json
+++ b/openfisca_france/tests/json/macc_mvct-faff0bc1fb12d64f08bd9a867cd9e68b2692e38cbe8cfd90f8673ca50271044e.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvlt-04e9c9f0c824fa2a339695a7a508a1d1576ac0337d9076ae4943eddea4c143d2.json
+++ b/openfisca_france/tests/json/macc_mvlt-04e9c9f0c824fa2a339695a7a508a1d1576ac0337d9076ae4943eddea4c143d2.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvlt-34dd2cc5d5fb0a039e80382c6d5f18f17d7203c97869302ff0e3607640867f7c.json
+++ b/openfisca_france/tests/json/macc_mvlt-34dd2cc5d5fb0a039e80382c6d5f18f17d7203c97869302ff0e3607640867f7c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvlt-3804248bb80e40ac5b61dc6ec9330c0fc2a38f68b9a73be4d296771635fcf7db.json
+++ b/openfisca_france/tests/json/macc_mvlt-3804248bb80e40ac5b61dc6ec9330c0fc2a38f68b9a73be4d296771635fcf7db.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvlt-4fd88e74fdb42442a3dba7ae15cbdec4dbe337c289fa8996f44e94ebec3c93af.json
+++ b/openfisca_france/tests/json/macc_mvlt-4fd88e74fdb42442a3dba7ae15cbdec4dbe337c289fa8996f44e94ebec3c93af.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvlt-57ed1ce84f9fede5219e286907c1a3d691cb10ffcb9a139c85e21a28a63a6cb7.json
+++ b/openfisca_france/tests/json/macc_mvlt-57ed1ce84f9fede5219e286907c1a3d691cb10ffcb9a139c85e21a28a63a6cb7.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvlt-6bc03ceffcd27eedd06b0b203ac363e957bac40f7b144848ed8e87ed3920fb8c.json
+++ b/openfisca_france/tests/json/macc_mvlt-6bc03ceffcd27eedd06b0b203ac363e957bac40f7b144848ed8e87ed3920fb8c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvlt-7bdec524e87dcfd1b4f266b23a7f9662c75bade43032c2316e7591d3f0a8a28e.json
+++ b/openfisca_france/tests/json/macc_mvlt-7bdec524e87dcfd1b4f266b23a7f9662c75bade43032c2316e7591d3f0a8a28e.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "macc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvlt-9f0c34396e8b1266c27683804cc942aaf82b7878f53481ecea8754b2e182ff40.json
+++ b/openfisca_france/tests/json/macc_mvlt-9f0c34396e8b1266c27683804cc942aaf82b7878f53481ecea8754b2e182ff40.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "macc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_mvlt-edb0eb964008dee7fb236c05d9a01650d65beda8f93574e8e3c1d9723ef6cb27.json
+++ b/openfisca_france/tests/json/macc_mvlt-edb0eb964008dee7fb236c05d9a01650d65beda8f93574e8e3c1d9723ef6cb27.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvce-336bf54c0849f8ae1938cc8e0a9465d23bc84d446ab5fbda2c3c687d4a36ff51.json
+++ b/openfisca_france/tests/json/macc_pvce-336bf54c0849f8ae1938cc8e0a9465d23bc84d446ab5fbda2c3c687d4a36ff51.json
@@ -123,7 +123,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvce-5d6de806625455d50710bca27c3fc9609cb13c84c11a59a02c8769129f683f6d.json
+++ b/openfisca_france/tests/json/macc_pvce-5d6de806625455d50710bca27c3fc9609cb13c84c11a59a02c8769129f683f6d.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvce-780484634968295b659c3b434fba3ca55601156e03660c792c7a14290ef83593.json
+++ b/openfisca_france/tests/json/macc_pvce-780484634968295b659c3b434fba3ca55601156e03660c792c7a14290ef83593.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvce-7fabd013969990c3d06dfa2c5b7c6c7d06a9a682f35ffbdf80c0c05b44123bba.json
+++ b/openfisca_france/tests/json/macc_pvce-7fabd013969990c3d06dfa2c5b7c6c7d06a9a682f35ffbdf80c0c05b44123bba.json
@@ -128,7 +128,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvce-828a31e4092e5ebb17a85c32bb7f091c6d0d249f9cfcb246603bbf0b8ae78c9e.json
+++ b/openfisca_france/tests/json/macc_pvce-828a31e4092e5ebb17a85c32bb7f091c6d0d249f9cfcb246603bbf0b8ae78c9e.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvce-886aa0251437bcc8224dcb72e97c06244fd1f6c83cf82a22da2c0625c335ac29.json
+++ b/openfisca_france/tests/json/macc_pvce-886aa0251437bcc8224dcb72e97c06244fd1f6c83cf82a22da2c0625c335ac29.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvce-936a3ef4eaf4213bae1f98a4bc78002f697f8112f88a0f4ad1d0d43044036879.json
+++ b/openfisca_france/tests/json/macc_pvce-936a3ef4eaf4213bae1f98a4bc78002f697f8112f88a0f4ad1d0d43044036879.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvce-e4546bd7a9d9de1c31ed35b508bc4a195a872ada5de5161ec058eae2cb679759.json
+++ b/openfisca_france/tests/json/macc_pvce-e4546bd7a9d9de1c31ed35b508bc4a195a872ada5de5161ec058eae2cb679759.json
@@ -128,7 +128,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvce-f29acda361f4fd732eab099d25e2e61b7fbf352f443188b1be2c3ad9a6651c59.json
+++ b/openfisca_france/tests/json/macc_pvce-f29acda361f4fd732eab099d25e2e61b7fbf352f443188b1be2c3ad9a6651c59.json
@@ -118,7 +118,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvct-07e04076f1f984b3558927c00e92c46e6470457c5e92618781697962245e9eb8.json
+++ b/openfisca_france/tests/json/macc_pvct-07e04076f1f984b3558927c00e92c46e6470457c5e92618781697962245e9eb8.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvct-0d5251b5aa01e9397c4b6531a1b4945e2fb1eec5a1dba741439e9d3228edf23c.json
+++ b/openfisca_france/tests/json/macc_pvct-0d5251b5aa01e9397c4b6531a1b4945e2fb1eec5a1dba741439e9d3228edf23c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvct-2983483ec8a9103c919d5bd032df493f3fd0dd79c8e5606db3a714db21884177.json
+++ b/openfisca_france/tests/json/macc_pvct-2983483ec8a9103c919d5bd032df493f3fd0dd79c8e5606db3a714db21884177.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvct-561a7846762e5e34409b29f1f163aad09116444ebc82fb7976784fd47e8e4014.json
+++ b/openfisca_france/tests/json/macc_pvct-561a7846762e5e34409b29f1f163aad09116444ebc82fb7976784fd47e8e4014.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvct-602b74b051f2474775af64a9bc85fd19f03b6368fb66e9aacd3af219ff6e3f91.json
+++ b/openfisca_france/tests/json/macc_pvct-602b74b051f2474775af64a9bc85fd19f03b6368fb66e9aacd3af219ff6e3f91.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvct-a9e6162a2918588f0cf566663c6f7017c02a7820371be0690b77ffbd67f844af.json
+++ b/openfisca_france/tests/json/macc_pvct-a9e6162a2918588f0cf566663c6f7017c02a7820371be0690b77ffbd67f844af.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvct-aa9def3811cac2e8224e22befcabb6df244be260655a8c9bccf6f7b7cabcd731.json
+++ b/openfisca_france/tests/json/macc_pvct-aa9def3811cac2e8224e22befcabb6df244be260655a8c9bccf6f7b7cabcd731.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvct-d312f60bfaeb90b33ecb16b39bd4f90736797bcb6270eea2755eb7d215edd26b.json
+++ b/openfisca_france/tests/json/macc_pvct-d312f60bfaeb90b33ecb16b39bd4f90736797bcb6270eea2755eb7d215edd26b.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/macc_pvct-efd2941b1ed7800a199c62c607aa39cc1b5b43aba12a397861ba3f305a908e3c.json
+++ b/openfisca_france/tests/json/macc_pvct-efd2941b1ed7800a199c62c607aa39cc1b5b43aba12a397861ba3f305a908e3c.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "macc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_exon-09163a94818c6d45b29595c5ce39d4e8ad68d72c09c79733fcf716097d79ce3c.json
+++ b/openfisca_france/tests/json/mbic_exon-09163a94818c6d45b29595c5ce39d4e8ad68d72c09c79733fcf716097d79ce3c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_exon-2ceb05016587649007877e41e205963cbef8a80466c9f02e24bb024f102838c5.json
+++ b/openfisca_france/tests/json/mbic_exon-2ceb05016587649007877e41e205963cbef8a80466c9f02e24bb024f102838c5.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "mbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_exon-3aef4ca49776db0310948c95bc942997d8056d9103bafeebeed225e7d026eed4.json
+++ b/openfisca_france/tests/json/mbic_exon-3aef4ca49776db0310948c95bc942997d8056d9103bafeebeed225e7d026eed4.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_exon-62ea2e6d3c54a055793420b7c4758feb0f3f8cc45c90fa46a59293bafb4434e6.json
+++ b/openfisca_france/tests/json/mbic_exon-62ea2e6d3c54a055793420b7c4758feb0f3f8cc45c90fa46a59293bafb4434e6.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_exon-a77fb30f8f36e2a09f4e1ed3afca9a67775383c8c52c6b7f5139ebecbf22703b.json
+++ b/openfisca_france/tests/json/mbic_exon-a77fb30f8f36e2a09f4e1ed3afca9a67775383c8c52c6b7f5139ebecbf22703b.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_exon-a90698e94343fa50bc420fbcd0b52d935e8dd6d11bdb76fe972af67c1bb8fda9.json
+++ b/openfisca_france/tests/json/mbic_exon-a90698e94343fa50bc420fbcd0b52d935e8dd6d11bdb76fe972af67c1bb8fda9.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_exon-a9edd4cfadc2c9e2f2404227e9a4c1a6ab737e1861de52cd310de624e1d99f05.json
+++ b/openfisca_france/tests/json/mbic_exon-a9edd4cfadc2c9e2f2404227e9a4c1a6ab737e1861de52cd310de624e1d99f05.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_exon-d5ff1608370ee61f017d17ab2a1f6f15d517b8a3573c90ca985064ad018490e8.json
+++ b/openfisca_france/tests/json/mbic_exon-d5ff1608370ee61f017d17ab2a1f6f15d517b8a3573c90ca985064ad018490e8.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_exon-eb6966b056dc6aaa778b49bb159f1901a5a77ee62d46d0e9679719a4b900c1b2.json
+++ b/openfisca_france/tests/json/mbic_exon-eb6966b056dc6aaa778b49bb159f1901a5a77ee62d46d0e9679719a4b900c1b2.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_imps-00bd2e7f078a6aba79ef9275f791504d6a58b53b4fc784c4f729ed3cb4373bf0.json
+++ b/openfisca_france/tests/json/mbic_imps-00bd2e7f078a6aba79ef9275f791504d6a58b53b4fc784c4f729ed3cb4373bf0.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_imps-023287ec4ef1bb0f395fc7d6a951d9a95d369314c4152c58c955f4de3383e5f7.json
+++ b/openfisca_france/tests/json/mbic_imps-023287ec4ef1bb0f395fc7d6a951d9a95d369314c4152c58c955f4de3383e5f7.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_imps-095a759cb0230cd3c6d26afdc44c4445633fd999d587f05a0acf1416c766818b.json
+++ b/openfisca_france/tests/json/mbic_imps-095a759cb0230cd3c6d26afdc44c4445633fd999d587f05a0acf1416c766818b.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_imps-1f343355c17aa162ee57e5fab9b1835bab988a99958d68da1b4e467c71c64ff4.json
+++ b/openfisca_france/tests/json/mbic_imps-1f343355c17aa162ee57e5fab9b1835bab988a99958d68da1b4e467c71c64ff4.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_imps-5103ad76fac9f2df9ec0a9191741f9f181b31cbc8c2f8c955ab96fcde404878e.json
+++ b/openfisca_france/tests/json/mbic_imps-5103ad76fac9f2df9ec0a9191741f9f181b31cbc8c2f8c955ab96fcde404878e.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "mbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_imps-70bf29ffbc6bec6828a58c7e1fabcfcd55123cf8da74c12381c3ac60357eabe3.json
+++ b/openfisca_france/tests/json/mbic_imps-70bf29ffbc6bec6828a58c7e1fabcfcd55123cf8da74c12381c3ac60357eabe3.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_imps-bfc542983411c3eb5f64ef38e3a9dbe35f6fea2707a5140aba8a4efaffa07a86.json
+++ b/openfisca_france/tests/json/mbic_imps-bfc542983411c3eb5f64ef38e3a9dbe35f6fea2707a5140aba8a4efaffa07a86.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_imps-d8dad29a979240adb406de97bcd892e08643faeddbbd40c93038d22d207741a0.json
+++ b/openfisca_france/tests/json/mbic_imps-d8dad29a979240adb406de97bcd892e08643faeddbbd40c93038d22d207741a0.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_imps-ea15f371e67bc42fe20adf88bf5b9e6c4ef202cec36ad8bc8f6c5781aef29b63.json
+++ b/openfisca_france/tests/json/mbic_imps-ea15f371e67bc42fe20adf88bf5b9e6c4ef202cec36ad8bc8f6c5781aef29b63.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_impv-23986d10651338fc6b69b1f09bc8683578fedd5e96b5e62ce89c14452e80f712.json
+++ b/openfisca_france/tests/json/mbic_impv-23986d10651338fc6b69b1f09bc8683578fedd5e96b5e62ce89c14452e80f712.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_impv-2414c41eb2c152d636191a753a92270bb602ffab32a975897c2d227daec79d01.json
+++ b/openfisca_france/tests/json/mbic_impv-2414c41eb2c152d636191a753a92270bb602ffab32a975897c2d227daec79d01.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_impv-260bc8ba8d141d9f652374a687d155154047c4ab713b175c47d56ff84df0bd0e.json
+++ b/openfisca_france/tests/json/mbic_impv-260bc8ba8d141d9f652374a687d155154047c4ab713b175c47d56ff84df0bd0e.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_impv-42afebd6cdbdacab17816bbe51776d5984a73f1f9324c14964c96b1b85741455.json
+++ b/openfisca_france/tests/json/mbic_impv-42afebd6cdbdacab17816bbe51776d5984a73f1f9324c14964c96b1b85741455.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "mbic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_impv-5f992c3cbca41016d1b8f358f6e53c1b16e768f44ffe7f47fa32e9ab2bcec609.json
+++ b/openfisca_france/tests/json/mbic_impv-5f992c3cbca41016d1b8f358f6e53c1b16e768f44ffe7f47fa32e9ab2bcec609.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_impv-6b91f11a449a2b61d95c237ed4f70469955bd1b9de818d76ba16ca15bba4e6c1.json
+++ b/openfisca_france/tests/json/mbic_impv-6b91f11a449a2b61d95c237ed4f70469955bd1b9de818d76ba16ca15bba4e6c1.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_impv-cf4bb9733a9a61691f7cdb74b61c13ba88474f4e4cfa0fd8515617c5f0c6d008.json
+++ b/openfisca_france/tests/json/mbic_impv-cf4bb9733a9a61691f7cdb74b61c13ba88474f4e4cfa0fd8515617c5f0c6d008.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_impv-ed2e8133a81fb2dcfcbc91d5719dcb64e3bbe9fcd091eb7a5ab3d5a602ed70bc.json
+++ b/openfisca_france/tests/json/mbic_impv-ed2e8133a81fb2dcfcbc91d5719dcb64e3bbe9fcd091eb7a5ab3d5a602ed70bc.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_impv-ef911cadd6e8858a43c938c3c4e468c40edf57abbfd1465cc21ab7e2f76420ce.json
+++ b/openfisca_france/tests/json/mbic_impv-ef911cadd6e8858a43c938c3c4e468c40edf57abbfd1465cc21ab7e2f76420ce.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_impv": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvct-07ad1b7583cf1523881bb34e4d4e7e43424baee34f3d4e5680d528503d0ca5b6.json
+++ b/openfisca_france/tests/json/mbic_mvct-07ad1b7583cf1523881bb34e4d4e7e43424baee34f3d4e5680d528503d0ca5b6.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvct-12afe3a9575c813810baa738fa6144df3a335212a2b2cb66cd03327fde95190a.json
+++ b/openfisca_france/tests/json/mbic_mvct-12afe3a9575c813810baa738fa6144df3a335212a2b2cb66cd03327fde95190a.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvct-2be99153ce94f074d6d67fdb539eb08b29c7d203dfa1ba1cbda135995877e086.json
+++ b/openfisca_france/tests/json/mbic_mvct-2be99153ce94f074d6d67fdb539eb08b29c7d203dfa1ba1cbda135995877e086.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvct-652a8474c2f2d1f4790b3647a5a2a4b5917bf5f6034a67129fb01c69116420aa.json
+++ b/openfisca_france/tests/json/mbic_mvct-652a8474c2f2d1f4790b3647a5a2a4b5917bf5f6034a67129fb01c69116420aa.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvct-66a4b85dfd76a9dc6cb1f4131bfb51b75e01c612ac7171b3dd2a8f2ab7dc80cd.json
+++ b/openfisca_france/tests/json/mbic_mvct-66a4b85dfd76a9dc6cb1f4131bfb51b75e01c612ac7171b3dd2a8f2ab7dc80cd.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvct-7cf286dbe274f990de651994616ae79a56ad499f12de1e0ebcca503bfdfad9bc.json
+++ b/openfisca_france/tests/json/mbic_mvct-7cf286dbe274f990de651994616ae79a56ad499f12de1e0ebcca503bfdfad9bc.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvct-8f66680d181e33172770d43bc5ebc94e3429d944c15d7575f5666aae168a2418.json
+++ b/openfisca_france/tests/json/mbic_mvct-8f66680d181e33172770d43bc5ebc94e3429d944c15d7575f5666aae168a2418.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvct-b26b5a32a0b6306788005a13788000d85db327a1b82966dfd564ea57d5c71e04.json
+++ b/openfisca_france/tests/json/mbic_mvct-b26b5a32a0b6306788005a13788000d85db327a1b82966dfd564ea57d5c71e04.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvct-f5ffb95fe1ed8d5a4100370d2b28ac9cad606e6dde014077553ba85451a662a0.json
+++ b/openfisca_france/tests/json/mbic_mvct-f5ffb95fe1ed8d5a4100370d2b28ac9cad606e6dde014077553ba85451a662a0.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvlt-104433f4de2b4c468a05cd88a665444af068dd199abe5371e5890f4b012f2ec0.json
+++ b/openfisca_france/tests/json/mbic_mvlt-104433f4de2b4c468a05cd88a665444af068dd199abe5371e5890f4b012f2ec0.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvlt-5ae5e22e0c85c91ed22fbabd27dc2ca6d5593565bf5cb5cae1d85801d95dddad.json
+++ b/openfisca_france/tests/json/mbic_mvlt-5ae5e22e0c85c91ed22fbabd27dc2ca6d5593565bf5cb5cae1d85801d95dddad.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvlt-6045424cfc4c2e0a9c14d6a1a264341b49886067be190e622ee430d82185480f.json
+++ b/openfisca_france/tests/json/mbic_mvlt-6045424cfc4c2e0a9c14d6a1a264341b49886067be190e622ee430d82185480f.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvlt-78a489da15d229ab0e67a0a46cde50b28cb20ba98d0142359beee7d611f5d693.json
+++ b/openfisca_france/tests/json/mbic_mvlt-78a489da15d229ab0e67a0a46cde50b28cb20ba98d0142359beee7d611f5d693.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvlt-8502ef6661bbe80ac6b60c483623ce29c0f7d24a5f56fe329c3dd5c143f04718.json
+++ b/openfisca_france/tests/json/mbic_mvlt-8502ef6661bbe80ac6b60c483623ce29c0f7d24a5f56fe329c3dd5c143f04718.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvlt-918520e9291fc3a22b907f5c0344a15b8f2ff423308644004bf15c0e19bf6c1b.json
+++ b/openfisca_france/tests/json/mbic_mvlt-918520e9291fc3a22b907f5c0344a15b8f2ff423308644004bf15c0e19bf6c1b.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvlt-c1ea7775e74a222e18ffdcfd3f73365b5a2d7353077d071135543405b794c096.json
+++ b/openfisca_france/tests/json/mbic_mvlt-c1ea7775e74a222e18ffdcfd3f73365b5a2d7353077d071135543405b794c096.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "mbic_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvlt-c20752f8c204be50be15f9a13c938fd506684423aa7de72136ac41dad32932d1.json
+++ b/openfisca_france/tests/json/mbic_mvlt-c20752f8c204be50be15f9a13c938fd506684423aa7de72136ac41dad32932d1.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_mvlt-cf9679cae694107f5412f3131d766fd566bc082635429cb8cc3890d03ecad93d.json
+++ b/openfisca_france/tests/json/mbic_mvlt-cf9679cae694107f5412f3131d766fd566bc082635429cb8cc3890d03ecad93d.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbic_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvce-0eaad652e2dd2bc91976a91928fcd4717fdbb42c659e7bf6c98620bab36459b2.json
+++ b/openfisca_france/tests/json/mbic_pvce-0eaad652e2dd2bc91976a91928fcd4717fdbb42c659e7bf6c98620bab36459b2.json
@@ -118,7 +118,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvce-12ce0368e5edaedfc7c75e14e964509f8ccb338bf0b953dfd0b53368ea3d23ae.json
+++ b/openfisca_france/tests/json/mbic_pvce-12ce0368e5edaedfc7c75e14e964509f8ccb338bf0b953dfd0b53368ea3d23ae.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvce-291ef09ffedbc560c4493ea950ccfbf86c2bec234b6373be8d3cca78a216648e.json
+++ b/openfisca_france/tests/json/mbic_pvce-291ef09ffedbc560c4493ea950ccfbf86c2bec234b6373be8d3cca78a216648e.json
@@ -128,7 +128,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvce-2d0f2d6c9108a1d09a831d3378e06ae48532f2180b8eab1a97f78c4810f50f1a.json
+++ b/openfisca_france/tests/json/mbic_pvce-2d0f2d6c9108a1d09a831d3378e06ae48532f2180b8eab1a97f78c4810f50f1a.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvce-5624189c95cbab0411753379be6c6a567b7fa14cb7a22e10f5c2be0d34b90c8a.json
+++ b/openfisca_france/tests/json/mbic_pvce-5624189c95cbab0411753379be6c6a567b7fa14cb7a22e10f5c2be0d34b90c8a.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvce-580a6b6beb87509e650f904d5a71ef7afa5a91b50dff6e12397475e9b3fa1b8f.json
+++ b/openfisca_france/tests/json/mbic_pvce-580a6b6beb87509e650f904d5a71ef7afa5a91b50dff6e12397475e9b3fa1b8f.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvce-f29a597d08ef06b3104f409a61e10b66c1bba62c9ff910fe4877d20cefc8a3e5.json
+++ b/openfisca_france/tests/json/mbic_pvce-f29a597d08ef06b3104f409a61e10b66c1bba62c9ff910fe4877d20cefc8a3e5.json
@@ -128,7 +128,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvce-f2de9fec177057ce43514a8b74045b72d6f60e9adf58fea507e2bf0cf8c2dd28.json
+++ b/openfisca_france/tests/json/mbic_pvce-f2de9fec177057ce43514a8b74045b72d6f60e9adf58fea507e2bf0cf8c2dd28.json
@@ -123,7 +123,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvce-ff96308686ea3725b18c28f22253306149cbf912af2bdbaac936182f078692da.json
+++ b/openfisca_france/tests/json/mbic_pvce-ff96308686ea3725b18c28f22253306149cbf912af2bdbaac936182f078692da.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvct-1cdfdb1cc3d8cf44c5b04298007c44131980a8a17b1a3ae2fe03d6d4f29b9af0.json
+++ b/openfisca_france/tests/json/mbic_pvct-1cdfdb1cc3d8cf44c5b04298007c44131980a8a17b1a3ae2fe03d6d4f29b9af0.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvct-279b728dc32e9d346e914d61e606e54a5c6c2fa73457f11420363997d8193134.json
+++ b/openfisca_france/tests/json/mbic_pvct-279b728dc32e9d346e914d61e606e54a5c6c2fa73457f11420363997d8193134.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvct-2a05f43a31ceb89668c132bbcb302c8ec078336e2f15ef411d4b03049fbffc29.json
+++ b/openfisca_france/tests/json/mbic_pvct-2a05f43a31ceb89668c132bbcb302c8ec078336e2f15ef411d4b03049fbffc29.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvct-5beeea92d3c37eaa294dc9868173032dccf72745cc66beaffd79d2c7b0e3fcde.json
+++ b/openfisca_france/tests/json/mbic_pvct-5beeea92d3c37eaa294dc9868173032dccf72745cc66beaffd79d2c7b0e3fcde.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvct-a0d074bdd867aefb8bf769fd9a17d25cce907ab95e27cc7d20abc4d4e35a5acf.json
+++ b/openfisca_france/tests/json/mbic_pvct-a0d074bdd867aefb8bf769fd9a17d25cce907ab95e27cc7d20abc4d4e35a5acf.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvct-a8353fbb6c732e9e8db4d3ea6bd64db9839a31c57e902757ccbd51288d63920c.json
+++ b/openfisca_france/tests/json/mbic_pvct-a8353fbb6c732e9e8db4d3ea6bd64db9839a31c57e902757ccbd51288d63920c.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvct-c0bd6848294154440b44cf933c22d05abf784dedffa734525fce3a9e167309cd.json
+++ b/openfisca_france/tests/json/mbic_pvct-c0bd6848294154440b44cf933c22d05abf784dedffa734525fce3a9e167309cd.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvct-e9700535f4858bd2b66aaf237df5f70b93a36ee4c9dd78c7c5f7adb1620c9f4c.json
+++ b/openfisca_france/tests/json/mbic_pvct-e9700535f4858bd2b66aaf237df5f70b93a36ee4c9dd78c7c5f7adb1620c9f4c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbic_pvct-ffd61d67526997490f89ae6daaade1dbe73ed8d121729b6cee32d9cee82e84ff.json
+++ b/openfisca_france/tests/json/mbic_pvct-ffd61d67526997490f89ae6daaade1dbe73ed8d121729b6cee32d9cee82e84ff.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbic_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_exon-0cd412a51ad0b03b40c94653becba0a6e61cdba6b4a5e22c752e8b0b554bdd42.json
+++ b/openfisca_france/tests/json/mbnc_exon-0cd412a51ad0b03b40c94653becba0a6e61cdba6b4a5e22c752e8b0b554bdd42.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_exon-29d94d9d8d70ae702729bec37e05c420b3dcde58d23b0434e3eba78d0a083ee9.json
+++ b/openfisca_france/tests/json/mbnc_exon-29d94d9d8d70ae702729bec37e05c420b3dcde58d23b0434e3eba78d0a083ee9.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_exon-4a27101b866736288278ec9d1c14d6facc026e513bdebf8eb03732e7e941fd33.json
+++ b/openfisca_france/tests/json/mbnc_exon-4a27101b866736288278ec9d1c14d6facc026e513bdebf8eb03732e7e941fd33.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_exon-6a84d48eb8f284bee53f8baef60979b9c631b088c559b4116b27324b08e5201e.json
+++ b/openfisca_france/tests/json/mbnc_exon-6a84d48eb8f284bee53f8baef60979b9c631b088c559b4116b27324b08e5201e.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_exon-8172684abd21ab88dbcc239336a5af1ec37c7f91280b72fb19a35bd0e448e7bf.json
+++ b/openfisca_france/tests/json/mbnc_exon-8172684abd21ab88dbcc239336a5af1ec37c7f91280b72fb19a35bd0e448e7bf.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_exon-81f9f2374a58de0b2b41e1c0672a55be1b38c239207778f70fb68020471891a0.json
+++ b/openfisca_france/tests/json/mbnc_exon-81f9f2374a58de0b2b41e1c0672a55be1b38c239207778f70fb68020471891a0.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_exon-a54bf68f11fe458075dcb4f07258bd770d93838e5799b95267f972020fd04de4.json
+++ b/openfisca_france/tests/json/mbnc_exon-a54bf68f11fe458075dcb4f07258bd770d93838e5799b95267f972020fd04de4.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_exon-e22d4b0af769c7bc26d17f35cae574bcc4074dd1b2acd6b1c527338d13e0611a.json
+++ b/openfisca_france/tests/json/mbnc_exon-e22d4b0af769c7bc26d17f35cae574bcc4074dd1b2acd6b1c527338d13e0611a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_exon-e31f9f430f03b92a118c357ad442b4acd1cfdd4fbc86e41c1ae73410e112a049.json
+++ b/openfisca_france/tests/json/mbnc_exon-e31f9f430f03b92a118c357ad442b4acd1cfdd4fbc86e41c1ae73410e112a049.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_impo-07dc4ee1177fd59b11baebde769328bc532798bb6374339096a7fb528b6762e2.json
+++ b/openfisca_france/tests/json/mbnc_impo-07dc4ee1177fd59b11baebde769328bc532798bb6374339096a7fb528b6762e2.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_impo-1f9c42f3900dc8b9ee5a457bf276e201b0744eb60b683a1b2d7890caaddec880.json
+++ b/openfisca_france/tests/json/mbnc_impo-1f9c42f3900dc8b9ee5a457bf276e201b0744eb60b683a1b2d7890caaddec880.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_impo-57d07896f8e8fda89f9c7cf866206908c99693d26677ce9802ad862cd30d779d.json
+++ b/openfisca_france/tests/json/mbnc_impo-57d07896f8e8fda89f9c7cf866206908c99693d26677ce9802ad862cd30d779d.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_impo-5c187b59c67cb81d6d051ba728589ce5006af83e2b4e8ac468403f2b8e85e572.json
+++ b/openfisca_france/tests/json/mbnc_impo-5c187b59c67cb81d6d051ba728589ce5006af83e2b4e8ac468403f2b8e85e572.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_impo-683dc7c6befec91c1be72a42d7cd86d2ca64de55c137fe2bafbac7ca55df7dea.json
+++ b/openfisca_france/tests/json/mbnc_impo-683dc7c6befec91c1be72a42d7cd86d2ca64de55c137fe2bafbac7ca55df7dea.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_impo-95a450e9cf3937807abf01c427027de6c21a843c2b5603a42199a775c70ffa95.json
+++ b/openfisca_france/tests/json/mbnc_impo-95a450e9cf3937807abf01c427027de6c21a843c2b5603a42199a775c70ffa95.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_impo-a51104676c928ba55e27210c55c6ee0db76652fad566c68a6942d17df9276d27.json
+++ b/openfisca_france/tests/json/mbnc_impo-a51104676c928ba55e27210c55c6ee0db76652fad566c68a6942d17df9276d27.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_impo-b2b8302eca72d7767759a32a44614991946df21b2736dd2308602bd50d9ebc74.json
+++ b/openfisca_france/tests/json/mbnc_impo-b2b8302eca72d7767759a32a44614991946df21b2736dd2308602bd50d9ebc74.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_impo-f1d2c2feeea735a5ccf01dd75d14928218c11a16ddbf4a68cb8630f4f5e02051.json
+++ b/openfisca_france/tests/json/mbnc_impo-f1d2c2feeea735a5ccf01dd75d14928218c11a16ddbf4a68cb8630f4f5e02051.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_mvlt-34e950ece8e9529057474d7abac998064638f133e762f5711e25dc45f385131d.json
+++ b/openfisca_france/tests/json/mbnc_mvlt-34e950ece8e9529057474d7abac998064638f133e762f5711e25dc45f385131d.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_mvlt-4771385a6bcf1919efddbe1756f041ea54c472edeca488af94031e1f44262bc0.json
+++ b/openfisca_france/tests/json/mbnc_mvlt-4771385a6bcf1919efddbe1756f041ea54c472edeca488af94031e1f44262bc0.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_mvlt-5b5ff435724fcd79174781ab04252a2ede9f1b3543332fcb7ea6ef78598f3912.json
+++ b/openfisca_france/tests/json/mbnc_mvlt-5b5ff435724fcd79174781ab04252a2ede9f1b3543332fcb7ea6ef78598f3912.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_mvlt-79725e997c4106efb09f7e5cc27195257e7a2a5e90ca2e5600fc60e8e192aa9f.json
+++ b/openfisca_france/tests/json/mbnc_mvlt-79725e997c4106efb09f7e5cc27195257e7a2a5e90ca2e5600fc60e8e192aa9f.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_mvlt-93f6cdb8094d34d3e237aaaf7da6cc6465492960ae727e0f2ae8ba5a5bf74332.json
+++ b/openfisca_france/tests/json/mbnc_mvlt-93f6cdb8094d34d3e237aaaf7da6cc6465492960ae727e0f2ae8ba5a5bf74332.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_mvlt-cccadb0a2d97f34cef8503a65026c0fcfa90df0e0490e15532be3a2ea5eee612.json
+++ b/openfisca_france/tests/json/mbnc_mvlt-cccadb0a2d97f34cef8503a65026c0fcfa90df0e0490e15532be3a2ea5eee612.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_mvlt-d99711deb429b3bdbf28866bed624609bb894fecadf1ddb6f6cee26f60b9ff83.json
+++ b/openfisca_france/tests/json/mbnc_mvlt-d99711deb429b3bdbf28866bed624609bb894fecadf1ddb6f6cee26f60b9ff83.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_mvlt-e8db1206f530d86e19abb42b5d14acc840ca036052a972c3f29adecd851d4d99.json
+++ b/openfisca_france/tests/json/mbnc_mvlt-e8db1206f530d86e19abb42b5d14acc840ca036052a972c3f29adecd851d4d99.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_mvlt-f1d94bb986841743e5393ab67df536c7c510e59e4e90a5b3fe26e3eae74a0529.json
+++ b/openfisca_france/tests/json/mbnc_mvlt-f1d94bb986841743e5393ab67df536c7c510e59e4e90a5b3fe26e3eae74a0529.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvce-175cbdd65d2accba3ce29f3763900050a8e8e0f647d6a30552b68719ee9c85c4.json
+++ b/openfisca_france/tests/json/mbnc_pvce-175cbdd65d2accba3ce29f3763900050a8e8e0f647d6a30552b68719ee9c85c4.json
@@ -128,7 +128,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvce-35af3a738a9c04630c934231f1b5be5ae9db8c2297bf2da222d270db832a4b06.json
+++ b/openfisca_france/tests/json/mbnc_pvce-35af3a738a9c04630c934231f1b5be5ae9db8c2297bf2da222d270db832a4b06.json
@@ -128,7 +128,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvce-52e1029cd5c5930fda95ba785c857802d2a6eb7ac385305ab627178d9d334933.json
+++ b/openfisca_france/tests/json/mbnc_pvce-52e1029cd5c5930fda95ba785c857802d2a6eb7ac385305ab627178d9d334933.json
@@ -123,7 +123,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvce-5d5067932760402c9d3b941bfb23664e1be00e6f1a913023a95e25bce2dfede5.json
+++ b/openfisca_france/tests/json/mbnc_pvce-5d5067932760402c9d3b941bfb23664e1be00e6f1a913023a95e25bce2dfede5.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvce-63a3467b49149087ffedc48589d87a00d6d2117d110b2207ec1c9fe71b253cff.json
+++ b/openfisca_france/tests/json/mbnc_pvce-63a3467b49149087ffedc48589d87a00d6d2117d110b2207ec1c9fe71b253cff.json
@@ -118,7 +118,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvce-7bbd1726a6405756da7f4a8d4aacde0400d064509e5bd1ba59e9451a8110f388.json
+++ b/openfisca_france/tests/json/mbnc_pvce-7bbd1726a6405756da7f4a8d4aacde0400d064509e5bd1ba59e9451a8110f388.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvce-91d6bed69cba9f9f7cae4bec3137140711803d3db0709593a7e504c1a57fc76a.json
+++ b/openfisca_france/tests/json/mbnc_pvce-91d6bed69cba9f9f7cae4bec3137140711803d3db0709593a7e504c1a57fc76a.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvce-aafeb30f05af2d4661ab3dda0398208cef107fa0272733677848c9d7d191f1b2.json
+++ b/openfisca_france/tests/json/mbnc_pvce-aafeb30f05af2d4661ab3dda0398208cef107fa0272733677848c9d7d191f1b2.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvce-b97508b07061dfe7d65d9cfa211a7681bccf3229c5cb2d689fe5cd014e3acce9.json
+++ b/openfisca_france/tests/json/mbnc_pvce-b97508b07061dfe7d65d9cfa211a7681bccf3229c5cb2d689fe5cd014e3acce9.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvct-108ba31b3958d8299d019c772557aa2c43a423fbce970d5ef07cad78fb3108d9.json
+++ b/openfisca_france/tests/json/mbnc_pvct-108ba31b3958d8299d019c772557aa2c43a423fbce970d5ef07cad78fb3108d9.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvct-31d2376ac67768639287679e81a5312a0d0e1ff18a65b3103db7b765168823ae.json
+++ b/openfisca_france/tests/json/mbnc_pvct-31d2376ac67768639287679e81a5312a0d0e1ff18a65b3103db7b765168823ae.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvct-350891dd07f2e168016fecf5079255c4032a05af8b545ad0f8a5f89539e0430d.json
+++ b/openfisca_france/tests/json/mbnc_pvct-350891dd07f2e168016fecf5079255c4032a05af8b545ad0f8a5f89539e0430d.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvct-4f357ae2c4f08d44646c3972541bcf942928714c79321a415329fc7686b6fc71.json
+++ b/openfisca_france/tests/json/mbnc_pvct-4f357ae2c4f08d44646c3972541bcf942928714c79321a415329fc7686b6fc71.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvct-6199de7f08aa06853f137d8e6ed8cdba4b87aa339667b7618bdb6fbeaaf14d27.json
+++ b/openfisca_france/tests/json/mbnc_pvct-6199de7f08aa06853f137d8e6ed8cdba4b87aa339667b7618bdb6fbeaaf14d27.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvct-61e417c173d62c7c66971162462d9a362c8c5684cbb6816fc49329cbdfdcdb75.json
+++ b/openfisca_france/tests/json/mbnc_pvct-61e417c173d62c7c66971162462d9a362c8c5684cbb6816fc49329cbdfdcdb75.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvct-832884f1222b28dc28af02349239a6904abb5ede9253dc35a692c0bcae2a44b9.json
+++ b/openfisca_france/tests/json/mbnc_pvct-832884f1222b28dc28af02349239a6904abb5ede9253dc35a692c0bcae2a44b9.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvct-e11732d223463d0e86d09e5504c330dedfc370d3f3bbe10c1e6db9d55909d359.json
+++ b/openfisca_france/tests/json/mbnc_pvct-e11732d223463d0e86d09e5504c330dedfc370d3f3bbe10c1e6db9d55909d359.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mbnc_pvct-e4617b645fba68464a3bc0ce9c6c61886f0f2b2f1e59f234a7eb83735ab8ed07.json
+++ b/openfisca_france/tests/json/mbnc_pvct-e4617b645fba68464a3bc0ce9c6c61886f0f2b2f1e59f234a7eb83735ab8ed07.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mbnc_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_impo-08e31d44267c3ba7892b503f722c6300f5cd07d92c0bce8dd908ab5a488f9c43.json
+++ b/openfisca_france/tests/json/mncn_impo-08e31d44267c3ba7892b503f722c6300f5cd07d92c0bce8dd908ab5a488f9c43.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_impo-1a161c5d43af2ecf43d90858956ad152a4b95e505f441304540f7f5ebf9742d8.json
+++ b/openfisca_france/tests/json/mncn_impo-1a161c5d43af2ecf43d90858956ad152a4b95e505f441304540f7f5ebf9742d8.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_impo-1cb73950deb2966a98d6c17184a23aabf2b97f84a656b08d252a18e07358cbc4.json
+++ b/openfisca_france/tests/json/mncn_impo-1cb73950deb2966a98d6c17184a23aabf2b97f84a656b08d252a18e07358cbc4.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "mncn_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_impo-2c2e85d49af4344c18bd16ccf655275922e4499e947c86fb041e44a3ac7f3d82.json
+++ b/openfisca_france/tests/json/mncn_impo-2c2e85d49af4344c18bd16ccf655275922e4499e947c86fb041e44a3ac7f3d82.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_impo-37d98c1d1521b4477776697e49172e3a7f4d4fa98908f4ea690b064d95dc6ba7.json
+++ b/openfisca_france/tests/json/mncn_impo-37d98c1d1521b4477776697e49172e3a7f4d4fa98908f4ea690b064d95dc6ba7.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_impo-5bc1d2761f63aeeeb238ae7c869d311db7a7776cc419c33730fe86bcf02daba7.json
+++ b/openfisca_france/tests/json/mncn_impo-5bc1d2761f63aeeeb238ae7c869d311db7a7776cc419c33730fe86bcf02daba7.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_impo-6de5fed0e273e66a4e27c9de826dc9dd3e87328f49966263e0781d543e776b22.json
+++ b/openfisca_france/tests/json/mncn_impo-6de5fed0e273e66a4e27c9de826dc9dd3e87328f49966263e0781d543e776b22.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mncn_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_impo-8a13c503f22db36e816f3e34a0671fccdaa833758504a1c9c7a4538578cf2c99.json
+++ b/openfisca_france/tests/json/mncn_impo-8a13c503f22db36e816f3e34a0671fccdaa833758504a1c9c7a4538578cf2c99.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_impo-93f4af54ef729ee5c67ce938b99ffb29bf2e7f074a3c74d098853760a41e02dd.json
+++ b/openfisca_france/tests/json/mncn_impo-93f4af54ef729ee5c67ce938b99ffb29bf2e7f074a3c74d098853760a41e02dd.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvct-075bd96866edd4f9c7781fd2bd3984da10c078570a650b37cecdd73d9b70405e.json
+++ b/openfisca_france/tests/json/mncn_mvct-075bd96866edd4f9c7781fd2bd3984da10c078570a650b37cecdd73d9b70405e.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvct-1bcb4a7b13f77a152fe4f79b513732fad378262a7de855d63082f3c5de829dd7.json
+++ b/openfisca_france/tests/json/mncn_mvct-1bcb4a7b13f77a152fe4f79b513732fad378262a7de855d63082f3c5de829dd7.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvct-4236d6f94e83ef96c6fac4ce4de4e9a0d5b9c7522a3d707dd5af6b59f4bcf890.json
+++ b/openfisca_france/tests/json/mncn_mvct-4236d6f94e83ef96c6fac4ce4de4e9a0d5b9c7522a3d707dd5af6b59f4bcf890.json
@@ -93,7 +93,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvct-6bda5a06ddbad74a59e103aa2a5303ab1477419bb05a28319248422ede043fca.json
+++ b/openfisca_france/tests/json/mncn_mvct-6bda5a06ddbad74a59e103aa2a5303ab1477419bb05a28319248422ede043fca.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvct-6cda90916887b6a052da43703b2e28e41c90b47d47f9a438c852da823522f74f.json
+++ b/openfisca_france/tests/json/mncn_mvct-6cda90916887b6a052da43703b2e28e41c90b47d47f9a438c852da823522f74f.json
@@ -83,7 +83,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvct-8f22bb6c87c8b39e866b0655b028e434310bcb119324b13cf9eafed4297f87bf.json
+++ b/openfisca_france/tests/json/mncn_mvct-8f22bb6c87c8b39e866b0655b028e434310bcb119324b13cf9eafed4297f87bf.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvct-afe3702a4c8695b10bce1cb51928f2100a4d412121ce0e08e4d019bbd40ca8dd.json
+++ b/openfisca_france/tests/json/mncn_mvct-afe3702a4c8695b10bce1cb51928f2100a4d412121ce0e08e4d019bbd40ca8dd.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvct-bf7790add5870b5fc726099232e4a71b6bf6041bf584c72d6e4bf71ea91019f3.json
+++ b/openfisca_france/tests/json/mncn_mvct-bf7790add5870b5fc726099232e4a71b6bf6041bf584c72d6e4bf71ea91019f3.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvct-c5bcda91e2d5ac9ec0b667b15fd410aa31e23412e4c804652dbe99bc9e2410e5.json
+++ b/openfisca_france/tests/json/mncn_mvct-c5bcda91e2d5ac9ec0b667b15fd410aa31e23412e4c804652dbe99bc9e2410e5.json
@@ -88,7 +88,7 @@
           "activite": 0,
           "date_naissance": "1970-01-01",
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvlt-14c619964d669758b1b1547712f4609656147d7ed25f53ddf8a07f24c2dfab24.json
+++ b/openfisca_france/tests/json/mncn_mvlt-14c619964d669758b1b1547712f4609656147d7ed25f53ddf8a07f24c2dfab24.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvlt-1cd6a39e97fd8c1ba4fb803ddd7dfa23ae00f35732ea6686306494fff6f45f64.json
+++ b/openfisca_france/tests/json/mncn_mvlt-1cd6a39e97fd8c1ba4fb803ddd7dfa23ae00f35732ea6686306494fff6f45f64.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvlt-1f7a4c164a568e58afab9e5567891b7e1cfae8929d0e7621321a5d0ac9d9d948.json
+++ b/openfisca_france/tests/json/mncn_mvlt-1f7a4c164a568e58afab9e5567891b7e1cfae8929d0e7621321a5d0ac9d9d948.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvlt-68668dfcfa5fffdb07c66be1501e0246974ce8aa5dc6640645dbd41438d669f8.json
+++ b/openfisca_france/tests/json/mncn_mvlt-68668dfcfa5fffdb07c66be1501e0246974ce8aa5dc6640645dbd41438d669f8.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvlt-7fe2043182e9976ee969e514a1c5e968defac71f28e9c6e46d9b23b1dded7277.json
+++ b/openfisca_france/tests/json/mncn_mvlt-7fe2043182e9976ee969e514a1c5e968defac71f28e9c6e46d9b23b1dded7277.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvlt-b67ddff04a799421485b107c9d3971186043a9b4b9d4e070e147046e1f50abda.json
+++ b/openfisca_france/tests/json/mncn_mvlt-b67ddff04a799421485b107c9d3971186043a9b4b9d4e070e147046e1f50abda.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mncn_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvlt-b728a9f886a3fabf9191cf1a643f01da1074fd472d1887a899423ca3e4c0b729.json
+++ b/openfisca_france/tests/json/mncn_mvlt-b728a9f886a3fabf9191cf1a643f01da1074fd472d1887a899423ca3e4c0b729.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvlt-c78f07ad1a54ff9c1860dd018d977d820a107007f1ff449eb61b093befecd6f0.json
+++ b/openfisca_france/tests/json/mncn_mvlt-c78f07ad1a54ff9c1860dd018d977d820a107007f1ff449eb61b093befecd6f0.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "mncn_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_mvlt-e3c001091b2a12cfcd93ba1ea542af66328fb39c238a69c60d2096989b2bf0a0.json
+++ b/openfisca_france/tests/json/mncn_mvlt-e3c001091b2a12cfcd93ba1ea542af66328fb39c238a69c60d2096989b2bf0a0.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_mvlt": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvce-045d36ed9af18e11617bcc0b0480460881ff3f2ca97615d10db70630e2f7af06.json
+++ b/openfisca_france/tests/json/mncn_pvce-045d36ed9af18e11617bcc0b0480460881ff3f2ca97615d10db70630e2f7af06.json
@@ -118,7 +118,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvce-1da27ac0d78f5cbe7f641060149d008b7376ca4979650a0bfbf65cf5dd3573ee.json
+++ b/openfisca_france/tests/json/mncn_pvce-1da27ac0d78f5cbe7f641060149d008b7376ca4979650a0bfbf65cf5dd3573ee.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvce-28eca78899a90a2840c9a81a5d4a031d509ca18e06b5869a4047f2b5d1462394.json
+++ b/openfisca_france/tests/json/mncn_pvce-28eca78899a90a2840c9a81a5d4a031d509ca18e06b5869a4047f2b5d1462394.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvce-757ca74fc7058ccb46c13fa60b325a84e58402e1840626af2a167a3aef38b9c9.json
+++ b/openfisca_france/tests/json/mncn_pvce-757ca74fc7058ccb46c13fa60b325a84e58402e1840626af2a167a3aef38b9c9.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvce-86517eaa7c8fc3eb6edc09402f6efba3dd92fc8b1c0bfe2e92a0fa19325edc8d.json
+++ b/openfisca_france/tests/json/mncn_pvce-86517eaa7c8fc3eb6edc09402f6efba3dd92fc8b1c0bfe2e92a0fa19325edc8d.json
@@ -128,7 +128,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvce-a14ac5150d899f122f47c3aa4039862a0914d4bcd55b53340486dc96795d0513.json
+++ b/openfisca_france/tests/json/mncn_pvce-a14ac5150d899f122f47c3aa4039862a0914d4bcd55b53340486dc96795d0513.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvce-a9208884ca7a6eebfee870aebe6cbf6f509ac76c1ca66bb84e96415c72943e86.json
+++ b/openfisca_france/tests/json/mncn_pvce-a9208884ca7a6eebfee870aebe6cbf6f509ac76c1ca66bb84e96415c72943e86.json
@@ -128,7 +128,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvce-db93bee705e9887bff002cae17ab2928557df902907042b0f1ee7bf5bf95b955.json
+++ b/openfisca_france/tests/json/mncn_pvce-db93bee705e9887bff002cae17ab2928557df902907042b0f1ee7bf5bf95b955.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvce-f66559fd0179738f934eabc69dd229ba9b6926f535fde8de5f53f997670a0986.json
+++ b/openfisca_france/tests/json/mncn_pvce-f66559fd0179738f934eabc69dd229ba9b6926f535fde8de5f53f997670a0986.json
@@ -123,7 +123,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvct-0660c2d608d7ca6183ca62ec4afc82f887e09487dde305c5e23a283095bc689a.json
+++ b/openfisca_france/tests/json/mncn_pvct-0660c2d608d7ca6183ca62ec4afc82f887e09487dde305c5e23a283095bc689a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvct-0d1275e9ecdcdad609018b6a4064b92454220182d535629ebcdb2c63c2b5c558.json
+++ b/openfisca_france/tests/json/mncn_pvct-0d1275e9ecdcdad609018b6a4064b92454220182d535629ebcdb2c63c2b5c558.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvct-35835c71ab9a195b0a2821e3bbc66a619e9891ac7e2a32c3d2541b02aab5a766.json
+++ b/openfisca_france/tests/json/mncn_pvct-35835c71ab9a195b0a2821e3bbc66a619e9891ac7e2a32c3d2541b02aab5a766.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvct-4b593eb5cdc0a86c7415875bd696372068fab22fb1a3436a23f989062e5a5562.json
+++ b/openfisca_france/tests/json/mncn_pvct-4b593eb5cdc0a86c7415875bd696372068fab22fb1a3436a23f989062e5a5562.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvct-7c3daee2335d174d61b08f00416ecb0fa55d1121829f67b7605f322bd866ee52.json
+++ b/openfisca_france/tests/json/mncn_pvct-7c3daee2335d174d61b08f00416ecb0fa55d1121829f67b7605f322bd866ee52.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvct-a88836b0f9ad7f079e799ab27240afbe327c52361cd71c87238848c8a4f2c373.json
+++ b/openfisca_france/tests/json/mncn_pvct-a88836b0f9ad7f079e799ab27240afbe327c52361cd71c87238848c8a4f2c373.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvct-ca1ac5414aa9e71a53ebfa0ec32a8ff23223d64c4c943fb4f848b45bc1e45a94.json
+++ b/openfisca_france/tests/json/mncn_pvct-ca1ac5414aa9e71a53ebfa0ec32a8ff23223d64c4c943fb4f848b45bc1e45a94.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvct-de0773abfb5d81463a2a0c1eeb694edf902c4ce5afc49fd836cf5e7e07edc106.json
+++ b/openfisca_france/tests/json/mncn_pvct-de0773abfb5d81463a2a0c1eeb694edf902c4ce5afc49fd836cf5e7e07edc106.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/mncn_pvct-fb66ef497dac5ee08bbc790bb85fe2facab7af30ede0a666a9f9338f92d46159.json
+++ b/openfisca_france/tests/json/mncn_pvct-fb66ef497dac5ee08bbc790bb85fe2facab7af30ede0a666a9f9338f92d46159.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "mncn_pvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defn-0ef85d9d7bf4cecfafb084080f8ccb10ba8c8dade3b2d444425709c8ab925d4c.json
+++ b/openfisca_france/tests/json/nacc_defn-0ef85d9d7bf4cecfafb084080f8ccb10ba8c8dade3b2d444425709c8ab925d4c.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defn-3a2969ef4c3c26d96b2ce5b75fe228edda87b716f95d10e26a6404568f8faf46.json
+++ b/openfisca_france/tests/json/nacc_defn-3a2969ef4c3c26d96b2ce5b75fe228edda87b716f95d10e26a6404568f8faf46.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defn-510a0824ce661dd2181a5cd0ff315348a605cd2ce1689e5f7f3f4ad3d9582c31.json
+++ b/openfisca_france/tests/json/nacc_defn-510a0824ce661dd2181a5cd0ff315348a605cd2ce1689e5f7f3f4ad3d9582c31.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defn-6c76b671c2766122af933f1745a74e7dae07a91c150f5d03fe940ea2a450f1ef.json
+++ b/openfisca_france/tests/json/nacc_defn-6c76b671c2766122af933f1745a74e7dae07a91c150f5d03fe940ea2a450f1ef.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defn-9c0ff9156a254645f73c3e1b6551ff664b4d35c6472ece594f4d0f8f42f4164a.json
+++ b/openfisca_france/tests/json/nacc_defn-9c0ff9156a254645f73c3e1b6551ff664b4d35c6472ece594f4d0f8f42f4164a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defn-ddb2c913be195e72c2047f4acb36c80ee2a0bdad2c76076f19dd3a43bcf72f5b.json
+++ b/openfisca_france/tests/json/nacc_defn-ddb2c913be195e72c2047f4acb36c80ee2a0bdad2c76076f19dd3a43bcf72f5b.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defn-e0c1a3e467c6f8990cb915dd41b93c95339942562eb2b5166739e545f0411d36.json
+++ b/openfisca_france/tests/json/nacc_defn-e0c1a3e467c6f8990cb915dd41b93c95339942562eb2b5166739e545f0411d36.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defn-e48d9d7353ea834edc79c9369fa063bffa9a19b73a95696c62d2647db9cb783e.json
+++ b/openfisca_france/tests/json/nacc_defn-e48d9d7353ea834edc79c9369fa063bffa9a19b73a95696c62d2647db9cb783e.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defn-e9a3132b1b0efaa4919f05562bf4d99ca1a6368f98b0498260be55512b78b7d6.json
+++ b/openfisca_france/tests/json/nacc_defn-e9a3132b1b0efaa4919f05562bf4d99ca1a6368f98b0498260be55512b78b7d6.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-02e09ad145fca7cd295d65238071455b211296cdcae2ada85adae7970b9df242.json
+++ b/openfisca_france/tests/json/nacc_defs-02e09ad145fca7cd295d65238071455b211296cdcae2ada85adae7970b9df242.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-16035b450dc4341e5c3ca5617c5d662fd07a992b17368e1c5fd30d9297a0f751.json
+++ b/openfisca_france/tests/json/nacc_defs-16035b450dc4341e5c3ca5617c5d662fd07a992b17368e1c5fd30d9297a0f751.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-18084068d2353bcee0f2ba739de8350c7de4f9abc8bf9168112eeb89c2faa34e.json
+++ b/openfisca_france/tests/json/nacc_defs-18084068d2353bcee0f2ba739de8350c7de4f9abc8bf9168112eeb89c2faa34e.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-2006-96efe47597cd862854085774120ee802cd205f9bb7f6cb62b5e9200a023a0b3a.json
+++ b/openfisca_france/tests/json/nacc_defs-2006-96efe47597cd862854085774120ee802cd205f9bb7f6cb62b5e9200a023a0b3a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-2008-67c8974f6d35d86734be1243636feaae13d19819e8d0a154d8b118b9344079fe.json
+++ b/openfisca_france/tests/json/nacc_defs-2008-67c8974f6d35d86734be1243636feaae13d19819e8d0a154d8b118b9344079fe.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-2009-38c4c3a8ebbe618116806514f5f2ef681b15decb74a61ace9368750e56e9553e.json
+++ b/openfisca_france/tests/json/nacc_defs-2009-38c4c3a8ebbe618116806514f5f2ef681b15decb74a61ace9368750e56e9553e.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-2010-97a37352d5e6dde9330d08bd33c91073a7e2358e20538ed3032bd6c6da611217.json
+++ b/openfisca_france/tests/json/nacc_defs-2010-97a37352d5e6dde9330d08bd33c91073a7e2358e20538ed3032bd6c6da611217.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-2011-fe6d13b261537738b57611bfd0e023e8701624651b399a1425c547efd9484b6a.json
+++ b/openfisca_france/tests/json/nacc_defs-2011-fe6d13b261537738b57611bfd0e023e8701624651b399a1425c547efd9484b6a.json
@@ -89,7 +89,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-2012-a7d69d25e3d9616761112f35e09d8dfa5c8ed9a2aeab5c240c3c79869420051c.json
+++ b/openfisca_france/tests/json/nacc_defs-2012-a7d69d25e3d9616761112f35e09d8dfa5c8ed9a2aeab5c240c3c79869420051c.json
@@ -84,7 +84,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-2013-e87e39173171385d2dcfae6e4428473590340f50092f8d9487ba5f61d76cab02.json
+++ b/openfisca_france/tests/json/nacc_defs-2013-e87e39173171385d2dcfae6e4428473590340f50092f8d9487ba5f61d76cab02.json
@@ -94,7 +94,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-21304c60030321d6939ab1b21c29a182bc202e8b13f307556ea19c066b69d395.json
+++ b/openfisca_france/tests/json/nacc_defs-21304c60030321d6939ab1b21c29a182bc202e8b13f307556ea19c066b69d395.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-3e6f72af25e9a86cc772a081f8201225f2f244a5a643824b670189db780eb272.json
+++ b/openfisca_france/tests/json/nacc_defs-3e6f72af25e9a86cc772a081f8201225f2f244a5a643824b670189db780eb272.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-49a9683713be27394894b1566a19ba3cb725ce8b111761d8f9ac67ec05fa4c3a.json
+++ b/openfisca_france/tests/json/nacc_defs-49a9683713be27394894b1566a19ba3cb725ce8b111761d8f9ac67ec05fa4c3a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-4e49f04a054773aa08a1206928c09bbcba659731e489c5d278cd33bec06b9d67.json
+++ b/openfisca_france/tests/json/nacc_defs-4e49f04a054773aa08a1206928c09bbcba659731e489c5d278cd33bec06b9d67.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-5108d4ded1f0c36c6f076ed259f5bc3d5f6e2cdbef87bae7a759786619ba1462.json
+++ b/openfisca_france/tests/json/nacc_defs-5108d4ded1f0c36c6f076ed259f5bc3d5f6e2cdbef87bae7a759786619ba1462.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-55ad1abbf6bbd939dbd4fe2d4f89ec25096674996d84f47d18ebcfa9a362083d.json
+++ b/openfisca_france/tests/json/nacc_defs-55ad1abbf6bbd939dbd4fe2d4f89ec25096674996d84f47d18ebcfa9a362083d.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-7cc0dbb817fed5ff0292120275994228939cb410340cd80d08126f166f982bd4.json
+++ b/openfisca_france/tests/json/nacc_defs-7cc0dbb817fed5ff0292120275994228939cb410340cd80d08126f166f982bd4.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-9a0bba73b9555204dc04629741466e5f13dadd3fe903c9750752b2846847e933.json
+++ b/openfisca_france/tests/json/nacc_defs-9a0bba73b9555204dc04629741466e5f13dadd3fe903c9750752b2846847e933.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-b5f95c4fc177acbea057c296d0281b40690c17e57c558d45f45c8c7fb764163a.json
+++ b/openfisca_france/tests/json/nacc_defs-b5f95c4fc177acbea057c296d0281b40690c17e57c558d45f45c8c7fb764163a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-bc663bf26d67c08d3d68dc85e6f004e83c88ee9ad2401837a825f622e9db1adb.json
+++ b/openfisca_france/tests/json/nacc_defs-bc663bf26d67c08d3d68dc85e6f004e83c88ee9ad2401837a825f622e9db1adb.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-c7922f2e4c65ec4f9f780b6a4ad9589927aff3bd6ff51eb296a58e08cb2dcfdc.json
+++ b/openfisca_france/tests/json/nacc_defs-c7922f2e4c65ec4f9f780b6a4ad9589927aff3bd6ff51eb296a58e08cb2dcfdc.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_defs-cda1cc08be01cab292f61dfd3e4800e92f09995ab6471281fb088aebceab4335.json
+++ b/openfisca_france/tests/json/nacc_defs-cda1cc08be01cab292f61dfd3e4800e92f09995ab6471281fb088aebceab4335.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_defs": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_exon-7631ed9ed97b60b1d0c92c414f2004ddfb2f2bcb2b930fdd74c9f7fcc07663b2.json
+++ b/openfisca_france/tests/json/nacc_exon-7631ed9ed97b60b1d0c92c414f2004ddfb2f2bcb2b930fdd74c9f7fcc07663b2.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_exon-7895224ed6ac03eb36e1e190c60218cb47cf75929fb1fe47dd66f5ad861d466a.json
+++ b/openfisca_france/tests/json/nacc_exon-7895224ed6ac03eb36e1e190c60218cb47cf75929fb1fe47dd66f5ad861d466a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_exon-822249d35259aeeda9af42337bb4e4b9b541eb5d3f4e206537563086277b0c4b.json
+++ b/openfisca_france/tests/json/nacc_exon-822249d35259aeeda9af42337bb4e4b9b541eb5d3f4e206537563086277b0c4b.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nacc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_exon-8a131847dd174c974f8fb72f5ee577337b9d09cdb9a376a1747d2c7b49a7f410.json
+++ b/openfisca_france/tests/json/nacc_exon-8a131847dd174c974f8fb72f5ee577337b9d09cdb9a376a1747d2c7b49a7f410.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_exon-b3b50c8656fcb419c34451f60ee6246a2a754a94aa5a8c88962dfed6df24b468.json
+++ b/openfisca_france/tests/json/nacc_exon-b3b50c8656fcb419c34451f60ee6246a2a754a94aa5a8c88962dfed6df24b468.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_exon-bf989bb4e3e3fcf6269ea822091ac9b54ca9e80d22701c06ad8e5d19a5017ff3.json
+++ b/openfisca_france/tests/json/nacc_exon-bf989bb4e3e3fcf6269ea822091ac9b54ca9e80d22701c06ad8e5d19a5017ff3.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_exon-c7dbfbc07fdcc5d0d329f4ae2fcbf419307c16de156119abba90c9e23776d90c.json
+++ b/openfisca_france/tests/json/nacc_exon-c7dbfbc07fdcc5d0d329f4ae2fcbf419307c16de156119abba90c9e23776d90c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_exon-cdfb3f1c222d59ecf2d18e3e71468c20e2da3b1ec6dbc13086aa5d07b9d8d655.json
+++ b/openfisca_france/tests/json/nacc_exon-cdfb3f1c222d59ecf2d18e3e71468c20e2da3b1ec6dbc13086aa5d07b9d8d655.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nacc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_exon-eb1cf3c5cb4771e0fb232aca98895dee7438f74645c805b02ee35a5d379b167b.json
+++ b/openfisca_france/tests/json/nacc_exon-eb1cf3c5cb4771e0fb232aca98895dee7438f74645c805b02ee35a5d379b167b.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_impn-61bb8b21c33ec7b8d221533c9f8be0516b58b79ad0d7bd15b623c354e5bd297d.json
+++ b/openfisca_france/tests/json/nacc_impn-61bb8b21c33ec7b8d221533c9f8be0516b58b79ad0d7bd15b623c354e5bd297d.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_impn-6cf9133074a858f816a44d9e4bd78a2ed90e787710ecd74e5a8811454a8d7767.json
+++ b/openfisca_france/tests/json/nacc_impn-6cf9133074a858f816a44d9e4bd78a2ed90e787710ecd74e5a8811454a8d7767.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_impn-931280632dde618cf86d5744a22e95edd0a50635995838157d5204fd7cd9bac6.json
+++ b/openfisca_france/tests/json/nacc_impn-931280632dde618cf86d5744a22e95edd0a50635995838157d5204fd7cd9bac6.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_impn-9dc7d0fae6d9f38279e4442ba67ffebb864187e64dcff7df818bf9e6cf1bbe11.json
+++ b/openfisca_france/tests/json/nacc_impn-9dc7d0fae6d9f38279e4442ba67ffebb864187e64dcff7df818bf9e6cf1bbe11.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nacc_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_impn-b636b8b35c7df56270a02ea44d7e30704c59f3f5f1ab31ff2d5a8e3e6eb513ce.json
+++ b/openfisca_france/tests/json/nacc_impn-b636b8b35c7df56270a02ea44d7e30704c59f3f5f1ab31ff2d5a8e3e6eb513ce.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_impn-d320c98fa1bdc143b7e14300805b8216da28c767cd3a459e0ce896f338aa0c93.json
+++ b/openfisca_france/tests/json/nacc_impn-d320c98fa1bdc143b7e14300805b8216da28c767cd3a459e0ce896f338aa0c93.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_impn-d4f0c48a4a18ee8bc5dfe1b651574c15bad3bc06549953c719beab9d0c125a62.json
+++ b/openfisca_france/tests/json/nacc_impn-d4f0c48a4a18ee8bc5dfe1b651574c15bad3bc06549953c719beab9d0c125a62.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nacc_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_impn-dd3ae7bc31abef06adaf2ca64db40991fb21f22604ff03aad29bc2015f21f651.json
+++ b/openfisca_france/tests/json/nacc_impn-dd3ae7bc31abef06adaf2ca64db40991fb21f22604ff03aad29bc2015f21f651.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_impn-e74b03ef079a5ee4573ac61586b8df65e6bafa72ad76d4597c46888375820254.json
+++ b/openfisca_france/tests/json/nacc_impn-e74b03ef079a5ee4573ac61586b8df65e6bafa72ad76d4597c46888375820254.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_meup-2007-902c80ee3193ebf67912bac7cb0b24314269ace497091ed34ba8429db91d26f0.json
+++ b/openfisca_france/tests/json/nacc_meup-2007-902c80ee3193ebf67912bac7cb0b24314269ace497091ed34ba8429db91d26f0.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_meup": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_meup-2008-4a1eb2cf1eb986f562ad4937c8f870e39d945d7f8b55af7240f5f04891357608.json
+++ b/openfisca_france/tests/json/nacc_meup-2008-4a1eb2cf1eb986f562ad4937c8f870e39d945d7f8b55af7240f5f04891357608.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_meup": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_meup-2009-1eebc325fb487969e8d23c8e85240db3770ee507ad658e5f3a8fe51164a8c680.json
+++ b/openfisca_france/tests/json/nacc_meup-2009-1eebc325fb487969e8d23c8e85240db3770ee507ad658e5f3a8fe51164a8c680.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_meup": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_meup-2010-e2d37e694a8d422a06cebb8e8fcca789e154f2240493ad6e0445cbe3dad97b93.json
+++ b/openfisca_france/tests/json/nacc_meup-2010-e2d37e694a8d422a06cebb8e8fcca789e154f2240493ad6e0445cbe3dad97b93.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_meup": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_meup-2011-875ddd31c69419c2e989f1d1cbeb7c2f45abddb93bcbcbbbfd72adc691bf69a8.json
+++ b/openfisca_france/tests/json/nacc_meup-2011-875ddd31c69419c2e989f1d1cbeb7c2f45abddb93bcbcbbbfd72adc691bf69a8.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_meup": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_meup-2012-48754710226c464e769bb4b9cc53690f935675f8374ed8f268834afdec8f44d8.json
+++ b/openfisca_france/tests/json/nacc_meup-2012-48754710226c464e769bb4b9cc53690f935675f8374ed8f268834afdec8f44d8.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nacc_meup": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_meup-2013-66ae105b583146fc1f0f65ce849bb42e99b48761be7387199de42f1a8f9e93e2.json
+++ b/openfisca_france/tests/json/nacc_meup-2013-66ae105b583146fc1f0f65ce849bb42e99b48761be7387199de42f1a8f9e93e2.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nacc_meup": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_pvce-1ed0362907d77675abb7dc7d75d086405e233a882dc9a124ae5ddd7894ea665a.json
+++ b/openfisca_france/tests/json/nacc_pvce-1ed0362907d77675abb7dc7d75d086405e233a882dc9a124ae5ddd7894ea665a.json
@@ -123,7 +123,7 @@
           "date_naissance": "1970-01-01",
           "nacc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_pvce-7f49d14041f4a4f666f9cad47734c83dbb59930624e464ffb5cc28abc0821c56.json
+++ b/openfisca_france/tests/json/nacc_pvce-7f49d14041f4a4f666f9cad47734c83dbb59930624e464ffb5cc28abc0821c56.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_pvce-923c05b8d3a63a0dd5d003c894a5b428e83b0f8fd2c50f856746fbefe1a1352f.json
+++ b/openfisca_france/tests/json/nacc_pvce-923c05b8d3a63a0dd5d003c894a5b428e83b0f8fd2c50f856746fbefe1a1352f.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_pvce-a97a42f25e222cf84b227f3d34c20b0814b48a8962693f4015bcd9bfd828e985.json
+++ b/openfisca_france/tests/json/nacc_pvce-a97a42f25e222cf84b227f3d34c20b0814b48a8962693f4015bcd9bfd828e985.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_pvce-e5d0bce42b7d58ee6a6384f1fbc5577c8bfbc10248b030d48e24617df6ea6fbf.json
+++ b/openfisca_france/tests/json/nacc_pvce-e5d0bce42b7d58ee6a6384f1fbc5577c8bfbc10248b030d48e24617df6ea6fbf.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nacc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_pvce-e66d2681cb76ad20f7b1ee40c75a819356580f1309b0f71d2e10c9e6df30659f.json
+++ b/openfisca_france/tests/json/nacc_pvce-e66d2681cb76ad20f7b1ee40c75a819356580f1309b0f71d2e10c9e6df30659f.json
@@ -118,7 +118,7 @@
           "date_naissance": "1970-01-01",
           "nacc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nacc_pvce-efaf91c469491dc730d52fed59700d8d7445fea647e3cc3a6e1f322e1c580792.json
+++ b/openfisca_france/tests/json/nacc_pvce-efaf91c469491dc730d52fed59700d8d7445fea647e3cc3a6e1f322e1c580792.json
@@ -113,7 +113,7 @@
           "date_naissance": "1970-01-01",
           "nacc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_apch-01beaed1e4c055a0a2dc45d23bd953a97156f4bf8221b8c20328845d759ba370.json
+++ b/openfisca_france/tests/json/nbic_apch-01beaed1e4c055a0a2dc45d23bd953a97156f4bf8221b8c20328845d759ba370.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_apch": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_apch-1469f2b2d9f50a03098772821e22d93d2e644496f0d10bbf9c503f44d87ec514.json
+++ b/openfisca_france/tests/json/nbic_apch-1469f2b2d9f50a03098772821e22d93d2e644496f0d10bbf9c503f44d87ec514.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_apch": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_apch-542dee220ef991ac6fa28828cbe5c5002806a7ec951eed1ddc6d899a05384d13.json
+++ b/openfisca_france/tests/json/nbic_apch-542dee220ef991ac6fa28828cbe5c5002806a7ec951eed1ddc6d899a05384d13.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nbic_apch": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_apch-8986f935c06ae71e7115bfc05bd5ebbb1055f6923853587de618e2ffdf7fed6f.json
+++ b/openfisca_france/tests/json/nbic_apch-8986f935c06ae71e7115bfc05bd5ebbb1055f6923853587de618e2ffdf7fed6f.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nbic_apch": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_apch-8a173a9c5bcbc602ede4eaffb78d1f36335822fda06312fc7bd2ac712783e5d3.json
+++ b/openfisca_france/tests/json/nbic_apch-8a173a9c5bcbc602ede4eaffb78d1f36335822fda06312fc7bd2ac712783e5d3.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_apch": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_apch-cbf3e213571c75fa63dcae9bdffe189691e7c3e51b6eddab14dd57d04c5274ad.json
+++ b/openfisca_france/tests/json/nbic_apch-cbf3e213571c75fa63dcae9bdffe189691e7c3e51b6eddab14dd57d04c5274ad.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_apch": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_apch-f62069f4f515916e54a7e68823c4610d1b39f009213e9f0f4d2a66b218323a88.json
+++ b/openfisca_france/tests/json/nbic_apch-f62069f4f515916e54a7e68823c4610d1b39f009213e9f0f4d2a66b218323a88.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_apch": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_apch-f62f3e91cd5996e03dcb7236de87c1c2135734d8f18a4bd0df39419a3346974a.json
+++ b/openfisca_france/tests/json/nbic_apch-f62f3e91cd5996e03dcb7236de87c1c2135734d8f18a4bd0df39419a3346974a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_apch": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_apch-fd43369e414590594aeb80fc55f659e358396f75e32ebe1e2d9b7ca012cd8ec8.json
+++ b/openfisca_france/tests/json/nbic_apch-fd43369e414590594aeb80fc55f659e358396f75e32ebe1e2d9b7ca012cd8ec8.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_apch": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defn-1d40807822de1b52d712df98c5671b0171e5cba094d4d60f066168e26a2cbbe6.json
+++ b/openfisca_france/tests/json/nbic_defn-1d40807822de1b52d712df98c5671b0171e5cba094d4d60f066168e26a2cbbe6.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defn-4f4724d36fb9d4e8faaa51d9080d371026d159e7c699f3cd82009c4e296da934.json
+++ b/openfisca_france/tests/json/nbic_defn-4f4724d36fb9d4e8faaa51d9080d371026d159e7c699f3cd82009c4e296da934.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defn-5f99ec928fc0013bcd19d0a08bcbf32952fb3abf72d6ccfd3fbd2dc9a20ebca1.json
+++ b/openfisca_france/tests/json/nbic_defn-5f99ec928fc0013bcd19d0a08bcbf32952fb3abf72d6ccfd3fbd2dc9a20ebca1.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defn-673c35a6bcb57c94baea1bcc50ea0c2df4134c8ce102c9ed6fdc6feca3155b80.json
+++ b/openfisca_france/tests/json/nbic_defn-673c35a6bcb57c94baea1bcc50ea0c2df4134c8ce102c9ed6fdc6feca3155b80.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defn-734cfabe117e97f1a47650157ac23b60ccbebda2f0e8642645317c7e4cddce65.json
+++ b/openfisca_france/tests/json/nbic_defn-734cfabe117e97f1a47650157ac23b60ccbebda2f0e8642645317c7e4cddce65.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defn-73c520276d7e5103df108e21cbbdc5012d6fe605ced0701e391284b4790a0a76.json
+++ b/openfisca_france/tests/json/nbic_defn-73c520276d7e5103df108e21cbbdc5012d6fe605ced0701e391284b4790a0a76.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defn-c671f89eeb8ea51e57f9bb92efc9ff6fc18c848b9d6c48eb0fbd723916b31237.json
+++ b/openfisca_france/tests/json/nbic_defn-c671f89eeb8ea51e57f9bb92efc9ff6fc18c848b9d6c48eb0fbd723916b31237.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defn-c6ea20130a77bc393822e4c21d9862daeefbf93970f8191bf529d2fbb099c543.json
+++ b/openfisca_france/tests/json/nbic_defn-c6ea20130a77bc393822e4c21d9862daeefbf93970f8191bf529d2fbb099c543.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defn-d315f3d9b6b0cef5a33eb2975c780ee68cf33a147b5d35e7aa0bec1cb350d5c8.json
+++ b/openfisca_france/tests/json/nbic_defn-d315f3d9b6b0cef5a33eb2975c780ee68cf33a147b5d35e7aa0bec1cb350d5c8.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defs-0b6be58c61c3aa4508badaa60d422d3aa6cfb92c69f1772d9837f476b5b95a95.json
+++ b/openfisca_france/tests/json/nbic_defs-0b6be58c61c3aa4508badaa60d422d3aa6cfb92c69f1772d9837f476b5b95a95.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defs-1170fa8ec09c2b831374587e34fe1ddeee9f9d924df42c815b20ef76a12cd285.json
+++ b/openfisca_france/tests/json/nbic_defs-1170fa8ec09c2b831374587e34fe1ddeee9f9d924df42c815b20ef76a12cd285.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defs-3ada20cc7a592f88b62aaeff9ba1afaac942a307554ea380c5fd40cbcf932ef1.json
+++ b/openfisca_france/tests/json/nbic_defs-3ada20cc7a592f88b62aaeff9ba1afaac942a307554ea380c5fd40cbcf932ef1.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defs-8a64e6dd86d3ce28b8809f398506ea462106d0e7b281f36f844e5b1c5c99765e.json
+++ b/openfisca_france/tests/json/nbic_defs-8a64e6dd86d3ce28b8809f398506ea462106d0e7b281f36f844e5b1c5c99765e.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defs-b47e9282f8c0bace5d9c125c2319f7a09d9548cbaf866a3c81add305bb19fe24.json
+++ b/openfisca_france/tests/json/nbic_defs-b47e9282f8c0bace5d9c125c2319f7a09d9548cbaf866a3c81add305bb19fe24.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defs-b61c6230ca482f85396061ac4a5aa2c37a406afb97aa477595319c74beb1289c.json
+++ b/openfisca_france/tests/json/nbic_defs-b61c6230ca482f85396061ac4a5aa2c37a406afb97aa477595319c74beb1289c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defs-c273ac0880fafa48eff9b0b693d7fb700f240512f8c645dfe578fca89506c58b.json
+++ b/openfisca_france/tests/json/nbic_defs-c273ac0880fafa48eff9b0b693d7fb700f240512f8c645dfe578fca89506c58b.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defs-dea839ab74242478fece8551f57d7936c2d515e14ae8b28f9077dbfca6f68bff.json
+++ b/openfisca_france/tests/json/nbic_defs-dea839ab74242478fece8551f57d7936c2d515e14ae8b28f9077dbfca6f68bff.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_defs-fc1ab1b0e47dd5a98ae055c4344a7d92620d2e644c636b7601e43208e5b6589f.json
+++ b/openfisca_france/tests/json/nbic_defs-fc1ab1b0e47dd5a98ae055c4344a7d92620d2e644c636b7601e43208e5b6589f.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_defs": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_exon-074b93d6b0a898036021d6f567aaf976a95f78f35dc47f38a3e1ddce389d257a.json
+++ b/openfisca_france/tests/json/nbic_exon-074b93d6b0a898036021d6f567aaf976a95f78f35dc47f38a3e1ddce389d257a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_exon-3fd07aa918cc8b2a7e58bed3d0332de4e69c7c84dc3ed2d8b51e73dba6189763.json
+++ b/openfisca_france/tests/json/nbic_exon-3fd07aa918cc8b2a7e58bed3d0332de4e69c7c84dc3ed2d8b51e73dba6189763.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_exon-45b883bda09542562744f1f50fc7a2d46cebd949d85ec908c0f08c67f951e8f4.json
+++ b/openfisca_france/tests/json/nbic_exon-45b883bda09542562744f1f50fc7a2d46cebd949d85ec908c0f08c67f951e8f4.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_exon-6e7d27a5c331c112b52679dee857dafe4a3406c601b001c610436548eaef1477.json
+++ b/openfisca_france/tests/json/nbic_exon-6e7d27a5c331c112b52679dee857dafe4a3406c601b001c610436548eaef1477.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_exon-97df1be46db5cb4b68419984a3ce3d29e2fe9fa52dc35d90ef09ba5cfdf24103.json
+++ b/openfisca_france/tests/json/nbic_exon-97df1be46db5cb4b68419984a3ce3d29e2fe9fa52dc35d90ef09ba5cfdf24103.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_exon-a750a2efe154751b310a493221957c8561bc8cb4930d86c789f1c5a55d8dcb93.json
+++ b/openfisca_france/tests/json/nbic_exon-a750a2efe154751b310a493221957c8561bc8cb4930d86c789f1c5a55d8dcb93.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_exon-d3172826c5f9b8e9011f9598e68c828f051668f7af876fde4638da2f97362a86.json
+++ b/openfisca_france/tests/json/nbic_exon-d3172826c5f9b8e9011f9598e68c828f051668f7af876fde4638da2f97362a86.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_exon-dba018b2413cdf2cf04e20a28c7016955d0d3fcaaea19757af4fb106f9a53157.json
+++ b/openfisca_france/tests/json/nbic_exon-dba018b2413cdf2cf04e20a28c7016955d0d3fcaaea19757af4fb106f9a53157.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_exon-e62d09d36807605b805a2564e1d1a3fa79bfa2e60690c2e7308e97223c67c72a.json
+++ b/openfisca_france/tests/json/nbic_exon-e62d09d36807605b805a2564e1d1a3fa79bfa2e60690c2e7308e97223c67c72a.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nbic_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_impn-2ae5086a3678682521aea983ec25b392b9553f6f377e278d2a245a6bf619795a.json
+++ b/openfisca_france/tests/json/nbic_impn-2ae5086a3678682521aea983ec25b392b9553f6f377e278d2a245a6bf619795a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_impn-4507ff3a9cd11bff9be5872128869ed3839da4e8171381363b743f2344074b1f.json
+++ b/openfisca_france/tests/json/nbic_impn-4507ff3a9cd11bff9be5872128869ed3839da4e8171381363b743f2344074b1f.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_impn-59567fc856a5f18c94cdf6aff3678112871325e7cebcdf5b1811b425d1605878.json
+++ b/openfisca_france/tests/json/nbic_impn-59567fc856a5f18c94cdf6aff3678112871325e7cebcdf5b1811b425d1605878.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_impn-6d735346467971b94712a48264a73727d17eff086886e28f761a0b4c87dc0583.json
+++ b/openfisca_france/tests/json/nbic_impn-6d735346467971b94712a48264a73727d17eff086886e28f761a0b4c87dc0583.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_impn-78d23d1d2ab525535060dc5fa16922745fa735e109ca0136bd7129afa6657b42.json
+++ b/openfisca_france/tests/json/nbic_impn-78d23d1d2ab525535060dc5fa16922745fa735e109ca0136bd7129afa6657b42.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_impn-842af20bffca1ddbd72c209b15bd07c1bfec048cd7aa190d4b9f61026262074b.json
+++ b/openfisca_france/tests/json/nbic_impn-842af20bffca1ddbd72c209b15bd07c1bfec048cd7aa190d4b9f61026262074b.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nbic_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_impn-86913d22ed56aad31faf87a9d1c91e96efce38c37cf8f591a878d69721e593c3.json
+++ b/openfisca_france/tests/json/nbic_impn-86913d22ed56aad31faf87a9d1c91e96efce38c37cf8f591a878d69721e593c3.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nbic_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_impn-b507b8e96e80c8e6889c50da5458c6ae15fbfb0ca2a90f313b21152ae8b034d6.json
+++ b/openfisca_france/tests/json/nbic_impn-b507b8e96e80c8e6889c50da5458c6ae15fbfb0ca2a90f313b21152ae8b034d6.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_impn-c7bd416ac1e8a0eb094863166d3e0d69dc33f03ed886380db1acf90bad9fe4fc.json
+++ b/openfisca_france/tests/json/nbic_impn-c7bd416ac1e8a0eb094863166d3e0d69dc33f03ed886380db1acf90bad9fe4fc.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_impn": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_imps-0b1f2c305565c137ec7bd9be5e11c4aec2fa6d3bb88bb96d1179b6311d55c5fd.json
+++ b/openfisca_france/tests/json/nbic_imps-0b1f2c305565c137ec7bd9be5e11c4aec2fa6d3bb88bb96d1179b6311d55c5fd.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nbic_imps": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_imps-1f51b9c5be3ba4b5aa261c29f565c2d667dc0f068f73d4eeac06dd9cbc84c033.json
+++ b/openfisca_france/tests/json/nbic_imps-1f51b9c5be3ba4b5aa261c29f565c2d667dc0f068f73d4eeac06dd9cbc84c033.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_imps": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_imps-295b7ab1dd351dc5321a2ebe83562af6b924c6fc994bcf2a3d73385c6e3ad976.json
+++ b/openfisca_france/tests/json/nbic_imps-295b7ab1dd351dc5321a2ebe83562af6b924c6fc994bcf2a3d73385c6e3ad976.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_imps-2da358c030a0d312248f47d183b069d53e70ace53654b42274a20712b4d59de2.json
+++ b/openfisca_france/tests/json/nbic_imps-2da358c030a0d312248f47d183b069d53e70ace53654b42274a20712b4d59de2.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_imps-4249251af23959314c76fdf97e4939d77941b1e74d7eef1bf0fd76ebef1f498d.json
+++ b/openfisca_france/tests/json/nbic_imps-4249251af23959314c76fdf97e4939d77941b1e74d7eef1bf0fd76ebef1f498d.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nbic_imps": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_imps-4ada2d15715daf74a818858fa11ebc39f8412af9fb4616dae1d47f47dee8d67e.json
+++ b/openfisca_france/tests/json/nbic_imps-4ada2d15715daf74a818858fa11ebc39f8412af9fb4616dae1d47f47dee8d67e.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_imps-704d3af867191d0f352c5c3b32d50acf601a7872b2459edb9e9cae5e143b6a96.json
+++ b/openfisca_france/tests/json/nbic_imps-704d3af867191d0f352c5c3b32d50acf601a7872b2459edb9e9cae5e143b6a96.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_imps": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_imps-b22a16f44a25101cdc3283997b54e933da0237f04d793512619efa81f5ba03d0.json
+++ b/openfisca_france/tests/json/nbic_imps-b22a16f44a25101cdc3283997b54e933da0237f04d793512619efa81f5ba03d0.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_imps-bdd7ea0f0e4aea2cf5f9cc18d7a255a3b9c862f2d6c8470b51d9a9010cef2276.json
+++ b/openfisca_france/tests/json/nbic_imps-bdd7ea0f0e4aea2cf5f9cc18d7a255a3b9c862f2d6c8470b51d9a9010cef2276.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_imps": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_imps-d53c20e530ba05cf88a11f3e98e9b53a50246d48e3cd1cc61a7bac7b6b8b95d7.json
+++ b/openfisca_france/tests/json/nbic_imps-d53c20e530ba05cf88a11f3e98e9b53a50246d48e3cd1cc61a7bac7b6b8b95d7.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_imps": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_imps-e58d7920aae9488c49fa7c520402becfba8fab99ef55968f80bb23022d313db8.json
+++ b/openfisca_france/tests/json/nbic_imps-e58d7920aae9488c49fa7c520402becfba8fab99ef55968f80bb23022d313db8.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_imps": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_mvct-4df34227d377a70ff859fe15eaab6d61d22d99a74a63e1df9bf95a8e5f5f9f71.json
+++ b/openfisca_france/tests/json/nbic_mvct-4df34227d377a70ff859fe15eaab6d61d22d99a74a63e1df9bf95a8e5f5f9f71.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_mvct": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_mvct-5552f4a0aba78c563060f5f2c5743e86ce0f17db15b88180a339343d963f7be8.json
+++ b/openfisca_france/tests/json/nbic_mvct-5552f4a0aba78c563060f5f2c5743e86ce0f17db15b88180a339343d963f7be8.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_mvct": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_mvct-669af7ea9a3b9fa69b4095697b3f623d20d157bd83e52e69f339d43979f64c63.json
+++ b/openfisca_france/tests/json/nbic_mvct-669af7ea9a3b9fa69b4095697b3f623d20d157bd83e52e69f339d43979f64c63.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_mvct": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_mvct-9fedce681a7d8e9bb1eee32c75e1fd273194933bd1e189bf4908321527d60eec.json
+++ b/openfisca_france/tests/json/nbic_mvct-9fedce681a7d8e9bb1eee32c75e1fd273194933bd1e189bf4908321527d60eec.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_mvct": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_mvct-cc9756a80a08a1cf6885aff60fcd9a5a2dc8e90983d8898373e181151c8e733c.json
+++ b/openfisca_france/tests/json/nbic_mvct-cc9756a80a08a1cf6885aff60fcd9a5a2dc8e90983d8898373e181151c8e733c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_mvct": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_mvct-e4ca88aa35541664029ff8e21da34053743be094d8704ffc63c07affd8bae210.json
+++ b/openfisca_france/tests/json/nbic_mvct-e4ca88aa35541664029ff8e21da34053743be094d8704ffc63c07affd8bae210.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nbic_mvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_mvct-ec1d7f8cc65fb1d759b0691b79ce1523b4296efe8664cd78d8123ca926d38883.json
+++ b/openfisca_france/tests/json/nbic_mvct-ec1d7f8cc65fb1d759b0691b79ce1523b4296efe8664cd78d8123ca926d38883.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nbic_mvct": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_pvce-2007-4feaee010a6c4d08448b20e30a76c408aac660aa40f413ea6b5376656c298912.json
+++ b/openfisca_france/tests/json/nbic_pvce-2007-4feaee010a6c4d08448b20e30a76c408aac660aa40f413ea6b5376656c298912.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_pvce-2008-f3a8d5c37f1f947888387bb956e89f017b5b77ba7c07c0d93aef571941ce2d76.json
+++ b/openfisca_france/tests/json/nbic_pvce-2008-f3a8d5c37f1f947888387bb956e89f017b5b77ba7c07c0d93aef571941ce2d76.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_pvce-2009-09ace9ab091011172352c3903ef4363d49149c53bd412b7d03149b93042c6f79.json
+++ b/openfisca_france/tests/json/nbic_pvce-2009-09ace9ab091011172352c3903ef4363d49149c53bd412b7d03149b93042c6f79.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_pvce-2010-287e9e10de286e3d7cc4636268d7f99a610e6def4e3d314bcfd5da0973eb0551.json
+++ b/openfisca_france/tests/json/nbic_pvce-2010-287e9e10de286e3d7cc4636268d7f99a610e6def4e3d314bcfd5da0973eb0551.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_pvce-2011-33372298b0e0a847a5271b3893269de4fe1fd3fd060c0063d60176f3313de690.json
+++ b/openfisca_france/tests/json/nbic_pvce-2011-33372298b0e0a847a5271b3893269de4fe1fd3fd060c0063d60176f3313de690.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_pvce-2012-560bf73d21b5de0cce67d0d92a25ed2ba9e625ae09adece821c2d766462adf1b.json
+++ b/openfisca_france/tests/json/nbic_pvce-2012-560bf73d21b5de0cce67d0d92a25ed2ba9e625ae09adece821c2d766462adf1b.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbic_pvce-2013-5cb58170ccc437b246bc0ce6e871a08d4155bcd60d3ac2ea8050efc826d02a1f.json
+++ b/openfisca_france/tests/json/nbic_pvce-2013-5cb58170ccc437b246bc0ce6e871a08d4155bcd60d3ac2ea8050efc826d02a1f.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nbic_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_defi-3551c79b118052a62f6ee8ea84f94f9cb7662174e09634b98772c746e19e03aa.json
+++ b/openfisca_france/tests/json/nbnc_defi-3551c79b118052a62f6ee8ea84f94f9cb7662174e09634b98772c746e19e03aa.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_defi-3576ff5034ca48408b9c1d5b8a81b3ad60d986348b52243ed1927ae5a5a47fd0.json
+++ b/openfisca_france/tests/json/nbnc_defi-3576ff5034ca48408b9c1d5b8a81b3ad60d986348b52243ed1927ae5a5a47fd0.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_defi-4304dc9cb5b4feaa6898f1feabd2f27d18075982e1d83e8cdf551e058b2badbd.json
+++ b/openfisca_france/tests/json/nbnc_defi-4304dc9cb5b4feaa6898f1feabd2f27d18075982e1d83e8cdf551e058b2badbd.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_defi-53016747b9192a606dbfc29175863048507977a2800d71e3107549094b96fbc1.json
+++ b/openfisca_france/tests/json/nbnc_defi-53016747b9192a606dbfc29175863048507977a2800d71e3107549094b96fbc1.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_defi-5790eafb944232e59e2b05c33e538cb5f45b2acb5f1c5cc27241f53c7ad62903.json
+++ b/openfisca_france/tests/json/nbnc_defi-5790eafb944232e59e2b05c33e538cb5f45b2acb5f1c5cc27241f53c7ad62903.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_defi-7c92571977193434cdd359faf54ba0d274cea39d6978f3ad519a1fb21c3b4d99.json
+++ b/openfisca_france/tests/json/nbnc_defi-7c92571977193434cdd359faf54ba0d274cea39d6978f3ad519a1fb21c3b4d99.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_defi-88107452d67640b4730553209990919164d776d18a598b21d57ab2997f938314.json
+++ b/openfisca_france/tests/json/nbnc_defi-88107452d67640b4730553209990919164d776d18a598b21d57ab2997f938314.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_defi-c5bfe5ecf6f8ed3572c23f1d1b11a5d052059dc5344a077ac31f725c703eae79.json
+++ b/openfisca_france/tests/json/nbnc_defi-c5bfe5ecf6f8ed3572c23f1d1b11a5d052059dc5344a077ac31f725c703eae79.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_defi-ff47d6a2c1984dae0257de109820edbed7c4a1f011b74ce6b125561ef696bd68.json
+++ b/openfisca_france/tests/json/nbnc_defi-ff47d6a2c1984dae0257de109820edbed7c4a1f011b74ce6b125561ef696bd68.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_exon-048888245f7464fa2cc97d8a806d3e3d23a59c710d2bdeed63e67112f11bdab7.json
+++ b/openfisca_france/tests/json/nbnc_exon-048888245f7464fa2cc97d8a806d3e3d23a59c710d2bdeed63e67112f11bdab7.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_exon-193bf13c87177d4d37e19e4e1f80a3094dd29039abfb39ad0f4fe4abfb17bf30.json
+++ b/openfisca_france/tests/json/nbnc_exon-193bf13c87177d4d37e19e4e1f80a3094dd29039abfb39ad0f4fe4abfb17bf30.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_exon-4998d64c64a51dfd31a1030d516c313a5e7beb3457ac8364becaaf2f5d5778ec.json
+++ b/openfisca_france/tests/json/nbnc_exon-4998d64c64a51dfd31a1030d516c313a5e7beb3457ac8364becaaf2f5d5778ec.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_exon-728702b7f9da375446526e5b6b15c2e3e77b63429565502d5e1ed406040abc64.json
+++ b/openfisca_france/tests/json/nbnc_exon-728702b7f9da375446526e5b6b15c2e3e77b63429565502d5e1ed406040abc64.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_exon-bb0b65d57e4e5f65f54cbc6b424a2cdfc85999e271d096816128ea0f34764380.json
+++ b/openfisca_france/tests/json/nbnc_exon-bb0b65d57e4e5f65f54cbc6b424a2cdfc85999e271d096816128ea0f34764380.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_exon-c39f97ebb4068addbe7e936830379bfbe877a4387fc179cae9561d7082dbd202.json
+++ b/openfisca_france/tests/json/nbnc_exon-c39f97ebb4068addbe7e936830379bfbe877a4387fc179cae9561d7082dbd202.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_exon-df7ac42799df9f801cfdc53f58800a1a9754e3c29bf738701d84b971190e7658.json
+++ b/openfisca_france/tests/json/nbnc_exon-df7ac42799df9f801cfdc53f58800a1a9754e3c29bf738701d84b971190e7658.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_exon-f0d06b88926fe88c5ffe993a05995b7ecf226cfb61102023cc2555da6f9544fd.json
+++ b/openfisca_france/tests/json/nbnc_exon-f0d06b88926fe88c5ffe993a05995b7ecf226cfb61102023cc2555da6f9544fd.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_exon-f29eb0c28f029fa8ad192617f6ab94ad5b8dd12984c427a9199f8b2437272421.json
+++ b/openfisca_france/tests/json/nbnc_exon-f29eb0c28f029fa8ad192617f6ab94ad5b8dd12984c427a9199f8b2437272421.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_impo-07e4d4f8d090fd4b219f7d3b553e3bb376078414bccd388f5eb3cb4eb34ad857.json
+++ b/openfisca_france/tests/json/nbnc_impo-07e4d4f8d090fd4b219f7d3b553e3bb376078414bccd388f5eb3cb4eb34ad857.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_impo-388d15d7787e4560f96a75f6cbb4bc223eb32fc8da206d81e661989186bf39fd.json
+++ b/openfisca_france/tests/json/nbnc_impo-388d15d7787e4560f96a75f6cbb4bc223eb32fc8da206d81e661989186bf39fd.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_impo-46f600e038ca24db81c8bff7d05731a09e8356c91d84a493cd346fbe2f7a1d2b.json
+++ b/openfisca_france/tests/json/nbnc_impo-46f600e038ca24db81c8bff7d05731a09e8356c91d84a493cd346fbe2f7a1d2b.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_impo-4eaf4805e3314d494e9a0df0ec52b5f9c6538614fb143c68d4b930fe4b367e25.json
+++ b/openfisca_france/tests/json/nbnc_impo-4eaf4805e3314d494e9a0df0ec52b5f9c6538614fb143c68d4b930fe4b367e25.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_impo-778219e596e9646f8e5c99030be7c16dc3fcc2ec54007851346d43c873d1eb3d.json
+++ b/openfisca_france/tests/json/nbnc_impo-778219e596e9646f8e5c99030be7c16dc3fcc2ec54007851346d43c873d1eb3d.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_impo-881db0dffdc31866f834f4edf0d5b761c5bad41cda68b570df0c52dff627e8fb.json
+++ b/openfisca_france/tests/json/nbnc_impo-881db0dffdc31866f834f4edf0d5b761c5bad41cda68b570df0c52dff627e8fb.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_impo-a49ab583c19546847ccdf73ee5e180a38c810b87fd476ad5038563e435e55a87.json
+++ b/openfisca_france/tests/json/nbnc_impo-a49ab583c19546847ccdf73ee5e180a38c810b87fd476ad5038563e435e55a87.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_impo-e02e222696bcb21a17f9e4f2a347f34a9577630c182854332ec7feb41fc5af50.json
+++ b/openfisca_france/tests/json/nbnc_impo-e02e222696bcb21a17f9e4f2a347f34a9577630c182854332ec7feb41fc5af50.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_impo-f8f2a83258623103b71152113a84b70e1b7e4d9b2cc7f3d60e16de17315585bb.json
+++ b/openfisca_france/tests/json/nbnc_impo-f8f2a83258623103b71152113a84b70e1b7e4d9b2cc7f3d60e16de17315585bb.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_impo": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_pvce-094b06c55723cd066ba566e4021bbb5201c636f99056ae6737b417b1b0e1785f.json
+++ b/openfisca_france/tests/json/nbnc_pvce-094b06c55723cd066ba566e4021bbb5201c636f99056ae6737b417b1b0e1785f.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_pvce-0963e61a13348215d31097298190d50e426aa8573a3a7e5527b43cdff2f21c8a.json
+++ b/openfisca_france/tests/json/nbnc_pvce-0963e61a13348215d31097298190d50e426aa8573a3a7e5527b43cdff2f21c8a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_pvce-2010-b3fa1a14852ed4718d4885231917e6ebf46b3dbcd54b501291826448c4b55575.json
+++ b/openfisca_france/tests/json/nbnc_pvce-2010-b3fa1a14852ed4718d4885231917e6ebf46b3dbcd54b501291826448c4b55575.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_pvce-2012-10d07bf601a0e35775a740908666b915e1238842d82d6d86fb10818220d3a02c.json
+++ b/openfisca_france/tests/json/nbnc_pvce-2012-10d07bf601a0e35775a740908666b915e1238842d82d6d86fb10818220d3a02c.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_pvce-2013-1bdeef6d98a16f103d31e511ef1c46fa0482f9a1b84d5bf63b668a80ccb4f230.json
+++ b/openfisca_france/tests/json/nbnc_pvce-2013-1bdeef6d98a16f103d31e511ef1c46fa0482f9a1b84d5bf63b668a80ccb4f230.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_pvce": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_pvce-3b1362e96e7d7d40d1aa66848fd0fb5f9e5669f912d21f645fbbe0dba1da698d.json
+++ b/openfisca_france/tests/json/nbnc_pvce-3b1362e96e7d7d40d1aa66848fd0fb5f9e5669f912d21f645fbbe0dba1da698d.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nbnc_pvce-a7ed5de90d371bd85201f438892fbb67092d7dfb764868251c1b7983e85daeb1.json
+++ b/openfisca_france/tests/json/nbnc_pvce-a7ed5de90d371bd85201f438892fbb67092d7dfb764868251c1b7983e85daeb1.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nbnc_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_ajag-0d8281fa04f99044b6948317a4bbe26edb8c6855230ea65d8c67fd1f35dff09c.json
+++ b/openfisca_france/tests/json/nrag_ajag-0d8281fa04f99044b6948317a4bbe26edb8c6855230ea65d8c67fd1f35dff09c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_ajag": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_ajag-1ad6305d9d599bbf15ae4f17f81b6c8834cddd695ab81fb644d5ac43f4f5cbf4.json
+++ b/openfisca_france/tests/json/nrag_ajag-1ad6305d9d599bbf15ae4f17f81b6c8834cddd695ab81fb644d5ac43f4f5cbf4.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nrag_ajag": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_ajag-39a9de0ee9d6640c210c5a2b31dbdab1c184522996bcc644e98eaf223728a609.json
+++ b/openfisca_france/tests/json/nrag_ajag-39a9de0ee9d6640c210c5a2b31dbdab1c184522996bcc644e98eaf223728a609.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_ajag": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_ajag-432e94657e4c7fef210bcbb543f05cb3ad8e426910740304e7920fe1f0355064.json
+++ b/openfisca_france/tests/json/nrag_ajag-432e94657e4c7fef210bcbb543f05cb3ad8e426910740304e7920fe1f0355064.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_ajag": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_ajag-56cc914677d1eae065af3edc1ed31d4567e50a565fdd36d7806b6b806aa449d5.json
+++ b/openfisca_france/tests/json/nrag_ajag-56cc914677d1eae065af3edc1ed31d4567e50a565fdd36d7806b6b806aa449d5.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nrag_ajag": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_ajag-c0ab945b345c58427d3bb4aabb80966034323cf0b9415db1a22068edcc4130c5.json
+++ b/openfisca_france/tests/json/nrag_ajag-c0ab945b345c58427d3bb4aabb80966034323cf0b9415db1a22068edcc4130c5.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_ajag": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_ajag-d8f5ffc48002c3ce072c3e45a401ab5bd848d50d92e719c4718202f5785e8cfb.json
+++ b/openfisca_france/tests/json/nrag_ajag-d8f5ffc48002c3ce072c3e45a401ab5bd848d50d92e719c4718202f5785e8cfb.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_ajag": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_ajag-f648b936bb134dea45e2b94a14f32c03a7854df2be674f4f32339e9eb94e881e.json
+++ b/openfisca_france/tests/json/nrag_ajag-f648b936bb134dea45e2b94a14f32c03a7854df2be674f4f32339e9eb94e881e.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_ajag": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_ajag-fe0f1a9a9705a809573c67030eacefa3be4bf9e9562c03e24f54ae0eae00bb5f.json
+++ b/openfisca_france/tests/json/nrag_ajag-fe0f1a9a9705a809573c67030eacefa3be4bf9e9562c03e24f54ae0eae00bb5f.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_ajag": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_defi-4b01c792fb439b47308ba345b3e53ca20016e2e8dd08680504678ed93226fd37.json
+++ b/openfisca_france/tests/json/nrag_defi-4b01c792fb439b47308ba345b3e53ca20016e2e8dd08680504678ed93226fd37.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_defi-6ba2cabef9f6a42991bcb1be4ee2e24222bf85cf8ea9a23a6e61d34cea3e3dfe.json
+++ b/openfisca_france/tests/json/nrag_defi-6ba2cabef9f6a42991bcb1be4ee2e24222bf85cf8ea9a23a6e61d34cea3e3dfe.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_defi-74f8988dc5b9b9b09bc25c3a75738def2958539d0784f10e081a330190915981.json
+++ b/openfisca_france/tests/json/nrag_defi-74f8988dc5b9b9b09bc25c3a75738def2958539d0784f10e081a330190915981.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_defi-9d8c1ba6ac1898b1760c9ca510cac9d877ebe78d71382b64a5ddab28929326f1.json
+++ b/openfisca_france/tests/json/nrag_defi-9d8c1ba6ac1898b1760c9ca510cac9d877ebe78d71382b64a5ddab28929326f1.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_defi-bd92464d0f863db368256a57848dca6cc794fa1a0822c1551b658c679d636be6.json
+++ b/openfisca_france/tests/json/nrag_defi-bd92464d0f863db368256a57848dca6cc794fa1a0822c1551b658c679d636be6.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nrag_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_defi-c2d6c0e93f65890b31c071cacfafcd8aa6f813aee2fb13603a7a863bd2ef094c.json
+++ b/openfisca_france/tests/json/nrag_defi-c2d6c0e93f65890b31c071cacfafcd8aa6f813aee2fb13603a7a863bd2ef094c.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nrag_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_defi-c7613c984261afcf6a1acc15f7e4eedd13d59ebb45eb955d968eed951cb1db8a.json
+++ b/openfisca_france/tests/json/nrag_defi-c7613c984261afcf6a1acc15f7e4eedd13d59ebb45eb955d968eed951cb1db8a.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_defi-d2d9d2a4f92268e57477ec069c7594078edf7d61c40da0040bcb2d5a1651143f.json
+++ b/openfisca_france/tests/json/nrag_defi-d2d9d2a4f92268e57477ec069c7594078edf7d61c40da0040bcb2d5a1651143f.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_defi-e2739f7c5a6621ab0952f081e0f8c3627684f3b2e82695fe5ca0df72e97d2ba1.json
+++ b/openfisca_france/tests/json/nrag_defi-e2739f7c5a6621ab0952f081e0f8c3627684f3b2e82695fe5ca0df72e97d2ba1.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_defi": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_exon-5bf06712a74b60c14b8bcaa484672ab21d00045d1dd71288d8d6202d1ddfece6.json
+++ b/openfisca_france/tests/json/nrag_exon-5bf06712a74b60c14b8bcaa484672ab21d00045d1dd71288d8d6202d1ddfece6.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nrag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_exon-6a948422fb3f4aa096cf406f76d91eb3225814031b4ea3ef4c6de551c6497e89.json
+++ b/openfisca_france/tests/json/nrag_exon-6a948422fb3f4aa096cf406f76d91eb3225814031b4ea3ef4c6de551c6497e89.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_exon-a51c0d4e511edd56e64b685a2f4b6deddd659981ee79f9b88203b3616c4dab32.json
+++ b/openfisca_france/tests/json/nrag_exon-a51c0d4e511edd56e64b685a2f4b6deddd659981ee79f9b88203b3616c4dab32.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nrag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_exon-c1ca3f71b239f3bd36d5ac209e9a45bdb6f18306d1a8465aa8c0c63bbaff2819.json
+++ b/openfisca_france/tests/json/nrag_exon-c1ca3f71b239f3bd36d5ac209e9a45bdb6f18306d1a8465aa8c0c63bbaff2819.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_exon-d1b32c58babc39cf9fe0953fe3c45943a027c82f53f60df908b9273b1d1e6fb5.json
+++ b/openfisca_france/tests/json/nrag_exon-d1b32c58babc39cf9fe0953fe3c45943a027c82f53f60df908b9273b1d1e6fb5.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_exon-d559f74894c6a323868ad49eef94a09a2f2bc5f1a2488612145dc88c8ad8178b.json
+++ b/openfisca_france/tests/json/nrag_exon-d559f74894c6a323868ad49eef94a09a2f2bc5f1a2488612145dc88c8ad8178b.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_exon-d66b24b0a45a01eff9580ae9b06061307b2faf9487c91a964b0afff23188b41f.json
+++ b/openfisca_france/tests/json/nrag_exon-d66b24b0a45a01eff9580ae9b06061307b2faf9487c91a964b0afff23188b41f.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_exon-e1729017c9e2a80c23c4af5840d96d6648b708de1710d451e7db08813c49fe6f.json
+++ b/openfisca_france/tests/json/nrag_exon-e1729017c9e2a80c23c4af5840d96d6648b708de1710d451e7db08813c49fe6f.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_exon-ecb620954e7c799e06d78e6f29b0fd633b32e783d5f346d3f38fba6cad93d6ad.json
+++ b/openfisca_france/tests/json/nrag_exon-ecb620954e7c799e06d78e6f29b0fd633b32e783d5f346d3f38fba6cad93d6ad.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_exon": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_impg-1dbf0df71b8fbce0f57c0d8c4aeb98ad920faa9d58bd82202265dfdff26fbce0.json
+++ b/openfisca_france/tests/json/nrag_impg-1dbf0df71b8fbce0f57c0d8c4aeb98ad920faa9d58bd82202265dfdff26fbce0.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_impg": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_impg-1ddebd4803af72dbff9eb97526ffafbc2b82840fbdcbac245d33999db39738ce.json
+++ b/openfisca_france/tests/json/nrag_impg-1ddebd4803af72dbff9eb97526ffafbc2b82840fbdcbac245d33999db39738ce.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_impg": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_impg-2fedfb655cb52ddb0e6051c55fa030da3438be10cb59fb4cc8f4b987b4b2d9c2.json
+++ b/openfisca_france/tests/json/nrag_impg-2fedfb655cb52ddb0e6051c55fa030da3438be10cb59fb4cc8f4b987b4b2d9c2.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nrag_impg": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_impg-631b1ee96ec26c31f82f412c0c47bf88354a5fad74e7dfe4e1317c8bb79f9936.json
+++ b/openfisca_france/tests/json/nrag_impg-631b1ee96ec26c31f82f412c0c47bf88354a5fad74e7dfe4e1317c8bb79f9936.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_impg": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_impg-910af8fea8be0e5e1f0c808dfd673c0a70424618f9519aabc53c8170d616ad2e.json
+++ b/openfisca_france/tests/json/nrag_impg-910af8fea8be0e5e1f0c808dfd673c0a70424618f9519aabc53c8170d616ad2e.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_impg": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_impg-b4d56fe9fe8a7047577d597bb1c2d3da6ac8bd3b12860ca14dd4b9f73b58a8e5.json
+++ b/openfisca_france/tests/json/nrag_impg-b4d56fe9fe8a7047577d597bb1c2d3da6ac8bd3b12860ca14dd4b9f73b58a8e5.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_impg": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_impg-d72462082008cb33fbbb4a48c7d504d18ad48f5860107ccc546ac4f267616a86.json
+++ b/openfisca_france/tests/json/nrag_impg-d72462082008cb33fbbb4a48c7d504d18ad48f5860107ccc546ac4f267616a86.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nrag_impg": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_impg-ef4bda499a053b03743a07a3f824b115de12e08e507a14297b25944e8a885b73.json
+++ b/openfisca_france/tests/json/nrag_impg-ef4bda499a053b03743a07a3f824b115de12e08e507a14297b25944e8a885b73.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_impg": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_impg-f38e0447540553f5c0aadcb438b28fad76fadd7cf98127d8c97907f5eabf59f2.json
+++ b/openfisca_france/tests/json/nrag_impg-f38e0447540553f5c0aadcb438b28fad76fadd7cf98127d8c97907f5eabf59f2.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_impg": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_pvce-15154b32231f98863397f689a7c2ea0e269f8ac5762e5d13ebc56decbdcc6118.json
+++ b/openfisca_france/tests/json/nrag_pvce-15154b32231f98863397f689a7c2ea0e269f8ac5762e5d13ebc56decbdcc6118.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_pvce-36c33f0d1afe39caedfc91d7025b8e9973c17735ec9f6724ed78650f5f9cf26e.json
+++ b/openfisca_france/tests/json/nrag_pvce-36c33f0d1afe39caedfc91d7025b8e9973c17735ec9f6724ed78650f5f9cf26e.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "nrag_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_pvce-379647db83602e0de9048412068f8c89398b01f53dc30d82d9edd1e4f0cd5602.json
+++ b/openfisca_france/tests/json/nrag_pvce-379647db83602e0de9048412068f8c89398b01f53dc30d82d9edd1e4f0cd5602.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_pvce-3fe7855632f8a9241c2ee999633e8a8d60eda2c83207944fc85101dcce23e461.json
+++ b/openfisca_france/tests/json/nrag_pvce-3fe7855632f8a9241c2ee999633e8a8d60eda2c83207944fc85101dcce23e461.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_pvce-6fe68eaefa578a7673ce698f93cf44906a7589d739bd64daef7cb8016562e2a6.json
+++ b/openfisca_france/tests/json/nrag_pvce-6fe68eaefa578a7673ce698f93cf44906a7589d739bd64daef7cb8016562e2a6.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_pvce-8542d12174a155b0df3aaa42310eb980fd72826f48cb71f970798ae6bac5d6d8.json
+++ b/openfisca_france/tests/json/nrag_pvce-8542d12174a155b0df3aaa42310eb980fd72826f48cb71f970798ae6bac5d6d8.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_pvce-b4cd0fd74597e473455a145fc246034f747662feb0d410043045e1595b615200.json
+++ b/openfisca_france/tests/json/nrag_pvce-b4cd0fd74597e473455a145fc246034f747662feb0d410043045e1595b615200.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "nrag_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_pvce-b893daf1550d8d5e8cd18a446acb5cb8068ddcc76c9b987e96fb8c15bdb2e078.json
+++ b/openfisca_france/tests/json/nrag_pvce-b893daf1550d8d5e8cd18a446acb5cb8068ddcc76c9b987e96fb8c15bdb2e078.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_pvce-bf6552a94e83bae2a93cee072f73df67ca541be674aad18c412845b77cd9932f.json
+++ b/openfisca_france/tests/json/nrag_pvce-bf6552a94e83bae2a93cee072f73df67ca541be674aad18c412845b77cd9932f.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/nrag_pvce-ca184ab26a08ee5c69f3af776a3c50bd72c214ecadab693d5bea592b05a8ccbd.json
+++ b/openfisca_france/tests/json/nrag_pvce-ca184ab26a08ee5c69f3af776a3c50bd72c214ecadab693d5bea592b05a8ccbd.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "nrag_pvce": 0,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ppe_du_ns-1dc158404c7027df020750df736ba33efa95ba6170b210dd434d2b8f8d1cc21d.json
+++ b/openfisca_france/tests/json/ppe_du_ns-1dc158404c7027df020750df736ba33efa95ba6170b210dd434d2b8f8d1cc21d.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ppe_du_ns": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ppe_du_ns-36f72f78d518d5610b0e9dbf5e0589e7ce49533117522f3e007b9e56c0faec4b.json
+++ b/openfisca_france/tests/json/ppe_du_ns-36f72f78d518d5610b0e9dbf5e0589e7ce49533117522f3e007b9e56c0faec4b.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ppe_du_ns": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ppe_du_ns-3cdd1a937af986dc7a3755866eed69f2a0768e3960c9491fad768fbde9468586.json
+++ b/openfisca_france/tests/json/ppe_du_ns-3cdd1a937af986dc7a3755866eed69f2a0768e3960c9491fad768fbde9468586.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ppe_du_ns": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ppe_du_ns-6ff33e714abb213c90e6d7ef83ae9052293ebc7e85353605203db8b4a1c6c762.json
+++ b/openfisca_france/tests/json/ppe_du_ns-6ff33e714abb213c90e6d7ef83ae9052293ebc7e85353605203db8b4a1c6c762.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ppe_du_ns": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ppe_du_ns-73d0e97ff07f3e92405da462753454e19b89d717cb4079e22dedae5fe33c4d41.json
+++ b/openfisca_france/tests/json/ppe_du_ns-73d0e97ff07f3e92405da462753454e19b89d717cb4079e22dedae5fe33c4d41.json
@@ -83,7 +83,7 @@
           "date_naissance": "1970-01-01",
           "ppe_du_ns": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ppe_du_ns-91d1cb04dea063c0ad97e0fe35cf5e101ce4b52f42c0c33ee1462c8e15430e95.json
+++ b/openfisca_france/tests/json/ppe_du_ns-91d1cb04dea063c0ad97e0fe35cf5e101ce4b52f42c0c33ee1462c8e15430e95.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ppe_du_ns": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ppe_du_ns-cf870df2eb39a4c2734eb89fcd5118de3120f792c8dd9776b10117eeb4df2b6c.json
+++ b/openfisca_france/tests/json/ppe_du_ns-cf870df2eb39a4c2734eb89fcd5118de3120f792c8dd9776b10117eeb4df2b6c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ppe_du_ns": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ppe_du_ns-e1405b345020ae7e577c2a9f45b876789d90c47f2009628c581356396cba683d.json
+++ b/openfisca_france/tests/json/ppe_du_ns-e1405b345020ae7e577c2a9f45b876789d90c47f2009628c581356396cba683d.json
@@ -93,7 +93,7 @@
           "date_naissance": "1970-01-01",
           "ppe_du_ns": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/json/ppe_du_ns-f5ddc8b9a4a172a516414f5be675cee9b81767969bd4486385eddfb85817380c.json
+++ b/openfisca_france/tests/json/ppe_du_ns-f5ddc8b9a4a172a516414f5be675cee9b81767969bd4486385eddfb85817380c.json
@@ -88,7 +88,7 @@
           "date_naissance": "1970-01-01",
           "ppe_du_ns": 1500,
           "salaire_imposable": 24000,
-          "statmarit": 2
+          "statut_marital": 2
         }
       },
       "menages": {

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d220ce159e330200810b8e.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d220ce159e330200810b8e.yaml
@@ -42,7 +42,7 @@ individus:
       2014-06: 950
       2014-07: 950
       year:2013-07: 2850
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d25137e40a7902009c3384.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d25137e40a7902009c3384.yaml
@@ -33,7 +33,7 @@ individus:
       2014-06: 185.2
       2014-07: 185.2
       year:2013-07: 555.5999999999999
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d251e4e40a7902009c338b.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d251e4e40a7902009c338b.yaml
@@ -33,7 +33,7 @@ individus:
       2014-06: 787.1
       2014-07: 787.1
       year:2013-07: 2361.3
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d25233e40a7902009c3392.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d25233e40a7902009c3392.yaml
@@ -33,7 +33,7 @@ individus:
       2014-06: 1157.5
       2014-07: 1157.5
       year:2013-07: 3472.5
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d25591e40a7902009c33a3.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d25591e40a7902009c33a3.yaml
@@ -33,7 +33,7 @@ individus:
       2014-06: 926
       2014-07: 926
       year:2013-07: 2778
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d255efe40a7902009c33aa.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d255efe40a7902009c33aa.yaml
@@ -33,7 +33,7 @@ individus:
       2014-06: 1157.5
       2014-07: 1157.5
       year:2013-07: 3472.5
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d79c9df6aa390200a6cd23.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d79c9df6aa390200a6cd23.yaml
@@ -26,7 +26,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d79d67f6aa390200a6cd2c.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d79d67f6aa390200a6cd2c.yaml
@@ -34,7 +34,7 @@ individus:
       2014-06: 200
       2014-07: 200
       year:2013-07: 600
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d79de9f6aa390200a6cd31.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d79de9f6aa390200a6cd31.yaml
@@ -17,7 +17,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d79e98f6aa390200a6cd37.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d79e98f6aa390200a6cd37.yaml
@@ -15,7 +15,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d79ee2f6aa390200a6cd3b.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53d79ee2f6aa390200a6cd3b.yaml
@@ -17,7 +17,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53fb5fc02f1265020080b6ad.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53fb5fc02f1265020080b6ad.yaml
@@ -17,7 +17,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53fb60ad2f1265020080b6b8.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_53fb60ad2f1265020080b6b8.yaml
@@ -18,7 +18,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_544a0c02444b963225484646.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_544a0c02444b963225484646.yaml
@@ -70,7 +70,7 @@ individus:
       2014-09: 1080
       2014-10: 1080
       year:2013-10: 12960
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_545a4dc2ffe6a1e044e6c2a2.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_545a4dc2ffe6a1e044e6c2a2.yaml
@@ -16,7 +16,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_545a4ee5ffe6a1e044e6c2a3.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_545a4ee5ffe6a1e044e6c2a3.yaml
@@ -22,7 +22,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 5
+    statut_marital: 5
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_545a4ff9d0485dd744fc56a9.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_545a4ff9d0485dd744fc56a9.yaml
@@ -16,7 +16,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_545a512bd0485dd744fc56aa.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_545a512bd0485dd744fc56aa.yaml
@@ -21,7 +21,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_545a53d20e9bb9d9441ed67d.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_545a53d20e9bb9d9441ed67d.yaml
@@ -22,7 +22,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_545bbcd7332947f9128c0497.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_545bbcd7332947f9128c0497.yaml
@@ -51,7 +51,7 @@ individus:
       2014-10: 92.6
       2014-11: 92.6
       year:2013-11: 1111.2
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_546b3208fb9f05fb6373bce8.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_546b3208fb9f05fb6373bce8.yaml
@@ -18,7 +18,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_546b389a492eaff5637e3bf9.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_546b389a492eaff5637e3bf9.yaml
@@ -18,7 +18,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_546b4bbcf76135f463c9e43a.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_546b4bbcf76135f463c9e43a.yaml
@@ -17,7 +17,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_546c9981efc21c287d798168.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_546c9981efc21c287d798168.yaml
@@ -17,7 +17,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_546cc5196c5820403d9b9c8d.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_546cc5196c5820403d9b9c8d.yaml
@@ -73,7 +73,7 @@ individus:
       2014-10: 970
       2014-11: 970
       year:2013-11: 11640
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_547491ade1e8823c3da3ef4d.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_547491ade1e8823c3da3ef4d.yaml
@@ -69,7 +69,7 @@ individus:
       2014-10: 1790
       2014-11: 1790
       year:2013-11: 21480
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5475abacf6912100729cc791.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5475abacf6912100729cc791.yaml
@@ -67,7 +67,7 @@ individus:
       2014-10: 555.6
       2014-11: 555.6
       year:2013-11: 6667.200000000002
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 60000
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54789fdafccedf3f260aeb4c.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54789fdafccedf3f260aeb4c.yaml
@@ -51,7 +51,7 @@ individus:
       2014-10: 555.6
       2014-11: 555.6
       year:2013-11: 6667.200000000002
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_547d8779d97a8932263c2914.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_547d8779d97a8932263c2914.yaml
@@ -102,7 +102,7 @@ individus:
       2014-11: 117
       2014-12: 117
       year:2013-12: 1404
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54818e47aad65891668c6d8c.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54818e47aad65891668c6d8c.yaml
@@ -18,7 +18,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54818eb3ed60b88866befd7a.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54818eb3ed60b88866befd7a.yaml
@@ -18,7 +18,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54818fdc1c33cd866618760b.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54818fdc1c33cd866618760b.yaml
@@ -18,7 +18,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54857378bf1777d606ad1bf4.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54857378bf1777d606ad1bf4.yaml
@@ -49,7 +49,7 @@ individus:
       2014-11: 200
       2014-12: 200
       year:2013-12: 2400
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5485adad62ae92d806fed28e.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5485adad62ae92d806fed28e.yaml
@@ -55,7 +55,7 @@ individus:
       2014-11: 555.6
       2014-12: 555.6
       year:2013-12: 6667.200000000002
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5485b12e62ae92d806fed2d5.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5485b12e62ae92d806fed2d5.yaml
@@ -55,7 +55,7 @@ individus:
       2014-11: 555.6
       2014-12: 555.6
       year:2013-12: 6667.200000000002
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_548ebc636e7c8953021319c5.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_548ebc636e7c8953021319c5.yaml
@@ -57,7 +57,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_548eda8bdf990f5b0286b9f0.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_548eda8bdf990f5b0286b9f0.yaml
@@ -57,7 +57,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_548f01937b8500590228332d.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_548f01937b8500590228332d.yaml
@@ -76,7 +76,7 @@ individus:
       2014-11: 482
       2014-12: 482
       year:2013-12: 4413.000000000002
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_548f06218dac136002468aed.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_548f06218dac136002468aed.yaml
@@ -57,7 +57,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5490398040562f54026efa7e.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5490398040562f54026efa7e.yaml
@@ -65,7 +65,7 @@ individus:
       2014-10: 0
       2014-11: 0
       year:2013-12: 9999.99
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54903df1df990f5b0286c425.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54903df1df990f5b0286c425.yaml
@@ -70,7 +70,7 @@ individus:
       2014-11: 1500
       2014-12: 1500
       year:2013-12: 17500.000000000004
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54903ed6df990f5b0286c429.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54903ed6df990f5b0286c429.yaml
@@ -70,7 +70,7 @@ individus:
       2014-11: 1400
       2014-12: 1400
       year:2013-12: 17600
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_549041e16e7c895302132b89.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_549041e16e7c895302132b89.yaml
@@ -68,7 +68,7 @@ individus:
       2014-10: 0
       2014-11: 0
       year:2013-12: 9999.99
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5490524009d6285e02d4f087.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5490524009d6285e02d4f087.yaml
@@ -73,7 +73,7 @@ individus:
       2014-11: 2000
       2014-12: 2000
       year:2013-12: 21000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_549069be8dac1360024697f6.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_549069be8dac1360024697f6.yaml
@@ -70,7 +70,7 @@ individus:
       2014-11: 2000
       2014-12: 2000
       year:2013-12: 21050.000000000004
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54906bdfccf374520212a6ad.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54906bdfccf374520212a6ad.yaml
@@ -73,7 +73,7 @@ individus:
       2014-11: 1382
       2014-12: 1382
       year:2013-12: 16579.999999999996
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_549159d26e7c89530213381a.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_549159d26e7c89530213381a.yaml
@@ -73,7 +73,7 @@ individus:
       2014-11: 2000
       2014-12: 2000
       year:2013-12: 22899.999999999996
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54915af640562f54026f069b.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54915af640562f54026f069b.yaml
@@ -73,7 +73,7 @@ individus:
       2014-11: 2000
       2014-12: 2000
       year:2013-12: 23000.000000000004
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54918b1a7b85005902284ba7.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54918b1a7b85005902284ba7.yaml
@@ -66,7 +66,7 @@ individus:
       2014-10: 0
       2014-11: 0
       year:2013-12: 14430.960000000003
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54931713f6dab3dc7a59442b.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54931713f6dab3dc7a59442b.yaml
@@ -87,7 +87,7 @@ individus:
       2014-10: 0
       2014-11: 0
       year:2013-12: 13771
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54931dcec85c31d77ab6bd9a.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54931dcec85c31d77ab6bd9a.yaml
@@ -94,7 +94,7 @@ individus:
       2014-10: 0
       2014-11: 0
       year:2013-12: 6885.989999999999
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_549320765db991d97a5e9815.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_549320765db991d97a5e9815.yaml
@@ -72,7 +72,7 @@ individus:
       2014-10: 0
       2014-11: 0
       year:2013-12: 13771
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5493f5730f5aeede7a7a986d.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5493f5730f5aeede7a7a986d.yaml
@@ -25,7 +25,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5493f78ff6dab3dc7a594673.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5493f78ff6dab3dc7a594673.yaml
@@ -24,7 +24,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5493f8dcc85c31d77ab6bfcb.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5493f8dcc85c31d77ab6bfcb.yaml
@@ -62,7 +62,7 @@ individus:
       2014-10: 0
       2014-11: 0
       year:2013-12: 13770.990000000002
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54ac0ceed20bc238169b4b06.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54ac0ceed20bc238169b4b06.yaml
@@ -33,7 +33,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54ac15d34939ba3216001203.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54ac15d34939ba3216001203.yaml
@@ -32,7 +32,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54b54affd5b79b733e797cfe.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54b54affd5b79b733e797cfe.yaml
@@ -68,7 +68,7 @@ individus:
       2014-12: 964
       2015-01: 964
       year:2014-01: 11568
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54b54c014e77a2773ea5d9b4.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54b54c014e77a2773ea5d9b4.yaml
@@ -68,7 +68,7 @@ individus:
       2014-12: 984
       2015-01: 984
       year:2014-01: 11808
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54b54e7544b1ef7a3e841b4a.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54b54e7544b1ef7a3e841b4a.yaml
@@ -68,7 +68,7 @@ individus:
       2014-12: 1157
       2015-01: 1157
       year:2014-01: 13884
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54b54f08d5b79b733e797d08.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54b54f08d5b79b733e797d08.yaml
@@ -68,7 +68,7 @@ individus:
       2014-12: 1177
       2015-01: 1177
       year:2014-01: 14124
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54c61ccc83c41aa758c290e9.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54c61ccc83c41aa758c290e9.yaml
@@ -43,7 +43,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54d497ade45751d544f06aa3.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54d497ade45751d544f06aa3.yaml
@@ -83,7 +83,7 @@ individus:
       year:2014-02: 21999.999999999996
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54d4d6934ec19fce4422736b.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54d4d6934ec19fce4422736b.yaml
@@ -32,7 +32,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54d8c3945c1babd0441a12b5.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54d8c3945c1babd0441a12b5.yaml
@@ -22,7 +22,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54d8e0821fe4e8cf448e2bf3.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54d8e0821fe4e8cf448e2bf3.yaml
@@ -45,7 +45,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54e223d04dd883622de4bc72.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54e223d04dd883622de4bc72.yaml
@@ -107,7 +107,7 @@ individus:
       2015-01: 649.74
       2015-02: 649.74
       year:2014-02: 7796.879999999998
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54e5c1dada3bc55340837b6a.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54e5c1dada3bc55340837b6a.yaml
@@ -90,7 +90,7 @@ individus:
       2015-01: 1000
       2015-02: 1000
       year:2014-02: 12000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54e708c870a3f65f40b60f37.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54e708c870a3f65f40b60f37.yaml
@@ -72,7 +72,7 @@ individus:
       2014-12: 0
       2015-01: 0
       year:2014-02: 45000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54ef4e8999fc215675536d0f.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54ef4e8999fc215675536d0f.yaml
@@ -48,7 +48,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 18000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54f7282125be8dd27ba42168.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54f7282125be8dd27ba42168.yaml
@@ -76,7 +76,7 @@ individus:
     2015-02: 1400
     2015-03: 1400
     year:2014-03: 16800
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -92,7 +92,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54f73d1471bd0dd87b7d9a2a.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54f73d1471bd0dd87b7d9a2a.yaml
@@ -68,7 +68,7 @@ individus:
       2015-02: 200
       2015-03: 200
       year:2014-03: 2400
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -135,7 +135,7 @@ individus:
       2015-02: 150
       2015-03: 150
       year:2014-03: 1800
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5500761c66ca2f8a47241270.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5500761c66ca2f8a47241270.yaml
@@ -27,7 +27,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -51,7 +51,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_550166db50a4762d5ab000a2.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_550166db50a4762d5ab000a2.yaml
@@ -27,7 +27,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -51,7 +51,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55016793cc1bb4365a5d7256.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55016793cc1bb4365a5d7256.yaml
@@ -27,7 +27,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -51,7 +51,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_550167f2e471d52f5a015621.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_550167f2e471d52f5a015621.yaml
@@ -27,7 +27,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -51,7 +51,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5501689950a4762d5ab000be.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5501689950a4762d5ab000be.yaml
@@ -28,7 +28,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -52,7 +52,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_550169da50a4762d5ab000d3.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_550169da50a4762d5ab000d3.yaml
@@ -28,7 +28,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -52,7 +52,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55016b85110d64385a0318ee.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55016b85110d64385a0318ee.yaml
@@ -28,7 +28,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -52,7 +52,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55016c79ffc0602c5a813cc2.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55016c79ffc0602c5a813cc2.yaml
@@ -28,7 +28,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -52,7 +52,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5501c4c5569add1527598636.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5501c4c5569add1527598636.yaml
@@ -27,7 +27,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -51,7 +51,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5502b3df11f4501f2700e651.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5502b3df11f4501f2700e651.yaml
@@ -25,7 +25,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -49,7 +49,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55252a6c86e10bba11f76d3f.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55252a6c86e10bba11f76d3f.yaml
@@ -71,7 +71,7 @@ individus:
       2015-03: 1000
       2015-04: 1000
       year:2014-04: 14599.999999999998
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -87,7 +87,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55252c8fa7629db1117ea8c2.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55252c8fa7629db1117ea8c2.yaml
@@ -70,7 +70,7 @@ individus:
       2015-03: 1600
       2015-04: 1600
       year:2014-04: 20000.000000000004
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -86,7 +86,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55364727b2f8f07f2d4461fe.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55364727b2f8f07f2d4461fe.yaml
@@ -72,7 +72,7 @@ individus:
       2015-03: 1000
       2015-04: 1000
       year:2014-04: 12000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -88,7 +88,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_553fb691f0058c5b39237060.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_553fb691f0058c5b39237060.yaml
@@ -20,7 +20,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   tns_benefice_exploitant_agricole:
     '2014': 11500
   valeur_locative_immo_non_loue:
@@ -38,7 +38,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_553fb81b46bea9643939510f.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_553fb81b46bea9643939510f.yaml
@@ -20,7 +20,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   tns_benefice_exploitant_agricole:
     '2014': 13800
   valeur_locative_immo_non_loue:
@@ -38,7 +38,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_553fb8f917d9db60391c3418.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_553fb8f917d9db60391c3418.yaml
@@ -20,7 +20,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   tns_benefice_exploitant_agricole:
     '2014': 16500
   valeur_locative_immo_non_loue:
@@ -38,7 +38,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_555b397095a4fe5b31975c90.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_555b397095a4fe5b31975c90.yaml
@@ -74,7 +74,7 @@ individus:
       2015-03: 1290
       2015-04: 1290
       year:2014-04: 15480
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -90,7 +90,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_555db98d95a4fe5b31976053.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_555db98d95a4fe5b31976053.yaml
@@ -18,7 +18,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -34,7 +34,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_555dba495dcb456331928c74.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_555dba495dcb456331928c74.yaml
@@ -20,7 +20,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -36,7 +36,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55643d7ba0084c3b26e9c8c7.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55643d7ba0084c3b26e9c8c7.yaml
@@ -69,7 +69,7 @@ individus:
       2015-04: 800
       2015-05: 800
       year:2014-05: 12999.999999999998
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -85,7 +85,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55643f366aca6d3826e553a4.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55643f366aca6d3826e553a4.yaml
@@ -69,7 +69,7 @@ individus:
       2015-04: 800
       2015-05: 800
       year:2014-05: 13400.000000000002
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -85,7 +85,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55688ea5a3f5be1046accf60.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55688ea5a3f5be1046accf60.yaml
@@ -64,7 +64,7 @@ individus:
     2015-03: 0
     2015-04: 0
     year:2014-05: 34000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -80,7 +80,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55688f456ea9111d461fc01c.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55688f456ea9111d461fc01c.yaml
@@ -66,7 +66,7 @@ individus:
       2015-04: 1000
       2015-05: 1000
       year:2014-05: 36000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -82,7 +82,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55689215fefdb1174642804f.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55689215fefdb1174642804f.yaml
@@ -74,7 +74,7 @@ individus:
     2015-04: 2000
     2015-05: 2000
     year:2014-05: 40000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -98,7 +98,7 @@ individus:
     '2013': 0
   salaire_imposable:
     '2013': 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_556892e773b0dc114668b0ae.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_556892e773b0dc114668b0ae.yaml
@@ -66,7 +66,7 @@ individus:
       2015-04: 4000
       2015-05: 4000
       year:2014-05: 43000.00000000001
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -82,7 +82,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_558178e578ebb479142d6d0b.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_558178e578ebb479142d6d0b.yaml
@@ -73,7 +73,7 @@ individus:
       2015-05: 720.08
       2015-06: 720.08
       year:2014-06: 8641.000000000002
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -144,7 +144,7 @@ individus:
       2015-05: 1401.9
       2015-06: 1401.9
       year:2014-06: 16822.999999999996
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_558179ec78ebb479142d6d0f.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_558179ec78ebb479142d6d0f.yaml
@@ -53,7 +53,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -120,7 +120,7 @@ individus:
       2015-05: 1625.78
       2015-06: 1625.78
       year:2014-06: 19509
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55817e4d3b5af67e1402acc1.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55817e4d3b5af67e1402acc1.yaml
@@ -67,7 +67,7 @@ individus:
       2015-05: 663
       2015-06: 663
       year:2014-06: 7956
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -167,7 +167,7 @@ individus:
       2015-05: 1271
       2015-06: 1271
       year:2014-06: 15255.000000000002
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5582ce6a3b5af67e1402b18f.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5582ce6a3b5af67e1402b18f.yaml
@@ -54,7 +54,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -154,7 +154,7 @@ individus:
       2015-04: 0
       2015-05: 0
       year:2014-06: 8961
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5591635b7ae4c40130761eb7.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5591635b7ae4c40130761eb7.yaml
@@ -54,7 +54,7 @@ individus:
       2015-05: 1057.98
       2015-06: 1057.98
       year:2014-06: 12695.679999999997
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -70,7 +70,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55929dc82f56a0fd2f63356b.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55929dc82f56a0fd2f63356b.yaml
@@ -16,7 +16,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -32,7 +32,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5592b42d131e5b05301ebc8f.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_5592b42d131e5b05301ebc8f.yaml
@@ -26,7 +26,7 @@ individus:
     '2013': 0
   salaire_imposable:
     '2013': 100000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -52,7 +52,7 @@ individus:
     '2013': 0
   salaire_imposable:
     '2013': 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_559b96c52f56a0fd2f634210.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_559b96c52f56a0fd2f634210.yaml
@@ -43,7 +43,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 77777.77777777778
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -67,7 +67,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_559bb0852f56a0fd2f63423d.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_559bb0852f56a0fd2f63423d.yaml
@@ -29,7 +29,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 118488.88888888889
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -53,7 +53,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_559e4fe4fa617858013d9a39.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_559e4fe4fa617858013d9a39.yaml
@@ -25,7 +25,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -51,7 +51,7 @@ individus:
       2013: 0
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_559f93cdaf0afd4601df5df1.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_559f93cdaf0afd4601df5df1.yaml
@@ -104,7 +104,7 @@ individus:
       2015-06: 237
       2015-07: 237
       year:2014-07: 2932.0000000000005
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -120,7 +120,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_559fb03faf0afd4601df5e04.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_559fb03faf0afd4601df5e04.yaml
@@ -21,7 +21,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -37,7 +37,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_559fb2edb205974e01346df4.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_559fb2edb205974e01346df4.yaml
@@ -68,7 +68,7 @@ individus:
       2015-06: 1350
       2015-07: 1350
       year:2014-07: 16200
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -84,7 +84,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55b245693b849ed774af6ff1.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55b245693b849ed774af6ff1.yaml
@@ -70,7 +70,7 @@ individus:
       2015-06: 1000
       2015-07: 1000
       year:2014-07: 12000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -88,7 +88,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55b2483a3b849ed774af700d.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55b2483a3b849ed774af700d.yaml
@@ -70,7 +70,7 @@ individus:
       2015-06: 1000
       2015-07: 1000
       year:2014-07: 12000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -88,7 +88,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55b9b8bdf0f7e3ac6b8f4f52.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55b9b8bdf0f7e3ac6b8f4f52.yaml
@@ -45,7 +45,7 @@ individus:
       2013: 1967
     salaire_imposable:
       2013: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -150,7 +150,7 @@ individus:
       2015-06: 1239
       2015-07: 1239
       year:2014-07: 14868
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55bb70a5f0ac7bb86ba0523d.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55bb70a5f0ac7bb86ba0523d.yaml
@@ -17,7 +17,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -35,7 +35,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eda4be8c9ccb340464e3d0.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eda4be8c9ccb340464e3d0.yaml
@@ -65,7 +65,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 50999.99999999999
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -83,7 +83,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eda5c5dbd69f2b04f562f4.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eda5c5dbd69f2b04f562f4.yaml
@@ -65,7 +65,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 52000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -83,7 +83,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eda68d7869142d0487485e.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eda68d7869142d0487485e.yaml
@@ -65,7 +65,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 59000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -83,7 +83,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eda7a10df1c6360477f25c.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eda7a10df1c6360477f25c.yaml
@@ -65,7 +65,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 62000.00000000001
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -83,7 +83,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eda9170df1c6360477f26b.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eda9170df1c6360477f26b.yaml
@@ -65,7 +65,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 20000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -129,7 +129,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 25000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eda9a90df1c6360477f276.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eda9a90df1c6360477f276.yaml
@@ -65,7 +65,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 20000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -129,7 +129,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 29000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55edaa78bb8d0c380477618e.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55edaa78bb8d0c380477618e.yaml
@@ -65,7 +65,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 20000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -129,7 +129,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 33000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55edab1ebd7b102a0438a595.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55edab1ebd7b102a0438a595.yaml
@@ -65,7 +65,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 20000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -129,7 +129,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 35000.00000000001
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55edad33bb8d0c380477619f.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55edad33bb8d0c380477619f.yaml
@@ -67,7 +67,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 33000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -85,7 +85,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55edb36fbd7b102a0438a5b7.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55edb36fbd7b102a0438a5b7.yaml
@@ -66,7 +66,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 36999.99999999999
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -84,7 +84,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55edb40b1e52de32043690f2.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55edb40b1e52de32043690f2.yaml
@@ -67,7 +67,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 40000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -85,7 +85,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eea677bd7b102a0438a75d.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eea677bd7b102a0438a75d.yaml
@@ -68,7 +68,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 48000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -86,7 +86,7 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eea8ce7869142d04874b44.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eea8ce7869142d04874b44.yaml
@@ -68,7 +68,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 20000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -134,7 +134,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 24000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eea9917869142d04874b54.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eea9917869142d04874b54.yaml
@@ -68,7 +68,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 20000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -134,7 +134,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 31000.000000000004
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eeaa37bb8d0c3804776402.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eeaa37bb8d0c3804776402.yaml
@@ -68,7 +68,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 20000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -134,7 +134,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 29999.999999999996
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eeaaea7869142d04874b5d.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eeaaea7869142d04874b5d.yaml
@@ -66,7 +66,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 20000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -130,7 +130,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 38000
-    statmarit: 1
+    statut_marital: 1
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eeaccf0df1c6360477f4db.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eeaccf0df1c6360477f4db.yaml
@@ -67,7 +67,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 29999.999999999996
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -85,7 +85,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eed4a97869142d04874c1a.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eed4a97869142d04874c1a.yaml
@@ -65,7 +65,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 34000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -83,7 +83,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eed5a2bb8d0c3804776563.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eed5a2bb8d0c3804776563.yaml
@@ -65,7 +65,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 34000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -83,7 +83,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eed6250df1c6360477f572.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eed6250df1c6360477f572.yaml
@@ -67,7 +67,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 40000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -85,7 +85,7 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eed71a0df1c6360477f581.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eed71a0df1c6360477f581.yaml
@@ -65,7 +65,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 20000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -129,7 +129,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 17000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eed8090df1c6360477f58c.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eed8090df1c6360477f58c.yaml
@@ -65,7 +65,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 20000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -129,7 +129,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 22500
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eef6a30df1c6360477f5f5.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55eef6a30df1c6360477f5f5.yaml
@@ -65,7 +65,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 20000
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:
@@ -129,7 +129,7 @@ individus:
     2015-07: 0
     2015-08: 0
     year:2014-09: 22000.000000000004
-  statmarit: 1
+  statut_marital: 1
   valeur_locative_immo_non_loue:
     2012-01: 0
   valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55f02ebc0d70943004ddcd72.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55f02ebc0d70943004ddcd72.yaml
@@ -70,7 +70,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 0
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:
@@ -136,7 +136,7 @@ individus:
       2015-07: 0
       2015-08: 0
       year:2014-09: 0
-    statmarit: 2
+    statut_marital: 2
     valeur_locative_immo_non_loue:
       2012-01: 0
     valeur_locative_terrains_non_loue:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_56379c176555c55604db1e46.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_56379c176555c55604db1e46.yaml
@@ -67,7 +67,7 @@ individus:
     2015-09: 0
     2015-10: 0
     year:2014-11: 12000
-  statmarit: 1
+  statut_marital: 1
   tns_auto_entrepreneur_type_activite: bic
   tns_autres_revenus_type_activite: bic
   tns_micro_entreprise_type_activite: bic
@@ -175,7 +175,7 @@ individus:
     2015-09: 0
     2015-10: 0
     year:2014-11: 12000
-  statmarit: 1
+  statut_marital: 1
   tns_auto_entrepreneur_type_activite: bic
   tns_autres_revenus_type_activite: bic
   tns_micro_entreprise_type_activite: bic

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_563b8ecc6555c55604db2d1f.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_563b8ecc6555c55604db2d1f.yaml
@@ -65,7 +65,7 @@ individus:
     2015-09: 0
     2015-10: 0
     year:2014-11: 12000
-  statmarit: 1
+  statut_marital: 1
   tns_auto_entrepreneur_type_activite: bic
   tns_autres_revenus_type_activite: bic
   tns_micro_entreprise_type_activite: bic
@@ -173,7 +173,7 @@ individus:
     2015-09: 0
     2015-10: 0
     year:2014-11: 12000
-  statmarit: 1
+  statut_marital: 1
   tns_auto_entrepreneur_type_activite: bic
   tns_autres_revenus_type_activite: bic
   tns_micro_entreprise_type_activite: bic

--- a/run-travis-tests.sh
+++ b/run-travis-tests.sh
@@ -35,4 +35,4 @@ then
 fi
 
 
-# make test
+make test

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '2.0.0',
+    version = '3.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Make `enfant_a_charge` usable in monthly mode so that we can re-use it in mes-aides. 
* Broaden definition of `enfant_a_charge`: `True` when `garde_alternee`.
* Deprecate `nombre_enfants_a_charge_menage`, `enfant_a_charge_invalide`, `enfant_a_charge_garde_alternee`, `enfant_a_charge_garde_alternee_invalide`, non-necessary intermediate variables.
* Refactor and test nbF, nbG, nbH, nbI
* Some renaming:
    * `statmarit` -> `statut_marital`		
    * `marpac` -> `maries_ou_pacses`		
    * `celdiv` -> `celibataire_ou_divorce`
    * `jveuf` -> `jeune_veuf`