### PR TITLE
Reimplement not-a-time date values with date.min

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.1.17
 
-* Reimplement `rsa_indemnites_journalieres_activite` and `date_arret_de_travail` using `datetime.date.max`.
+* Reimplement `rsa_indemnites_journalieres_activite` and `date_arret_de_travail` using `datetime.date.min`.
 
 ## 4.1.16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.17
+
+* Reimplement `rsa_indemnites_journalieres_activite` and `date_arret_de_travail` using `datetime.date.max`.
+
 ## 4.1.16
 
 * Correct wrong behaviour in the combination of exemptions with the dispositif Jeune Entreprise Innovante (JEI)

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -346,8 +346,8 @@ class rsa_indemnites_journalieres_activite(Variable):
         three_months_ago = datetime64(m_3.start)
         condition_date_arret_travail = date_arret_de_travail > three_months_ago
 
-        # Si la date d'arrêt de travail n'est pas définie (et vaut donc par défaut date.max), mais qu'il n'y a pas d'IJSS à M-3, on estime que l'arrêt est récent.
-        is_date_arret_de_travail_undefined = (date_arret_de_travail == datetime.date.max)
+        # Si la date d'arrêt de travail n'est pas définie (et vaut donc par défaut date.min), mais qu'il n'y a pas d'IJSS à M-3, on estime que l'arrêt est récent.
+        is_date_arret_de_travail_undefined = (date_arret_de_travail == datetime.date.min)
         condition_arret_recent = is_date_arret_de_travail_undefined * (ijss_activite_sous_condition(m_3) == 0)
 
         condition_activite = simulation.calculate('salaire_net', period) > 0

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -346,9 +346,9 @@ class rsa_indemnites_journalieres_activite(Variable):
         three_months_ago = datetime64(m_3.start)
         condition_date_arret_travail = date_arret_de_travail > three_months_ago
 
-        # Si la date d'arrêt de travail n'est pas définie, mais qu'il n'y a pas d'IJSS à M-3, on estime que l'arrêt est récent.
-        is_date_arret_de_travail_max = (date_arret_de_travail == datetime.date.max)
-        condition_arret_recent = is_date_arret_de_travail_max * (ijss_activite_sous_condition(m_3) == 0)
+        # Si la date d'arrêt de travail n'est pas définie (et vaut donc par défaut date.max), mais qu'il n'y a pas d'IJSS à M-3, on estime que l'arrêt est récent.
+        is_date_arret_de_travail_undefined = (date_arret_de_travail == datetime.date.max)
+        condition_arret_recent = is_date_arret_de_travail_undefined * (ijss_activite_sous_condition(m_3) == 0)
 
         condition_activite = simulation.calculate('salaire_net', period) > 0
 

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import division
+import datetime
 
 from numpy import (floor, logical_and as and_, logical_not as not_, logical_or as or_, maximum as max_, minimum as min_, select, where, datetime64)
 
@@ -346,11 +347,10 @@ class rsa_indemnites_journalieres_activite(Variable):
         condition_date_arret_travail = date_arret_de_travail > three_months_ago
 
         # Si la date d'arrêt de travail n'est pas définie, mais qu'il n'y a pas d'IJSS à M-3, on estime que l'arrêt est récent.
-        is_date_arret_de_travail_undefined = (date_arret_de_travail == datetime64('NaT'))
-        condition_arret_recent = is_date_arret_de_travail_undefined * (ijss_activite_sous_condition(m_3) == 0)
+        is_date_arret_de_travail_max = (date_arret_de_travail == datetime.date.max)
+        condition_arret_recent = is_date_arret_de_travail_max * (ijss_activite_sous_condition(m_3) == 0)
 
         condition_activite = simulation.calculate('salaire_net', period) > 0
-
 
         ijss_activite = sum(simulation.calculate(ressource, period) for ressource in [
             # IJSS toujours prises en compte comme un revenu d'activité

--- a/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
+++ b/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
+import datetime
+
 from openfisca_france.model.base import *  # noqa analysis:ignore
-from numpy import nan
+
 
 class indemnites_journalieres_maternite(Variable):
     column = FloatCol
@@ -75,7 +77,7 @@ class indemnites_journalieres_imposables(Variable):
         return period, result
 
 class date_arret_de_travail(Variable):
-    column = DateCol(default = nan)
+    column = DateCol(default = datetime.date.max)
     entity_class = Individus
     is_permanent = True
     label = u"Date depuis laquelle la personne est en arrêt de travail"

--- a/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
+++ b/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
@@ -77,7 +77,7 @@ class indemnites_journalieres_imposables(Variable):
         return period, result
 
 class date_arret_de_travail(Variable):
-    column = DateCol(default = datetime.date.max)
+    column = DateCol(default = datetime.date.min)
     entity_class = Individus
     is_permanent = True
     label = u"Date depuis laquelle la personne est en arrêt de travail"

--- a/openfisca_france/tests/formulas/ppa.yaml
+++ b/openfisca_france/tests/formulas/ppa.yaml
@@ -669,16 +669,22 @@
       2015-11: 1000
       2015-10: 1000
       2015-09: 1000
+      2015-08: 1000
+      2015-07: 1000
     indemnites_journalieres_accident_travail:
       2015-12: 1000
       2015-11: 1000
       2015-10: 1000
       2015-09: 1000
+      2015-08: 1000
+      2015-07: 1000
     indemnites_journalieres_maladie_professionnelle:
       2015-12: 1000
       2015-11: 1000
       2015-10: 1000
       2015-09: 1000
+      2015-08: 1000
+      2015-07: 1000
   output_variables:
     ppa: 0
     ppa_revenu_activite:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '4.1.16',
+    version = '4.1.17',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
This pull request follows [this discussion](https://github.com/openfisca/openfisca-france/pull/567#discussion_r83694666).

I tried to get rid of not-a-time date values and replace them by either [`date.min`](https://docs.python.org/2/library/datetime.html#datetime.date.min) or [`date.max`](https://docs.python.org/2/library/datetime.html#datetime.date.max) values.

The problem was that using not-a-time values broke the JSON transformation functions, in the context of the Web API but not only.

@fpagnoux Does this reimplementation seems correct to you?

See also [Core modification](https://github.com/openfisca/openfisca-core/pull/414): I enforced `DateCol.default` to be a `date`.
