### PR TITLE
Add a new build to build with "ignore" flagged tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 4.0.3 - [diff](https://github.com/openfisca/openfisca-france/compare/4.0.2..4.0.3)
+* Add a build to run all tests, including the ones flagged as ignored in their yaml properties.
 
 ## 4.0.2 - [diff](https://github.com/openfisca/openfisca-france/compare/4.0.1..4.0.2)
 * Remove wrong stop date of `aeeh`

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,6 @@ test: check-syntax-errors check-no-prints
 	@# Launch tests from openfisca_france/tests directory (and not .) because TaxBenefitSystem must be initialized
 	@# before parsing source files containing formulas.
 	nosetests openfisca_france/tests --exe --with-doctest
+
+test-xunit-force: check-syntax-errors check-no-prints
+	export FORCE=true; nosetests openfisca_france/tests/test_yaml.py --exe --with-xunit

--- a/openfisca_france/tests/test_yaml.py
+++ b/openfisca_france/tests/test_yaml.py
@@ -207,6 +207,12 @@ def check_calculate_output(yaml_path, name, period_str, test, force, verbose = F
 
 
 def test(force = False, name_filter = None, options_by_path = None):
+    force_flag=os.getenv('FORCE')
+    if(force_flag == 'TRUE'):
+        force=True
+    else:
+        force=False
+
     if isinstance(name_filter, str):
         name_filter = name_filter.decode('utf-8')
     if options_by_path is None:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '4.0.2',
+    version = '4.0.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Created a new build definition in the makefile to allow running all tests even those flagged as "ignored" in their yaml definition with the nosetests tool. This was previously only possible through directly using `openfisca_france/tests/test_yaml.py`.

Output generated is in the xunit format.
