### PR TITLE
Use "python -m compileall" to check for syntax errors, not flake8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.2
+
+* Use "python -m compileall" to check for syntax errors, not flake8
+
 ## 4.1.1
 
 * Add labels to several variables

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,7 @@ check-no-prints:
 	@test -z "`git grep -w print openfisca_france/model`"
 
 check-syntax-errors:
-	@# This is a hack around flake8 not displaying E910 errors with the select option.
-	@# Do not analyse .gitignored files.
-	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
-	@test -z "`flake8 --first $(shell git ls-files | grep "\.py$$") | grep E901`"
+	python -m compileall -q .
 
 clean:
 	rm -rf build dist

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '4.1.1',
+    version = '4.1.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Reason: `flake8 --first` is no more an option and made fail tests.