### PR TITLE
Ags formula returns NaN sometimes

### DIFF
--- a/openfisca_france/tests/formulas/ags.yaml
+++ b/openfisca_france/tests/formulas/ags.yaml
@@ -11,5 +11,6 @@
   individus:
     - id: "parent1"
       contrat_de_travail: 1
+      salaire_de_base: 1000
   output_variables:
     ags: 0

--- a/openfisca_france/tests/formulas/ags.yaml
+++ b/openfisca_france/tests/formulas/ags.yaml
@@ -12,6 +12,6 @@
     - id: "parent1"
       contrat_de_travail: 1
       heures_remunerees_volume: 20
-      salaire_de_base: 1000
+      salaire_de_base: 0
   output_variables:
     ags: 0

--- a/openfisca_france/tests/formulas/ags.yaml
+++ b/openfisca_france/tests/formulas/ags.yaml
@@ -11,6 +11,7 @@
   individus:
     - id: "parent1"
       contrat_de_travail: 1
+      heures_remunerees_volume: 20
       salaire_de_base: 1000
   output_variables:
     ags: 0

--- a/openfisca_france/tests/formulas/ags.yaml
+++ b/openfisca_france/tests/formulas/ags.yaml
@@ -1,0 +1,15 @@
+- name: AGS does not return NaN
+  description:
+  period: 2016-01
+  absolute_error_margin: 0.03
+  familles:
+    parents: ["parent1"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+  menages:
+    personne_de_reference: "parent1"
+  individus:
+    - id: "parent1"
+      contrat_de_travail: 1
+  output_variables:
+    ags: 0


### PR DESCRIPTION
I created a new test for [`ags`](https://legislation.openfisca.fr/variables/ags) failing because it returns a `NaN`.

Please could someone ( @benjello or @laem I think) help me to find why? I'm quite lost in the helpers about "cotisations".

To run the test:

```
openfisca-run-test -n ags
```

The result on my machine:

```
=============================================================================================================================
Test 1: /home/cbenz/Dev/openfisca/openfisca-france/openfisca_france/tests/formulas/ags.yaml AGS does not return NaN - 2016-01
=============================================================================================================================
/home/cbenz/.virtualenvs/openfisca/local/lib/python2.7/site-packages/numpy/core/numeric.py:1093: RuntimeWarning: invalid value encountered in multiply
  return multiply(a.ravel()[:, newaxis], b.ravel()[newaxis,:], out)
/home/cbenz/Dev/openfisca/openfisca-core/openfisca_core/tools.py:36: RuntimeWarning: invalid value encountered in absolute
  assert (abs(target_value - value) <= absolute_error_margin).all(), \
/home/cbenz/Dev/openfisca/openfisca-core/openfisca_core/tools.py:38: RuntimeWarning: invalid value encountered in absolute
  abs(target_value - value), absolute_error_margin)
Traceback (most recent call last):
  File "/home/cbenz/.virtualenvs/openfisca/bin/openfisca-run-test", line 9, in <module>
    load_entry_point('OpenFisca-France', 'console_scripts', 'openfisca-run-test')()
  File "/home/cbenz/Dev/openfisca/openfisca-france/openfisca_france/tests/test_yaml.py", line 329, in main
    checker(yaml_path, name, period_str, test, force, args.verbose)
  File "/home/cbenz/Dev/openfisca/openfisca-france/openfisca_france/tests/test_yaml.py", line 168, in check
    relative_error_margin = test.get('relative_error_margin'),
  File "/home/cbenz/Dev/openfisca/openfisca-core/openfisca_core/tools.py", line 38, in assert_near
    abs(target_value - value), absolute_error_margin)
AssertionError: ags@2016-01: [ nan] differs from [ 0.] with an absolute margin [ nan] > 0.03
```

I'm using OpenFisca-Core 3.0.1 and OpenFisca-France 4.1.11

Thanks