### PR TITLE
Les indemnités journalière ne sont un revenu d'activité que les 3 premiers mois.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 4.1.15
+
+* Consider some indemnités journalieres as revenus de remplacement in PPA (and RSA), according to the date of the arret de travail.
+* Introduce
+	* `rsa_indemnites_journalieres_hors_activite`
+	* `rsa_indemnites_journalieres_activite`
+	* `date_arret_de_travail`
+
 ## 4.1.14
 
 * Add cerfa boxe : 3vt (PEA)

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -108,8 +108,8 @@ class ppa_revenu_activite_individu(Variable):
             'revenus_stage_formation_pro',
             'bourse_recherche',
             'indemnites_chomage_partiel',
-            'indemnites_journalieres',
             'tns_auto_entrepreneur_benefice',
+            'rsa_indemnites_journalieres_activite'
             ]
 
         revenus_mensualises = sum(
@@ -171,6 +171,7 @@ class ppa_ressources_hors_activite_individu(Variable):
             'prestation_compensatoire',
             'revenus_locatifs',
             'prime_forfaitaire_mensuelle_reprise_activite',
+            'rsa_indemnites_journalieres_hors_activite',
             ]
 
         ressources_hors_activite_i = sum(

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -333,6 +333,7 @@ class rsa_indemnites_journalieres_activite(Variable):
         date_arret_de_travail = simulation.calculate('date_arret_de_travail')
         three_months_ago = datetime64(period.start.offset(-3,'month'))
         condition_date_arret_travail =  date_arret_de_travail > three_months_ago
+        condition_activite = simulation.calculate('salaire_net', period) > 0
 
         # IJSS prises en compte comme un revenu d'activité seulement les 3 premiers mois qui suivent l'arrêt de travail
         ijss_activite_sous_condition = sum(simulation.calculate(ressource, period) for ressource in [
@@ -346,7 +347,7 @@ class rsa_indemnites_journalieres_activite(Variable):
             'indemnites_journalieres_maternite',
             'indemnites_journalieres_paternite',
             'indemnites_journalieres_adoption',
-        ]) + condition_date_arret_travail * ijss_activite_sous_condition
+        ]) + (condition_date_arret_travail + condition_activite) * ijss_activite_sous_condition
 
         return period, ijss_activite
 

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -93,6 +93,7 @@ class rsa_base_ressources_individu(Variable):
             'retraite_titre_onereux_declarant1',
             'revenus_fonciers_minima_sociaux',
             'rsa_base_ressources_patrimoine_individu',
+            'rsa_indemnites_journalieres_hors_activite',
             ]
 
         # Les revenus non-pro interrompus au mois M sont neutralisés dans la limite d'un montant forfaitaire,
@@ -375,7 +376,6 @@ class rsa_revenu_activite_individu(Variable):
 
         types_revenus_activite = [
             'salaire_net',
-            'indemnites_journalieres',
             'indemnites_chomage_partiel',
             'indemnites_volontariat',
             'revenus_stage_formation_pro',
@@ -383,6 +383,7 @@ class rsa_revenu_activite_individu(Variable):
             'hsup',
             'etr',
             'tns_auto_entrepreneur_benefice',
+            'rsa_indemnites_journalieres_activite',
         ]
 
         has_ressources_substitution = simulation.calculate('rsa_has_ressources_substitution', period)

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -349,6 +349,15 @@ class rsa_indemnites_journalieres_activite(Variable):
 
         return period, ijss_activite
 
+class rsa_indemnites_journalieres_hors_activite(Variable):
+    column = FloatCol
+    label = u"Indemnités journalières prises en compte comme revenu de remplacement"
+    entity_class = Individus
+
+    def function(self, simulation, period):
+        period = period.this_month
+        return period, simulation.calculate('indemnites_journalieres', period) - simulation.calculate('rsa_indemnites_journalieres_activite', period)
+
 class rsa_revenu_activite_individu(Variable):
     column = FloatCol
     label = u"Revenus d'activité du Rsa - Individuel"

--- a/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
+++ b/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
+from numpy import nan
 
 class indemnites_journalieres_maternite(Variable):
     column = FloatCol
@@ -74,7 +75,7 @@ class indemnites_journalieres_imposables(Variable):
         return period, result
 
 class date_arret_de_travail(Variable):
-    column = DateCol
+    column = DateCol(default = nan)
     entity_class = Individus
     is_permanent = True
     label = u"Date depuis laquelle la personne est en arrêt de travail"

--- a/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
+++ b/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
@@ -38,8 +38,6 @@ class indemnites_journalieres_maladie_professionnelle(Variable):
     label = u"Indemnités journalières de maladie professionnelle"
 
 
-
-
 class indemnites_journalieres(Variable):
     column = FloatCol
     label = u"Total des indemnités journalières"
@@ -74,3 +72,9 @@ class indemnites_journalieres_imposables(Variable):
         )
 
         return period, result
+
+class date_arret_de_travail(Variable):
+    column = DateCol
+    entity_class = Individus
+    is_permanent = True
+    label = u"Date depuis laquelle la personne est en arrêt de travail"

--- a/openfisca_france/tests/formulas/ppa.yaml
+++ b/openfisca_france/tests/formulas/ppa.yaml
@@ -384,14 +384,12 @@
       2015-12: 500
     indemnites_journalieres_maternite:
       2015-12: 500
-    indemnites_journalieres_accident_travail:
-      2015-12: 500
     indemnites_chomage_partiel:
       2015-12: 500
   output_variables:
     ppa: 0
     ppa_revenu_activite:
-      2015-12: 3000
+      2015-12: 2500
 
 - name: "PPA: ressources prises en compte hors activité (M-1)"
   period: 2016-02

--- a/openfisca_france/tests/formulas/ppa.yaml
+++ b/openfisca_france/tests/formulas/ppa.yaml
@@ -613,3 +613,75 @@
       2015-12: 250
     ppa_ressources_hors_activite_individu:
       2015-12: 800
+
+- name: "PPA - Les IJSS sont considérés comme un revenu de remplacement après 3 mois "
+  period: 2016-01
+  relative_error_margin: 0.05
+  input_variables:
+    date_naissance: '1998-01-01' # age < 18 sur le trimestre de référence
+    indemnites_journalieres_maladie:
+      2015-12: 500
+      2015-11: 500
+      2015-10: 500
+    date_arret_de_travail: 2015-07-01
+  output_variables:
+    ppa: 0
+    ppa_revenu_activite:
+      2015-12: 0
+      2015-11: 0
+      2015-10: 0
+    ppa_base_ressources:
+      2015-12: 500
+      2015-11: 500
+      2015-10: 500
+
+
+- name: "PPA - Les IJSS sont considérés comme un revenu d'activité les 3 premiers mois "
+  period: 2016-01
+  relative_error_margin: 0.05
+  input_variables:
+    date_naissance: '1998-01-01' # age < 18 sur le trimestre de référence
+    indemnites_journalieres_maladie:
+      2015-12: 500
+      2015-11: 500
+      2015-10: 500
+    indemnites_journalieres_accident_travail:
+      2015-12: 500
+      2015-11: 500
+      2015-10: 500
+    indemnites_journalieres_maladie_professionnelle:
+      2015-12: 500
+      2015-11: 500
+      2015-10: 500
+    date_arret_de_travail: 2015-08-01
+  output_variables:
+    ppa: 0
+    ppa_revenu_activite:
+      2015-12: 0
+      2015-11: 0
+      2015-10: 1500
+
+- name: "PPA - Les IJSS maternité/paternité/adoptions sont toujours considérés comme un revenu d'activité"
+  period: 2016-01
+  relative_error_margin: 0.05
+  input_variables:
+    date_naissance: '1998-01-01' # age < 18 sur le trimestre de référence
+    indemnites_journalieres_maternite:
+      2015-12: 500
+      2015-11: 500
+      2015-10: 500
+    indemnites_journalieres_paternite:
+      2015-12: 500
+      2015-11: 500
+      2015-10: 500
+    indemnites_journalieres_adoption:
+      2015-12: 500
+      2015-11: 500
+      2015-10: 500
+    date_arret_de_travail: 2015-01-01
+  output_variables:
+    ppa: 0
+    ppa_revenu_activite:
+      2015-12: 1500
+      2015-11: 1500
+      2015-10: 1500

--- a/openfisca_france/tests/formulas/ppa.yaml
+++ b/openfisca_france/tests/formulas/ppa.yaml
@@ -616,7 +616,7 @@
   period: 2016-01
   relative_error_margin: 0.05
   input_variables:
-    date_naissance: '1998-01-01' # age < 18 sur le trimestre de référence
+    date_naissance: '1980-01-01'
     indemnites_journalieres_maladie:
       2015-12: 500
       2015-11: 500
@@ -638,61 +638,121 @@
   period: 2016-01
   relative_error_margin: 0.05
   input_variables:
-    date_naissance: '1998-01-01' # age < 18 sur le trimestre de référence
+    date_naissance: '1980-01-01'
     indemnites_journalieres_maladie:
-      2015-12: 500
-      2015-11: 500
-      2015-10: 500
+      2015-12: 1000
+      2015-11: 1000
+      2015-10: 1000
     indemnites_journalieres_accident_travail:
-      2015-12: 500
-      2015-11: 500
-      2015-10: 500
+      2015-12: 1000
+      2015-11: 1000
+      2015-10: 1000
     indemnites_journalieres_maladie_professionnelle:
-      2015-12: 500
-      2015-11: 500
-      2015-10: 500
+      2015-12: 1000
+      2015-11: 1000
+      2015-10: 1000
     date_arret_de_travail: 2015-08-01
   output_variables:
     ppa: 0
     ppa_revenu_activite:
       2015-12: 0
       2015-11: 0
-      2015-10: 1500
+      2015-10: 3000
+
+- name: "PPA - Si aucune date n'est déclarée et qu'il y a des IJSS à M-3, on considère les IJSS comme un revenu de remplacement "
+  period: 2016-01
+  relative_error_margin: 0.05
+  input_variables:
+    date_naissance: '1980-01-01'
+    indemnites_journalieres_maladie:
+      2015-12: 1000
+      2015-11: 1000
+      2015-10: 1000
+      2015-09: 1000
+    indemnites_journalieres_accident_travail:
+      2015-12: 1000
+      2015-11: 1000
+      2015-10: 1000
+      2015-09: 1000
+    indemnites_journalieres_maladie_professionnelle:
+      2015-12: 1000
+      2015-11: 1000
+      2015-10: 1000
+      2015-09: 1000
+  output_variables:
+    ppa: 0
+    ppa_revenu_activite:
+      2015-12: 0
+
+- name: "PPA - Si aucune date n'est déclarée et qu'il n'y a pas d'IJSS à M-3, on considère les IJSS comme un revenu d'activité "
+  period: 2016-01
+  relative_error_margin: 0.05
+  input_variables:
+    date_naissance: '1980-01-01'
+    indemnites_journalieres_maladie:
+      2015-12: 1000
+      2015-11: 1000
+      2015-10: 1000
+      2015-09: 0
+    indemnites_journalieres_accident_travail:
+      2015-12: 1000
+      2015-11: 1000
+      2015-10: 1000
+      2015-09: 0
+    indemnites_journalieres_maladie_professionnelle:
+      2015-12: 1000
+      2015-11: 1000
+      2015-10: 1000
+      2015-09: 0
+  output_variables:
+    ppa: 0
+    ppa_revenu_activite:
+      2015-12: 3000
+      2015-11: 3000
+      2015-10: 3000
+    ppa_fictive:
+      2015-12: 0
+      2015-11: 0
+      2015-10: 0
 
 - name: "PPA - Les IJSS maternité/paternité/adoptions sont toujours considérés comme un revenu d'activité"
   period: 2016-01
   relative_error_margin: 0.05
   input_variables:
-    date_naissance: '1998-01-01' # age < 18 sur le trimestre de référence
+    date_naissance: '1980-01-01' # age < 18 sur le trimestre de référence
     indemnites_journalieres_maternite:
-      2015-12: 500
-      2015-11: 500
-      2015-10: 500
+      2015-12: 1000
+      2015-11: 1000
+      2015-10: 1000
     indemnites_journalieres_paternite:
-      2015-12: 500
-      2015-11: 500
-      2015-10: 500
+      2015-12: 1000
+      2015-11: 1000
+      2015-10: 1000
     indemnites_journalieres_adoption:
-      2015-12: 500
-      2015-11: 500
-      2015-10: 500
+      2015-12: 1000
+      2015-11: 1000
+      2015-10: 1000
     date_arret_de_travail: 2015-01-01
   output_variables:
     ppa: 0
     ppa_revenu_activite:
-      2015-12: 1500
-      2015-11: 1500
-      2015-10: 1500
+      2015-12: 3000
+      2015-11: 3000
+      2015-10: 3000
+    ppa_fictive:
+      2015-12: 0
+      2015-11: 0
+      2015-10: 0
 
 - name: "PPA - Les IJSS sont toujours considérés comme un revenu d'activité quand un autre revenu d'activité est perçu"
   period: 2016-01
   relative_error_margin: 0.05
   input_variables:
-    date_naissance: '1998-01-01' # age < 18 sur le trimestre de référence
+    date_naissance: '1980-01-01'
     indemnites_journalieres_maladie:
-      2015-12: 500
-      2015-11: 500
-      2015-10: 500
+      2015-12: 2000
+      2015-11: 2000
+      2015-10: 2000
     salaire_net:
       2015-12: 300
       2015-11: 300
@@ -701,6 +761,6 @@
   output_variables:
     ppa: 0
     ppa_revenu_activite:
-      2015-12: 800
-      2015-11: 800
-      2015-10: 800
+      2015-12: 2300
+      2015-11: 2300
+      2015-10: 2300

--- a/openfisca_france/tests/formulas/ppa.yaml
+++ b/openfisca_france/tests/formulas/ppa.yaml
@@ -683,3 +683,24 @@
       2015-12: 1500
       2015-11: 1500
       2015-10: 1500
+
+- name: "PPA - Les IJSS sont toujours considérés comme un revenu d'activité quand un autre revenu d'activité est perçu"
+  period: 2016-01
+  relative_error_margin: 0.05
+  input_variables:
+    date_naissance: '1998-01-01' # age < 18 sur le trimestre de référence
+    indemnites_journalieres_maladie:
+      2015-12: 500
+      2015-11: 500
+      2015-10: 500
+    salaire_net:
+      2015-12: 300
+      2015-11: 300
+      2015-10: 300
+    date_arret_de_travail: 2015-01-01
+  output_variables:
+    ppa: 0
+    ppa_revenu_activite:
+      2015-12: 800
+      2015-11: 800
+      2015-10: 800

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54817e07ed60b88866befc03.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54817e07ed60b88866befc03.yaml
@@ -13,6 +13,7 @@ individus:
   etudiant: 0
   id: 54817dd876be8a87669fc438
   inapte_travail: 0
+  date_arret_de_travail: 2014-09-01
   indemnites_chomage_partiel:
     2012: 600
     2013-12: 50

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55915f4c9e2a9d0330e7a20f.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55915f4c9e2a9d0330e7a20f.yaml
@@ -412,4 +412,3 @@ output_variables:
   asf: 301.73
   bourse_college: 228
   cf: 185.2
-  rsa: 96.02

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '4.1.14',
+    version = '4.1.15',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Consider some indemnités journalieres as revenus de remplacement in PPA (and RSA), according to the date of the arret de travail.
* Introduce
	* `rsa_indemnites_journalieres_hors_activite`
	* `rsa_indemnites_journalieres_activite`
	* `date_arret_de_travail`