### PR TITLE
Add console script to run yaml tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.1.0
+
+* Run yaml tests from CLI
+	* Exemple: `openfisca-run-test my_test.yaml`
+
 ## 4.0.11
 
 * Enhance and move getting-started notebook

--- a/openfisca_france/tests/test_yaml.py
+++ b/openfisca_france/tests/test_yaml.py
@@ -206,7 +206,7 @@ def check_calculate_output(yaml_path, name, period_str, test, force, verbose = F
                     )
 
 
-def test(force = False, name_filter = None, options_by_path = None):
+def run_test(force = False, name_filter = None, options_by_path = None):
     if isinstance(name_filter, str):
         name_filter = name_filter.decode('utf-8')
     if options_by_path is None:
@@ -278,8 +278,7 @@ def test(force = False, name_filter = None, options_by_path = None):
                 yield checker, yaml_path, test.get('name') or filename_core, unicode(test['scenario'].period), test, \
                     force
 
-
-if __name__ == "__main__":
+def main():
     import argparse
     import logging
     import sys
@@ -310,7 +309,7 @@ if __name__ == "__main__":
 
     tests_found = False
     for test_index, (checker, yaml_path, name, period_str, test, force) in enumerate(
-            test(
+            run_test(
                 force = args.force,
                 name_filter = args.name,
                 options_by_path = options_by_path,
@@ -334,3 +333,6 @@ if __name__ == "__main__":
         sys.exit(1)
 
     sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '4.0.11',
+    version = '4.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ setup(
         ('share/locale/fr/LC_MESSAGES', ['openfisca_france/i18n/fr/LC_MESSAGES/openfisca-france.mo']),
         ('share/openfisca/openfisca-france', ['CHANGELOG.md', 'LICENSE', 'README.md']),
         ],
+    entry_points = {
+        'console_scripts': ['openfisca-run-test=openfisca_france.tests.test_yaml:main'],
+        },
     extras_require = {
         'inversion_revenus': [
             'scipy >= 0.17',


### PR DESCRIPTION
In some contexts (when using extensions, as far as I'm concerned), it is annoying to get `../../../test_yaml.py` to run a yaml test. This just provides a CLI shortcut to be able to do it from anywhere.

Usage: 
```sh
openfisca-run-test my_test.yaml
```

I'm open to suggestion about the command name.