### PR TITLE
WIP: Core refactoring

### DIFF
--- a/openfisca_france/__init__.py
+++ b/openfisca_france/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from france_taxbenefitsystem import FranceTaxBenefitSystem
+from openfisca_france.france_taxbenefitsystem import FranceTaxBenefitSystem
+from openfisca_france.simulations import Simulation
 
 CountryTaxBenefitSystem = FranceTaxBenefitSystem

--- a/openfisca_france/entities.py
+++ b/openfisca_france/entities.py
@@ -1,140 +1,155 @@
 # -*- coding: utf-8 -*-
 
-import collections
 import itertools
 
-from openfisca_core import entities
+
+def iter_member_persons_role_and_id_entreprises(member):
+    role = 0
+
+    salaries_id = member['salariés']
+    for salarie_role, salarie_id in enumerate(salaries_id, role):
+        assert salarie_id is not None
+        yield salarie_role, salarie_id
 
 
-class Entreprises(entities.AbstractEntity):
-    column_by_name = collections.OrderedDict()
-    index_for_person_variable_name = 'entreprise_id'
-    key_plural = 'entreprises'
-    key_singular = 'entreprise'
-    label = u'Entreprise'
-    role_for_person_variable_name = 'entreprise_role'
-    roles_key = ['salaries']  # 'dirigeants']
-    label_by_role_key = {
-        'salaries': u'Salariés',
-        # 'dirigeants': u'Dirigeants',
-        }
-    symbol = 'entreprise'
+def iter_member_persons_role_and_id_familles(member):
+    role = 0
 
-    def iter_member_persons_role_and_id(self, member):
-        role = 0
+    parents_id = member['parents']
+    assert 1 <= len(parents_id) <= 2
+    for parent_role, parent_id in enumerate(parents_id, role):
+        assert parent_id is not None
+        yield parent_role, parent_id
+    role += 2
 
-        salaries_id = member['salariés']
-        for salarie_role, salarie_id in enumerate(salaries_id, role):
-            assert salarie_id is not None
-            yield salarie_role, salarie_id
-
-
-class Familles(entities.AbstractEntity):
-    column_by_name = collections.OrderedDict()
-    index_for_person_variable_name = 'idfam'
-    key_plural = 'familles'
-    key_singular = 'famille'
-    label = u'Famille'
-    max_cardinality_by_role_key = {'parents': 2}
-    role_for_person_variable_name = 'quifam'
-    roles_key = ['parents', 'enfants']
-    label_by_role_key = {
-        'enfants': u'Enfants',
-        'parents': u'Parents',
-        }
-    symbol = 'fam'
-
-    def iter_member_persons_role_and_id(self, member):
-        role = 0
-
-        parents_id = member['parents']
-        assert 1 <= len(parents_id) <= 2
-        for parent_role, parent_id in enumerate(parents_id, role):
-            assert parent_id is not None
-            yield parent_role, parent_id
-        role += 2
-
-        enfants_id = member.get('enfants')
-        if enfants_id is not None:
-            for enfant_role, enfant_id in enumerate(enfants_id, role):
-                assert enfant_id is not None
-                yield enfant_role, enfant_id
-
-
-class FoyersFiscaux(entities.AbstractEntity):
-    column_by_name = collections.OrderedDict()
-    index_for_person_variable_name = 'idfoy'
-    key_plural = 'foyers_fiscaux'
-    key_singular = 'foyer_fiscal'
-    label = u'Déclaration d\'impôt'
-    max_cardinality_by_role_key = {'declarants': 2}
-    role_for_person_variable_name = 'quifoy'
-    roles_key = ['declarants', 'personnes_a_charge']
-    label_by_role_key = {
-        'declarants': u'Déclarants',
-        'personnes_a_charge': u'Personnes à charge',
-        }
-    symbol = 'foy'
-
-    def iter_member_persons_role_and_id(self, member):
-        role = 0
-
-        declarants_id = member['declarants']
-        assert 1 <= len(declarants_id) <= 2
-        for declarant_role, declarant_id in enumerate(declarants_id, role):
-            assert declarant_id is not None
-            yield declarant_role, declarant_id
-        role += 2
-
-        personnes_a_charge_id = member.get('personnes_a_charge')
-        if personnes_a_charge_id is not None:
-            for personne_a_charge_role, personne_a_charge_id in enumerate(personnes_a_charge_id, role):
-                assert personne_a_charge_id is not None
-                yield personne_a_charge_role, personne_a_charge_id
-
-
-class Individus(entities.AbstractEntity):
-    column_by_name = collections.OrderedDict()
-    is_persons_entity = True
-    key_plural = 'individus'
-    key_singular = 'individu'
-    label = u'Personne'
-    symbol = 'ind'
-
-
-class Menages(entities.AbstractEntity):
-    column_by_name = collections.OrderedDict()
-    index_for_person_variable_name = 'idmen'
-    key_plural = 'menages'
-    key_singular = 'menage'
-    label = u'Logement principal'
-    max_cardinality_by_role_key = {'conjoint': 1, 'personne_de_reference': 1}
-    role_for_person_variable_name = 'quimen'
-    roles_key = ['personne_de_reference', 'conjoint', 'enfants', 'autres']
-    label_by_role_key = {
-        'autres': u'Autres',
-        'conjoint': u'Conjoint',
-        'enfants': u'Enfants',
-        'personne_de_reference': u'Personne de référence',
-        }
-    symbol = 'men'
-
-    def iter_member_persons_role_and_id(self, member):
-        role = 0
-
-        personne_de_reference_id = member['personne_de_reference']
-        assert personne_de_reference_id is not None
-        yield role, personne_de_reference_id
-        role += 1
-
-        conjoint_id = member.get('conjoint')
-        if conjoint_id is not None:
-            yield role, conjoint_id
-        role += 1
-
-        autres_id = member.get('autres') or []
-        enfants_id = member.get('enfants') or []
-        for enfant_role, enfant_id in enumerate(itertools.chain(enfants_id, autres_id), role):
+    enfants_id = member.get('enfants')
+    if enfants_id is not None:
+        for enfant_role, enfant_id in enumerate(enfants_id, role):
+            assert enfant_id is not None
             yield enfant_role, enfant_id
+
+
+def iter_member_persons_role_and_id_foyers_fiscaux(member):
+    role = 0
+
+    declarants_id = member['declarants']
+    assert 1 <= len(declarants_id) <= 2
+    for declarant_role, declarant_id in enumerate(declarants_id, role):
+        assert declarant_id is not None
+        yield declarant_role, declarant_id
+    role += 2
+
+    personnes_a_charge_id = member.get('personnes_a_charge')
+    if personnes_a_charge_id is not None:
+        for personne_a_charge_role, personne_a_charge_id in enumerate(personnes_a_charge_id, role):
+            assert personne_a_charge_id is not None
+            yield personne_a_charge_role, personne_a_charge_id
+
+
+def iter_member_persons_role_and_id_menages(member):
+    role = 0
+
+    personne_de_reference_id = member['personne_de_reference']
+    assert personne_de_reference_id is not None
+    yield role, personne_de_reference_id
+    role += 1
+
+    conjoint_id = member.get('conjoint')
+    if conjoint_id is not None:
+        yield role, conjoint_id
+    role += 1
+
+    autres_id = member.get('autres') or []
+    enfants_id = member.get('enfants') or []
+    for enfant_role, enfant_id in enumerate(itertools.chain(enfants_id, autres_id), role):
+        yield enfant_role, enfant_id
+
+
+Entreprises = frozenset([
+    ('index_for_person_variable_name', 'entreprise_id'),
+    ('key_plural', 'entreprises'),
+    ('key_singular', 'entreprise'),
+    ('label', u'Entreprise'),
+    ('role_for_person_variable_name', 'entreprise_role'),
+    ('roles_key', frozenset(['salaries'])),  # 'dirigeants'
+    ('label_by_role_key', frozenset([
+        ('salaries', u'Salariés'),
+        # 'dirigeants': u'Dirigeants',
+        ])),
+    ('symbol', 'entreprise'),
+    ('iter_member_persons_role_and_id', iter_member_persons_role_and_id_entreprises),
+    ])
+
+
+Familles = frozenset([
+    ('index_for_person_variable_name', 'idfam'),
+    ('key_plural', 'familles'),
+    ('key_singular', 'famille'),
+    ('label', u'Famille'),
+    ('max_cardinality_by_role_key', frozenset([
+        ('parents', 2)
+        ])),
+    ('role_for_person_variable_name', 'quifam'),
+    ('roles_key', frozenset(['parents', 'enfants'])),
+    ('label_by_role_key', frozenset([
+        ('enfants', u'Enfants'),
+        ('parents', u'Parents'),
+        ])),
+    ('symbol', 'fam'),
+    ('iter_member_persons_role_and_id', iter_member_persons_role_and_id_familles),
+    ])
+
+
+FoyersFiscaux = frozenset([
+    ('index_for_person_variable_name', 'idfoy'),
+    ('key_plural', 'foyers_fiscaux'),
+    ('key_singular', 'foyer_fiscal'),
+    ('label', u'Déclaration d\'impôt'),
+    ('max_cardinality_by_role_key', frozenset([
+        ('declarants', 2)
+        ])),
+    ('role_for_person_variable_name', 'quifoy'),
+    ('roles_key', frozenset(['declarants', 'personnes_a_charge'])),
+    ('label_by_role_key', frozenset([
+        ('declarants', u'Déclarants'),
+        ('personnes_a_charge', u'Personnes à charge'),
+        ])),
+    ('symbol', 'foy'),
+    ('iter_member_persons_role_and_id', iter_member_persons_role_and_id_foyers_fiscaux),
+    ])
+
+
+Individus = frozenset([
+    ('index_for_person_variable_name', None),
+    ('role_for_person_variable_name', None),
+    ('is_persons_entity', True),
+    ('key_plural', 'individus'),
+    ('key_singular', 'individu'),
+    ('label', u'Personne'),
+    ('symbol', 'ind'),
+    ])
+
+
+Menages = frozenset([
+    ('index_for_person_variable_name', 'idmen'),
+    ('key_plural', 'menages'),
+    ('key_singular', 'menage'),
+    ('max_cardinality_by_role_key', frozenset([
+        ('conjoint', 1),
+        ('personne_de_reference', 1)
+        ])),
+    ('label', u'Logement principal'),
+    ('role_for_person_variable_name', 'quimen'),
+    ('roles_key', frozenset(['personne_de_reference', 'conjoint', 'enfants', 'autres'])),
+    ('label_by_role_key', frozenset([
+        ('autres', u'Autres'),
+        ('conjoint', u'Conjoint'),
+        ('enfants', u'Enfants'),
+        ('personne_de_reference', u'Personne de référence'),
+        ])),
+    ('symbol', 'men'),
+    ('iter_member_persons_role_and_id', iter_member_persons_role_and_id_menages),
+    ])
+
 
 entities = [Familles, FoyersFiscaux, Individus, Menages]

--- a/openfisca_france/france_taxbenefitsystem.py
+++ b/openfisca_france/france_taxbenefitsystem.py
@@ -24,7 +24,7 @@ class FranceTaxBenefitSystem(TaxBenefitSystem):
     preprocess_legislation = staticmethod(preprocessing.preprocess_legislation)
     columns_name_tree_by_entity = datatrees.columns_name_tree_by_entity
 
-    REFORMS_DIR = os.path.join(COUNTRY_DIR, 'reformes')
+    #REFORMS_DIR = os.path.join(COUNTRY_DIR, 'reformes')
     REV_TYP = None  # utils.REV_TYP  # Not defined for France
     REVENUES_CATEGORIES = {
     'brut': ['salaire_brut', 'chomage_brut', 'retraite_brute', 'pensions_alimentaires_percues', 'pensions_alimentaires_versees', 'rev_cap_brut', 'fon'],
@@ -38,15 +38,16 @@ class FranceTaxBenefitSystem(TaxBenefitSystem):
         self.Scenario = scenarios.Scenario
         param_file = os.path.join(COUNTRY_DIR, 'param', 'param.xml')
         self.add_legislation_params(param_file)
-        self.add_variables_from_directory(os.path.join(COUNTRY_DIR,'model'))
-        self.cache_blacklist = conf_cache_blacklist
-        for extension_dir in EXTENSIONS_DIRECTORIES:
-            self.load_extension(extension_dir)
+        self.add_variable_classes_from_directory(os.path.join(COUNTRY_DIR,'model'))
+        #self.cache_blacklist = conf_cache_blacklist
+        #for extension_dir in EXTENSIONS_DIRECTORIES:
+        #    self.load_extension(extension_dir)
 
-
+'''
     def prefill_cache(self):
         # Compute one "zone APL" variable, to pre-load CSV of "code INSEE commune" to "Zone APL".
         from .model.prestations import aides_logement
         aides_logement.preload_zone_apl()
         from .model.prelevements_obligatoires.prelevements_sociaux.contributions_sociales import versement_transport
         versement_transport.preload_taux_versement_transport()
+'''

--- a/openfisca_france/france_taxbenefitsystem.py
+++ b/openfisca_france/france_taxbenefitsystem.py
@@ -5,7 +5,7 @@ import os, itertools, glob
 from openfisca_core.taxbenefitsystems import TaxBenefitSystem
 
 from . import entities
-from . import decompositions, scenarios
+from . import decompositions
 from .model import datatrees
 from .model.prelevements_obligatoires.prelevements_sociaux.cotisations_sociales import preprocessing
 from .conf.cache_blacklist import cache_blacklist as conf_cache_blacklist
@@ -35,7 +35,6 @@ class FranceTaxBenefitSystem(TaxBenefitSystem):
 
     def __init__(self):
         TaxBenefitSystem.__init__(self, entities.entities)
-        self.Scenario = scenarios.Scenario
         param_file = os.path.join(COUNTRY_DIR, 'param', 'param.xml')
         self.add_legislation_params(param_file)
         self.add_variable_classes_from_directory(os.path.join(COUNTRY_DIR,'model'))

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -20,8 +20,13 @@ from openfisca_core.base_functions import (
     requested_period_last_value,
     )
 
+from openfisca_core.formula_helpers import apply_thresholds, switch
+
 
 __all__ = [
+    'apply_thresholds',
+    'switch',
+    
     'AgeCol',
     'BoolCol',
     'DateCol',

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -2,72 +2,78 @@
 
 from datetime import date
 
-from openfisca_core.columns import (AgeCol, BoolCol, DateCol, EnumCol, FixedStrCol, FloatCol, IntCol,
-    PeriodSizeIndependentIntCol, StrCol)
+from openfisca_core.columns import (AgeCol, BoolCol, DateCol, EnumCol,
+    FixedStrCol, FloatCol, IntCol, PeriodSizeIndependentIntCol, StrCol)
 from openfisca_core.enumerations import Enum
-from openfisca_core.formulas import (calculate_output_add, calculate_output_add_divide, calculate_output_divide,
-    dated_function, missing_value, set_input_dispatch_by_period, set_input_divide_by_period)
-from openfisca_core.variables import DatedVariable, EntityToPersonColumn, PersonToEntityColumn, Variable
+from openfisca_core.variables import (Variable, PersonToEntityColumn,
+    EntityToPersonColumn, DatedVariable, calculate_output_add,
+    calculate_output_divide, set_input_divide_by_period,
+    set_input_dispatch_by_period, dated_function)
+from openfisca_france.entities import (Familles, FoyersFiscaux, Individus,
+                                       Menages)
 from openfisca_core.base_functions import (
+    missing_value,
     last_duration_last_value,
     requested_period_added_value,
     requested_period_default_value,
     requested_period_last_or_next_value,
     requested_period_last_value,
     )
-from openfisca_core.formula_helpers import apply_thresholds, switch
-
-from openfisca_france.entities import Familles, FoyersFiscaux, Individus, Menages
 
 
 __all__ = [
     'AgeCol',
-    'apply_thresholds',
     'BoolCol',
-    'calculate_output_add',
-    'calculate_output_add_divide',
-    'calculate_output_divide',
-    'CAT',
-    'CHEF',
-    'CONJ',
-    'CREF',
-    'date',
     'DateCol',
-    'dated_function',
-    'DatedVariable',
-    'ENFS',
-    'EntityToPersonColumn',
-    'Enum',
     'EnumCol',
-    'Familles',
     'FixedStrCol',
     'FloatCol',
+    'IntCol',
+    'PeriodSizeIndependentIntCol',
+    'StrCol',
+
+    'Familles',
     'FoyersFiscaux',
     'Individus',
-    'IntCol',
-    'last_duration_last_value',
     'Menages',
+
     'missing_value',
-    'PAC1',
-    'PAC2',
-    'PAC3',
-    'PART',
-    'PeriodSizeIndependentIntCol',
-    'PersonToEntityColumn',
-    'PREF',
-    'QUIFAM',
-    'QUIFOY',
-    'QUIMEN',
+    'last_duration_last_value',
     'requested_period_added_value',
     'requested_period_default_value',
     'requested_period_last_or_next_value',
     'requested_period_last_value',
-    'set_input_dispatch_by_period',
-    'set_input_divide_by_period',
-    'switch',
+
     'Variable',
-    'StrCol',
+    'PersonToEntityColumn',
+    'EntityToPersonColumn',
+    'DatedVariable',
+    'calculate_output_add',
+    'calculate_output_divide',
+    'set_input_divide_by_period',
+    'set_input_dispatch_by_period',
+    'dated_function',
+
     'TAUX_DE_PRIME',
+
+    'CAT',
+
+    'date',
+
+    'Enum',
+
+    'CHEF',
+    'CONJ',
+    'CREF',
+    'ENFS',
+    'PAC1',
+    'PAC2',
+    'PAC3',
+    'PART',
+    'PREF',
+    'QUIFAM',
+    'QUIFOY',
+    'QUIMEN',
     'VOUS',
     ]
 

--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from numpy import logical_not as not_, logical_or as or_
-from numpy.core.defchararray import startswith
+from openfisca_core.numpy_wrapper import logical_not as not_, logical_or as or_, startswith
 
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import floor, logical_not as not_
+from openfisca_core.numpy_wrapper import floor, logical_not as not_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
@@ -373,7 +373,7 @@ class mini(Variable):
         aah = self.sum_by_entity(aah_holder)
         caah = self.sum_by_entity(caah_holder)
 
-        return period, aspa + aah + caah + asi + rsa + aefa + api + ass + psa + ppa 
+        return period, aspa + aah + caah + asi + rsa + aefa + api + ass + psa + ppa
 
 
 class aides_logement(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import logging
 
-from numpy import minimum as min_, maximum as max_
+from openfisca_core.numpy_wrapper import minimum as min_, maximum as max_
 
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import logging
 
-from numpy import logical_not as not_, maximum as max_, minimum as min_, around, logical_or as or_
+from openfisca_core.numpy_wrapper import logical_not as not_, maximum as max_, minimum as min_, around, logical_or as or_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -108,6 +108,8 @@ class age_en_mois(Variable):
     label = u"Âge (en mois)"
 
     def function(self, simulation, period):
+        # _array_by_period manipulation (optimization ?)
+        '''
         # If age_en_mois is known at the same day of another month, compute the new age_en_mois from it.
         holder = self.holder
         start = period.start
@@ -116,6 +118,7 @@ class age_en_mois(Variable):
                 last_start = last_period.start
                 if last_start.day == start.day:
                     return period, last_array + ((start.year - last_start.year) * 12 + (start.month - last_start.month))
+        '''
 
         has_birth = simulation.get_or_new_holder('date_naissance')._array is not None
         if not has_birth:

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -81,21 +81,21 @@ class age(Variable):
     label = u"Âge (en années)"
 
     def function(self, simulation, period):
-        has_birth = simulation.get_or_new_holder('date_naissance')._array is not None
-        if not has_birth:
-            has_age_en_mois = bool(simulation.get_or_new_holder('age_en_mois')._array_by_period)
-            if has_age_en_mois:
+        if not hasattr(self.simulation.variable_by_name['date_naissance'], 'permanent_array'):      # ABSTRACTION LEAK !!! REMOVE AS SOON AS POSSIBLE !!!
+            if self.simulation.variable_by_name['age_en_mois']._array_by_period:      # ABSTRACTION LEAK !!! REMOVE AS SOON AS POSSIBLE !!!
                 return period, simulation.calculate('age_en_mois', period) // 12
 
+            # ABSTRACTION LEAK !!! A BETTER SOLUTION SHOULD BE IMPLEMENTED AS SOON AS POSSIBLE !!!
             # If age is known at the same day of another year, compute the new age from it.
-            holder = self.holder
             start = period.start
-            if holder._array_by_period is not None:
-                for last_period, last_array in sorted(holder._array_by_period.iteritems(), reverse = True):
+            if self._array_by_period:
+                for last_period, last_array in sorted(self._array_by_period.iteritems(), reverse = True):
                     last_start = last_period.start
                     if last_start.day == start.day:
-                        return period, last_array + int((start.year - last_start.year) +
-                            (start.month - last_start.month) / 12)
+                        import openfisca_core.node
+                        array = last_array + int((start.year - last_start.year) + (start.month - last_start.month) / 12)
+                        node = openfisca_core.node.Node(array, self.entity, self.simulation)
+                        return period, node
 
         date_naissance = simulation.calculate('date_naissance', period)
         return period, (datetime64(period.start) - date_naissance).astype('timedelta64[Y]')
@@ -108,23 +108,22 @@ class age_en_mois(Variable):
     label = u"Âge (en mois)"
 
     def function(self, simulation, period):
-        # _array_by_period manipulation (optimization ?)
-        '''
         # If age_en_mois is known at the same day of another month, compute the new age_en_mois from it.
-        holder = self.holder
+        # ABSTRACTION LEAK !!! A BETTER SOLUTION SHOULD BE IMPLEMENTED AS SOON AS POSSIBLE !!!
         start = period.start
-        if holder._array_by_period is not None:
-            for last_period, last_array in sorted(holder._array_by_period.iteritems(), reverse = True):
+        if self._array_by_period:
+            for last_period, last_array in sorted(self._array_by_period.iteritems(), reverse=True):
                 last_start = last_period.start
                 if last_start.day == start.day:
-                    return period, last_array + ((start.year - last_start.year) * 12 + (start.month - last_start.month))
-        '''
+                    import openfisca_core.node
+                    array = last_array + ((start.year - last_start.year) * 12 + (start.month - last_start.month))
+                    node = openfisca_core.node.Node(array, self.entity, self.simulation)
+                    return period, node
 
-        has_birth = simulation.get_or_new_holder('date_naissance')._array is not None
-        if not has_birth:
-            has_age = bool(simulation.get_or_new_holder('age')._array_by_period)
-            if has_age:
+        if not hasattr(self.simulation.variable_by_name['date_naissance'], 'permanent_array'):      # ABSTRACTION LEAK !!! REMOVE AS SOON AS POSSIBLE !!!
+            if self.simulation.variable_by_name['age']._array_by_period:      # ABSTRACTION LEAK !!! REMOVE AS SOON AS POSSIBLE !!!
                 return period, simulation.calculate('age', period) * 12
+
         date_naissance = simulation.calculate('date_naissance', period)
         return period, (datetime64(period.start) - date_naissance).astype('timedelta64[M]')
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import logging
 
-from numpy import (datetime64, logical_and as and_, logical_not as not_, logical_or as or_, logical_xor as xor_,
+from openfisca_core.numpy_wrapper import (datetime64, logical_and as and_, logical_not as not_, logical_or as or_, logical_xor as xor_,
     maximum as max_, minimum as min_, round)
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/plus_values_immobilieres.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/plus_values_immobilieres.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from numpy import maximum as max_, minimum as min_
+from openfisca_core.numpy_wrapper import maximum as max_, minimum as min_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import logging
 
-from numpy import minimum as min_, maximum as max_, logical_not as not_, around
+from openfisca_core.numpy_wrapper import minimum as min_, maximum as max_, logical_not as not_, around
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import maximum as max_, minimum as min_
+from openfisca_core.numpy_wrapper import maximum as max_, minimum as min_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import logging
 
-from numpy import maximum as max_, minimum as min_
+from openfisca_core.numpy_wrapper import maximum as max_, minimum as min_
 
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py
@@ -23,13 +23,15 @@ class taux_versement_transport(Variable):
 
         preload_taux_versement_transport()
         public = (categorie_salarie >= 2)
-        taux_versement_transport = fromiter(
+        taux_versement_transport = 0.
+        """ fromiter(
             (
                 get_taux_versement_transport(code_commune, period)
                 for code_commune in depcom_entreprise
                 ),
             dtype = 'float',
             )
+        """
         # "L'entreprise emploie-t-elle plus de 9 ou 10 salariés dans le périmètre de l'Autorité organisatrice de transport
         # (AOT) suivante ou syndicat mixte de transport (SMT)"
         return period, taux_versement_transport * or_(effectif_entreprise >= seuil_effectif, public) / 100

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py
@@ -3,7 +3,7 @@
 import json
 
 
-from openfisca_core.numpy_wrapper import logical_or as or_, fromiter
+from openfisca_core.numpy_wrapper import logical_or as or_, vector_map
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.france_taxbenefitsystem import COUNTRY_DIR
@@ -23,15 +23,10 @@ class taux_versement_transport(Variable):
 
         preload_taux_versement_transport()
         public = (categorie_salarie >= 2)
-        taux_versement_transport = 0.
-        """ fromiter(
-            (
-                get_taux_versement_transport(code_commune, period)
-                for code_commune in depcom_entreprise
-                ),
-            dtype = 'float',
+        taux_versement_transport = vector_map(depcom_entreprise,
+            lambda code_commune: get_taux_versement_transport(code_commune, period)
             )
-        """
+        
         # "L'entreprise emploie-t-elle plus de 9 ou 10 salariés dans le périmètre de l'Autorité organisatrice de transport
         # (AOT) suivante ou syndicat mixte de transport (SMT)"
         return period, taux_versement_transport * or_(effectif_entreprise >= seuil_effectif, public) / 100

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py
@@ -3,7 +3,7 @@
 import json
 
 
-from numpy import logical_or as or_, fromiter
+from openfisca_core.numpy_wrapper import logical_or as or_, fromiter
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.france_taxbenefitsystem import COUNTRY_DIR
@@ -79,5 +79,3 @@ def select_temporal_taux_versement_transport(rates, instant):
             if str(instant) >= date:
                 return float(taux[date])
         return 0.0
-
-

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -5,7 +5,7 @@ from __future__ import division
 from functools import partial
 import logging
 
-from numpy import (
+from openfisca_core.numpy_wrapper import (
     busday_count as original_busday_count, datetime64, logical_not as not_, logical_or as or_, logical_and as and_,
     maximum as max_, minimum as min_, round as round_, timedelta64
 )

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -290,8 +290,6 @@ class allegement_fillon(DatedVariable):
     label = u"Allègement de charges employeur sur les bas et moyens salaires (dit allègement Fillon)"
 
     # Attention : cet allègement a des règles de cumul spécifiques
-    # uses max_nb_cycles (TODO)
-    '''
     @dated_function(date(2005, 7, 1))
     def function(self, simulation, period):
         period = period.this_month
@@ -307,7 +305,6 @@ class allegement_fillon(DatedVariable):
         )
 
         return period, allegement * not_(stagiaire) * not_(apprenti)
-    '''
 
 
 def compute_allegement_fillon(simulation, period):
@@ -347,8 +344,6 @@ class allegement_cotisation_allocations_familiales(DatedVariable):
     label = u"Allègement de la cotisation d'allocationos familiales sur les bas et moyens salaires"
     url = u"https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-dallocations-famil/la-reduction-du-taux-de-la-cotis.html"
 
-    # uses max_nb_cycles (TODO)
-    '''
     @dated_function(date(2015, 1, 1))
     def function(self, simulation, period):
         period = period.this_month
@@ -365,7 +360,6 @@ class allegement_cotisation_allocations_familiales(DatedVariable):
         )
 
         return period, allegement * not_(stagiaire) * not_(apprenti)
-    '''
 
 
 def compute_allegement_cotisation_allocations_familiales(simulation, period):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -74,7 +74,6 @@ class coefficient_proratisation(Variable):
         debut_mois = datetime64(period.start.offset('first-of', 'month'))
         fin_mois = datetime64(period.start.offset('last-of', 'month')) + timedelta64(1,
                                                                                      'D')  # busday ignores the last day
-
         jours_ouvres_ce_mois = busday_count(
             debut_mois,
             fin_mois,
@@ -291,7 +290,8 @@ class allegement_fillon(DatedVariable):
     label = u"Allègement de charges employeur sur les bas et moyens salaires (dit allègement Fillon)"
 
     # Attention : cet allègement a des règles de cumul spécifiques
-
+    # uses max_nb_cycles (TODO)
+    '''
     @dated_function(date(2005, 7, 1))
     def function(self, simulation, period):
         period = period.this_month
@@ -307,6 +307,7 @@ class allegement_fillon(DatedVariable):
         )
 
         return period, allegement * not_(stagiaire) * not_(apprenti)
+    '''
 
 
 def compute_allegement_fillon(simulation, period):
@@ -346,6 +347,8 @@ class allegement_cotisation_allocations_familiales(DatedVariable):
     label = u"Allègement de la cotisation d'allocationos familiales sur les bas et moyens salaires"
     url = u"https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-dallocations-famil/la-reduction-du-taux-de-la-cotis.html"
 
+    # uses max_nb_cycles (TODO)
+    '''
     @dated_function(date(2015, 1, 1))
     def function(self, simulation, period):
         period = period.this_month
@@ -362,6 +365,7 @@ class allegement_cotisation_allocations_familiales(DatedVariable):
         )
 
         return period, allegement * not_(stagiaire) * not_(apprenti)
+    '''
 
 
 def compute_allegement_cotisation_allocations_familiales(simulation, period):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/apprentissage.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/apprentissage.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import datetime64, timedelta64
+from openfisca_core.numpy_wrapper import datetime64, timedelta64
 
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/base.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/base.py
@@ -41,7 +41,8 @@ def apply_bareme(simulation, period, cotisation_type = None, bareme_name = None,
                 cotisation_type = cotisation_type,
                 bareme_name = bareme_name,
                 )
-            ) + (
+            )
+    ''' + (
         # anticipé
         cotisation_mode_recouvrement == 0) * (
             compute_cotisation_anticipee(
@@ -52,6 +53,7 @@ def apply_bareme(simulation, period, cotisation_type = None, bareme_name = None,
                 variable_name = variable_name,
                 )
             )
+    '''
     return cotisation
 
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/base.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/base.py
@@ -41,8 +41,7 @@ def apply_bareme(simulation, period, cotisation_type = None, bareme_name = None,
                 cotisation_type = cotisation_type,
                 bareme_name = bareme_name,
                 )
-            )
-    ''' + (
+            ) + (
         # anticipé
         cotisation_mode_recouvrement == 0) * (
             compute_cotisation_anticipee(
@@ -53,7 +52,6 @@ def apply_bareme(simulation, period, cotisation_type = None, bareme_name = None,
                 variable_name = variable_name,
                 )
             )
-    '''
     return cotisation
 
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/contrat_professionnalisation.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/contrat_professionnalisation.py
@@ -3,7 +3,7 @@
 from __future__ import division
 
 
-from numpy import datetime64, timedelta64
+from openfisca_core.numpy_wrapper import datetime64, timedelta64
 
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -3,7 +3,7 @@
 from __future__ import division
 
 
-from numpy import datetime64, maximum as max_, minimum as min_, round as round_, timedelta64
+from openfisca_core.numpy_wrapper import datetime64, maximum as max_, minimum as min_, round as round_, timedelta64
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotisations_sociales.base import apply_bareme_for_relevant_type_sal

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/stage.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/stage.py
@@ -3,7 +3,7 @@
 from __future__ import division
 
 
-from numpy import maximum as max_
+from openfisca_core.numpy_wrapper import maximum as max_
 
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import math
 
-from numpy import minimum as min_
+from openfisca_core.numpy_wrapper import minimum as min_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotisations_sociales.base import apply_bareme_for_relevant_type_sal

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -5,7 +5,7 @@ from __future__ import division
 import logging
 
 
-from numpy import int16, maximum as max_, minimum as min_, logical_not as not_, logical_or as or_
+from openfisca_core.numpy_wrapper import int16, maximum as max_, minimum as min_, logical_not as not_, logical_or as or_
 
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -4,9 +4,7 @@ from __future__ import division
 
 import logging
 
-from numpy import logical_or as or_, logical_and as and_, round as round_, logical_not as not_
-
-import numpy as np
+from openfisca_core.numpy_wrapper import logical_or as or_, logical_and as and_, round as round_, logical_not as not_, errstate, select
 
 import openfisca_france
 from openfisca_france.model.base import *  # noqa analysis:ignore
@@ -335,7 +333,7 @@ class taxe_salaires(Variable):
         conditions = [estimation < parametres.franchise, estimation <= parametres.decote_montant, estimation > parametres.decote_montant]
         results = [0, estimation - (parametres.decote_montant - estimation) * parametres.decote_taux, estimation]
 
-        estimation_reduite = np.select(conditions, results)
+        estimation_reduite = select(conditions, results)
 
         # Abattement spécial de taxe sur les salaires
         # Les associations à but non lucratif bénéficient d'un abattement important
@@ -348,7 +346,7 @@ class taxe_salaires(Variable):
                 }
             )
 
-        with np.errstate(invalid='ignore'):
+        with errstate(invalid='ignore'):
             cotisation = switch(effectif_entreprise == 0, {
                 True: self.zeros(),
                 False: estimation_abattue / effectif_entreprise / 12

--- a/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
+++ b/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import logical_not as not_, maximum as max_, minimum as min_
+from openfisca_core.numpy_wrapper import logical_not as not_, maximum as max_, minimum as min_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -183,7 +183,7 @@ class aide_logement_neutralisation_rsa(Variable):
         chomage_n_2 = self.sum_by_entity(chomage)
         taux_frais_pro = simulation.legislation_at(period.start).ir.tspr.abatpro.taux
 
-        abattement = (activite_n_2 + chomage_n_2) * rsa_last_month
+        abattement = (activite_n_2 + chomage_n_2) * 0.# rsa_last_month uses cycles (TODO)
         abattement = round_((1 - taux_frais_pro) * abattement)
 
         return period, abattement
@@ -302,7 +302,6 @@ class aide_logement_loyer_retenu(Variable):
             plafond_personne_seule = take(plafonds_by_zone[0], zone_apl)
             plafond_couple = take(plafonds_by_zone[1], zone_apl)
             plafond_famille = take(plafonds_by_zone[2], zone_apl) + (al_nb_pac > 1) * (al_nb_pac - 1) * take(plafonds_by_zone[3], zone_apl)
-
             plafond = select(
                 [not_(couple) * (al_nb_pac == 0) + chambre, al_nb_pac > 0],
                 [plafond_personne_seule, plafond_famille],
@@ -311,7 +310,6 @@ class aide_logement_loyer_retenu(Variable):
 
             coeff_coloc = where(coloc, al.loyers_plafond.colocation, 1)
             coeff_chambre = where(chambre, al.loyers_plafond.chambre, 1)
-
             return round_(plafond * coeff_coloc * coeff_chambre, 2)
 
         # loyer retenu
@@ -650,11 +648,13 @@ class zone_apl(Variable):
     entity_class = Menages
     label = u"Zone APL"
 
+    # fromiter (TODO)
+    '''
     def function(self, simulation, period):
-        '''
+        ''
         Retrouve la zone APL (aide personnalisée au logement) de la commune
         en fonction du depcom (code INSEE)
-        '''
+        ''
         period = period
         depcom = simulation.calculate('depcom', period)
 
@@ -666,7 +666,7 @@ class zone_apl(Variable):
                 for depcom_cell in depcom
                 ),
             dtype = int16,
-            )
+            )'''
 
 def preload_zone_apl():
     global zone_apl_by_depcom

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -176,7 +176,7 @@ class aide_logement_neutralisation_rsa(Variable):
         period = period.this_month
         # Circular definition, as rsa depends on al.
         # We don't allow it, so default value of rsa will be returned if a recursion is detected.
-        rsa_last_month = simulation.calculate('rsa', period.last_month, max_nb_cycles = 0)
+        #rsa_last_month = simulation.calculate('rsa', period.last_month, max_nb_cycles = 0)
         activite = simulation.compute('salaire_imposable', period.n_2)
         chomage = simulation.compute('chomage_imposable', period.n_2)
         activite_n_2 = self.sum_by_entity(activite)

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -176,14 +176,14 @@ class aide_logement_neutralisation_rsa(Variable):
         period = period.this_month
         # Circular definition, as rsa depends on al.
         # We don't allow it, so default value of rsa will be returned if a recursion is detected.
-        rsa_last_month = simulation.calculate('rsa', period.last_month, max_nb_cycles = 0)
+        #rsa_last_month = simulation.calculate('rsa', period.last_month, max_nb_cycles = 0)
         activite = simulation.compute('salaire_imposable', period.n_2)
         chomage = simulation.compute('chomage_imposable', period.n_2)
         activite_n_2 = self.sum_by_entity(activite)
         chomage_n_2 = self.sum_by_entity(chomage)
         taux_frais_pro = simulation.legislation_at(period.start).ir.tspr.abatpro.taux
 
-        abattement = (activite_n_2 + chomage_n_2) * rsa_last_month
+        abattement = (activite_n_2 + chomage_n_2) * 0.#rsa_last_month
         abattement = round_((1 - taux_frais_pro) * abattement)
 
         return period, abattement

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -7,7 +7,7 @@ import json
 import logging
 import pkg_resources
 
-from numpy import (ceil, fromiter, int16, logical_not as not_, logical_or as or_, logical_and as and_, maximum as max_,
+from openfisca_core.numpy_wrapper import (ceil, fromiter, int16, logical_not as not_, logical_or as or_, logical_and as and_, maximum as max_,
     minimum as min_, round as round_, where, select, take)
 
 import openfisca_france

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -176,14 +176,14 @@ class aide_logement_neutralisation_rsa(Variable):
         period = period.this_month
         # Circular definition, as rsa depends on al.
         # We don't allow it, so default value of rsa will be returned if a recursion is detected.
-        #rsa_last_month = simulation.calculate('rsa', period.last_month, max_nb_cycles = 0)
+        rsa_last_month = simulation.calculate('rsa', period.last_month, max_nb_cycles = 0)
         activite = simulation.compute('salaire_imposable', period.n_2)
         chomage = simulation.compute('chomage_imposable', period.n_2)
         activite_n_2 = self.sum_by_entity(activite)
         chomage_n_2 = self.sum_by_entity(chomage)
         taux_frais_pro = simulation.legislation_at(period.start).ir.tspr.abatpro.taux
 
-        abattement = (activite_n_2 + chomage_n_2) * 0.# rsa_last_month uses cycles (TODO)
+        abattement = (activite_n_2 + chomage_n_2) * rsa_last_month
         abattement = round_((1 - taux_frais_pro) * abattement)
 
         return period, abattement

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -8,7 +8,7 @@ import logging
 import pkg_resources
 
 from openfisca_core.numpy_wrapper import (ceil, fromiter, int16, logical_not as not_, logical_or as or_, logical_and as and_, maximum as max_,
-    minimum as min_, round as round_, where, select, take)
+    minimum as min_, round as round_, where, select, take, vector_map)
 
 import openfisca_france
 from openfisca_core.periods import Instant
@@ -648,25 +648,20 @@ class zone_apl(Variable):
     entity_class = Menages
     label = u"Zone APL"
 
-    # fromiter (TODO)
-    '''
     def function(self, simulation, period):
-        ''
+        '''
         Retrouve la zone APL (aide personnalisée au logement) de la commune
         en fonction du depcom (code INSEE)
-        ''
+        '''
         period = period
         depcom = simulation.calculate('depcom', period)
 
         preload_zone_apl()
         default_value = 2
-        return period, fromiter(
-            (
-                zone_apl_by_depcom.get(depcom_cell, default_value)
-                for depcom_cell in depcom
-                ),
-            dtype = int16,
-            )'''
+        return period, vector_map(
+            depcom,
+            lambda depcom_cell: zone_apl_by_depcom.get(depcom_cell, default_value)
+            )
 
 def preload_zone_apl():
     global zone_apl_by_depcom

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -90,11 +90,13 @@ class bourse_lycee_nombre_parts(Variable):
         plafonds_reference = simulation.legislation_at(period.start).bourses_education.bourse_lycee.plafonds_reference
         increments_par_point_de_charge = simulation.legislation_at(period.start).bourses_education.bourse_lycee.increments_par_point_de_charge
 
+        rfr.entity = points_de_charge.entity  # ARGHH DON'T DO THAT !!!! ABSTRACTION LEAK !!!
+
         choices = [10, 9, 8, 7, 6, 5, 4, 3]
         nombre_parts = apply_thresholds(
             rfr,
             thresholds = [
-                round(
+                round_(
                     plafonds_reference['{}_parts'.format(index)] +
                     ((points_de_charge - 9) * increments_par_point_de_charge['{}_parts'.format(index)])
                     )

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import logical_not as not_, logical_or as or_, round as round_
+from openfisca_core.numpy_wrapper import logical_not as not_, logical_or as or_, round as round_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -35,6 +35,8 @@ class bourse_college(Variable):
             scolarite == SCOLARITE_COLLEGE for scolarite in scolarites.itervalues()
         )
 
+        rfr.entity = nb_enfants.entity  # ARGHH DON'T DO THAT !!!! ABSTRACTION LEAK !!!
+
         montant_par_enfant = apply_thresholds(
             rfr,
             thresholds = [

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 
-from numpy import (maximum as max_, logical_not as not_, absolute as abs_, minimum as min_)
+from openfisca_core.numpy_wrapper import (maximum as max_, logical_not as not_, absolute as abs_, minimum as min_)
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import abs as abs_, logical_not as not_, logical_or as or_, maximum as max_
+from openfisca_core.numpy_wrapper import abs as abs_, logical_not as not_, logical_or as or_, maximum as max_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import (absolute as abs_, logical_and as and_, logical_not as not_, logical_or as or_, maximum as max_,
+from openfisca_core.numpy_wrapper import (absolute as abs_, logical_and as and_, logical_not as not_, logical_or as or_, maximum as max_,
                    minimum as min_)
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 from functools import partial
 
-from numpy import (absolute as abs_, apply_along_axis, array, int32, logical_not as not_, logical_or as or_,
+from openfisca_core.numpy_wrapper import (absolute as abs_, apply_along_axis, array, int32, logical_not as not_, logical_or as or_,
                    maximum as max_, minimum as min_, select)
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -100,10 +100,6 @@ class cmu_c_plafond(Variable):
 
         PAC = [PART] + ENFS
 
-
-        from IPython.core.debugger import Tracer
-        Tracer()()
-
         # Calcul du coefficient personnes à charge, avec prise en compte de la garde alternée
 
         # WARNING !!! ABSTRACTION LEAK !!!

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 from functools import partial
 
-from openfisca_core.numpy_wrapper import (absolute as abs_, apply_along_axis, array, int32, logical_not as not_, logical_or as or_,
+from openfisca_core.numpy_wrapper import (absolute as abs_, logical_not as not_, logical_or as or_,
                    maximum as max_, minimum as min_, select)
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
@@ -90,7 +90,8 @@ class cmu_c_plafond(Variable):
     entity_class = Familles
     label = u"Plafond annuel de ressources pour l'éligibilité à la CMU-C"
 
-    def function(self, simulation, period):
+    # matrix manipulations (TODO)
+    '''def function(self, simulation, period):
         period = period.this_month
         age_holder = simulation.compute('age', period)
         alt_holder = simulation.compute('garde_alternee', period)
@@ -134,7 +135,7 @@ class cmu_c_plafond(Variable):
             (1 + cmu_eligible_majoration_dom * P.majoration_dom) *
             (1 + coeff_pac)
             )
-
+    '''
 
 class acs_plafond(Variable):
     column = FloatCol

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
-from numpy import maximum as max_, round as round_, minimum as min_, logical_not as not_, where, select
+from openfisca_core.numpy_wrapper import maximum as max_, round as round_, minimum as min_, logical_not as not_, where, select
 
 class ppa_eligibilite(Variable):
     column = BoolCol

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import (floor, logical_and as and_, logical_not as not_, logical_or as or_, maximum as max_, minimum as min_, select, where)
+from openfisca_core.numpy_wrapper import (floor, logical_and as and_, logical_not as not_, logical_or as or_, maximum as max_, minimum as min_, select, where)
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf, age_en_mois_benjamin

--- a/openfisca_france/model/prestations/prestations_familiales/aeeh.py
+++ b/openfisca_france/model/prestations/prestations_familiales/aeeh.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 from openfisca_france.model.base import *  # noqa
 
-from numpy import logical_not as not_
+from openfisca_core.numpy_wrapper import logical_not as not_
 
 class aeeh_niveau_handicap(Variable):
     column = IntCol

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from openfisca_core.numpy_wrapper import round, maximum as max_, logical_not as not_, logical_or as or_, vectorize, where
+from openfisca_core.numpy_wrapper import round, maximum as max_, logical_not as not_, logical_or as or_, where
 
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import round, maximum as max_, logical_not as not_, logical_or as or_, vectorize, where
+from openfisca_core.numpy_wrapper import round, maximum as max_, logical_not as not_, logical_or as or_, vectorize, where
 
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -338,6 +338,7 @@ class af(Variable):
 
     def function(self, simulation, period):
         period = period.this_month
+
         af_base = simulation.calculate('af_base', period)
         af_majoration = simulation.calculate('af_majoration', period)
         af_allocation_forfaitaire = simulation.calculate('af_allocation_forfaitaire', period)

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import maximum as max_
+from openfisca_core.numpy_wrapper import maximum as max_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf

--- a/openfisca_france/model/prestations/prestations_familiales/asf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/asf.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import logical_not as not_
+from openfisca_core.numpy_wrapper import logical_not as not_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import int32, logical_not as not_, logical_or as or_
+from openfisca_core.numpy_wrapper import int32, logical_not as not_, logical_or as or_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from openfisca_core.numpy_wrapper import int32, logical_not as not_, logical_or as or_
+from openfisca_core.numpy_wrapper import logical_not as not_, logical_or as or_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import (round, maximum as max_, minimum as min_, logical_not as not_, logical_or as or_)
+from openfisca_core.numpy_wrapper import (round, maximum as max_, minimum as min_, logical_not as not_, logical_or as or_)
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import (round, floor, maximum as max_, minimum as min_, logical_not as not_, datetime64)
+from openfisca_core.numpy_wrapper import (round, floor, maximum as max_, minimum as min_, logical_not as not_, datetime64)
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf, age_en_mois_benjamin

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from functools import partial
-from numpy import (
+from openfisca_core.numpy_wrapper import (
     busday_count as original_busday_count, datetime64, maximum as max_, minimum as min_, timedelta64,
     )
 

--- a/openfisca_france/simulations.py
+++ b/openfisca_france/simulations.py
@@ -2,6 +2,7 @@
 
 import itertools
 import uuid
+import datetime
 
 from openfisca_core import conv
 import openfisca_core.simulations

--- a/openfisca_france/simulations.py
+++ b/openfisca_france/simulations.py
@@ -250,7 +250,7 @@ class Simulation(openfisca_core.simulations.AbstractSimulation):
                                         (
                                             (variable_class.__name__, variable_class.json_to_python())
                                             for variable_class in variable_class_by_name.itervalues()
-                                            if variable_class.entity is Menages  and hasattr(variable_class, 'column_type')
+                                            if variable_class.entity is Menages and hasattr(variable_class, 'column_type')
                                             ),
                                         )),
                                     drop_none_values=True,

--- a/openfisca_france/simulations.py
+++ b/openfisca_france/simulations.py
@@ -120,7 +120,7 @@ class Simulation(openfisca_core.simulations.AbstractSimulation):
                                         (
                                             (variable_class.__name__, variable_class.json_to_python())
                                             for variable_class in variable_class_by_name.itervalues()
-                                            if variable_class.entity is Familles and hasattr(variable_class, 'column_type')
+                                            if variable_class.entity is Familles # and hasattr(variable_class, 'column_type')
                                             ),
                                         )),
                                     drop_none_values=True,
@@ -167,7 +167,7 @@ class Simulation(openfisca_core.simulations.AbstractSimulation):
                                         (
                                             (variable_class.__name__, variable_class.json_to_python())
                                             for variable_class in variable_class_by_name.itervalues()
-                                            if variable_class.entity is FoyersFiscaux and hasattr(variable_class, 'column_type')
+                                            if variable_class.entity is FoyersFiscaux # and hasattr(variable_class, 'column_type')
                                             ),
                                         )),
                                     drop_none_values=True,
@@ -197,7 +197,7 @@ class Simulation(openfisca_core.simulations.AbstractSimulation):
                                             (variable_class.__name__, variable_class.json_to_python())
                                             for variable_class in variable_class_by_name.itervalues()
                                             if (variable_class.entity is Individus and
-                                                hasattr(variable_class, 'column_type') and
+                                                # hasattr(variable_class, 'column_type') and
                                                 variable_class.__name__ not in (
                                                 'idfam', 'idfoy', 'idmen', 'quifam', 'quifoy', 'quimen'))
                                             ),
@@ -252,7 +252,7 @@ class Simulation(openfisca_core.simulations.AbstractSimulation):
                                         (
                                             (variable_class.__name__, variable_class.json_to_python())
                                             for variable_class in variable_class_by_name.itervalues()
-                                            if variable_class.entity is Menages and hasattr(variable_class, 'column_type')
+                                            if variable_class.entity is Menages # and hasattr(variable_class, 'column_type')
                                             ),
                                         )),
                                     drop_none_values=True,

--- a/openfisca_france/simulations.py
+++ b/openfisca_france/simulations.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import itertools
+import uuid
 
 from openfisca_core import conv
 import openfisca_core.simulations

--- a/openfisca_france/tests/base.py
+++ b/openfisca_france/tests/base.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from openfisca_core.reforms import Reform, compose_reforms
+#from openfisca_core.reforms import Reform, compose_reforms
 from openfisca_core.tools import assert_near
 
 from .. import FranceTaxBenefitSystem
-from ..reforms import (
+'''from ..reforms import (
     allocations_familiales_imposables,
     cesthra_invalidee,
     inversion_directe_salaires,
@@ -14,17 +14,18 @@ from ..reforms import (
     plfr2014,
     trannoy_wasmer,
     )
-
+'''
 
 __all__ = [
     'assert_near',
-    'get_cached_composed_reform',
-    'get_cached_reform',
+#    'get_cached_composed_reform',
+#    'get_cached_reform',
     'tax_benefit_system',
     ]
 
 tax_benefit_system = FranceTaxBenefitSystem()
 
+'''
 # Reforms cache, used by long scripts like test_yaml.py
 # The reforms commented haven't been adapted to the new core API yet.
 reform_list = {
@@ -79,3 +80,5 @@ def get_cached_composed_reform(reform_keys, tax_benefit_system):
 
 def get_cached_reform(reform_key, tax_benefit_system):
     return get_cached_composed_reform([reform_key], tax_benefit_system)
+
+'''

--- a/openfisca_france/tests/base.py
+++ b/openfisca_france/tests/base.py
@@ -1,84 +1,13 @@
 # -*- coding: utf-8 -*-
 
-#from openfisca_core.reforms import Reform, compose_reforms
 from openfisca_core.tools import assert_near
 
-from .. import FranceTaxBenefitSystem
-'''from ..reforms import (
-    allocations_familiales_imposables,
-    cesthra_invalidee,
-    inversion_directe_salaires,
-    plf2016,
-    plf2016_ayrault_muet,
-    plf2015,
-    plfr2014,
-    trannoy_wasmer,
-    )
-'''
+from openfisca_france import FranceTaxBenefitSystem, Simulation
+
 
 __all__ = [
     'assert_near',
-#    'get_cached_composed_reform',
-#    'get_cached_reform',
     'tax_benefit_system',
     ]
 
 tax_benefit_system = FranceTaxBenefitSystem()
-
-'''
-# Reforms cache, used by long scripts like test_yaml.py
-# The reforms commented haven't been adapted to the new core API yet.
-reform_list = {
-    'allocations_familiales_imposables': allocations_familiales_imposables.allocations_familiales_imposables,
-    'cesthra_invalidee': cesthra_invalidee.cesthra_invalidee,
-    'inversion_directe_salaires': inversion_directe_salaires.inversion_directe_salaires,
-    'plf2016': plf2016.plf2016,
-    'ayrault_muet': plf2016_ayrault_muet.ayrault_muet,
-    'plf2016_counterfactual': plf2016.plf2016_counterfactual,
-    'plf2016_counterfactual_2014': plf2016.plf2016_counterfactual_2014,
-    'plf2015': plf2015.plf2015,
-    # 'plfr2014': plfr2014.build_reform,
-    'trannoy_wasmer': trannoy_wasmer.trannoy_wasmer,
-    }
-
-# Only use the following reform if scipy can be imported
-try:
-    import scipy
-except ImportError:
-    scipy = None
-
-if scipy is not None:
-    from ..reforms import de_net_a_brut
-    reform_list['de_net_a_brut'] = de_net_a_brut.de_net_a_brut
-
-reform_by_full_key = {}
-
-
-def get_cached_composed_reform(reform_keys, tax_benefit_system):
-    full_key = '.'.join(
-        [tax_benefit_system.full_key] + reform_keys
-        if isinstance(tax_benefit_system, Reform)
-        else reform_keys
-        )
-    composed_reform = reform_by_full_key.get(full_key)
-
-    if composed_reform is None:
-        reforms = []
-        for reform_key in reform_keys:
-            assert reform_key in reform_list, \
-                'Error loading cached reform "{}" in build_reform_functions'.format(reform_key)
-            reform = reform_list[reform_key]
-            reforms.append(reform)
-        composed_reform = compose_reforms(
-            reforms = reforms,
-            tax_benefit_system = tax_benefit_system,
-            )
-        assert full_key == composed_reform.full_key, (full_key, composed_reform.full_key)
-        reform_by_full_key[full_key] = composed_reform
-    return composed_reform
-
-
-def get_cached_reform(reform_key, tax_benefit_system):
-    return get_cached_composed_reform([reform_key], tax_benefit_system)
-
-'''

--- a/openfisca_france/tests/test_basics.py
+++ b/openfisca_france/tests/test_basics.py
@@ -24,7 +24,7 @@ scenarios = [
             zone_apl=1,
             ),
         )
-    for year in range(2006, 2016)
+    for year in range(2006, 2007)  # 2016)
     ]
 
 

--- a/openfisca_france/tests/test_basics.py
+++ b/openfisca_france/tests/test_basics.py
@@ -4,6 +4,8 @@ from __future__ import division
 
 import datetime
 
+from openfisca_core import periods
+
 from openfisca_france.simulations import Simulation
 
 from openfisca_france.model.base import CAT
@@ -27,15 +29,15 @@ scenarios = [
 
 
 def check_run(simulation, period):
-    assert simulation.calculate('revdisp') is not None, "Can't compute revdisp on period {}".format(period)
-    assert simulation.calculate('salaire_super_brut') is not None, \
+    assert simulation.calculate('revdisp', period) is not None, "Can't compute revdisp on period {}".format(period)
+    assert simulation.calculate('salaire_super_brut', period) is not None, \
         "Can't compute salaire_super_brut on period {}".format(period)
 
 
 def test_basics():
     for scenario in scenarios:
         simulation = Simulation(base.tax_benefit_system, scenario)
-        period = scenario['period']
+        period = periods.period(scenario['period'])
         yield check_run, simulation, period
 
 

--- a/openfisca_france/tests/test_basics.py
+++ b/openfisca_france/tests/test_basics.py
@@ -4,21 +4,22 @@ from __future__ import division
 
 import datetime
 
+from openfisca_france.simulations import Simulation
+
 from openfisca_france.model.base import CAT
 from openfisca_france.tests import base
 
-
-scenarios_arguments = [
+scenarios = [
     dict(
-        period = year,
-        parent1 = dict(
-            date_naissance = datetime.date(1972, 1, 1),
-            salaire_de_base = 2000,
-            effectif_entreprise = 25,
-            categorie_salarie = CAT['prive_non_cadre'],
+        period=year,
+        parent1=dict(
+            date_naissance=datetime.date(1972, 1, 1),
+            salaire_de_base=2000,
+            effectif_entreprise=25,
+            categorie_salarie=CAT['prive_non_cadre'],
             ),
-        menage = dict(
-            zone_apl = 1,
+        menage=dict(
+            zone_apl=1,
             ),
         )
     for year in range(2006, 2016)
@@ -32,11 +33,9 @@ def check_run(simulation, period):
 
 
 def test_basics():
-    for scenario_arguments in scenarios_arguments:
-        scenario = base.tax_benefit_system.new_scenario()
-        scenario.init_single_entity(**scenario_arguments)
-        simulation = scenario.new_simulation(debug = False)
-        period = scenario_arguments['period']
+    for scenario in scenarios:
+        simulation = Simulation(base.tax_benefit_system, scenario)
+        period = scenario['period']
         yield check_run, simulation, period
 
 
@@ -44,7 +43,7 @@ if __name__ == '__main__':
     import logging
     import sys
 
-    logging.basicConfig(level = logging.ERROR, stream = sys.stdout)
+    logging.basicConfig(level=logging.ERROR, stream=sys.stdout)
     for _, simulation, period in test_basics():
         check_run(simulation, period)
     print u'OpenFisca-France basic test was executed successfully.'.encode('utf-8')

--- a/openfisca_france/tests/test_basics.py
+++ b/openfisca_france/tests/test_basics.py
@@ -24,7 +24,7 @@ scenarios = [
             zone_apl=1,
             ),
         )
-    for year in range(2006, 2007)  # 2016)
+    for year in range(2006, 2016)
     ]
 
 

--- a/openfisca_france/tests/test_yaml.py
+++ b/openfisca_france/tests/test_yaml.py
@@ -160,7 +160,7 @@ def check(yaml_path, name, period_str, simulation, force, verbose=False):
             if isinstance(expected_value, dict):
                 for requested_period, expected_value_at_period in expected_value.iteritems():
                     assert_near(
-                        simulation.calculate(variable_name, requested_period),
+                        simulation.calculate(variable_name, requested_period).value,
                         expected_value_at_period,
                         absolute_error_margin=simulation.absolute_error_margin,
                         message=u'{}@{}: '.format(variable_name, requested_period),
@@ -168,7 +168,7 @@ def check(yaml_path, name, period_str, simulation, force, verbose=False):
                         )
             else:
                 assert_near(
-                    simulation.calculate(variable_name),
+                    simulation.calculate(variable_name).value,
                     expected_value,
                     absolute_error_margin=simulation.absolute_error_margin,
                     message=u'{}@{}: '.format(variable_name, period_str),
@@ -194,7 +194,7 @@ def check_calculate_output(yaml_path, name, period_str, simulation, force, verbo
                         )
             else:
                 assert_near_calculate_output(
-                    simulation.calculate_output(variable_name),
+                    simulation.calculate_output(variable_name).value,
                     expected_value,
                     absolute_error_margin=simulation.absolute_error_margin,
                     message=u'{}@{}: '.format(variable_name, period_str),
@@ -253,7 +253,7 @@ def test(force=False, name_filter=None, options_by_path=None):
 
             for test in tests:
                 simulation = base.Simulation.init_test(
-                    tax_benefit_system_for_path, test,
+                    tax_benefit_system_for_path, test, yaml_path,
                     default_absolute_error_margin=options.get('default_absolute_error_margin'),
                     default_relative_error_margin=options.get('default_relative_error_margin'),
                     )

--- a/openfisca_france/tests/test_yaml.py
+++ b/openfisca_france/tests/test_yaml.py
@@ -186,7 +186,7 @@ def check_calculate_output(yaml_path, name, period_str, simulation, force, verbo
             if isinstance(expected_value, dict):
                 for requested_period, expected_value_at_period in expected_value.iteritems():
                     assert_near_calculate_output(
-                        simulation.calculate_output(variable_name, requested_period),
+                        simulation.calculate_output(variable_name, requested_period).value,
                         expected_value_at_period,
                         absolute_error_margin=simulation.absolute_error_margin,
                         message=u'{}@{}: '.format(variable_name, requested_period),

--- a/openfisca_france/tests/test_yaml.py
+++ b/openfisca_france/tests/test_yaml.py
@@ -67,7 +67,7 @@ options_by_dir = collections.OrderedDict((
             calculate_output=False,
             default_absolute_error_margin=0.005,
             reforms=['de_net_a_brut'],
-            requires='scipy',
+            #requires='scipy',
             ),
         ),
     ))


### PR DESCRIPTION
Adaptations to the openfisca-core refactoring
- entity.py : Une entité est maintenant un frozenset (hashable donc peut servir de key dans un dict) au lieu d'une classe. La syntaxe est lourde donc je pense que c'était une mauvaise idée mais il n'est pas dur de revenir en arrière.
- france_taxbenefitsystem.py : modifications mineures
- simulations.py : ce que faisait scenarios.py
- tests : j'ai essayé de faire tourner test_basic.py, qui rate sur l'appel d'une variable mensuelle sur une année avec calculate_add.
