### PR TITLE
Adapt France to core-v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 5.0.0
+
+* Adapt France to Openfisca-Core#v4
+	* Declare entities in the new way
+
+* Deprecate all conversion variables:
+	* `cotsoc_bar_declarant1
+	* `cotsoc_lib_declarant1
+	* `crds_cap_bar_declarant1
+	* `crds_cap_lib_declarant1
+	* `csg_cap_bar_declarant1
+	* `csg_cap_lib_declarant1
+	* `loyer_famille
+	* `loyer_individu
+	* `maj_cga_individu
+	* `pensions_alimentaires_versees_declarant1
+	* `prelsoc_cap_bar_declarant1
+	* `prelsoc_cap_lib_declarant1
+	* `retraite_titre_onereux_declarant1
+	* `retraite_titre_onereux_net_declarant1
+	* `rev_microsocial_declarant1
+	* `statut_occupation_famille
+	* `statut_occupation_logement_individu
+	* `zone_apl_famille* `
+	* `zone_apl_individu* `
+
+* Deprecate entity structure variables:
+	* `idmen`
+	* `idfoy`
+	* `idfam`
+	* `quimen`
+	* `quifoy`
+	* `quifam`
+
+* Change some variables entity:
+	* `FoyersFiscaux` -> `Individus`
+		* `maj_cga`
+	* `Individus` -> `FoyersFiscaux
+		* `rev_coll`
+	* `Individus` -> `Menages`
+		* `coloc`
+		* `logement_chambre`
+	* `Familles` -> `Individus`
+		* `aah_non_calculable`
+	* `Familles` -> `Menages`
+		* `residence_dom`
+		* `residence_guadeloupe`
+		* `residence_martinique`
+		* `residence_guyane`
+		* `residence_reunion`
+		* `residence_mayotte`
+
+* Introduce:
+    * `cotsoc_bar`
+    * `cotsoc_lib`
+
 ## 4.1.20
 
  * Set `set_input` attribute to `set_input_divide_by_period` for variables `heures_remunerees_volume` et `heures_non_remunerees_volume`.

--- a/openfisca_france/entities.py
+++ b/openfisca_france/entities.py
@@ -12,12 +12,14 @@ class Familles(GroupEntity):
     label = u'Famille'
     roles = [
         {
-            'key': 'parents',
+            'key': 'parent',
+            'plural': 'parents',
             'label': u'Parents',
             'max': 2
             },
         {
-            'key': 'enfants',
+            'key': 'enfant',
+            'plural': 'enfants',
             'label': u'Enfants'
             }
         ]
@@ -46,7 +48,8 @@ class FoyersFiscaux(GroupEntity):
             'role_in_scenario': 'declarants'
             },
         {
-            'key': 'personnes_a_charge',
+            'key': 'personne_a_charge',
+            'plural': 'personnes_a_charge',
             'label': u'Personnes à charge'
             },
         ]
@@ -68,12 +71,14 @@ class Menages(GroupEntity):
             'max': 1
             },
         {
-            'key': 'enfants',
+            'key': 'enfant',
+            'plural': 'enfants',
             'label': u'Enfants',
             'max': 2
             },
         {
-            'key': 'autres',
+            'key': 'autre',
+            'plural': 'autres',
             'label': u'Autres'
             }
         ]

--- a/openfisca_france/entities.py
+++ b/openfisca_france/entities.py
@@ -3,19 +3,18 @@
 import collections
 import itertools
 
-from openfisca_core.entities import PersonEntity, GroupEntity
+from openfisca_core.entities import build_entity
 
-
-class Familles(GroupEntity):
-    key = "famille"
-    plural = "familles"
-    label = u'Famille'
+Familles = build_entity(
+    key = "famille",
+    plural = "familles",
+    label = u'Famille',
     roles = [
         {
             'key': 'parent',
             'plural': 'parents',
             'label': u'Parents',
-            'max': 2
+            'subroles': ['demandeur', 'conjoint']
             },
         {
             'key': 'enfant',
@@ -23,29 +22,25 @@ class Familles(GroupEntity):
             'label': u'Enfants'
             }
         ]
+    )
 
-class Individus(PersonEntity):
-    key = "individu"
-    plural = "individus"
-    label = u'Individu'
+Individus = build_entity(
+    key = "individu",
+    plural = "individus",
+    label = u'Individu',
+    is_person = True
+    )
 
-
-class FoyersFiscaux(GroupEntity):
-    key = "foyer_fiscal"
-    plural = "foyers_fiscaux"
-    label = u'Déclaration d’impôts'
+FoyersFiscaux = build_entity(
+    key = "foyer_fiscal",
+    plural = "foyers_fiscaux",
+    label = u'Déclaration d’impôts',
     roles = [
         {
             'key': 'declarant',
+            'plural': 'declarants',
             'label': u'Déclarants',
-            'max': 1,
-            'role_in_scenario': 'declarants'
-            },
-        {
-            'key': 'conjoint',
-            'label': u'Déclarants',
-            'max': 1,
-            'role_in_scenario': 'declarants'
+            'subroles': ['declarant_principal', 'conjoint']
             },
         {
             'key': 'personne_a_charge',
@@ -53,12 +48,12 @@ class FoyersFiscaux(GroupEntity):
             'label': u'Personnes à charge'
             },
         ]
+    )
 
-
-class Menages(GroupEntity):
-    key = "menage"
-    plural = "menages"
-    label = u'Logement principal'
+Menages = build_entity(
+    key = "menage",
+    plural = "menages",
+    label = u'Logement principal',
     roles = [
         {
             'key': 'personne_de_reference',
@@ -82,5 +77,6 @@ class Menages(GroupEntity):
             'label': u'Autres'
             }
         ]
+    )
 
 entities = [Individus, Familles, FoyersFiscaux, Menages]

--- a/openfisca_france/entities.py
+++ b/openfisca_france/entities.py
@@ -5,7 +5,7 @@ import itertools
 
 from openfisca_core.entities import build_entity
 
-Familles = build_entity(
+Famille = build_entity(
     key = "famille",
     plural = "familles",
     label = u'Famille',
@@ -24,14 +24,14 @@ Familles = build_entity(
         ]
     )
 
-Individus = build_entity(
+Individu = build_entity(
     key = "individu",
     plural = "individus",
     label = u'Individu',
     is_person = True
     )
 
-FoyersFiscaux = build_entity(
+FoyerFiscal = build_entity(
     key = "foyer_fiscal",
     plural = "foyers_fiscaux",
     label = u'Déclaration d’impôts',
@@ -50,7 +50,7 @@ FoyersFiscaux = build_entity(
         ]
     )
 
-Menages = build_entity(
+Menage = build_entity(
     key = "menage",
     plural = "menages",
     label = u'Logement principal',
@@ -79,4 +79,4 @@ Menages = build_entity(
         ]
     )
 
-entities = [Individus, Familles, FoyersFiscaux, Menages]
+entities = [Individu, Famille, FoyerFiscal, Menage]

--- a/openfisca_france/entities.py
+++ b/openfisca_france/entities.py
@@ -3,138 +3,79 @@
 import collections
 import itertools
 
-from openfisca_core import entities
+from openfisca_core.entities import PersonEntity, GroupEntity
 
 
-class Entreprises(entities.AbstractEntity):
-    column_by_name = collections.OrderedDict()
-    index_for_person_variable_name = 'entreprise_id'
-    key_plural = 'entreprises'
-    key_singular = 'entreprise'
-    label = u'Entreprise'
-    role_for_person_variable_name = 'entreprise_role'
-    roles_key = ['salaries']  # 'dirigeants']
-    label_by_role_key = {
-        'salaries': u'Salariés',
-        # 'dirigeants': u'Dirigeants',
-        }
-    symbol = 'entreprise'
-
-    def iter_member_persons_role_and_id(self, member):
-        role = 0
-
-        salaries_id = member['salariés']
-        for salarie_role, salarie_id in enumerate(salaries_id, role):
-            assert salarie_id is not None
-            yield salarie_role, salarie_id
-
-
-class Familles(entities.AbstractEntity):
-    column_by_name = collections.OrderedDict()
-    index_for_person_variable_name = 'idfam'
-    key_plural = 'familles'
-    key_singular = 'famille'
+class Familles(GroupEntity):
+    key = "famille"
+    plural = "familles"
     label = u'Famille'
-    max_cardinality_by_role_key = {'parents': 2}
-    role_for_person_variable_name = 'quifam'
-    roles_key = ['parents', 'enfants']
-    label_by_role_key = {
-        'enfants': u'Enfants',
-        'parents': u'Parents',
-        }
-    symbol = 'fam'
+    roles = [
+        {
+            'key': 'parents',
+            'label': u'Parents',
+            'max': 2
+            },
+        {
+            'key': 'enfants',
+            'label': u'Enfants'
+            }
+        ]
 
-    def iter_member_persons_role_and_id(self, member):
-        role = 0
-
-        parents_id = member['parents']
-        assert 1 <= len(parents_id) <= 2
-        for parent_role, parent_id in enumerate(parents_id, role):
-            assert parent_id is not None
-            yield parent_role, parent_id
-        role += 2
-
-        enfants_id = member.get('enfants')
-        if enfants_id is not None:
-            for enfant_role, enfant_id in enumerate(enfants_id, role):
-                assert enfant_id is not None
-                yield enfant_role, enfant_id
+class Individus(PersonEntity):
+    key = "individu"
+    plural = "individus"
+    label = u'Individu'
 
 
-class FoyersFiscaux(entities.AbstractEntity):
-    column_by_name = collections.OrderedDict()
-    index_for_person_variable_name = 'idfoy'
-    key_plural = 'foyers_fiscaux'
-    key_singular = 'foyer_fiscal'
-    label = u'Déclaration d\'impôt'
-    max_cardinality_by_role_key = {'declarants': 2}
-    role_for_person_variable_name = 'quifoy'
-    roles_key = ['declarants', 'personnes_a_charge']
-    label_by_role_key = {
-        'declarants': u'Déclarants',
-        'personnes_a_charge': u'Personnes à charge',
-        }
-    symbol = 'foy'
-
-    def iter_member_persons_role_and_id(self, member):
-        role = 0
-
-        declarants_id = member['declarants']
-        assert 1 <= len(declarants_id) <= 2
-        for declarant_role, declarant_id in enumerate(declarants_id, role):
-            assert declarant_id is not None
-            yield declarant_role, declarant_id
-        role += 2
-
-        personnes_a_charge_id = member.get('personnes_a_charge')
-        if personnes_a_charge_id is not None:
-            for personne_a_charge_role, personne_a_charge_id in enumerate(personnes_a_charge_id, role):
-                assert personne_a_charge_id is not None
-                yield personne_a_charge_role, personne_a_charge_id
+class FoyersFiscaux(GroupEntity):
+    key = "foyer_fiscal"
+    plural = "foyers_fiscaux"
+    label = u'Déclaration d’impôts'
+    roles = [
+        {
+            'key': 'declarant',
+            'label': u'Déclarants',
+            'max': 1,
+            'role_in_scenario': 'declarants'
+            },
+        {
+            'key': 'conjoint',
+            'label': u'Déclarants',
+            'max': 1,
+            'role_in_scenario': 'declarants'
+            },
+        {
+            'key': 'personnes_a_charge',
+            'label': u'Personnes à charge'
+            },
+        ]
 
 
-class Individus(entities.AbstractEntity):
-    column_by_name = collections.OrderedDict()
-    is_persons_entity = True
-    key_plural = 'individus'
-    key_singular = 'individu'
-    label = u'Personne'
-    symbol = 'ind'
-
-
-class Menages(entities.AbstractEntity):
-    column_by_name = collections.OrderedDict()
-    index_for_person_variable_name = 'idmen'
-    key_plural = 'menages'
-    key_singular = 'menage'
+class Menages(GroupEntity):
+    key = "menage"
+    plural = "menages"
     label = u'Logement principal'
-    max_cardinality_by_role_key = {'conjoint': 1, 'personne_de_reference': 1}
-    role_for_person_variable_name = 'quimen'
-    roles_key = ['personne_de_reference', 'conjoint', 'enfants', 'autres']
-    label_by_role_key = {
-        'autres': u'Autres',
-        'conjoint': u'Conjoint',
-        'enfants': u'Enfants',
-        'personne_de_reference': u'Personne de référence',
-        }
-    symbol = 'men'
+    roles = [
+        {
+            'key': 'personne_de_reference',
+            'label': u'Personne de référence',
+            'max': 1
+            },
+        {
+            'key': 'conjoint',
+            'label': u'Conjoint',
+            'max': 1
+            },
+        {
+            'key': 'enfants',
+            'label': u'Enfants',
+            'max': 2
+            },
+        {
+            'key': 'autres',
+            'label': u'Autres'
+            }
+        ]
 
-    def iter_member_persons_role_and_id(self, member):
-        role = 0
-
-        personne_de_reference_id = member['personne_de_reference']
-        assert personne_de_reference_id is not None
-        yield role, personne_de_reference_id
-        role += 1
-
-        conjoint_id = member.get('conjoint')
-        if conjoint_id is not None:
-            yield role, conjoint_id
-        role += 1
-
-        autres_id = member.get('autres') or []
-        enfants_id = member.get('enfants') or []
-        for enfant_role, enfant_id in enumerate(itertools.chain(enfants_id, autres_id), role):
-            yield enfant_role, enfant_id
-
-entities = [Familles, FoyersFiscaux, Individus, Menages]
+entities = [Individus, Familles, FoyersFiscaux, Menages]

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -31,15 +31,12 @@ __all__ = [
     'CAT',
     'CHEF',
     'CONJ',
-    'CONJOINT',
     'CREF',
     'date',
     'DateCol',
     'dated_function',
     'DatedVariable',
-    'DECLARANT',
     'DIVIDE',
-    'ENFANT',
     'ENFS',
     'Enum',
     'EnumCol',
@@ -55,10 +52,8 @@ __all__ = [
     'PAC1',
     'PAC2',
     'PAC3',
-    'PARENT',
     'PART',
     'PeriodSizeIndependentIntCol',
-    'PERSONNE_A_CHARGE',
     'PREF',
     'QUIFAM',
     'QUIFOY',
@@ -87,17 +82,6 @@ CAT = Enum([
     ])
 
 TAUX_DE_PRIME = 1 / 4  # primes_fonction_publique (hors suppl. familial et indemnité de résidence)/rémunération brute
-
-
-# New roles
-ROLES_DANS_FAMILLE = Familles.get_role_enum()
-ROLES_DANS_FOYER_FISCAL = FoyersFiscaux.get_role_enum()
-
-PARENT = ROLES_DANS_FAMILLE['parents']
-ENFANT = ROLES_DANS_FAMILLE['enfants']
-DECLARANT = ROLES_DANS_FOYER_FISCAL['declarant']
-CONJOINT = ROLES_DANS_FOYER_FISCAL['conjoint']
-PERSONNE_A_CHARGE = ROLES_DANS_FOYER_FISCAL['personnes_a_charge']
 
 # Legacy roles. To be removed when they are not used by formulas anymore.
 QUIFAM = Enum(['chef', 'part', 'enf1', 'enf2', 'enf3', 'enf4', 'enf5', 'enf6', 'enf7', 'enf8', 'enf9'])

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -17,7 +17,7 @@ from openfisca_core.base_functions import (
     )
 from openfisca_core.formula_helpers import apply_thresholds, switch
 
-from openfisca_france.entities import Familles, FoyersFiscaux, Individus, Menages
+from openfisca_france.entities import Famille, FoyerFiscal, Individu, Menage
 
 
 __all__ = [
@@ -40,14 +40,14 @@ __all__ = [
     'ENFS',
     'Enum',
     'EnumCol',
-    'Familles',
+    'Famille',
     'FixedStrCol',
     'FloatCol',
-    'FoyersFiscaux',
-    'Individus',
+    'FoyerFiscal',
+    'Individu',
     'IntCol',
     'last_duration_last_value',
-    'Menages',
+    'Menage',
     'missing_value',
     'PAC1',
     'PAC2',

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -7,7 +7,7 @@ from openfisca_core.columns import (AgeCol, BoolCol, DateCol, EnumCol, FixedStrC
 from openfisca_core.enumerations import Enum
 from openfisca_core.formulas import (calculate_output_add, calculate_output_add_divide, calculate_output_divide,
     dated_function, missing_value, set_input_dispatch_by_period, set_input_divide_by_period)
-from openfisca_core.variables import DatedVariable, EntityToPersonColumn, PersonToEntityColumn, Variable
+from openfisca_core.variables import DatedVariable, Variable
 from openfisca_core.base_functions import (
     last_duration_last_value,
     requested_period_added_value,
@@ -30,13 +30,15 @@ __all__ = [
     'CAT',
     'CHEF',
     'CONJ',
+    'CONJOINT',
     'CREF',
     'date',
     'DateCol',
     'dated_function',
     'DatedVariable',
+    'DECLARANT',
+    'ENFANT',
     'ENFS',
-    'EntityToPersonColumn',
     'Enum',
     'EnumCol',
     'Familles',
@@ -51,9 +53,10 @@ __all__ = [
     'PAC1',
     'PAC2',
     'PAC3',
+    'PARENT',
     'PART',
     'PeriodSizeIndependentIntCol',
-    'PersonToEntityColumn',
+    'PERSONNE_A_CHARGE',
     'PREF',
     'QUIFAM',
     'QUIFOY',
@@ -64,10 +67,10 @@ __all__ = [
     'requested_period_last_value',
     'set_input_dispatch_by_period',
     'set_input_divide_by_period',
-    'switch',
-    'Variable',
     'StrCol',
+    'switch',
     'TAUX_DE_PRIME',
+    'Variable',
     'VOUS',
     ]
 
@@ -83,6 +86,18 @@ CAT = Enum([
 
 TAUX_DE_PRIME = 1 / 4  # primes_fonction_publique (hors suppl. familial et indemnité de résidence)/rémunération brute
 
+
+# New roles
+ROLES_DANS_FAMILLE = Familles.get_role_enum()
+ROLES_DANS_FOYER_FISCAL = FoyersFiscaux.get_role_enum()
+
+PARENT = ROLES_DANS_FAMILLE['parents']
+ENFANT = ROLES_DANS_FAMILLE['enfants']
+DECLARANT = ROLES_DANS_FOYER_FISCAL['declarant']
+CONJOINT = ROLES_DANS_FOYER_FISCAL['conjoint']
+PERSONNE_A_CHARGE = ROLES_DANS_FOYER_FISCAL['personnes_a_charge']
+
+# Legacy roles. To be removed when they are not used by formulas anymore.
 QUIFAM = Enum(['chef', 'part', 'enf1', 'enf2', 'enf3', 'enf4', 'enf5', 'enf6', 'enf7', 'enf8', 'enf9'])
 QUIFOY = Enum(['vous', 'conj', 'pac1', 'pac2', 'pac3', 'pac4', 'pac5', 'pac6', 'pac7', 'pac8', 'pac9'])
 QUIMEN = Enum(['pref', 'cref', 'enf1', 'enf2', 'enf3', 'enf4', 'enf5', 'enf6', 'enf7', 'enf8', 'enf9'])

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -5,8 +5,8 @@ from datetime import date
 from openfisca_core.columns import (AgeCol, BoolCol, DateCol, EnumCol, FixedStrCol, FloatCol, IntCol,
     PeriodSizeIndependentIntCol, StrCol)
 from openfisca_core.enumerations import Enum
-from openfisca_core.formulas import (calculate_output_add, calculate_output_add_divide, calculate_output_divide,
-    dated_function, missing_value, set_input_dispatch_by_period, set_input_divide_by_period)
+from openfisca_core.formulas import (ADD, calculate_output_add, calculate_output_add_divide, calculate_output_divide,
+    dated_function, DIVIDE, missing_value, set_input_dispatch_by_period, set_input_divide_by_period)
 from openfisca_core.variables import DatedVariable, Variable
 from openfisca_core.base_functions import (
     last_duration_last_value,
@@ -21,6 +21,7 @@ from openfisca_france.entities import Familles, FoyersFiscaux, Individus, Menage
 
 
 __all__ = [
+    'ADD',
     'AgeCol',
     'apply_thresholds',
     'BoolCol',
@@ -37,6 +38,7 @@ __all__ = [
     'dated_function',
     'DatedVariable',
     'DECLARANT',
+    'DIVIDE',
     'ENFANT',
     'ENFS',
     'Enum',

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -175,7 +175,7 @@ class nb_parents(Variable):
         # Note : Cette variable est "instantanée" : quelque soit la période demandée, elle retourne la valeur au premier
         # jour, sans changer la période.
 
-        return period, famille.nb_persons(role = famille.parent)
+        return period, famille.nb_persons(role = famille.PARENT)
 
 class maries(Variable):
     column = BoolCol(default = False)
@@ -189,7 +189,7 @@ class maries(Variable):
         statut_marital = famille.members('statut_marital', period)
         individu_marie = (statut_marital == 1)
 
-        return period, famille.any(individu_marie, role = famille.parent)
+        return period, famille.any(individu_marie, role = famille.PARENT)
 
 
 class en_couple(Variable):
@@ -214,7 +214,7 @@ class est_enfant_dans_famille(Variable):
     label = u"Indique qe l'individu est un enfant dans une famille"
 
     def function(individu, period):
-        return period, individu.has_role(Familles.enfant)
+        return period, individu.has_role(Familles.ENFANT)
 
 class etudiant(Variable):
     column = BoolCol(default = False)

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -171,12 +171,11 @@ class nb_parents(Variable):
     entity_class = Familles
     label = u"Nombre d'adultes (parents) dans la famille"
 
-    def function(self, simulation, period):
+    def function(famille, period):
         # Note : Cette variable est "instantanée" : quelque soit la période demandée, elle retourne la valeur au premier
         # jour, sans changer la période.
 
-        return period, simulation.famille.nb_persons(role = PARENT)
-
+        return period, famille.nb_persons(role = famille.parent)
 
 class maries(Variable):
     column = BoolCol(default = False)
@@ -190,7 +189,7 @@ class maries(Variable):
         statut_marital = famille.members('statut_marital', period)
         individu_marie = (statut_marital == 1)
 
-        return period, famille.any(individu_marie, role = PARENT)
+        return period, famille.any(individu_marie, role = famille.parent)
 
 
 class en_couple(Variable):
@@ -215,7 +214,7 @@ class est_enfant_dans_famille(Variable):
     label = u"Indique qe l'individu est un enfant dans une famille"
 
     def function(individu, period):
-        return period, individu.has_role(ENFANT, Familles)
+        return period, individu.has_role(Familles.enfant, Familles)
 
 class etudiant(Variable):
     column = BoolCol(default = False)

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -187,7 +187,7 @@ class maries(Variable):
         """couple = 1 si couple marié sinon 0 TODO: faire un choix avec couple ?"""
         # Note : Cette variable est "instantanée" : quelque soit la période demandée, elle retourne la valeur au premier
         # jour, sans changer la période.
-        statut_marital = famille.members.calculate('statut_marital', period)
+        statut_marital = famille.members['statut_marital'](period)
         individu_marie = (statut_marital == 1)
 
         return period, famille.any(individu_marie, role = PARENT)

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -4,18 +4,18 @@ from openfisca_france.model.base import *  # noqa
 
 class date_naissance(Variable):
     column = DateCol(default = date(1970, 1, 1))
-    entity_class = Individus
+    entity = Individus
     is_permanent = True
     label = u"Date de naissance"
 
 class adoption(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Enfant adopté"
 
 class garde_alternee(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u'Enfant en garde alternée'
     base_function = requested_period_last_or_next_value
 
@@ -28,12 +28,12 @@ class activite(Variable):
             u'Retraité',
             u'Autre inactif']),
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Activité"
 
 class enceinte(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Est enceinte"
 
 class statut_marital(Variable):
@@ -46,7 +46,7 @@ class statut_marital(Variable):
             u"Pacsé",
             u"Jeune veuf"], start = 1),
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Statut marital"
 
 
@@ -54,14 +54,14 @@ class statut_marital(Variable):
 class nbN(Variable):
     cerfa_field = u"N"
     column = PeriodSizeIndependentIntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre d'enfants mariés/pacsés et d'enfants non mariés chargés de famille"
 
 
 class nbR(Variable):
     cerfa_field = u"R"
     column = PeriodSizeIndependentIntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre de titulaires (autres que les enfants) de la carte invalidité d'au moins 80 %"
 
 
@@ -69,7 +69,7 @@ class nbR(Variable):
 class caseE(Variable):
     cerfa_field = u"E"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Situation pouvant donner droit à une demi-part supplémentaire : vous vivez seul au 1er janvier de l'année de perception des revenus et vous avez élevé un enfant pendant moins de 5 ans durant la période où vous viviez seul"
     stop_date = date(2012, 12, 31)
 
@@ -77,21 +77,21 @@ class caseE(Variable):
 class caseF(Variable):
     cerfa_field = u"F"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Situation pouvant donner droit à une demi-part supplémentaire : conjoint titulaire d'une pension ou d'une carte d'invalidité (vivant ou décédé l'année de perception des revenus)"
 
 
 class caseG(Variable):
     cerfa_field = u"G"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Titulaire d'une pension de veuve de guerre"
 
   # attention, ne pas confondre caseG et nbG qui se rapportent toutes les 2 à une "case" G, l'une étant une vraie case que l'on remplt et l'autre une case que l'on coche
 class caseH(Variable):
     cerfa_field = u"H"
     column = PeriodSizeIndependentIntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Année de naissance des enfants à charge en garde alternée"
 
 
@@ -104,7 +104,7 @@ class caseH(Variable):
 class caseK(Variable):
     cerfa_field = u"K"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Situation pouvant donner droit à une demi-part supplémentaire: vous avez eu un enfant décédé après l’âge de 16 ans ou par suite de faits de guerre"
     stop_date = date(2011, 12, 31)
 
@@ -113,7 +113,7 @@ class caseK(Variable):
 class caseL(Variable):
     cerfa_field = u"L"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Situation pouvant donner droit à une demi-part supplémentaire: vous vivez seul au 1er janvier de l'année de perception des revenus et vous avez élevé un enfant pendant au moins 5 ans durant la période où vous viviez seul"
 
 
@@ -121,21 +121,21 @@ class caseL(Variable):
 class caseN(Variable):
     cerfa_field = u"N"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Vous ne viviez pas seul au 1er janvier de l'année de perception des revenus"
 
 
 class caseP(Variable):
     cerfa_field = u"P"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Titulaire d'une pension pour une invalidité d'au moins 40 % ou d'une carte d'invalidité d'au moins 80%"
 
 
 class caseS(Variable):
     cerfa_field = u"S"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Vous êtes mariés/pacsés et l'un des deux déclarants âgé de plus de 75 ans est titulaire de la carte du combattant ou d'une pension militaire d'invalidité ou de victime de guerre"
 
 
@@ -143,7 +143,7 @@ class caseS(Variable):
 class caseT(Variable):
     cerfa_field = u"T"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Vous êtes parent isolé au 1er janvier de l'année de perception des revenus"
 
 
@@ -151,24 +151,24 @@ class caseT(Variable):
 class caseW(Variable):
     cerfa_field = u"W"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Vous ou votre conjoint (même s'il est décédé), âgés de plus de 75 ans, êtes titulaire de la carte du combattant ou d'une pension militaire d'invalidité ou de victime de guerre"
 
 
 
 class handicap(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label= u"Individu en situation de handicap"
 
 class invalidite(Variable):
   column = BoolCol
-  entity_class = Individus
+  entity = Individus
   label=u"Individu titulaire d'une carte d'invalidité"
 
 class nb_parents(Variable):
     column = PeriodSizeIndependentIntCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Nombre d'adultes (parents) dans la famille"
 
     def function(famille, period):
@@ -179,7 +179,7 @@ class nb_parents(Variable):
 
 class maries(Variable):
     column = BoolCol(default = False)
-    entity_class = Familles
+    entity = Familles
     label = u"maries"
 
     def function(famille, period):
@@ -194,7 +194,7 @@ class maries(Variable):
 
 class en_couple(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Indicatrice de vie en couple"
 
     def function(self, simulation, period):
@@ -210,7 +210,7 @@ class en_couple(Variable):
 
 class est_enfant_dans_famille(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indique qe l'individu est un enfant dans une famille"
 
     def function(individu, period):
@@ -218,7 +218,7 @@ class est_enfant_dans_famille(Variable):
 
 class etudiant(Variable):
     column = BoolCol(default = False)
-    entity_class = Individus
+    entity = Individus
     label = u"Indicatrice individuelle étudiant"
 
     def function(self, simulation, period):
@@ -230,20 +230,20 @@ class etudiant(Variable):
 
 class rempli_obligation_scolaire(Variable):
     column = BoolCol(default = True)
-    entity_class = Individus
+    entity = Individus
     label = u"Rempli l'obligation scolaire"
 
 class ressortissant_eee(Variable):
     column = BoolCol(default = True)
-    entity_class = Individus
+    entity = Individus
     label = u"Ressortissant de l'EEE ou de la Suisse."
 
 class duree_possession_titre_sejour(Variable):
     column = IntCol
-    entity_class = Individus
+    entity = Individus
     label = u"Durée depuis laquelle l'individu possède un titre de séjour (en années)"
 
 class enfant_place(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Enfant placé en structure spécialisée ou famille d'accueil"

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -187,7 +187,7 @@ class maries(Variable):
         """couple = 1 si couple marié sinon 0 TODO: faire un choix avec couple ?"""
         # Note : Cette variable est "instantanée" : quelque soit la période demandée, elle retourne la valeur au premier
         # jour, sans changer la période.
-        statut_marital = famille.members['statut_marital'](period)
+        statut_marital = famille.members('statut_marital', period)
         individu_marie = (statut_marital == 1)
 
         return period, famille.any(individu_marie, role = PARENT)

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -174,11 +174,8 @@ class nb_parents(Variable):
     def function(self, simulation, period):
         # Note : Cette variable est "instantanée" : quelque soit la période demandée, elle retourne la valeur au premier
         # jour, sans changer la période.
-        quifam_holder = simulation.compute('quifam', period)
 
-        quifam = self.filter_role(quifam_holder, role = PART)
-
-        return period, 1 + 1 * (quifam == PART)
+        return period, simulation.famille.nb_persons(role = PARENT)
 
 
 class maries(Variable):
@@ -186,15 +183,14 @@ class maries(Variable):
     entity_class = Familles
     label = u"maries"
 
-    def function(self, simulation, period):
+    def function(famille, period):
         """couple = 1 si couple marié sinon 0 TODO: faire un choix avec couple ?"""
         # Note : Cette variable est "instantanée" : quelque soit la période demandée, elle retourne la valeur au premier
         # jour, sans changer la période.
-        statut_marital_holder = simulation.compute('statut_marital', period)
+        statut_marital = famille.members.calculate('statut_marital', period)
+        individu_marie = (statut_marital == 1)
 
-        statut_marital = self.filter_role(statut_marital_holder, role = CHEF)
-
-        return period, statut_marital == 1
+        return period, famille.any(individu_marie, role = PARENT)
 
 
 class en_couple(Variable):
@@ -218,10 +214,8 @@ class est_enfant_dans_famille(Variable):
     entity_class = Individus
     label = u"Indique qe l'individu est un enfant dans une famille"
 
-    def function(self, simulation, period):
-        quifam = simulation.calculate('quifam', period)
-        return period, quifam > PART
-
+    def function(individu, period):
+        return period, individu.role_in(Familles) == ENFANT
 
 class etudiant(Variable):
     column = BoolCol(default = False)

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -4,18 +4,18 @@ from openfisca_france.model.base import *  # noqa
 
 class date_naissance(Variable):
     column = DateCol(default = date(1970, 1, 1))
-    entity = Individus
+    entity = Individu
     is_permanent = True
     label = u"Date de naissance"
 
 class adoption(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Enfant adopté"
 
 class garde_alternee(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u'Enfant en garde alternée'
     base_function = requested_period_last_or_next_value
 
@@ -28,12 +28,12 @@ class activite(Variable):
             u'Retraité',
             u'Autre inactif']),
         )
-    entity = Individus
+    entity = Individu
     label = u"Activité"
 
 class enceinte(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Est enceinte"
 
 class statut_marital(Variable):
@@ -46,7 +46,7 @@ class statut_marital(Variable):
             u"Pacsé",
             u"Jeune veuf"], start = 1),
         )
-    entity = Individus
+    entity = Individu
     label = u"Statut marital"
 
 
@@ -54,14 +54,14 @@ class statut_marital(Variable):
 class nbN(Variable):
     cerfa_field = u"N"
     column = PeriodSizeIndependentIntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre d'enfants mariés/pacsés et d'enfants non mariés chargés de famille"
 
 
 class nbR(Variable):
     cerfa_field = u"R"
     column = PeriodSizeIndependentIntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre de titulaires (autres que les enfants) de la carte invalidité d'au moins 80 %"
 
 
@@ -69,7 +69,7 @@ class nbR(Variable):
 class caseE(Variable):
     cerfa_field = u"E"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Situation pouvant donner droit à une demi-part supplémentaire : vous vivez seul au 1er janvier de l'année de perception des revenus et vous avez élevé un enfant pendant moins de 5 ans durant la période où vous viviez seul"
     stop_date = date(2012, 12, 31)
 
@@ -77,21 +77,21 @@ class caseE(Variable):
 class caseF(Variable):
     cerfa_field = u"F"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Situation pouvant donner droit à une demi-part supplémentaire : conjoint titulaire d'une pension ou d'une carte d'invalidité (vivant ou décédé l'année de perception des revenus)"
 
 
 class caseG(Variable):
     cerfa_field = u"G"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Titulaire d'une pension de veuve de guerre"
 
   # attention, ne pas confondre caseG et nbG qui se rapportent toutes les 2 à une "case" G, l'une étant une vraie case que l'on remplt et l'autre une case que l'on coche
 class caseH(Variable):
     cerfa_field = u"H"
     column = PeriodSizeIndependentIntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Année de naissance des enfants à charge en garde alternée"
 
 
@@ -104,7 +104,7 @@ class caseH(Variable):
 class caseK(Variable):
     cerfa_field = u"K"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Situation pouvant donner droit à une demi-part supplémentaire: vous avez eu un enfant décédé après l’âge de 16 ans ou par suite de faits de guerre"
     stop_date = date(2011, 12, 31)
 
@@ -113,7 +113,7 @@ class caseK(Variable):
 class caseL(Variable):
     cerfa_field = u"L"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Situation pouvant donner droit à une demi-part supplémentaire: vous vivez seul au 1er janvier de l'année de perception des revenus et vous avez élevé un enfant pendant au moins 5 ans durant la période où vous viviez seul"
 
 
@@ -121,21 +121,21 @@ class caseL(Variable):
 class caseN(Variable):
     cerfa_field = u"N"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Vous ne viviez pas seul au 1er janvier de l'année de perception des revenus"
 
 
 class caseP(Variable):
     cerfa_field = u"P"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Titulaire d'une pension pour une invalidité d'au moins 40 % ou d'une carte d'invalidité d'au moins 80%"
 
 
 class caseS(Variable):
     cerfa_field = u"S"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Vous êtes mariés/pacsés et l'un des deux déclarants âgé de plus de 75 ans est titulaire de la carte du combattant ou d'une pension militaire d'invalidité ou de victime de guerre"
 
 
@@ -143,7 +143,7 @@ class caseS(Variable):
 class caseT(Variable):
     cerfa_field = u"T"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Vous êtes parent isolé au 1er janvier de l'année de perception des revenus"
 
 
@@ -151,24 +151,24 @@ class caseT(Variable):
 class caseW(Variable):
     cerfa_field = u"W"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Vous ou votre conjoint (même s'il est décédé), âgés de plus de 75 ans, êtes titulaire de la carte du combattant ou d'une pension militaire d'invalidité ou de victime de guerre"
 
 
 
 class handicap(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label= u"Individu en situation de handicap"
 
 class invalidite(Variable):
   column = BoolCol
-  entity = Individus
+  entity = Individu
   label=u"Individu titulaire d'une carte d'invalidité"
 
 class nb_parents(Variable):
     column = PeriodSizeIndependentIntCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Nombre d'adultes (parents) dans la famille"
 
     def function(famille, period):
@@ -179,7 +179,7 @@ class nb_parents(Variable):
 
 class maries(Variable):
     column = BoolCol(default = False)
-    entity = Familles
+    entity = Famille
     label = u"maries"
 
     def function(famille, period):
@@ -194,7 +194,7 @@ class maries(Variable):
 
 class en_couple(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Indicatrice de vie en couple"
 
     def function(self, simulation, period):
@@ -210,15 +210,15 @@ class en_couple(Variable):
 
 class est_enfant_dans_famille(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Indique qe l'individu est un enfant dans une famille"
 
     def function(individu, period):
-        return period, individu.has_role(Familles.ENFANT)
+        return period, individu.has_role(Famille.ENFANT)
 
 class etudiant(Variable):
     column = BoolCol(default = False)
-    entity = Individus
+    entity = Individu
     label = u"Indicatrice individuelle étudiant"
 
     def function(self, simulation, period):
@@ -230,20 +230,20 @@ class etudiant(Variable):
 
 class rempli_obligation_scolaire(Variable):
     column = BoolCol(default = True)
-    entity = Individus
+    entity = Individu
     label = u"Rempli l'obligation scolaire"
 
 class ressortissant_eee(Variable):
     column = BoolCol(default = True)
-    entity = Individus
+    entity = Individu
     label = u"Ressortissant de l'EEE ou de la Suisse."
 
 class duree_possession_titre_sejour(Variable):
     column = IntCol
-    entity = Individus
+    entity = Individu
     label = u"Durée depuis laquelle l'individu possède un titre de séjour (en années)"
 
 class enfant_place(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Enfant placé en structure spécialisée ou famille d'accueil"

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -214,7 +214,7 @@ class est_enfant_dans_famille(Variable):
     label = u"Indique qe l'individu est un enfant dans une famille"
 
     def function(individu, period):
-        return period, individu.has_role(Familles.enfant, Familles)
+        return period, individu.has_role(Familles.enfant)
 
 class etudiant(Variable):
     column = BoolCol(default = False)

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -215,7 +215,7 @@ class est_enfant_dans_famille(Variable):
     label = u"Indique qe l'individu est un enfant dans une famille"
 
     def function(individu, period):
-        return period, individu.role_in(Familles) == ENFANT
+        return period, individu.has_role(ENFANT, Familles)
 
 class etudiant(Variable):
     column = BoolCol(default = False)

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -2,63 +2,16 @@
 
 from openfisca_france.model.base import *  # noqa
 
-
-class idmen(Variable):
-    column = IntCol
-    entity_class = Individus
-    is_permanent = True
-    label = u"Identifiant du ménage"
-
-
-class idfoy(Variable):
-    column = IntCol
-    entity_class = Individus
-    is_permanent = True
-    label = u"Identifiant du foyer"
-
-
-class idfam(Variable):
-    column = IntCol
-    entity_class = Individus
-    is_permanent = True
-    label = u"Identifiant de la famille"
-
-
-
-class quimen(Variable):
-    column = EnumCol(enum = QUIMEN)
-    entity_class = Individus
-    is_permanent = True
-
-
-class quifoy(Variable):
-    column = EnumCol(enum = QUIFOY)
-    entity_class = Individus
-    is_permanent = True
-
-
-class quifam(Variable):
-    column = EnumCol(enum = QUIFAM)
-    entity_class = Individus
-    is_permanent = True
-
-
-
 class date_naissance(Variable):
     column = DateCol(default = date(1970, 1, 1))
     entity_class = Individus
     is_permanent = True
     label = u"Date de naissance"
 
-
-
-
 class adoption(Variable):
     column = BoolCol
     entity_class = Individus
     label = u"Enfant adopté"
-
-
 
 class garde_alternee(Variable):
     column = BoolCol
@@ -78,16 +31,10 @@ class activite(Variable):
     entity_class = Individus
     label = u"Activité"
 
-
-
-
 class enceinte(Variable):
     column = BoolCol
     entity_class = Individus
     label = u"Est enceinte"
-
-
-
 
 class statut_marital(Variable):
     column = EnumCol(

--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -44,7 +44,7 @@ class loyer_famille(Variable):
     label = u"Loyer de la famille"
 
     def function(famille, period):
-        loyer_menage = famille.members.menage['loyer'](period)
+        loyer_menage = famille.members.menage('loyer', period)
         return period, famille.transpose(loyer_menage, origin_entity = Menages)
 
 
@@ -80,7 +80,7 @@ class statut_occupation_logement_famille(Variable):
     )
 
     def function(famille, period):
-        statut_occupation_logement_menage = famille.members.menage['statut_occupation_logement'](period)
+        statut_occupation_logement_menage = famille.members.menage('statut_occupation_logement', period)
         return period, famille.transpose(statut_occupation_logement_menage, origin_entity = Menages)
 
 class residence_dom(Variable):

--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -44,8 +44,7 @@ class loyer_famille(Variable):
     label = u"Loyer de la famille"
 
     def function(famille, period):
-        loyer_menage = famille.members.menage('loyer', period)
-        return period, famille.transpose(loyer_menage, origin_entity = Menages)
+        return period, famille.first_person.menage('loyer', period)
 
 
 class charges_locatives(Variable):
@@ -80,8 +79,7 @@ class statut_occupation_logement_famille(Variable):
     )
 
     def function(famille, period):
-        statut_occupation_logement_menage = famille.members.menage('statut_occupation_logement', period)
-        return period, famille.transpose(statut_occupation_logement_menage, origin_entity = Menages)
+        return period, famille.first_person.menage('statut_occupation_logement', period)
 
 class residence_dom(Variable):
     column = BoolCol

--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -8,39 +8,39 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class coloc(Variable):
     column = BoolCol
-    entity_class = Menages
+    entity = Menages
     label = u"Vie en colocation"
 
 class logement_chambre(Variable):
     column = BoolCol
-    entity_class = Menages
+    entity = Menages
     label = u"Le logement est considéré comme une chambre"
 
 class loyer(Variable):
     column = FloatCol
-    entity_class = Menages
+    entity = Menages
     set_input = set_input_divide_by_period
     label = u"Loyer ou mensualité d'emprunt pour un primo-accédant"
 
 class depcom(Variable):
     column = FixedStrCol(max_length = 5)
-    entity_class = Menages
+    entity = Menages
     label = u"Code INSEE (depcom) du lieu de résidence"
 
 class charges_locatives(Variable):
     column = FloatCol
-    entity_class = Menages
+    entity = Menages
     set_input = set_input_divide_by_period
     label = u'Charges locatives'
 
 class proprietaire_proche_famille(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Le propriétaire du logement a un lien de parenté avec la personne de référence ou son conjoint"
 
 class habite_chez_parents(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"L'individu habite chez ses parents"
 
 class statut_occupation_logement(Variable):
@@ -56,13 +56,13 @@ class statut_occupation_logement(Variable):
             u"Locataire d'un foyer (résidence universitaire, maison de retraite, foyer de jeune travailleur, résidence sociale...)",
             u"Sans domicile stable"])
     )
-    entity_class = Menages
+    entity = Menages
     label = u"Statut d'occupation du logement"
     set_input = set_input_dispatch_by_period
 
 class residence_dom(Variable):
     column = BoolCol
-    entity_class = Menages
+    entity = Menages
 
     def function(menage, period):
         residence_guadeloupe = menage('residence_guadeloupe', period)
@@ -76,7 +76,7 @@ class residence_dom(Variable):
 
 class residence_guadeloupe(Variable):
     column = BoolCol
-    entity_class = Menages
+    entity = Menages
 
     def function(self, simulation, period):
         depcom = simulation.calculate('depcom', period)
@@ -85,7 +85,7 @@ class residence_guadeloupe(Variable):
 
 class residence_martinique(Variable):
     column = BoolCol
-    entity_class = Menages
+    entity = Menages
 
     def function(self, simulation, period):
         depcom = simulation.calculate('depcom', period)
@@ -94,7 +94,7 @@ class residence_martinique(Variable):
 
 class residence_guyane(Variable):
     column = BoolCol
-    entity_class = Menages
+    entity = Menages
 
     def function(self, simulation, period):
         depcom = simulation.calculate('depcom', period)
@@ -103,7 +103,7 @@ class residence_guyane(Variable):
 
 class residence_reunion(Variable):
     column = BoolCol
-    entity_class = Menages
+    entity = Menages
 
     def function(self, simulation, period):
         depcom = simulation.calculate('depcom', period)
@@ -112,7 +112,7 @@ class residence_reunion(Variable):
 
 class residence_mayotte(Variable):
     column = BoolCol
-    entity_class = Menages
+    entity = Menages
 
     def function(self, simulation, period):
         depcom = simulation.calculate('depcom', period)

--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -8,39 +8,39 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class coloc(Variable):
     column = BoolCol
-    entity = Menages
+    entity = Menage
     label = u"Vie en colocation"
 
 class logement_chambre(Variable):
     column = BoolCol
-    entity = Menages
+    entity = Menage
     label = u"Le logement est considéré comme une chambre"
 
 class loyer(Variable):
     column = FloatCol
-    entity = Menages
+    entity = Menage
     set_input = set_input_divide_by_period
     label = u"Loyer ou mensualité d'emprunt pour un primo-accédant"
 
 class depcom(Variable):
     column = FixedStrCol(max_length = 5)
-    entity = Menages
+    entity = Menage
     label = u"Code INSEE (depcom) du lieu de résidence"
 
 class charges_locatives(Variable):
     column = FloatCol
-    entity = Menages
+    entity = Menage
     set_input = set_input_divide_by_period
     label = u'Charges locatives'
 
 class proprietaire_proche_famille(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Le propriétaire du logement a un lien de parenté avec la personne de référence ou son conjoint"
 
 class habite_chez_parents(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"L'individu habite chez ses parents"
 
 class statut_occupation_logement(Variable):
@@ -56,13 +56,13 @@ class statut_occupation_logement(Variable):
             u"Locataire d'un foyer (résidence universitaire, maison de retraite, foyer de jeune travailleur, résidence sociale...)",
             u"Sans domicile stable"])
     )
-    entity = Menages
+    entity = Menage
     label = u"Statut d'occupation du logement"
     set_input = set_input_dispatch_by_period
 
 class residence_dom(Variable):
     column = BoolCol
-    entity = Menages
+    entity = Menage
 
     def function(menage, period):
         residence_guadeloupe = menage('residence_guadeloupe', period)
@@ -76,7 +76,7 @@ class residence_dom(Variable):
 
 class residence_guadeloupe(Variable):
     column = BoolCol
-    entity = Menages
+    entity = Menage
 
     def function(self, simulation, period):
         depcom = simulation.calculate('depcom', period)
@@ -85,7 +85,7 @@ class residence_guadeloupe(Variable):
 
 class residence_martinique(Variable):
     column = BoolCol
-    entity = Menages
+    entity = Menage
 
     def function(self, simulation, period):
         depcom = simulation.calculate('depcom', period)
@@ -94,7 +94,7 @@ class residence_martinique(Variable):
 
 class residence_guyane(Variable):
     column = BoolCol
-    entity = Menages
+    entity = Menage
 
     def function(self, simulation, period):
         depcom = simulation.calculate('depcom', period)
@@ -103,7 +103,7 @@ class residence_guyane(Variable):
 
 class residence_reunion(Variable):
     column = BoolCol
-    entity = Menages
+    entity = Menage
 
     def function(self, simulation, period):
         depcom = simulation.calculate('depcom', period)
@@ -112,7 +112,7 @@ class residence_reunion(Variable):
 
 class residence_mayotte(Variable):
     column = BoolCol
-    entity = Menages
+    entity = Menage
 
     def function(self, simulation, period):
         depcom = simulation.calculate('depcom', period)

--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -44,7 +44,7 @@ class loyer_famille(Variable):
     label = u"Loyer de la famille"
 
     def function(famille, period):
-        loyer_menage = famille.members.menage.calculate('loyer', period)
+        loyer_menage = famille.members.menage['loyer'](period)
         return period, famille.transpose(loyer_menage, origin_entity = Menages)
 
 
@@ -80,7 +80,7 @@ class statut_occupation_logement_famille(Variable):
     )
 
     def function(famille, period):
-        statut_occupation_logement_menage = famille.members.menage.calculate('statut_occupation_logement', period)
+        statut_occupation_logement_menage = famille.members.menage['statut_occupation_logement'](period)
         return period, famille.transpose(statut_occupation_logement_menage, origin_entity = Menages)
 
 class residence_dom(Variable):

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -250,7 +250,7 @@ class pen(Variable):
         pensions_alimentaires_versees = foyer_fiscal('pensions_alimentaires_versees', period)
         retraite_titre_onereux = foyer_fiscal('retraite_titre_onereux', period, options = [ADD])
         pen_foyer_fiscal = pensions_alimentaires_versees + retraite_titre_onereux
-        pen_foyer_fiscal_projetees = pen_foyer_fiscal * (individu.has_role(DECLARANT, foyer_fiscal))
+        pen_foyer_fiscal_projetees = pen_foyer_fiscal * (individu.has_role(foyer_fiscal.declarant, foyer_fiscal))
 
         return period, (chomage_net + retraite_nette + pensions_alimentaires_percues + pen_foyer_fiscal_projetees)
 
@@ -311,7 +311,7 @@ class rev_cap(Variable):
         cotsoc_bar = foyer_fiscal('cotsoc_bar', period)
 
         revenus_foyer_fiscal = fon + rev_cap_bar + cotsoc_lib + rev_cap_lib + imp_lib + cotsoc_bar
-        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(DECLARANT, foyer_fiscal)
+        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(foyer_fiscal.declarant, foyer_fiscal)
 
         rac = individu('rac', period)
 

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -250,7 +250,7 @@ class pen(Variable):
         pensions_alimentaires_versees = foyer_fiscal('pensions_alimentaires_versees', period)
         retraite_titre_onereux = foyer_fiscal('retraite_titre_onereux', period, options = [ADD])
         pen_foyer_fiscal = pensions_alimentaires_versees + retraite_titre_onereux
-        pen_foyer_fiscal_projetees = pen_foyer_fiscal * (individu.has_role(foyer_fiscal.declarant, foyer_fiscal))
+        pen_foyer_fiscal_projetees = pen_foyer_fiscal * (individu.has_role(foyer_fiscal.declarant))
 
         return period, (chomage_net + retraite_nette + pensions_alimentaires_percues + pen_foyer_fiscal_projetees)
 
@@ -311,7 +311,7 @@ class rev_cap(Variable):
         cotsoc_bar = foyer_fiscal('cotsoc_bar', period)
 
         revenus_foyer_fiscal = fon + rev_cap_bar + cotsoc_lib + rev_cap_lib + imp_lib + cotsoc_bar
-        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(foyer_fiscal.declarant, foyer_fiscal)
+        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(foyer_fiscal.declarant)
 
         rac = individu('rac', period)
 

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -136,7 +136,7 @@ class revnet(Variable):
     url = u"http://impotsurlerevenu.org/definitions/115-revenu-net-imposable.php",
 
     def function(menage, period):
-        revenu_net_individus = menage.members['revenu_net_individu'](period)
+        revenu_net_individus = menage.members('revenu_net_individu', period)
         return period, menage.sum(revenu_net_individus)
 
 
@@ -180,7 +180,7 @@ class revini(Variable):
     column = FloatCol
 
     def function(menage, period):
-        revenu_initial_individus = menage.members['revenu_initial_individu'](period)
+        revenu_initial_individus = menage.members('revenu_initial_individu', period)
         return period, simulation.menage.sum(revenu_initial_individus)
 
 
@@ -241,13 +241,13 @@ class pen(Variable):
         Pensions
         '''
         period = period.start.period('year').offset('first-of')
-        chomage_net = individu['chomage_net'](period)
-        retraite_nette = individu['retraite_nette'](period)
-        pensions_alimentaires_percues = individu['pensions_alimentaires_percues'](period)
+        chomage_net = individu('chomage_net', period)
+        retraite_nette = individu('retraite_nette', period)
+        pensions_alimentaires_percues = individu('pensions_alimentaires_percues', period)
 
         # Revenus du foyer fiscal
-        pensions_alimentaires_versees = individu.foyer_fiscal['pensions_alimentaires_versees'](period)
-        retraite_titre_onereux = individu.foyer_fiscal['retraite_titre_onereux'](period, options = [ADD])
+        pensions_alimentaires_versees = individu.foyer_fiscal('pensions_alimentaires_versees', period)
+        retraite_titre_onereux = individu.foyer_fiscal('retraite_titre_onereux', period, options = [ADD])
         pen_foyer_fiscal = pensions_alimentaires_versees + retraite_titre_onereux
         pen_foyer_fiscal_projetees = individu.foyer_fiscal.project_on_first_person(pen_foyer_fiscal)
 

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -534,16 +534,17 @@ class check_csk(Variable):
     entity_class = Menages
     label = u"check_csk"
 
-    def function(self, simulation, period):
+    def function(menage, period):
         period = period.this_year
 
-        # Prélevements effectués sur les revenus du foyer fiscal
-        prelsoc_cap_bar = simulation.calculate('prelsoc_cap_bar', period)
-        prelsoc_pv_mo = simulation.calculate('prelsoc_pv_mo', period)
-        prelsoc_fon = simulation.calculate('prelsoc_fon', period)
-        prel_foyer_fiscal = prelsoc_cap_bar + prelsoc_pv_mo + prelsoc_fon
+        foyer_fiscal = menage.first_person.foyer_fiscal
 
-        return period, simulation.menage.transpose(prel_foyer_fiscal, origin_entity = FoyersFiscaux)
+        # Prélevements effectués sur les revenus du foyer fiscal
+        prelsoc_cap_bar = foyer_fiscal('prelsoc_cap_bar', period)
+        prelsoc_pv_mo = foyer_fiscal('prelsoc_pv_mo', period)
+        prelsoc_fon = foyer_fiscal('prelsoc_fon', period)
+
+        return period, prelsoc_cap_bar + prelsoc_pv_mo + prelsoc_fon
 
 
 class check_csg(Variable):
@@ -551,17 +552,17 @@ class check_csg(Variable):
     entity_class = Menages
     label = u"check_csg"
 
-    def function(self, simulation, period):
+    def function(menage, period):
         period = period.this_year
 
+        foyer_fiscal = menage.first_person.foyer_fiscal
+
         # CSG prélevée sur les revenus du foyer fiscal
-        csg_cap_bar = simulation.calculate('csg_cap_bar', periop)
-        csg_pv_mo = simulation.calculate('csg_pv_mo', periop)
-        csg_fon = simulation.calculate('csg_fon', periop)
+        csg_cap_bar = foyer_fiscal('csg_cap_bar', periop)
+        csg_pv_mo = foyer_fiscal('csg_pv_mo', periop)
+        csg_fon = foyer_fiscal('csg_fon', periop)
 
-        csg_foyer_fiscal = csg_cap_bar + csg_pv_mo + csg_fon
-
-        return period, simulation.menage.transpose(csg_foyer_fiscal, origin_entity = FoyersFiscaux)
+        return period, csg_cap_bar + csg_pv_mo + csg_fon
 
 
 class check_crds(Variable):
@@ -569,14 +570,14 @@ class check_crds(Variable):
     entity_class = Menages
     label = u"check_crds"
 
-    def function(self, simulation, period):
+    def function(menage, period):
         period = period.this_year
 
+        foyer_fiscal = menage.first_person.foyer_fiscal
+
         # CRDS prélevée sur les revenus du foyer fiscal
-        crds_pv_mo = simulation.calculate('crds_pv_mo', period)
-        crds_fon = simulation.calculate('crds_fon', period)
-        crds_cap_bar = simulation.calculate('crds_cap_bar', period)
+        crds_pv_mo = foyer_fiscal('crds_pv_mo', period)
+        crds_fon = foyer_fiscal('crds_fon', period)
+        crds_cap_bar = foyer_fiscal('crds_cap_bar', period)
 
-        crds_foyer_fiscal = crds_pv_mo + crds_fon + crds_cap_bar
-
-        return period, simulation.menage.transpose(crds_foyer_fiscal, origin_entity = FoyersFiscaux)
+        return period, crds_pv_mo + crds_fon + crds_cap_bar

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -250,7 +250,7 @@ class pen(Variable):
         pensions_alimentaires_versees = foyer_fiscal('pensions_alimentaires_versees', period)
         retraite_titre_onereux = foyer_fiscal('retraite_titre_onereux', period, options = [ADD])
         pen_foyer_fiscal = pensions_alimentaires_versees + retraite_titre_onereux
-        pen_foyer_fiscal_projetees = pen_foyer_fiscal * (individu.has_role(foyer_fiscal.declarant))
+        pen_foyer_fiscal_projetees = pen_foyer_fiscal * (individu.has_role(foyer_fiscal.DECLARANT_PRINCIPAL))
 
         return period, (chomage_net + retraite_nette + pensions_alimentaires_percues + pen_foyer_fiscal_projetees)
 
@@ -311,7 +311,7 @@ class rev_cap(Variable):
         cotsoc_bar = foyer_fiscal('cotsoc_bar', period)
 
         revenus_foyer_fiscal = fon + rev_cap_bar + cotsoc_lib + rev_cap_lib + imp_lib + cotsoc_bar
-        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(foyer_fiscal.declarant)
+        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(foyer_fiscal.DECLARANT_PRINCIPAL)
 
         rac = individu('rac', period)
 

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -136,7 +136,7 @@ class revnet(Variable):
     url = u"http://impotsurlerevenu.org/definitions/115-revenu-net-imposable.php",
 
     def function(menage, period):
-        revenu_net_individus = menage.members.calculate('revenu_net_individu', period)
+        revenu_net_individus = menage.members['revenu_net_individu'](period)
         return period, menage.sum(revenu_net_individus)
 
 
@@ -180,7 +180,7 @@ class revini(Variable):
     column = FloatCol
 
     def function(menage, period):
-        revenu_initial_individus = menage.members.calculate('revenu_initial_individu', period)
+        revenu_initial_individus = menage.members['revenu_initial_individu'](period)
         return period, simulation.menage.sum(revenu_initial_individus)
 
 
@@ -241,13 +241,13 @@ class pen(Variable):
         Pensions
         '''
         period = period.start.period('year').offset('first-of')
-        chomage_net = individu.calculate('chomage_net', period)
-        retraite_nette = individu.calculate('retraite_nette', period)
-        pensions_alimentaires_percues = individu.calculate('pensions_alimentaires_percues', period)
+        chomage_net = individu['chomage_net'](period)
+        retraite_nette = individu['retraite_nette'](period)
+        pensions_alimentaires_percues = individu['pensions_alimentaires_percues'](period)
 
         # Revenus du foyer fiscal
-        pensions_alimentaires_versees = individu.foyer_fiscal.calculate('pensions_alimentaires_versees', period)
-        retraite_titre_onereux = individu.foyer_fiscal.calculate_add('retraite_titre_onereux', period)
+        pensions_alimentaires_versees = individu.foyer_fiscal['pensions_alimentaires_versees'](period)
+        retraite_titre_onereux = individu.foyer_fiscal['retraite_titre_onereux'](period, options = [ADD])
         pen_foyer_fiscal = pensions_alimentaires_versees + retraite_titre_onereux
         pen_foyer_fiscal_projetees = individu.foyer_fiscal.project_on_first_person(pen_foyer_fiscal)
 

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -9,7 +9,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class uc(Variable):
     column = FloatCol(default = 0)
-    entity_class = Menages
+    entity = Menages
     label = u"Unités de consommation"
 
     def function(self, simulation, period):
@@ -35,7 +35,7 @@ class uc(Variable):
 
 class typ_men(Variable):
     column = PeriodSizeIndependentIntCol(default = 0)
-    entity_class = Menages
+    entity = Menages
     label = u"Type de ménage"
 
     def function(self, simulation, period):
@@ -70,7 +70,7 @@ class typ_men(Variable):
 
 class revdisp(Variable):
     column = FloatCol(default = 0)
-    entity_class = Menages
+    entity = Menages
     label = u"Revenu disponible du ménage"
     url = "http://fr.wikipedia.org/wiki/Revenu_disponible"
 
@@ -100,7 +100,7 @@ class revdisp(Variable):
 
 class nivvie(Variable):
     column = FloatCol(default = 0)
-    entity_class = Menages
+    entity = Menages
     label = u"Niveau de vie du ménage"
 
     def function(self, simulation, period):
@@ -117,7 +117,7 @@ class nivvie(Variable):
 
 class revenu_net_individu(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenu net de l'individu"
 
     def function(self, simulation, period):
@@ -130,7 +130,7 @@ class revenu_net_individu(Variable):
 
 
 class revnet(Variable):
-    entity_class = Menages
+    entity = Menages
     label = u"Revenu net du ménage"
     column = FloatCol
     url = u"http://impotsurlerevenu.org/definitions/115-revenu-net-imposable.php",
@@ -142,7 +142,7 @@ class revnet(Variable):
 
 class nivvie_net(Variable):
     column = FloatCol(default = 0)
-    entity_class = Menages
+    entity = Menages
     label = u"Niveau de vie net du ménage"
 
     def function(self, simulation, period):
@@ -159,7 +159,7 @@ class nivvie_net(Variable):
 
 class revenu_initial_individu(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenu initial de l'individu"
 
     def function(self, simulation, period):
@@ -175,7 +175,7 @@ class revenu_initial_individu(Variable):
 
 
 class revini(Variable):
-    entity_class = Menages
+    entity = Menages
     label = u"Revenu initial du ménage"
     column = FloatCol
 
@@ -186,7 +186,7 @@ class revini(Variable):
 
 class nivvie_ini(Variable):
     column = FloatCol(default = 0)
-    entity_class = Menages
+    entity = Menages
     label = u"Niveau de vie initial du ménage"
 
     def function(self, simulation, period):
@@ -213,7 +213,7 @@ def _revprim(rev_trav, chomage_imposable, rev_cap, cotisations_employeur, cotisa
 
 class rev_trav(Variable):
     column = FloatCol(default = 0)
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus du travail (salariés et non salariés)"
     url = "http://fr.wikipedia.org/wiki/Revenu_du_travail"
 
@@ -232,7 +232,7 @@ class rev_trav(Variable):
 
 class pen(Variable):
     column = FloatCol(default = 0)
-    entity_class = Individus
+    entity = Individus
     label = u"Pensions et revenus de remplacement"
     url = "http://fr.wikipedia.org/wiki/Rente"
 
@@ -257,7 +257,7 @@ class pen(Variable):
 
 class cotsoc_bar(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Cotisations sociales sur les revenus du capital imposés au barème"
 
     def function(self, simulation, period):
@@ -274,7 +274,7 @@ class cotsoc_bar(Variable):
 
 class cotsoc_lib(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Cotisations sociales sur les revenus du capital soumis au prélèvement libératoire"
 
     def function(self, simulation, period):
@@ -291,7 +291,7 @@ class cotsoc_lib(Variable):
 
 class rev_cap(Variable):
     column = FloatCol(default = 0)
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus du patrimoine"
     url = "http://fr.wikipedia.org/wiki/Revenu#Revenu_du_Capital"
 
@@ -320,7 +320,7 @@ class rev_cap(Variable):
 
 class psoc(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Prestations sociales"
     url = "http://fr.wikipedia.org/wiki/Prestation_sociale"
 
@@ -338,7 +338,7 @@ class psoc(Variable):
 
 class pfam(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Prestations familiales"
     url = "http://www.social-sante.gouv.fr/informations-pratiques,89/fiches-pratiques,91/prestations-familiales,1885/les-prestations-familiales,12626.html"
 
@@ -360,7 +360,7 @@ class pfam(Variable):
 
 class mini(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Minima sociaux"
     url = "http://fr.wikipedia.org/wiki/Minima_sociaux"
 
@@ -388,7 +388,7 @@ class mini(Variable):
 
 class aides_logement(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Allocations logements"
     url = "http://vosdroits.service-public.fr/particuliers/N20360.xhtml"
 
@@ -407,7 +407,7 @@ class aides_logement(Variable):
 
 class impo(Variable):
     column = FloatCol(default = 0)
-    entity_class = Menages
+    entity = Menages
     label = u"Impôts directs"
     url = "http://fr.wikipedia.org/wiki/Imp%C3%B4t_direct"
 
@@ -427,7 +427,7 @@ class impo(Variable):
 
 class crds(Variable):
     column = FloatCol(default = 0)
-    entity_class = Individus
+    entity = Individus
     label = u"Contributions au remboursement de la dette sociale"
 
     def function(individu, period):
@@ -462,7 +462,7 @@ class crds(Variable):
 
 class csg(Variable):
     column = FloatCol(default = 0)
-    entity_class = Individus
+    entity = Individus
     label = u"Contributions sociales généralisées"
 
     def function(individu, period):
@@ -490,7 +490,7 @@ class csg(Variable):
 
 class cotsoc_noncontrib(Variable):
     column = FloatCol(default = 0)
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisations sociales non contributives"
 
     def function(self, simulation, period):
@@ -508,7 +508,7 @@ class cotsoc_noncontrib(Variable):
 
 class prelsoc_cap(Variable):
     column = FloatCol(default = 0)
-    entity_class = Individus
+    entity = Individus
     label = u"Prélèvements sociaux sur les revenus du capital"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&paf_dm=popup&paf_gm=content&typePage=cpr02&sfid=501&espId=1&impot=CS"
 
@@ -531,7 +531,7 @@ class prelsoc_cap(Variable):
 
 class check_csk(Variable):
     column = FloatCol(default = 0)
-    entity_class = Menages
+    entity = Menages
     label = u"check_csk"
 
     def function(menage, period):
@@ -549,7 +549,7 @@ class check_csk(Variable):
 
 class check_csg(Variable):
     column = FloatCol(default = 0)
-    entity_class = Menages
+    entity = Menages
     label = u"check_csg"
 
     def function(menage, period):
@@ -567,7 +567,7 @@ class check_csg(Variable):
 
 class check_crds(Variable):
     column = FloatCol(default = 0)
-    entity_class = Menages
+    entity = Menages
     label = u"check_crds"
 
     def function(menage, period):

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -129,12 +129,15 @@ class revenu_net_individu(Variable):
         return period, pen + rev_cap + rev_trav
 
 
-class revnet(PersonToEntityColumn):
+class revnet(Variable):
     entity_class = Menages
     label = u"Revenu net du ménage"
-    operation = 'add'
+    column = FloatCol
     url = u"http://impotsurlerevenu.org/definitions/115-revenu-net-imposable.php",
-    variable = revenu_net_individu
+
+    def function(menage, period):
+        revenu_net_individus = menage.members.calculate('revenu_net_individu', period)
+        return period, menage.sum(revenu_net_individus)
 
 
 class nivvie_net(Variable):
@@ -171,11 +174,14 @@ class revenu_initial_individu(Variable):
             cotisations_salariales_contributives)
 
 
-class revini(PersonToEntityColumn):
+class revini(Variable):
     entity_class = Menages
     label = u"Revenu initial du ménage"
-    operation = 'add'
-    variable = revenu_initial_individu
+    column = FloatCol
+
+    def function(menage, period):
+        revenu_initial_individus = menage.members.calculate('revenu_initial_individu', period)
+        return period, simulation.menage.sum(revenu_initial_individus)
 
 
 class nivvie_ini(Variable):
@@ -230,26 +236,27 @@ class pen(Variable):
     label = u"Pensions et revenus de remplacement"
     url = "http://fr.wikipedia.org/wiki/Rente"
 
-    def function(self, simulation, period):
+    def function(individu, period):
         '''
         Pensions
         '''
         period = period.start.period('year').offset('first-of')
-        chomage_net = simulation.calculate('chomage_net', period)
-        retraite_nette = simulation.calculate('retraite_nette', period)
-        pensions_alimentaires_percues = simulation.calculate('pensions_alimentaires_percues', period)
-        pensions_alimentaires_versees_declarant1 = simulation.calculate(
-            'pensions_alimentaires_versees_declarant1', period
-            )
-        retraite_titre_onereux_declarant1 = simulation.calculate_add('retraite_titre_onereux_declarant1', period)
+        chomage_net = individu.calculate('chomage_net', period)
+        retraite_nette = individu.calculate('retraite_nette', period)
+        pensions_alimentaires_percues = individu.calculate('pensions_alimentaires_percues', period)
 
-        return period, (chomage_net + retraite_nette + pensions_alimentaires_percues + pensions_alimentaires_versees_declarant1 +
-                    retraite_titre_onereux_declarant1)
+        # Revenus du foyer fiscal
+        pensions_alimentaires_versees = individu.foyer_fiscal.calculate('pensions_alimentaires_versees', period)
+        retraite_titre_onereux = individu.foyer_fiscal.calculate_add('retraite_titre_onereux', period)
+        pen_foyer_fiscal = pensions_alimentaires_versees + retraite_titre_onereux
+        pen_foyer_fiscal_projetees = individu.foyer_fiscal.project_on_first_person(pen_foyer_fiscal)
+
+        return period, (chomage_net + retraite_nette + pensions_alimentaires_percues + pen_foyer_fiscal_projetees)
 
 
-class cotsoc_bar_declarant1(Variable):
+class cotsoc_bar(Variable):
     column = FloatCol(default = 0)
-    entity_class = Individus
+    entity_class = FoyersFiscaux
     label = u"Cotisations sociales sur les revenus du capital imposés au barème"
 
     def function(self, simulation, period):
@@ -257,16 +264,16 @@ class cotsoc_bar_declarant1(Variable):
         Cotisations sociales sur les revenus du capital imposés au barème
         '''
         period = period.start.period('year').offset('first-of')
-        csg_cap_bar_declarant1 = simulation.calculate('csg_cap_bar_declarant1', period)
-        prelsoc_cap_bar_declarant1 = simulation.calculate('prelsoc_cap_bar_declarant1', period)
-        crds_cap_bar_declarant1 = simulation.calculate('crds_cap_bar_declarant1', period)
+        csg_cap_bar = simulation.calculate('csg_cap_bar', period)
+        prelsoc_cap_bar = simulation.calculate('prelsoc_cap_bar', period)
+        crds_cap_bar = simulation.calculate('crds_cap_bar', period)
 
-        return period, csg_cap_bar_declarant1 + prelsoc_cap_bar_declarant1 + crds_cap_bar_declarant1
+        return period, csg_cap_bar + prelsoc_cap_bar + crds_cap_bar
 
 
-class cotsoc_lib_declarant1(Variable):
-    column = FloatCol(default = 0)
-    entity_class = Individus
+class cotsoc_lib(Variable):
+    column = FloatCol
+    entity_class = FoyersFiscaux
     label = u"Cotisations sociales sur les revenus du capital soumis au prélèvement libératoire"
 
     def function(self, simulation, period):
@@ -274,11 +281,11 @@ class cotsoc_lib_declarant1(Variable):
         Cotisations sociales sur les revenus du capital soumis au prélèvement libératoire
         '''
         period = period.this_year
-        csg_cap_lib_declarant1 = simulation.calculate('csg_cap_lib_declarant1', period)
-        prelsoc_cap_lib_declarant1 = simulation.calculate('prelsoc_cap_lib_declarant1', period)
-        crds_cap_lib_declarant1 = simulation.calculate('crds_cap_lib_declarant1', period)
+        csg_cap_lib = simulation.calculate('csg_cap_lib', period)
+        prelsoc_cap_lib = simulation.calculate('prelsoc_cap_lib', period)
+        crds_cap_lib = simulation.calculate('crds_cap_lib', period)
 
-        return period, csg_cap_lib_declarant1 + prelsoc_cap_lib_declarant1 + crds_cap_lib_declarant1
+        return period, csg_cap_lib + prelsoc_cap_lib + crds_cap_lib
 
 
 class rev_cap(Variable):
@@ -292,20 +299,21 @@ class rev_cap(Variable):
         Revenus du patrimoine
         '''
         period = period.this_year
-        fon_holder = simulation.compute('fon', period)
-        rev_cap_bar_holder = simulation.compute_add('rev_cap_bar', period)
-        cotsoc_bar_declarant1 = simulation.calculate('cotsoc_bar_declarant1', period)
-        rev_cap_lib_holder = simulation.compute_add('rev_cap_lib', period)
-        cotsoc_lib_declarant1 = simulation.calculate('cotsoc_lib_declarant1', period)
-        imp_lib_holder = simulation.compute('imp_lib', period)
+
+        # Revenus du foyer fiscal
+        fon = simulation.calculate('fon', period)
+        rev_cap_bar = simulation.calculate_add('rev_cap_bar', period)
+        cotsoc_lib = simulation.calculate('cotsoc_lib', period)
+        rev_cap_lib = simulation.calculate_add('rev_cap_lib', period)
+        imp_lib = simulation.calculate('imp_lib', period)
+        cotsoc_bar = simulation.calculate('cotsoc_bar', period)
+
+        revenus_foyer_fiscal = fon + rev_cap_bar + cotsoc_lib + rev_cap_lib + imp_lib + cotsoc_bar
+        revenus_foyer_fiscal_i = simulation.foyer_fiscal.project_on_first_person(revenus_foyer_fiscal)
+
         rac = simulation.calculate('rac', period)
 
-        fon = self.cast_from_entity_to_role(fon_holder, role = VOUS)
-        imp_lib = self.cast_from_entity_to_role(imp_lib_holder, role = VOUS)
-        rev_cap_bar = self.cast_from_entity_to_role(rev_cap_bar_holder, role = VOUS)
-        rev_cap_lib = self.cast_from_entity_to_role(rev_cap_lib_holder, role = VOUS)
-
-        return period, fon + rev_cap_bar + cotsoc_bar_declarant1 + rev_cap_lib + cotsoc_lib_declarant1 + imp_lib + rac
+        return period, revenus_foyer_fiscal_i + rac
 
 
 class psoc(Variable):
@@ -423,28 +431,31 @@ class crds(Variable):
     def function(self, simulation, period):
         """Contribution au remboursement de la dette sociale"""
         period = period.this_year
+
+        # CRDS sur revenus individuels
         crds_salaire = simulation.calculate_add('crds_salaire', period)
         crds_retraite = simulation.calculate_add('crds_retraite', period)
         crds_chomage = simulation.calculate_add('crds_chomage', period)
-        crds_fon_holder = simulation.compute('crds_fon', period)
-        crds_cap_bar_declarant1 = simulation.calculate('crds_cap_bar_declarant1', period)
-        crds_cap_lib_declarant1 = simulation.calculate('crds_cap_lib_declarant1', period)
-        crds_pfam_holder = simulation.compute('crds_pfam', period)
-        crds_logement_holder = simulation.compute_add('crds_logement', period)
-        crds_mini_holder = simulation.compute_add('crds_mini', period)
-        crds_pv_mo_holder = simulation.compute('crds_pv_mo', period)
-        crds_pv_immo_holder = simulation.compute('crds_pv_immo', period)
+        crds_individu = crds_salaire + crds_retraite + crds_chomage
 
-        crds_fon = self.cast_from_entity_to_role(crds_fon_holder, role = VOUS)
-        crds_logement = self.cast_from_entity_to_role(crds_logement_holder, role = CHEF)
-        crds_mini = self.cast_from_entity_to_role(crds_mini_holder, role = CHEF)
-        crds_pfam = self.cast_from_entity_to_role(crds_pfam_holder, role = CHEF)
-        crds_pv_immo = self.cast_from_entity_to_role(crds_pv_immo_holder, role = VOUS)
-        crds_pv_mo = self.cast_from_entity_to_role(crds_pv_mo_holder, role = VOUS)
 
-        return period, (crds_salaire + crds_retraite + crds_chomage +
-                crds_fon + crds_cap_bar_declarant1 + crds_cap_lib_declarant1 + crds_pv_mo + crds_pv_immo +
-                crds_pfam + crds_logement + crds_mini)
+        # CRDS sur revenus de la famille
+        crds_pfam = simulation.calculate('crds_pfam', period)
+        crds_logement = simulation.calculate_add('crds_logement', period)
+        crds_mini = simulation.calculate_add('crds_mini', period)
+        crds_famille =  crds_pfam + crds_logement + crds_mini
+        crds_famille_projetes = simulation.famille.project_on_first_person(crds_famille)
+
+        # CRDS sur revenus du foyer fiscal
+        crds_fon = simulation.calculate('crds_fon', period)
+        crds_pv_mo = simulation.calculate('crds_pv_mo', period)
+        crds_pv_immo = simulation.calculate('crds_pv_immo', period)
+        crds_cap_bar = simulation.calculate('crds_cap_bar', period)
+        crds_cap_lib = simulation.calculate('crds_cap_lib', period)
+        crds_foyer_fiscal = crds_fon + crds_pv_mo + crds_pv_immo + crds_cap_bar + crds_cap_lib
+        crds_foyer_fiscal_projetee = simulation.foyer_fiscal.project_on_first_person(crds_foyer_fiscal)
+
+        return period, crds_individu + crds_famille_projetes + crds_foyer_fiscal_projetee
 
 
 class csg(Variable):
@@ -461,19 +472,18 @@ class csg(Variable):
         csg_deductible_chomage = simulation.calculate_add('csg_deductible_chomage', period)
         csg_imposable_retraite = simulation.calculate_add('csg_imposable_retraite', period)
         csg_deductible_retraite = simulation.calculate_add('csg_deductible_retraite', period)
-        csg_fon_holder = simulation.compute('csg_fon', period)
-        csg_cap_lib_declarant1 = simulation.calculate('csg_cap_lib_declarant1', period)
-        csg_cap_bar_declarant1 = simulation.calculate('csg_cap_bar_declarant1', period)
-        csg_pv_mo_holder = simulation.compute('csg_pv_mo', period)
-        csg_pv_immo_holder = simulation.compute('csg_pv_immo', period)
 
-        csg_fon = self.cast_from_entity_to_role(csg_fon_holder, role = VOUS)
-        csg_pv_immo = self.cast_from_entity_to_role(csg_pv_immo_holder, role = VOUS)
-        csg_pv_mo = self.cast_from_entity_to_role(csg_pv_mo_holder, role = VOUS)
+        # CSG prélevée sur les revenus du foyer fiscal
+        csg_fon = simulation.calculate('csg_fon', period)
+        csg_cap_lib = simulation.calculate('csg_cap_lib', period)
+        csg_cap_bar = simulation.calculate('csg_cap_bar', period)
+        csg_pv_mo = simulation.calculate('csg_pv_mo', period)
+        csg_pv_immo = simulation.calculate('csg_pv_immo', period)
+        csg_foyer_fiscal = csg_fon + csg_cap_lib + csg_cap_bar + csg_pv_mo + csg_pv_immo
+        csg_foyer_fiscal_projetee = simulation.foyer_fiscal.project_on_first_person(csg_foyer_fiscal)
 
         return period, (csg_imposable_salaire + csg_deductible_salaire + csg_imposable_chomage +
-                csg_deductible_chomage + csg_imposable_retraite + csg_deductible_retraite + csg_fon +
-                csg_cap_lib_declarant1 + csg_pv_mo + csg_pv_immo + csg_cap_bar_declarant1)
+                csg_deductible_chomage + csg_imposable_retraite + csg_deductible_retraite + csg_foyer_fiscal_projetee)
 
 
 class cotsoc_noncontrib(Variable):
@@ -505,18 +515,16 @@ class prelsoc_cap(Variable):
         Prélèvements sociaux sur les revenus du capital
         """
         period = period.this_year
-        prelsoc_fon_holder = simulation.compute('prelsoc_fon', period)
-        prelsoc_cap_lib_declarant1 = simulation.calculate('prelsoc_cap_lib_declarant1', period)
-        prelsoc_cap_bar_declarant1 = simulation.calculate('prelsoc_cap_bar_declarant1', period)
-        prelsoc_pv_mo_holder = simulation.compute('prelsoc_pv_mo', period)
-        prelsoc_pv_immo_holder = simulation.compute('prelsoc_pv_immo', period)
 
-        prelsoc_fon = self.cast_from_entity_to_role(prelsoc_fon_holder, role = VOUS)
-        prelsoc_pv_immo = self.cast_from_entity_to_role(prelsoc_pv_immo_holder, role = VOUS)
-        prelsoc_pv_mo = self.cast_from_entity_to_role(prelsoc_pv_mo_holder, role = VOUS)
+        # Prélevements effectués sur les revenus du foyer fiscal
+        prelsoc_fon = simulation.calculate('prelsoc_fon', period)
+        prelsoc_cap_lib = simulation.calculate('prelsoc_cap_lib', period)
+        prelsoc_cap_bar = simulation.calculate('prelsoc_cap_bar', period)
+        prelsoc_pv_mo = simulation.calculate('prelsoc_pv_mo', period)
+        prelsoc_pv_immo = simulation.calculate('prelsoc_pv_immo', period)
+        prel_foyer_fiscal = prelsoc_fon + prelsoc_cap_lib + prelsoc_cap_bar + prelsoc_pv_mo + prelsoc_pv_immo
 
-        return period, (prelsoc_fon + prelsoc_cap_lib_declarant1 + prelsoc_cap_bar_declarant1 + prelsoc_pv_mo +
-                    prelsoc_pv_immo)
+        return period, simulation.foyer_fiscal.project_on_first_person(prel_foyer_fiscal)
 
 
 class check_csk(Variable):
@@ -526,17 +534,14 @@ class check_csk(Variable):
 
     def function(self, simulation, period):
         period = period.this_year
-        prelsoc_cap_bar_declarant1_holder = simulation.compute('prelsoc_cap_bar_declarant1', period)
-        prelsoc_pv_mo_holder = simulation.compute('prelsoc_pv_mo', period)
-        prelsoc_fon_holder = simulation.compute('prelsoc_fon', period)
 
-        prelsoc_cap_bar = self.sum_by_entity(prelsoc_cap_bar_declarant1_holder)
-        prelsoc_pv_mo = self.cast_from_entity_to_role(prelsoc_pv_mo_holder, role = CHEF)
-        prelsoc_pv_mo = self.sum_by_entity(prelsoc_pv_mo)
-        prelsoc_fon = self.cast_from_entity_to_role(prelsoc_fon_holder, role = CHEF)
-        prelsoc_fon = self.sum_by_entity(prelsoc_fon)
+        # Prélevements effectués sur les revenus du foyer fiscal
+        prelsoc_cap_bar = simulation.calculate('prelsoc_cap_bar', period)
+        prelsoc_pv_mo = simulation.calculate('prelsoc_pv_mo', period)
+        prelsoc_fon = simulation.calculate('prelsoc_fon', period)
+        prel_foyer_fiscal = prelsoc_cap_bar + prelsoc_pv_mo + prelsoc_fon
 
-        return period, prelsoc_cap_bar + prelsoc_pv_mo + prelsoc_fon
+        return period, simulation.menage.transpose(prel_foyer_fiscal, origin_entity = FoyersFiscaux)
 
 
 class check_csg(Variable):
@@ -546,17 +551,15 @@ class check_csg(Variable):
 
     def function(self, simulation, period):
         period = period.this_year
-        csg_cap_bar_declarant1_holder = simulation.compute('csg_cap_bar_declarant1', period)
-        csg_pv_mo_holder = simulation.compute('csg_pv_mo', period)
-        csg_fon_holder = simulation.compute('csg_fon', period)
 
-        csg_cap_bar = self.sum_by_entity(csg_cap_bar_declarant1_holder)
-        csg_pv_mo = self.cast_from_entity_to_role(csg_pv_mo_holder, role = CHEF)
-        csg_pv_mo = self.sum_by_entity(csg_pv_mo)
-        csg_fon = self.cast_from_entity_to_role(csg_fon_holder, role = CHEF)
-        csg_fon = self.sum_by_entity(csg_fon)
+        # CSG prélevée sur les revenus du foyer fiscal
+        csg_cap_bar = simulation.calculate('csg_cap_bar', periop)
+        csg_pv_mo = simulation.calculate('csg_pv_mo', periop)
+        csg_fon = simulation.calculate('csg_fon', periop)
 
-        return period, csg_cap_bar + csg_pv_mo + csg_fon
+        csg_foyer_fiscal = csg_cap_bar + csg_pv_mo + csg_fon
+
+        return period, simulation.menage.transpose(csg_foyer_fiscal, origin_entity = FoyersFiscaux)
 
 
 class check_crds(Variable):
@@ -566,14 +569,12 @@ class check_crds(Variable):
 
     def function(self, simulation, period):
         period = period.this_year
-        crds_cap_bar_declarant1_holder = simulation.compute('crds_cap_bar_declarant1', period)
-        crds_pv_mo_holder = simulation.compute('crds_pv_mo', period)
-        crds_fon_holder = simulation.compute('crds_fon', period)
 
-        crds_cap_bar = self.sum_by_entity(crds_cap_bar_declarant1_holder)
-        crds_pv_mo = self.cast_from_entity_to_role(crds_pv_mo_holder, role = CHEF)
-        crds_pv_mo = self.sum_by_entity(crds_pv_mo)
-        crds_fon = self.cast_from_entity_to_role(crds_fon_holder, role = CHEF)
-        crds_fon = self.sum_by_entity(crds_fon)
+        # CRDS prélevée sur les revenus du foyer fiscal
+        crds_pv_mo = simulation.calculate('crds_pv_mo', period)
+        crds_fon = simulation.calculate('crds_fon', period)
+        crds_cap_bar = simulation.calculate('crds_cap_bar', period)
 
-        return period, crds_cap_bar + crds_pv_mo + crds_fon
+        crds_foyer_fiscal = crds_pv_mo + crds_fon + crds_cap_bar
+
+        return period, simulation.menage.transpose(crds_foyer_fiscal, origin_entity = FoyersFiscaux)

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -9,7 +9,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class uc(Variable):
     column = FloatCol(default = 0)
-    entity = Menages
+    entity = Menage
     label = u"Unités de consommation"
 
     def function(self, simulation, period):
@@ -35,7 +35,7 @@ class uc(Variable):
 
 class typ_men(Variable):
     column = PeriodSizeIndependentIntCol(default = 0)
-    entity = Menages
+    entity = Menage
     label = u"Type de ménage"
 
     def function(self, simulation, period):
@@ -70,7 +70,7 @@ class typ_men(Variable):
 
 class revdisp(Variable):
     column = FloatCol(default = 0)
-    entity = Menages
+    entity = Menage
     label = u"Revenu disponible du ménage"
     url = "http://fr.wikipedia.org/wiki/Revenu_disponible"
 
@@ -100,7 +100,7 @@ class revdisp(Variable):
 
 class nivvie(Variable):
     column = FloatCol(default = 0)
-    entity = Menages
+    entity = Menage
     label = u"Niveau de vie du ménage"
 
     def function(self, simulation, period):
@@ -117,7 +117,7 @@ class nivvie(Variable):
 
 class revenu_net_individu(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenu net de l'individu"
 
     def function(self, simulation, period):
@@ -130,7 +130,7 @@ class revenu_net_individu(Variable):
 
 
 class revnet(Variable):
-    entity = Menages
+    entity = Menage
     label = u"Revenu net du ménage"
     column = FloatCol
     url = u"http://impotsurlerevenu.org/definitions/115-revenu-net-imposable.php",
@@ -142,7 +142,7 @@ class revnet(Variable):
 
 class nivvie_net(Variable):
     column = FloatCol(default = 0)
-    entity = Menages
+    entity = Menage
     label = u"Niveau de vie net du ménage"
 
     def function(self, simulation, period):
@@ -159,7 +159,7 @@ class nivvie_net(Variable):
 
 class revenu_initial_individu(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenu initial de l'individu"
 
     def function(self, simulation, period):
@@ -175,7 +175,7 @@ class revenu_initial_individu(Variable):
 
 
 class revini(Variable):
-    entity = Menages
+    entity = Menage
     label = u"Revenu initial du ménage"
     column = FloatCol
 
@@ -186,7 +186,7 @@ class revini(Variable):
 
 class nivvie_ini(Variable):
     column = FloatCol(default = 0)
-    entity = Menages
+    entity = Menage
     label = u"Niveau de vie initial du ménage"
 
     def function(self, simulation, period):
@@ -213,7 +213,7 @@ def _revprim(rev_trav, chomage_imposable, rev_cap, cotisations_employeur, cotisa
 
 class rev_trav(Variable):
     column = FloatCol(default = 0)
-    entity = Individus
+    entity = Individu
     label = u"Revenus du travail (salariés et non salariés)"
     url = "http://fr.wikipedia.org/wiki/Revenu_du_travail"
 
@@ -232,7 +232,7 @@ class rev_trav(Variable):
 
 class pen(Variable):
     column = FloatCol(default = 0)
-    entity = Individus
+    entity = Individu
     label = u"Pensions et revenus de remplacement"
     url = "http://fr.wikipedia.org/wiki/Rente"
 
@@ -257,7 +257,7 @@ class pen(Variable):
 
 class cotsoc_bar(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Cotisations sociales sur les revenus du capital imposés au barème"
 
     def function(self, simulation, period):
@@ -274,7 +274,7 @@ class cotsoc_bar(Variable):
 
 class cotsoc_lib(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Cotisations sociales sur les revenus du capital soumis au prélèvement libératoire"
 
     def function(self, simulation, period):
@@ -291,7 +291,7 @@ class cotsoc_lib(Variable):
 
 class rev_cap(Variable):
     column = FloatCol(default = 0)
-    entity = Individus
+    entity = Individu
     label = u"Revenus du patrimoine"
     url = "http://fr.wikipedia.org/wiki/Revenu#Revenu_du_Capital"
 
@@ -320,7 +320,7 @@ class rev_cap(Variable):
 
 class psoc(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Prestations sociales"
     url = "http://fr.wikipedia.org/wiki/Prestation_sociale"
 
@@ -338,7 +338,7 @@ class psoc(Variable):
 
 class pfam(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Prestations familiales"
     url = "http://www.social-sante.gouv.fr/informations-pratiques,89/fiches-pratiques,91/prestations-familiales,1885/les-prestations-familiales,12626.html"
 
@@ -360,7 +360,7 @@ class pfam(Variable):
 
 class mini(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Minima sociaux"
     url = "http://fr.wikipedia.org/wiki/Minima_sociaux"
 
@@ -388,7 +388,7 @@ class mini(Variable):
 
 class aides_logement(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Allocations logements"
     url = "http://vosdroits.service-public.fr/particuliers/N20360.xhtml"
 
@@ -407,7 +407,7 @@ class aides_logement(Variable):
 
 class impo(Variable):
     column = FloatCol(default = 0)
-    entity = Menages
+    entity = Menage
     label = u"Impôts directs"
     url = "http://fr.wikipedia.org/wiki/Imp%C3%B4t_direct"
 
@@ -427,7 +427,7 @@ class impo(Variable):
 
 class crds(Variable):
     column = FloatCol(default = 0)
-    entity = Individus
+    entity = Individu
     label = u"Contributions au remboursement de la dette sociale"
 
     def function(individu, period):
@@ -446,7 +446,7 @@ class crds(Variable):
         crds_logement = individu.famille('crds_logement', period, options = [ADD])
         crds_mini = individu.famille('crds_mini', period, options = [ADD])
         crds_famille =  crds_pfam + crds_logement + crds_mini
-        crds_famille_projetes = crds_famille * individu.has_role(Familles.DEMANDEUR)
+        crds_famille_projetes = crds_famille * individu.has_role(Famille.DEMANDEUR)
 
         # CRDS sur revenus du foyer fiscal, projetés seulement sur la première personne
         crds_fon = individu.foyer_fiscal('crds_fon', period)
@@ -455,14 +455,14 @@ class crds(Variable):
         crds_cap_bar = individu.foyer_fiscal('crds_cap_bar', period)
         crds_cap_lib = individu.foyer_fiscal('crds_cap_lib', period)
         crds_foyer_fiscal = crds_fon + crds_pv_mo + crds_pv_immo + crds_cap_bar + crds_cap_lib
-        crds_foyer_fiscal_projetee = crds_foyer_fiscal * individu.has_role(FoyersFiscaux.DECLARANT_PRINCIPAL)
+        crds_foyer_fiscal_projetee = crds_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         return period, crds_individu + crds_famille_projetes + crds_foyer_fiscal_projetee
 
 
 class csg(Variable):
     column = FloatCol(default = 0)
-    entity = Individus
+    entity = Individu
     label = u"Contributions sociales généralisées"
 
     def function(individu, period):
@@ -482,7 +482,7 @@ class csg(Variable):
         csg_pv_mo = individu.foyer_fiscal('csg_pv_mo', period)
         csg_pv_immo = individu.foyer_fiscal('csg_pv_immo', period)
         csg_foyer_fiscal = csg_fon + csg_cap_lib + csg_cap_bar + csg_pv_mo + csg_pv_immo
-        csg_foyer_fiscal_projetee = csg_foyer_fiscal * individu.has_role(FoyersFiscaux.DECLARANT_PRINCIPAL)
+        csg_foyer_fiscal_projetee = csg_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         return period, (csg_imposable_salaire + csg_deductible_salaire + csg_imposable_chomage +
                 csg_deductible_chomage + csg_imposable_retraite + csg_deductible_retraite + csg_foyer_fiscal_projetee)
@@ -490,7 +490,7 @@ class csg(Variable):
 
 class cotsoc_noncontrib(Variable):
     column = FloatCol(default = 0)
-    entity = Individus
+    entity = Individu
     label = u"Cotisations sociales non contributives"
 
     def function(self, simulation, period):
@@ -508,7 +508,7 @@ class cotsoc_noncontrib(Variable):
 
 class prelsoc_cap(Variable):
     column = FloatCol(default = 0)
-    entity = Individus
+    entity = Individu
     label = u"Prélèvements sociaux sur les revenus du capital"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&paf_dm=popup&paf_gm=content&typePage=cpr02&sfid=501&espId=1&impot=CS"
 
@@ -526,12 +526,12 @@ class prelsoc_cap(Variable):
         prelsoc_pv_immo = individu.foyer_fiscal('prelsoc_pv_immo', period)
         prel_foyer_fiscal = prelsoc_fon + prelsoc_cap_lib + prelsoc_cap_bar + prelsoc_pv_mo + prelsoc_pv_immo
 
-        return period, prel_foyer_fiscal * individu.has_role(FoyersFiscaux.DECLARANT_PRINCIPAL)
+        return period, prel_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
 
 class check_csk(Variable):
     column = FloatCol(default = 0)
-    entity = Menages
+    entity = Menage
     label = u"check_csk"
 
     def function(menage, period):
@@ -549,7 +549,7 @@ class check_csk(Variable):
 
 class check_csg(Variable):
     column = FloatCol(default = 0)
-    entity = Menages
+    entity = Menage
     label = u"check_csg"
 
     def function(menage, period):
@@ -567,7 +567,7 @@ class check_csg(Variable):
 
 class check_crds(Variable):
     column = FloatCol(default = 0)
-    entity = Menages
+    entity = Menage
     label = u"check_crds"
 
     def function(menage, period):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 class f6de(Variable):
     cerfa_field = u"6DE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"CSG déductible calculée sur les revenus du patrimoine"
 
 
@@ -26,7 +26,7 @@ class f6de(Variable):
 class f6gi(Variable):
     cerfa_field = u"6GI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Pensions alimentaires versées à des enfants majeurs (décision de justice définitive avant 2006): 1er enfant"
 
 
@@ -34,7 +34,7 @@ class f6gi(Variable):
 class f6gj(Variable):
     cerfa_field = u"6GJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Pensions alimentaires versées à des enfants majeurs (décision de justice définitive avant 2006): 2eme enfant"
 
 
@@ -42,7 +42,7 @@ class f6gj(Variable):
 class f6el(Variable):
     cerfa_field = u"6EL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Autres pensions alimentaires versées à des enfants majeurs: 1er enfant"
     start_date = date(2006, 1, 1)
 
@@ -51,7 +51,7 @@ class f6el(Variable):
 class f6em(Variable):
     cerfa_field = u"6EM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Autres pensions alimentaires versées à des enfants majeurs: 2eme enfant"
     start_date = date(2006, 1, 1)
 
@@ -60,7 +60,7 @@ class f6em(Variable):
 class f6gp(Variable):
     cerfa_field = u"6GP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Autres pensions alimentaires versées décision de justice définitive avant 2006 (mineurs, ascendants)"
 
 
@@ -68,7 +68,7 @@ class f6gp(Variable):
 class f6gu(Variable):
     cerfa_field = u"6GU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Autres pensions alimentaires versées (mineurs, ascendants)"
     start_date = date(2006, 1, 1)
 
@@ -78,7 +78,7 @@ class f6gu(Variable):
 class f6eu(Variable):
     cerfa_field = u"6EU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Frais d'accueil de personnes de plus de 75 ans dans le besoin"
 
 
@@ -86,7 +86,7 @@ class f6eu(Variable):
 class f6ev(Variable):
     cerfa_field = u"6EV"
     column = PeriodSizeIndependentIntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre de personnes de plus de 75 ans dans le besoin accueillies sous votre toit"
 
 
@@ -95,7 +95,7 @@ class f6ev(Variable):
 class f6dd(Variable):
     cerfa_field = u"6DD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déductions diverses"
 
 
@@ -107,7 +107,7 @@ class f6ps(Variable):
         QUIFOY['pac1']: u"6PU",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plafond de déduction épargne retraite (plafond calculé sur les revenus perçus en n-1)"
 
   # (f6ps, f6pt, f6pu)
@@ -118,7 +118,7 @@ class f6rs(Variable):
         QUIFOY['pac1']: u"6RU",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisations d'épargne retraite versées au titre d'un PERP, PREFON, COREM et C.G.O.S"
 
   # (f6rs, f6rt, f6ru)))
@@ -129,7 +129,7 @@ class f6ss(Variable):
         QUIFOY['pac1']: u"6SU",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Rachat de cotisations PERP, PREFON, COREM et C.G.O.S"
 
   # (f6ss, f6st, f6su)))
@@ -138,7 +138,7 @@ class f6ss(Variable):
 class f6aa(Variable):
     cerfa_field = u"6AA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscriptions en faveur du cinéma ou de l’audiovisuel"
     start_date = date(2005, 1, 1)
     stop_date = date(2006, 12, 31)
@@ -149,7 +149,7 @@ class f6aa(Variable):
 class f6cc(Variable):
     cerfa_field = u"CC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscriptions au capital des SOFIPÊCHE"
     start_date = date(2005, 1, 1)
     stop_date = date(2005, 12, 31)
@@ -162,7 +162,7 @@ class f6cc(Variable):
 class f6eh(Variable):
     cerfa_field = u"EH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     start_date = date(2005, 1, 1)
     stop_date = date(2005, 12, 31)
 
@@ -173,7 +173,7 @@ class f6eh(Variable):
 class f6da(Variable):
     cerfa_field = u"DA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Pertes en capital consécutives à la souscription au capital de sociétés nouvelles ou de sociétés en difficulté"
     start_date = date(2005, 1, 1)
     stop_date = date(2005, 12, 31)
@@ -185,7 +185,7 @@ class f6da(Variable):
 class f6cb(Variable):
     cerfa_field = u"6CB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires (dépenses réalisées au cours de l'année de perception des revenus)"
     start_date = date(2009, 1, 1)
 
@@ -195,7 +195,7 @@ class f6cb(Variable):
 class f6hj(Variable):
     cerfa_field = u"6HJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses des années antérieures"
     start_date = date(2010, 1, 1)
 
@@ -204,7 +204,7 @@ class f6hj(Variable):
 class f6hk(Variable):
     cerfa_field = u"6HK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses des années antérieures"
     start_date = date(2011, 1, 1)
 
@@ -213,7 +213,7 @@ class f6hk(Variable):
 class f6hl(Variable):
     cerfa_field = u"6HL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses des années antérieures"
     start_date = date(2012, 1, 1)
 
@@ -222,7 +222,7 @@ class f6hl(Variable):
 class f6hm(Variable):
     cerfa_field = u"6HM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses des années antérieures"
     start_date = date(2013, 1, 1)
 
@@ -232,7 +232,7 @@ class f6hm(Variable):
 class f6gh(Variable):
     cerfa_field = u"6GH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Sommes à ajouter au revenu imposable"
 
 
@@ -241,7 +241,7 @@ class f6gh(Variable):
 class f6fa(Variable):
     cerfa_field = u"6FA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Deficits globaux des années antérieures non encore déduits les années précédentes: année de perception des revenus -6"
 
 
@@ -249,7 +249,7 @@ class f6fa(Variable):
 class f6fb(Variable):
     cerfa_field = u"6FB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -5"
 
 
@@ -257,7 +257,7 @@ class f6fb(Variable):
 class f6fc(Variable):
     cerfa_field = u"6FC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -4"
 
 
@@ -265,7 +265,7 @@ class f6fc(Variable):
 class f6fd(Variable):
     cerfa_field = u"6FD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -3"
 
 
@@ -273,7 +273,7 @@ class f6fd(Variable):
 class f6fe(Variable):
     cerfa_field = u"6FE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -2"
 
 
@@ -281,7 +281,7 @@ class f6fe(Variable):
 class f6fl(Variable):
     cerfa_field = u"6FL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -1"
 
 
@@ -289,7 +289,7 @@ class f6fl(Variable):
 
 class rfr_cd(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Charges déductibles entrant dans le revenus fiscal de référence"
     url = "http://impotsurlerevenu.org/definitions/215-charge-deductible.php"
 
@@ -305,7 +305,7 @@ class rfr_cd(Variable):
 
 class cd1(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Charges déductibles non plafonnées"
     url = "http://impotsurlerevenu.org/definitions/215-charge-deductible.php"
 
@@ -403,7 +403,7 @@ class cd1(DatedVariable):
 
 class cd2(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Charges déductibles plafonnées"
     url = "http://impotsurlerevenu.org/definitions/215-charge-deductible.php"
 
@@ -444,7 +444,7 @@ class cd2(DatedVariable):
 
 class rbg_int(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenu brut global intermédiaire"
 
     def function(self, simulation, period):
@@ -457,7 +457,7 @@ class rbg_int(Variable):
 
 class charges_deduc(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Charges déductibles"
     url = "http://impotsurlerevenu.org/definitions/215-charge-deductible.php"
 
@@ -471,7 +471,7 @@ class charges_deduc(Variable):
 
 class cd_penali(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"cd_penali"
     url = "http://frederic.anne.free.fr/Cours/ITV.htm"
 
@@ -503,7 +503,7 @@ class cd_penali(Variable):
 
 class cd_acc75a(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"cd_acc75a"
 
     def function(self, simulation, period):
@@ -521,7 +521,7 @@ class cd_acc75a(Variable):
 
 class cd_percap(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"cd_percap"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -559,7 +559,7 @@ class cd_percap(DatedVariable):
 
 class cd_deddiv(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"cd_deddiv"
 
     def function(self, simulation, period):
@@ -574,7 +574,7 @@ class cd_deddiv(Variable):
 
 class cd_doment(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"cd_doment"
     start_date = date(2002, 1, 1)
     stop_date = date(2005, 12, 31)
@@ -593,7 +593,7 @@ class cd_doment(Variable):
 
 class cd_eparet(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"cd_eparet"
     start_date = date(2004, 1, 1)
 
@@ -631,7 +631,7 @@ class cd_eparet(Variable):
 
 class cd_sofipe(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"cd_sofipe"
     start_date = date(2002, 1, 1)
     stop_date = date(2006, 12, 31)
@@ -654,7 +654,7 @@ class cd_sofipe(Variable):
 
 class cd_cinema(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"cd_cinema"
     start_date = date(2002, 1, 1)
     stop_date = date(2005, 12, 31)
@@ -676,7 +676,7 @@ class cd_cinema(Variable):
 
 class cd_ecodev(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"cd_ecodev"
     start_date = date(2007, 1, 1)
     stop_date = date(2008, 12, 31)
@@ -698,7 +698,7 @@ class cd_ecodev(Variable):
 
 class cd_grorep(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"cd_grorep"
     start_date = date(2009, 1, 1)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 class f6de(Variable):
     cerfa_field = u"6DE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"CSG déductible calculée sur les revenus du patrimoine"
 
 
@@ -26,7 +26,7 @@ class f6de(Variable):
 class f6gi(Variable):
     cerfa_field = u"6GI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Pensions alimentaires versées à des enfants majeurs (décision de justice définitive avant 2006): 1er enfant"
 
 
@@ -34,7 +34,7 @@ class f6gi(Variable):
 class f6gj(Variable):
     cerfa_field = u"6GJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Pensions alimentaires versées à des enfants majeurs (décision de justice définitive avant 2006): 2eme enfant"
 
 
@@ -42,7 +42,7 @@ class f6gj(Variable):
 class f6el(Variable):
     cerfa_field = u"6EL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Autres pensions alimentaires versées à des enfants majeurs: 1er enfant"
     start_date = date(2006, 1, 1)
 
@@ -51,7 +51,7 @@ class f6el(Variable):
 class f6em(Variable):
     cerfa_field = u"6EM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Autres pensions alimentaires versées à des enfants majeurs: 2eme enfant"
     start_date = date(2006, 1, 1)
 
@@ -60,7 +60,7 @@ class f6em(Variable):
 class f6gp(Variable):
     cerfa_field = u"6GP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Autres pensions alimentaires versées décision de justice définitive avant 2006 (mineurs, ascendants)"
 
 
@@ -68,7 +68,7 @@ class f6gp(Variable):
 class f6gu(Variable):
     cerfa_field = u"6GU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Autres pensions alimentaires versées (mineurs, ascendants)"
     start_date = date(2006, 1, 1)
 
@@ -78,7 +78,7 @@ class f6gu(Variable):
 class f6eu(Variable):
     cerfa_field = u"6EU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Frais d'accueil de personnes de plus de 75 ans dans le besoin"
 
 
@@ -86,7 +86,7 @@ class f6eu(Variable):
 class f6ev(Variable):
     cerfa_field = u"6EV"
     column = PeriodSizeIndependentIntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre de personnes de plus de 75 ans dans le besoin accueillies sous votre toit"
 
 
@@ -95,7 +95,7 @@ class f6ev(Variable):
 class f6dd(Variable):
     cerfa_field = u"6DD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déductions diverses"
 
 
@@ -107,7 +107,7 @@ class f6ps(Variable):
         QUIFOY['pac1']: u"6PU",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plafond de déduction épargne retraite (plafond calculé sur les revenus perçus en n-1)"
 
   # (f6ps, f6pt, f6pu)
@@ -118,7 +118,7 @@ class f6rs(Variable):
         QUIFOY['pac1']: u"6RU",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Cotisations d'épargne retraite versées au titre d'un PERP, PREFON, COREM et C.G.O.S"
 
   # (f6rs, f6rt, f6ru)))
@@ -129,7 +129,7 @@ class f6ss(Variable):
         QUIFOY['pac1']: u"6SU",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Rachat de cotisations PERP, PREFON, COREM et C.G.O.S"
 
   # (f6ss, f6st, f6su)))
@@ -138,7 +138,7 @@ class f6ss(Variable):
 class f6aa(Variable):
     cerfa_field = u"6AA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscriptions en faveur du cinéma ou de l’audiovisuel"
     start_date = date(2005, 1, 1)
     stop_date = date(2006, 12, 31)
@@ -149,7 +149,7 @@ class f6aa(Variable):
 class f6cc(Variable):
     cerfa_field = u"CC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscriptions au capital des SOFIPÊCHE"
     start_date = date(2005, 1, 1)
     stop_date = date(2005, 12, 31)
@@ -162,7 +162,7 @@ class f6cc(Variable):
 class f6eh(Variable):
     cerfa_field = u"EH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     start_date = date(2005, 1, 1)
     stop_date = date(2005, 12, 31)
 
@@ -173,7 +173,7 @@ class f6eh(Variable):
 class f6da(Variable):
     cerfa_field = u"DA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Pertes en capital consécutives à la souscription au capital de sociétés nouvelles ou de sociétés en difficulté"
     start_date = date(2005, 1, 1)
     stop_date = date(2005, 12, 31)
@@ -185,7 +185,7 @@ class f6da(Variable):
 class f6cb(Variable):
     cerfa_field = u"6CB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires (dépenses réalisées au cours de l'année de perception des revenus)"
     start_date = date(2009, 1, 1)
 
@@ -195,7 +195,7 @@ class f6cb(Variable):
 class f6hj(Variable):
     cerfa_field = u"6HJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses des années antérieures"
     start_date = date(2010, 1, 1)
 
@@ -204,7 +204,7 @@ class f6hj(Variable):
 class f6hk(Variable):
     cerfa_field = u"6HK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses des années antérieures"
     start_date = date(2011, 1, 1)
 
@@ -213,7 +213,7 @@ class f6hk(Variable):
 class f6hl(Variable):
     cerfa_field = u"6HL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses des années antérieures"
     start_date = date(2012, 1, 1)
 
@@ -222,7 +222,7 @@ class f6hl(Variable):
 class f6hm(Variable):
     cerfa_field = u"6HM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses des années antérieures"
     start_date = date(2013, 1, 1)
 
@@ -232,7 +232,7 @@ class f6hm(Variable):
 class f6gh(Variable):
     cerfa_field = u"6GH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Sommes à ajouter au revenu imposable"
 
 
@@ -241,7 +241,7 @@ class f6gh(Variable):
 class f6fa(Variable):
     cerfa_field = u"6FA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Deficits globaux des années antérieures non encore déduits les années précédentes: année de perception des revenus -6"
 
 
@@ -249,7 +249,7 @@ class f6fa(Variable):
 class f6fb(Variable):
     cerfa_field = u"6FB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -5"
 
 
@@ -257,7 +257,7 @@ class f6fb(Variable):
 class f6fc(Variable):
     cerfa_field = u"6FC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -4"
 
 
@@ -265,7 +265,7 @@ class f6fc(Variable):
 class f6fd(Variable):
     cerfa_field = u"6FD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -3"
 
 
@@ -273,7 +273,7 @@ class f6fd(Variable):
 class f6fe(Variable):
     cerfa_field = u"6FE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -2"
 
 
@@ -281,7 +281,7 @@ class f6fe(Variable):
 class f6fl(Variable):
     cerfa_field = u"6FL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -1"
 
 
@@ -289,7 +289,7 @@ class f6fl(Variable):
 
 class rfr_cd(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Charges déductibles entrant dans le revenus fiscal de référence"
     url = "http://impotsurlerevenu.org/definitions/215-charge-deductible.php"
 
@@ -305,7 +305,7 @@ class rfr_cd(Variable):
 
 class cd1(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Charges déductibles non plafonnées"
     url = "http://impotsurlerevenu.org/definitions/215-charge-deductible.php"
 
@@ -403,7 +403,7 @@ class cd1(DatedVariable):
 
 class cd2(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Charges déductibles plafonnées"
     url = "http://impotsurlerevenu.org/definitions/215-charge-deductible.php"
 
@@ -444,7 +444,7 @@ class cd2(DatedVariable):
 
 class rbg_int(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenu brut global intermédiaire"
 
     def function(self, simulation, period):
@@ -457,7 +457,7 @@ class rbg_int(Variable):
 
 class charges_deduc(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Charges déductibles"
     url = "http://impotsurlerevenu.org/definitions/215-charge-deductible.php"
 
@@ -471,7 +471,7 @@ class charges_deduc(Variable):
 
 class cd_penali(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"cd_penali"
     url = "http://frederic.anne.free.fr/Cours/ITV.htm"
 
@@ -503,7 +503,7 @@ class cd_penali(Variable):
 
 class cd_acc75a(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"cd_acc75a"
 
     def function(self, simulation, period):
@@ -521,7 +521,7 @@ class cd_acc75a(Variable):
 
 class cd_percap(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"cd_percap"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -559,7 +559,7 @@ class cd_percap(DatedVariable):
 
 class cd_deddiv(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"cd_deddiv"
 
     def function(self, simulation, period):
@@ -574,7 +574,7 @@ class cd_deddiv(Variable):
 
 class cd_doment(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"cd_doment"
     start_date = date(2002, 1, 1)
     stop_date = date(2005, 12, 31)
@@ -593,7 +593,7 @@ class cd_doment(Variable):
 
 class cd_eparet(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"cd_eparet"
     start_date = date(2004, 1, 1)
 
@@ -631,7 +631,7 @@ class cd_eparet(Variable):
 
 class cd_sofipe(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"cd_sofipe"
     start_date = date(2002, 1, 1)
     stop_date = date(2006, 12, 31)
@@ -654,7 +654,7 @@ class cd_sofipe(Variable):
 
 class cd_cinema(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"cd_cinema"
     start_date = date(2002, 1, 1)
     stop_date = date(2005, 12, 31)
@@ -676,7 +676,7 @@ class cd_cinema(Variable):
 
 class cd_ecodev(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"cd_ecodev"
     start_date = date(2007, 1, 1)
     stop_date = date(2008, 12, 31)
@@ -698,7 +698,7 @@ class cd_ecodev(Variable):
 
 class cd_grorep(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"cd_grorep"
     start_date = date(2009, 1, 1)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 class credits_impot(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédits d'impôt pour l'impôt sur les revenus"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -258,7 +258,7 @@ class credits_impot(DatedVariable):
 
 class nb_pac2(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"nb_pac2"
 
     def function(self, simulation, period):
@@ -273,7 +273,7 @@ class nb_pac2(Variable):
 
 class accult(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Acquisition de biens culturels"
     start_date = date(2002, 1, 1)
 
@@ -292,7 +292,7 @@ class accult(Variable):
 
 class acqgpl(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt pour dépense d'acquisition ou de transformation d'un véhicule GPL ou mixte"
     start_date = date(2002, 1, 1)
     stop_date = date(2007, 12, 31)
@@ -312,7 +312,7 @@ class acqgpl(Variable):
 
 class aidmob(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt aide à la mobilité"
     start_date = date(2005, 1, 1)
     stop_date = date(2008, 12, 31)
@@ -335,7 +335,7 @@ class aidmob(Variable):
 
 class aidper(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédits d’impôt pour dépenses en faveur de l’aide aux personnes"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2003, 12, 31))
@@ -516,7 +516,7 @@ class aidper(DatedVariable):
 
 class assloy(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d’impôt primes d’assurance pour loyers impayés"
     start_date = date(2005, 1, 1)
 
@@ -534,7 +534,7 @@ class assloy(Variable):
 
 class autent(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"autent"
     start_date = date(2009, 1, 1)
 
@@ -551,7 +551,7 @@ class autent(Variable):
 
 class ci_garext(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Frais de garde des enfants à l’extérieur du domicile"
     start_date = date(2005, 1, 1)
 
@@ -581,7 +581,7 @@ class ci_garext(Variable):
 
 class creimp_exc_2008(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt exceptionnel sur les revenus 2008"
 
     def function(self, simulation, period):
@@ -604,7 +604,7 @@ class creimp_exc_2008(Variable):
 
 class creimp(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Avoirs fiscaux et crédits d'impôt"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -886,7 +886,7 @@ class creimp(DatedVariable):
 
 class direpa(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d’impôt directive « épargne »"
 
     def function(self, simulation, period):
@@ -902,7 +902,7 @@ class direpa(Variable):
 
 class divide(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt dividendes"
     start_date = date(2005, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -926,7 +926,7 @@ class divide(Variable):
 
 class drbail(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d’impôt représentatif de la taxe additionnelle au droit de bail"
 
     def function(self, simulation, period):
@@ -944,7 +944,7 @@ class drbail(Variable):
 
 class inthab(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d’impôt intérêts des emprunts pour l’habitation principale"
 
     @dated_function(start = date(2007, 1, 1), stop = date(2007, 12, 31))
@@ -1136,7 +1136,7 @@ class inthab(DatedVariable):
 
 class jeunes(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"jeunes"
     start_date = date(2005, 1, 1)
     stop_date = date(2008, 12, 31)
@@ -1150,7 +1150,7 @@ class jeunes(Variable):
 
 class jeunes_ind(Variable):
     column = FloatCol(default = 0)
-    entity_class = Individus
+    entity = Individus
     label = u"Crédit d'impôt en faveur des jeunes"
     start_date = date(2005, 1, 1)
     stop_date = date(2008, 12, 31)
@@ -1194,7 +1194,7 @@ class jeunes_ind(Variable):
 
 class mecena(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Mécénat d'entreprise"
     start_date = date(2003, 1, 1)
 
@@ -1211,7 +1211,7 @@ class mecena(Variable):
 
 class percvm(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d’impôt pertes sur cessions de valeurs mobilières"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1230,7 +1230,7 @@ class percvm(Variable):
 
 class preetu(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d’impôt pour souscription de prêts étudiants"
 
     @dated_function(start = date(2005, 1, 1), stop = date(2005, 12, 31))
@@ -1283,7 +1283,7 @@ class preetu(DatedVariable):
 
 class prlire(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prélèvement libératoire à restituer (case 2DH)"
     stop_date = date(2013, 12, 31)
 
@@ -1305,7 +1305,7 @@ class prlire(Variable):
 
 class quaenv(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédits d’impôt pour dépenses en faveur de la qualité environnementale"
 
     @dated_function(start = date(2005, 1, 1), stop = date(2005, 12, 31))
@@ -1606,7 +1606,7 @@ class quaenv(DatedVariable):
 
 class quaenv_bouquet(Variable):
     column = BoolCol(default = False)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"quaenv_bouquet"
     start_date = date(2013, 1, 1)
 
@@ -1649,7 +1649,7 @@ class quaenv_bouquet(Variable):
 
 class saldom2(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d’impôt emploi d’un salarié à domicile"
 
     @dated_function(start = date(2007, 1, 1), stop = date(2008, 12, 31))

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 class credits_impot(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédits d'impôt pour l'impôt sur les revenus"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -258,7 +258,7 @@ class credits_impot(DatedVariable):
 
 class nb_pac2(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"nb_pac2"
 
     def function(self, simulation, period):
@@ -273,7 +273,7 @@ class nb_pac2(Variable):
 
 class accult(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Acquisition de biens culturels"
     start_date = date(2002, 1, 1)
 
@@ -292,7 +292,7 @@ class accult(Variable):
 
 class acqgpl(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt pour dépense d'acquisition ou de transformation d'un véhicule GPL ou mixte"
     start_date = date(2002, 1, 1)
     stop_date = date(2007, 12, 31)
@@ -312,7 +312,7 @@ class acqgpl(Variable):
 
 class aidmob(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt aide à la mobilité"
     start_date = date(2005, 1, 1)
     stop_date = date(2008, 12, 31)
@@ -335,7 +335,7 @@ class aidmob(Variable):
 
 class aidper(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédits d’impôt pour dépenses en faveur de l’aide aux personnes"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2003, 12, 31))
@@ -516,7 +516,7 @@ class aidper(DatedVariable):
 
 class assloy(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d’impôt primes d’assurance pour loyers impayés"
     start_date = date(2005, 1, 1)
 
@@ -534,7 +534,7 @@ class assloy(Variable):
 
 class autent(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"autent"
     start_date = date(2009, 1, 1)
 
@@ -551,7 +551,7 @@ class autent(Variable):
 
 class ci_garext(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Frais de garde des enfants à l’extérieur du domicile"
     start_date = date(2005, 1, 1)
 
@@ -581,7 +581,7 @@ class ci_garext(Variable):
 
 class creimp_exc_2008(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt exceptionnel sur les revenus 2008"
 
     def function(self, simulation, period):
@@ -604,7 +604,7 @@ class creimp_exc_2008(Variable):
 
 class creimp(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Avoirs fiscaux et crédits d'impôt"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -886,7 +886,7 @@ class creimp(DatedVariable):
 
 class direpa(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d’impôt directive « épargne »"
 
     def function(self, simulation, period):
@@ -902,7 +902,7 @@ class direpa(Variable):
 
 class divide(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt dividendes"
     start_date = date(2005, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -926,7 +926,7 @@ class divide(Variable):
 
 class drbail(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d’impôt représentatif de la taxe additionnelle au droit de bail"
 
     def function(self, simulation, period):
@@ -944,7 +944,7 @@ class drbail(Variable):
 
 class inthab(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d’impôt intérêts des emprunts pour l’habitation principale"
 
     @dated_function(start = date(2007, 1, 1), stop = date(2007, 12, 31))
@@ -1136,7 +1136,7 @@ class inthab(DatedVariable):
 
 class jeunes(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"jeunes"
     start_date = date(2005, 1, 1)
     stop_date = date(2008, 12, 31)
@@ -1150,7 +1150,7 @@ class jeunes(Variable):
 
 class jeunes_ind(Variable):
     column = FloatCol(default = 0)
-    entity = Individus
+    entity = Individu
     label = u"Crédit d'impôt en faveur des jeunes"
     start_date = date(2005, 1, 1)
     stop_date = date(2008, 12, 31)
@@ -1194,7 +1194,7 @@ class jeunes_ind(Variable):
 
 class mecena(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Mécénat d'entreprise"
     start_date = date(2003, 1, 1)
 
@@ -1211,7 +1211,7 @@ class mecena(Variable):
 
 class percvm(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d’impôt pertes sur cessions de valeurs mobilières"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1230,7 +1230,7 @@ class percvm(Variable):
 
 class preetu(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d’impôt pour souscription de prêts étudiants"
 
     @dated_function(start = date(2005, 1, 1), stop = date(2005, 12, 31))
@@ -1283,7 +1283,7 @@ class preetu(DatedVariable):
 
 class prlire(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prélèvement libératoire à restituer (case 2DH)"
     stop_date = date(2013, 12, 31)
 
@@ -1305,7 +1305,7 @@ class prlire(Variable):
 
 class quaenv(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédits d’impôt pour dépenses en faveur de la qualité environnementale"
 
     @dated_function(start = date(2005, 1, 1), stop = date(2005, 12, 31))
@@ -1606,7 +1606,7 @@ class quaenv(DatedVariable):
 
 class quaenv_bouquet(Variable):
     column = BoolCol(default = False)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"quaenv_bouquet"
     start_date = date(2013, 1, 1)
 
@@ -1649,7 +1649,7 @@ class quaenv_bouquet(Variable):
 
 class saldom2(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d’impôt emploi d’un salarié à domicile"
 
     @dated_function(start = date(2007, 1, 1), stop = date(2008, 12, 31))

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -148,7 +148,7 @@ class enfant_a_charge(Variable):
     def function(individu, period):
         age = individu('age', period)
         handicap = individu('handicap', period)
-        is_pac = individu.has_role(PERSONNE_A_CHARGE, FoyersFiscaux)
+        is_pac = individu.has_role(FoyersFiscaux.personne_a_charge, FoyersFiscaux)
 
         return period, is_pac * ((age < 18) + handicap)
 
@@ -218,7 +218,7 @@ class enfant_majeur_celibataire_sans_enfant(Variable):
         period = period.this_year
         age = individu('age', period)
         handicap = individu('handicap', period)
-        is_pac = individu.has_role(PERSONNE_A_CHARGE, FoyersFiscaux)
+        is_pac = individu.has_role(FoyersFiscaux.personne_a_charge, FoyersFiscaux)
 
         return period, is_pac * (age >= 18) * not_(handicap)
 
@@ -254,7 +254,7 @@ class maries_ou_pacses(Variable):
         statut_marital = foyer_fiscal.members('statut_marital', period)
         individu_marie_ou_pacse = (statut_marital == 1) | (statut_marital == 5)
 
-        return period, foyer_fiscal.value_from_person(individu_marie_ou_pacse, role = DECLARANT)
+        return period, foyer_fiscal.value_from_person(individu_marie_ou_pacse, role = foyer_fiscal.declarant)
 
 
 class celibataire_ou_divorce(Variable):
@@ -267,7 +267,7 @@ class celibataire_ou_divorce(Variable):
         statut_marital = foyer_fiscal.members('statut_marital', period)
         individu_celibataire_ou_divorce = (statut_marital == 2) | (statut_marital == 3)
 
-        return period, foyer_fiscal.value_from_person(individu_celibataire_ou_divorce, role = DECLARANT)
+        return period, foyer_fiscal.value_from_person(individu_celibataire_ou_divorce, role = foyer_fiscal.declarant)
 
 
 class veuf(Variable):
@@ -280,7 +280,7 @@ class veuf(Variable):
         statut_marital = foyer_fiscal.members('statut_marital', period)
         individu_veuf = (statut_marital == 4)
 
-        return period, foyer_fiscal.value_from_person(individu_veuf, role = DECLARANT)
+        return period, foyer_fiscal.value_from_person(individu_veuf, role = foyer_fiscal.declarant)
 
 
 class jeune_veuf(Variable):
@@ -293,7 +293,7 @@ class jeune_veuf(Variable):
         statut_marital = foyer_fiscal.members('statut_marital', period)
         individu_jeune_veuf = (statut_marital == 6)
 
-        return period, foyer_fiscal.value_from_person(individu_jeune_veuf, role = DECLARANT)
+        return period, foyer_fiscal.value_from_person(individu_jeune_veuf, role = foyer_fiscal.declarant)
 
 
 ###############################################################################
@@ -2468,7 +2468,7 @@ class abat_spe(Variable):
     label = u"Abattements spéciaux"
     url = "http://bofip.impots.gouv.fr/bofip/2036-PGP"
 
-    def function(self, simulation, period):
+    def function(foyer_fiscal, period, legislation):
         """
         Abattements spéciaux
 
@@ -2488,15 +2488,15 @@ class abat_spe(Variable):
           pour un célibataire avec un jeune enfant en résidence alternée.
         """
         period = period.this_year
-        caseP = simulation.calculate('caseP', period)
-        caseF = simulation.calculate('caseF', period)
-        rng = simulation.calculate('rng', period)
-        nbN = simulation.calculate('nbN', period)
-        abattements_speciaux = simulation.legislation_at(period.start).ir.abattements_speciaux
+        caseP = foyer_fiscal('caseP', period)
+        caseF = foyer_fiscal('caseF', period)
+        rng = foyer_fiscal('rng', period)
+        nbN = foyer_fiscal('nbN', period)
+        abattements_speciaux = legislation(period).ir.abattements_speciaux
 
-        age = simulation.calculate('age', period)
-        ageV = simulation.foyer_fiscal.value_from_person(age, DECLARANT)
-        ageC = simulation.foyer_fiscal.value_from_person(age, CONJOINT)
+        age = foyer_fiscal.members('age', period)
+        ageV = foyer_fiscal.value_from_person(age, foyer_fiscal.declarant)
+        ageC = foyer_fiscal.value_from_person(age, foyer_fiscal.conjoint)
 
         invV, invC = caseP, caseF
         nb_elig_as = (1 * (((ageV >= 65) | invV) & (ageV > 0)) +

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -254,7 +254,7 @@ class maries_ou_pacses(Variable):
         statut_marital = foyer_fiscal.members('statut_marital', period)
         individu_marie_ou_pacse = (statut_marital == 1) | (statut_marital == 5)
 
-        return period, foyer_fiscal.value_from_person(individu_marie_ou_pacse, role = foyer_fiscal.declarant)
+        return period, foyer_fiscal.value_from_person(individu_marie_ou_pacse, role = foyer_fiscal.declarant_principal)
 
 
 class celibataire_ou_divorce(Variable):
@@ -267,7 +267,7 @@ class celibataire_ou_divorce(Variable):
         statut_marital = foyer_fiscal.members('statut_marital', period)
         individu_celibataire_ou_divorce = (statut_marital == 2) | (statut_marital == 3)
 
-        return period, foyer_fiscal.value_from_person(individu_celibataire_ou_divorce, role = foyer_fiscal.declarant)
+        return period, foyer_fiscal.value_from_person(individu_celibataire_ou_divorce, role = foyer_fiscal.declarant_principal)
 
 
 class veuf(Variable):
@@ -280,7 +280,7 @@ class veuf(Variable):
         statut_marital = foyer_fiscal.members('statut_marital', period)
         individu_veuf = (statut_marital == 4)
 
-        return period, foyer_fiscal.value_from_person(individu_veuf, role = foyer_fiscal.declarant)
+        return period, foyer_fiscal.value_from_person(individu_veuf, role = foyer_fiscal.declarant_principal)
 
 
 class jeune_veuf(Variable):
@@ -293,7 +293,7 @@ class jeune_veuf(Variable):
         statut_marital = foyer_fiscal.members('statut_marital', period)
         individu_jeune_veuf = (statut_marital == 6)
 
-        return period, foyer_fiscal.value_from_person(individu_jeune_veuf, role = foyer_fiscal.declarant)
+        return period, foyer_fiscal.value_from_person(individu_jeune_veuf, role = foyer_fiscal.declarant_principal)
 
 
 ###############################################################################
@@ -2495,7 +2495,7 @@ class abat_spe(Variable):
         abattements_speciaux = legislation(period).ir.abattements_speciaux
 
         age = foyer_fiscal.members('age', period)
-        ageV = foyer_fiscal.value_from_person(age, foyer_fiscal.declarant)
+        ageV = foyer_fiscal.value_from_person(age, foyer_fiscal.declarant_principal)
         ageC = foyer_fiscal.value_from_person(age, foyer_fiscal.conjoint)
 
         invV, invC = caseP, caseF

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -148,7 +148,7 @@ class enfant_a_charge(Variable):
     def function(individu, period):
         age = individu('age', period)
         handicap = individu('handicap', period)
-        is_pac = individu.has_role(FoyersFiscaux.personne_a_charge, FoyersFiscaux)
+        is_pac = individu.has_role(FoyersFiscaux.personne_a_charge)
 
         return period, is_pac * ((age < 18) + handicap)
 
@@ -218,7 +218,7 @@ class enfant_majeur_celibataire_sans_enfant(Variable):
         period = period.this_year
         age = individu('age', period)
         handicap = individu('handicap', period)
-        is_pac = individu.has_role(FoyersFiscaux.personne_a_charge, FoyersFiscaux)
+        is_pac = individu.has_role(FoyersFiscaux.personne_a_charge)
 
         return period, is_pac * (age >= 18) * not_(handicap)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -148,7 +148,7 @@ class enfant_a_charge(Variable):
     def function(individu, period):
         age = individu('age', period)
         handicap = individu('handicap', period)
-        is_pac = individu.has_role(FoyersFiscaux.personne_a_charge)
+        is_pac = individu.has_role(FoyersFiscaux.PERSONNE_A_CHARGE)
 
         return period, is_pac * ((age < 18) + handicap)
 
@@ -218,7 +218,7 @@ class enfant_majeur_celibataire_sans_enfant(Variable):
         period = period.this_year
         age = individu('age', period)
         handicap = individu('handicap', period)
-        is_pac = individu.has_role(FoyersFiscaux.personne_a_charge)
+        is_pac = individu.has_role(FoyersFiscaux.PERSONNE_A_CHARGE)
 
         return period, is_pac * (age >= 18) * not_(handicap)
 
@@ -251,10 +251,10 @@ class maries_ou_pacses(Variable):
 
     def function(foyer_fiscal, period):
         period = period.this_year
-        statut_marital = foyer_fiscal.members('statut_marital', period)
-        individu_marie_ou_pacse = (statut_marital == 1) | (statut_marital == 5)
+        statut_marital = foyer_fiscal.declarant_principal('statut_marital', period)
+        marie_ou_pacse = (statut_marital == 1) | (statut_marital == 5)
 
-        return period, foyer_fiscal.value_from_person(individu_marie_ou_pacse, role = foyer_fiscal.declarant_principal)
+        return period, marie_ou_pacse
 
 
 class celibataire_ou_divorce(Variable):
@@ -264,11 +264,10 @@ class celibataire_ou_divorce(Variable):
 
     def function(foyer_fiscal, period):
         period = period.this_year
-        statut_marital = foyer_fiscal.members('statut_marital', period)
-        individu_celibataire_ou_divorce = (statut_marital == 2) | (statut_marital == 3)
+        statut_marital = foyer_fiscal.declarant_principal('statut_marital', period)
+        celibataire_ou_divorce = (statut_marital == 2) | (statut_marital == 3)
 
-        return period, foyer_fiscal.value_from_person(individu_celibataire_ou_divorce, role = foyer_fiscal.declarant_principal)
-
+        return period, celibataire_ou_divorce
 
 class veuf(Variable):
     column = BoolCol
@@ -277,11 +276,10 @@ class veuf(Variable):
 
     def function(foyer_fiscal, period):
         period = period.this_year
-        statut_marital = foyer_fiscal.members('statut_marital', period)
-        individu_veuf = (statut_marital == 4)
+        statut_marital = foyer_fiscal.declarant_principal('statut_marital', period)
+        veuf = (statut_marital == 4)
 
-        return period, foyer_fiscal.value_from_person(individu_veuf, role = foyer_fiscal.declarant_principal)
-
+        return period, veuf
 
 class jeune_veuf(Variable):
     column = BoolCol
@@ -290,11 +288,10 @@ class jeune_veuf(Variable):
 
     def function(foyer_fiscal, period):
         period = period.this_year
-        statut_marital = foyer_fiscal.members('statut_marital', period)
-        individu_jeune_veuf = (statut_marital == 6)
+        statut_marital = foyer_fiscal.declarant_principal('statut_marital', period)
+        jeune_veuf = (statut_marital == 6)
 
-        return period, foyer_fiscal.value_from_person(individu_jeune_veuf, role = foyer_fiscal.declarant_principal)
-
+        return period, jeune_veuf
 
 ###############################################################################
 # # Revenus catégoriels
@@ -2494,9 +2491,8 @@ class abat_spe(Variable):
         nbN = foyer_fiscal('nbN', period)
         abattements_speciaux = legislation(period).ir.abattements_speciaux
 
-        age = foyer_fiscal.members('age', period)
-        ageV = foyer_fiscal.value_from_person(age, foyer_fiscal.declarant_principal)
-        ageC = foyer_fiscal.value_from_person(age, foyer_fiscal.conjoint)
+        ageV = foyer_fiscal.declarant_principal('age', period)
+        ageC = foyer_fiscal.conjoint('age', period)
 
         invV, invC = caseP, caseF
         nb_elig_as = (1 * (((ageV >= 65) | invV) & (ageV > 0)) +

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -43,12 +43,12 @@ log = logging.getLogger(__name__)
 
 class jour_xyz(Variable):
     column = IntCol(default = 360)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Jours décomptés au titre de cette déclaration"
 
 class nbptr_n_2(Variable):
     column = PeriodSizeIndependentIntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre de parts année n - 2"
 
 
@@ -62,7 +62,7 @@ class nbptr_n_2(Variable):
 class age(Variable):
     base_function = missing_value
     column = AgeCol(val_type = "age")
-    entity_class = Individus
+    entity = Individus
     label = u"Âge (en années)"
 
     def function(self, simulation, period):
@@ -89,7 +89,7 @@ class age(Variable):
 class age_en_mois(Variable):
     base_function = missing_value
     column = AgeCol(val_type = "months")
-    entity_class = Individus
+    entity = Individus
     label = u"Âge (en mois)"
 
     def function(self, simulation, period):
@@ -113,7 +113,7 @@ class age_en_mois(Variable):
 
 class nb_adult(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre d'adulte(s) déclarants dans le foyer fiscal"
 
     def function(self, simulation, period):
@@ -127,7 +127,7 @@ class nb_adult(Variable):
 
 class nb_pac(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre de personnes à charge dans le foyer fiscal"
 
     def function(self, simulation, period):
@@ -141,7 +141,7 @@ class nb_pac(Variable):
 
 class enfant_a_charge(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Enfant à charge non marié, de moins de 18 ans au 1er janvier de l'année de perception des" \
         u" revenus, ou né durant la même année, ou handicapés quel que soit son âge"
 
@@ -155,7 +155,7 @@ class enfant_a_charge(Variable):
 
 class nbF(Variable):
     cerfa_field = u'F'
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     column = FloatCol
     label = u"Nombre d'enfants à charge non mariés, qui ne sont pas en résidence alternée, de moins de 18 ans au 1er janvier de l'année de perception des" \
         u" revenus, ou nés durant la même année ou handicapés quel que soit leur âge"
@@ -169,7 +169,7 @@ class nbF(Variable):
 
 class nbG(Variable):
     cerfa_field = u'G'
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     column = FloatCol
     label = u"Nombre d'enfants qui ne sont pas en résidence alternée à charge titulaires de la carte d'invalidité."
 
@@ -183,7 +183,7 @@ class nbG(Variable):
 
 class nbH(Variable):
     cerfa_field = u'H'
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     column = FloatCol
     label = u"Nombre d'enfants à charge en résidence alternée, non mariés de moins de 18 ans au 1er janvier de" \
         u" l'année de perception des revenus, ou nés durant la même année ou handicapés quel que soit leur âge"
@@ -197,7 +197,7 @@ class nbH(Variable):
 
 class nbI(Variable):
     cerfa_field = u'I'
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     column = FloatCol
     label = u"Nombre d'enfants à charge en résidence alternée titulaires de la carte d'invalidité"
 
@@ -211,7 +211,7 @@ class nbI(Variable):
 
 class enfant_majeur_celibataire_sans_enfant(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Enfant majeur célibataire sans enfant"
 
     def function(individu, period):
@@ -225,7 +225,7 @@ class enfant_majeur_celibataire_sans_enfant(Variable):
 
 class nbJ(Variable):
     cerfa_field = u'J'
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre d'enfants majeurs célibataires sans enfant"
     column = IntCol
 
@@ -235,7 +235,7 @@ class nbJ(Variable):
 
 
 class nombre_enfants_majeurs_celibataires_sans_enfant(Variable):
-    entity_class = Menages
+    entity = Menages
     label = u"Nombre d'enfants majeurs célibataires sans enfant"
     column = IntCol
 
@@ -246,7 +246,7 @@ class nombre_enfants_majeurs_celibataires_sans_enfant(Variable):
 
 class maries_ou_pacses(Variable):
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déclarants mariés ou pacsés"
 
     def function(foyer_fiscal, period):
@@ -259,7 +259,7 @@ class maries_ou_pacses(Variable):
 
 class celibataire_ou_divorce(Variable):
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déclarant célibataire ou divorcé"
 
     def function(foyer_fiscal, period):
@@ -271,7 +271,7 @@ class celibataire_ou_divorce(Variable):
 
 class veuf(Variable):
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déclarant veuf"
 
     def function(foyer_fiscal, period):
@@ -283,7 +283,7 @@ class veuf(Variable):
 
 class jeune_veuf(Variable):
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déclarant jeune veuf"
 
     def function(foyer_fiscal, period):
@@ -300,7 +300,7 @@ class jeune_veuf(Variable):
 
 class revenu_assimile_salaire(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenu imposé comme des salaires (salaires, mais aussi 3vj, 3vk)"
 
     def function(self, simulation, period):
@@ -313,7 +313,7 @@ class revenu_assimile_salaire(Variable):
 
 class revenu_assimile_salaire_apres_abattements(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Salaires et chômage imposables après abattements"
 
     def function(self, simulation, period):
@@ -332,7 +332,7 @@ class revenu_assimile_salaire_apres_abattements(Variable):
 
 class revenu_activite_salariee(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenu d'activité salariée"
 
     def function(self, simulation, period):
@@ -344,7 +344,7 @@ class revenu_activite_salariee(Variable):
 
 class revenu_activite_non_salariee(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenu d'activité non salariée"
 
     def function(self, simulation, period):
@@ -356,7 +356,7 @@ class revenu_activite_non_salariee(Variable):
 
 class revenu_activite(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus d'activités"
 
     def function(self, simulation, period):
@@ -370,7 +370,7 @@ class revenu_activite(Variable):
 
 class revenu_assimile_pension(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenu imposé comme des pensions (retraites, pensions alimentaires, etc.)"
 
     def function(self, simulation, period):
@@ -384,7 +384,7 @@ class revenu_assimile_pension(Variable):
 
 class revenu_assimile_pension_apres_abattements(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Pensions après abattements"
 
     def function(self, simulation, period):
@@ -404,7 +404,7 @@ class revenu_assimile_pension_apres_abattements(Variable):
 
 class indu_plaf_abat_pen(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Plafonnement de l'abattement de 10% sur les pensions du foyer"
 
     def function(self, simulation, period):
@@ -422,7 +422,7 @@ class indu_plaf_abat_pen(Variable):
 
 class abattement_salaires_pensions(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Abattement de 20% sur les salaires et pensions, en vigueur jusqu'à 2006"
     stop_date = date(2005, 12, 31)
 
@@ -442,7 +442,7 @@ class retraite_titre_onereux(Variable):
     """
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Rentes viagères (rentes à titre onéreux)"
     set_input = set_input_divide_by_period
     url = u"http://fr.wikipedia.org/wiki/Rente_viagère"
@@ -460,7 +460,7 @@ class retraite_titre_onereux(Variable):
 
 class retraite_titre_onereux_net(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Rentes viagères après abattements"
     url = u"http://www.lafinancepourtous.fr/Vie-professionnelle-et-retraite/Retraite/Epargne-retraite/La-rente-viagere/La-fiscalite-de-la-rente-viagere"  # noqa
 
@@ -477,7 +477,7 @@ class retraite_titre_onereux_net(Variable):
 
 class traitements_salaires_pensions_rentes(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Traitements salaires pensions et rentes individuelles"
 
     def function(individu, period):
@@ -497,7 +497,7 @@ class traitements_salaires_pensions_rentes(Variable):
 
 class rev_cat_pv(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenu catégoriel - Plus-values"
     start_date = date(2013, 1, 1)
     url = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
@@ -512,7 +512,7 @@ class rev_cat_pv(Variable):
 
 class rev_cat_tspr(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenu catégoriel - Traitements, salaires, pensions et rentes"
     url = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
 
@@ -528,7 +528,7 @@ class rev_cat_tspr(Variable):
 
 class deficit_rcm(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Deficit capitaux mobiliers"
     start_date = date(2009, 1, 1)
     url = "http://www.lefigaro.fr/impots/2008/04/25/05003-20080425ARTFIG00254-les-subtilites-des-revenus-de-capitaux-mobiliers-.php"
@@ -548,7 +548,7 @@ class deficit_rcm(Variable):
 
 class rev_cat_rvcm(DatedVariable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenu catégoriel - Capitaux"
     url = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
 
@@ -701,7 +701,7 @@ class rev_cat_rvcm(DatedVariable):
 
 class rfr_rvcm(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"rfr_rvcm"
 
     def function(self, simulation, period):
@@ -741,7 +741,7 @@ class rfr_rvcm(Variable):
 
 class rev_cat_rfon(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenu catégoriel - Foncier"
     url = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
 
@@ -775,7 +775,7 @@ class rev_cat_rfon(Variable):
 
 class rev_cat_rpns(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenu catégoriel - Revenus personnels non salariés"
     url = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
 
@@ -801,7 +801,7 @@ class rev_cat_rpns(Variable):
 
 class rev_cat(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus catégoriels"
     url = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
 
@@ -826,7 +826,7 @@ class rev_cat(Variable):
 
 class deficit_ante(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficit global antérieur"
     url = "http://impotsurlerevenu.org/declaration-de-revenus-fonciers-2044/796-deficits-anterieurs-restant-a-imputer-cadre-450.php"
 
@@ -847,7 +847,7 @@ class deficit_ante(Variable):
 
 class rbg(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenu brut global"
     url = "http://www.documentissime.fr/dossiers-droit-pratique/dossier-19-l-impot-sur-le-revenu-les-modalites-generales-d-imposition/la-determination-du-revenu-imposable/le-revenu-brut-global.html"
 
@@ -871,7 +871,7 @@ class rbg(Variable):
 
 class csg_deduc_patrimoine(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Csg déductible sur le patrimoine"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&typePage=cpr02&sfid=503&espId=1&communaute=1&impot=CS"
 
@@ -888,7 +888,7 @@ class csg_deduc_patrimoine(Variable):
 
 class csg_deduc_patrimoine_simulated(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Csg déductible sur le patrimoine simulée"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&typePage=cpr02&sfid=503&espId=1&communaute=1&impot=CS"
 
@@ -909,7 +909,7 @@ class csg_deduc_patrimoine_simulated(Variable):
 
 class csg_deduc(Variable):  # f6de
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Csg déductible sur le patrimoine"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&typePage=cpr02&sfid=503&espId=1&communaute=1&impot=CS"
 
@@ -925,7 +925,7 @@ class csg_deduc(Variable):  # f6de
 
 class rng(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenu net global"
     url = "http://impotsurlerevenu.org/definitions/114-revenu-net-global.php"
 
@@ -941,7 +941,7 @@ class rng(Variable):
 
 class rni(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenu net imposable"
     url = "http://impotsurlerevenu.org/definitions/115-revenu-net-imposable.php"
 
@@ -956,7 +956,7 @@ class rni(Variable):
 
 class ir_brut(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Impôt sur le revenu brut avant non imposabilité et plafonnement du quotient"
 
     def function(self, simulation, period):
@@ -971,7 +971,7 @@ class ir_brut(Variable):
 
 class ir_ss_qf(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Impôt sans quotient familial"
 
     def function(self, simulation, period):
@@ -989,7 +989,7 @@ class ir_ss_qf(Variable):
 
 class ir_plaf_qf(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Impôt après plafonnement du quotient familial et réduction complémentaire"
 
     def function(self, simulation, period):
@@ -1089,7 +1089,7 @@ class ir_plaf_qf(Variable):
 
 class avantage_qf(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Avantage quotient familial"
 
     def function(self, simulation, period):
@@ -1102,7 +1102,7 @@ class avantage_qf(Variable):
 
 class decote(DatedVariable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"décote"
 
     @dated_function(start = date(2015, 1, 1))
@@ -1140,7 +1140,7 @@ class decote(DatedVariable):
 
 class decote_gain_fiscal(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Gain fiscal de la décote/Décote au sens Dgfip tel que sur la feuille d'impôt"
     start_date = date(1982, 1, 1)
 
@@ -1157,7 +1157,7 @@ class decote_gain_fiscal(Variable):
 
 class nat_imp(Variable):
     column = BoolCol(default = False)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"nat_imp"
 
     def function(self, simulation, period):
@@ -1176,7 +1176,7 @@ class nat_imp(Variable):
 
 class ip_net(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Impôt sur le revenu après décote"
 
     def function(self, simulation, period):
@@ -1194,7 +1194,7 @@ class ip_net(Variable):
 
 class iaidrdi(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Impôt après imputation des réductions d'impôt"
 
     def function(self, simulation, period):
@@ -1210,7 +1210,7 @@ class iaidrdi(Variable):
 
 class cont_rev_loc(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Contribution sur les revenus locatifs"
     start_date = date(2001, 1, 1)
 
@@ -1227,7 +1227,7 @@ class cont_rev_loc(Variable):
 
 class teicaa(Variable):  # f5rm
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Taxe exceptionelle sur l'indemnité compensatrice des agents d'assurance"
 
     def function(self, simulation, period):
@@ -1246,7 +1246,7 @@ class teicaa(Variable):  # f5rm
 
 class assiette_vente(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Assiette régime microsociale pour les ventes"
     start_date = date(2009, 1, 1)
 
@@ -1262,7 +1262,7 @@ class assiette_vente(Variable):
 
 class assiette_service(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Assiette régime microsociale pour les prestations et services"
     start_date = date(2009, 1, 1)
 
@@ -1281,7 +1281,7 @@ class assiette_service(Variable):
 
 class assiette_proflib(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Assiette régime microsociale pour les professions libérales"
     start_date = date(2009, 1, 1)
 
@@ -1302,7 +1302,7 @@ class assiette_proflib(Variable):
 
 class microsocial(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Assiette régime microsociale totale"
     start_date = date(2009, 1, 1)
     url = "http://fr.wikipedia.org/wiki/R%C3%A9gime_micro-social"
@@ -1322,7 +1322,7 @@ class microsocial(Variable):
 
 class microentreprise(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"microentreprise"
     start_date = date(2009, 1, 1)
 
@@ -1343,7 +1343,7 @@ class microentreprise(Variable):
 
 class plus_values(DatedVariable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Taxation des plus_values"
 
     @dated_function(start = date(2007, 1, 1), stop = date(2007, 12, 31))
@@ -1518,7 +1518,7 @@ class plus_values(DatedVariable):
 
 class iai(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Impôt avant imputations de l'impôt sur le revenu"
     url = "http://forum-juridique.net-iris.fr/finances-fiscalite-assurance/43963-declaration-impots.html"
 
@@ -1537,7 +1537,7 @@ class iai(Variable):
 
 class cehr(DatedVariable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Contribution exceptionnelle sur les hauts revenus"
     url = "http://www.legifrance.gouv.fr/affichCode.do?cidTexte=LEGITEXT000006069577&idSectionTA=LEGISCTA000025049019"
 
@@ -1558,7 +1558,7 @@ class cehr(DatedVariable):
 
 class irpp(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Impôt sur le revenu des personnes physiques"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_impot_revenu&espId=1&impot=IR&sfid=50"
 
@@ -1585,7 +1585,7 @@ class irpp(Variable):
 
 class foyer_impose(Variable):
     column = BoolCol(default = False)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Le foyer fiscal est imposé"
 
     def function(self, simulation, period):
@@ -1600,7 +1600,7 @@ class foyer_impose(Variable):
 
 class pensions_alimentaires_versees(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Pensions alimentaires versées"
     url = u"http://vosdroits.service-public.fr/particuliers/F2.xhtml"
 
@@ -1618,7 +1618,7 @@ class pensions_alimentaires_versees(Variable):
 
 class rfr(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenu fiscal de référence"
 
     def function(self, simulation, period):
@@ -1648,7 +1648,7 @@ class rfr(Variable):
 
 class glo(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Gain de levée d'options"
     url = "http://www.officeo.fr/imposition-au-bareme-progressif-de-l-impot-sur-le-revenu-des-gains-de-levee-d-options-sur-actions-et-attributions-d-actions-gratuites"
 
@@ -1674,7 +1674,7 @@ class rev_cap_bar(Variable):
     """
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus du capital imposés au barème"
     set_input = set_input_divide_by_period
     url = "http://fr.wikipedia.org/wiki/Revenu#Revenu_du_Capital"
@@ -1713,7 +1713,7 @@ class rev_cap_lib(DatedVariable):
     '''
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenu du capital imposé au prélèvement libératoire"
     set_input = set_input_divide_by_period
     url = "http://fr.wikipedia.org/wiki/Revenu#Revenu_du_Capital"
@@ -1746,7 +1746,7 @@ class rev_cap_lib(DatedVariable):
 
 class avf(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Avoir fiscal et crédits d'impôt"
 
     def function(self, simulation, period):
@@ -1761,7 +1761,7 @@ class avf(Variable):
 
 class imp_lib(DatedVariable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prelèvement libératoire sur les revenus du capital"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&paf_dm=popup&paf_gm=content&typePage=cpr02&sfid=501&espId=1&impot=CS"
 
@@ -1799,7 +1799,7 @@ class imp_lib(DatedVariable):
 
 class fon(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus fonciers"
     url = "http://impotsurlerevenu.org/definitions/220-revenu-foncier.php"
 
@@ -1820,7 +1820,7 @@ class fon(Variable):
 
 class rpns_pvce(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Plus values de cession - Revenu des professions non salariées"
 
     def function(self, simulation, period):
@@ -1856,7 +1856,7 @@ class rpns_pvce(Variable):
 
 class rpns_exon(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Plus values de cession exonérées -Revenu des professions non salariées"
 
     def function(self, simulation, period):
@@ -1907,7 +1907,7 @@ class rpns_exon(Variable):
 
 class defrag(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficit agricole des années antérieures"
 
     def function(self, simulation, period):
@@ -1936,7 +1936,7 @@ class defrag(Variable):
 
 class defacc(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficit industriels et commerciaux non professionnels des années antérieures"
 
     def function(self, simulation, period):
@@ -1971,7 +1971,7 @@ class defacc(Variable):
 
 class defncn(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficit non commerciaux non professionnels des années antérieures"
 
     def function(self, simulation, period):
@@ -2001,7 +2001,7 @@ class defncn(Variable):
 
 class defmeu(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficit des locations meublées non professionnelles des années antérieures"
 
     def function(self, simulation, period):
@@ -2026,7 +2026,7 @@ class defmeu(Variable):
 
 class rag(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus agricoles"
     url = "http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&impot=BA&pageId=prof_ba&sfid=50"
 
@@ -2063,7 +2063,7 @@ class rag(Variable):
 
 class ric(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Bénéfices industriels et commerciaux"
     url = "http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?pageId=prof_bic&espId=2&impot=BIC&sfid=50"
 
@@ -2128,7 +2128,7 @@ class ric(Variable):
 
 class rac(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus accessoires individuels"
     url = "http://vosdroits.service-public.fr/particuliers/F1225.xhtml"
 
@@ -2189,7 +2189,7 @@ class rac(Variable):
 
 class rnc(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus non commerciaux individuels"
     url = "http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&pageId=prof_bnc&impot=BNC&sfid=50"
 
@@ -2230,7 +2230,7 @@ class rnc(Variable):
 
 class rpns(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus individuels des professions non salariées"
 
     def function(self, simulation, period):
@@ -2245,7 +2245,7 @@ class rpns(Variable):
 
 class rpns_pvct(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Plus values de court terme -Revenu des professions non salariées"
 
     def function(self, simulation, period):
@@ -2270,7 +2270,7 @@ class rpns_pvct(Variable):
 
 class rpns_mvct(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Moins values de court terme - Revenu des professions non salariées"
 
     def function(self, simulation, period):
@@ -2293,7 +2293,7 @@ class rpns_mvct(Variable):
 
 class rpns_mvlt(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Moins values de long terme - Revenu des professions non salariées"
 
     def function(self, simulation, period):
@@ -2316,7 +2316,7 @@ class rpns_mvlt(Variable):
 
 class rpns_individu(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus des professions non salariées individuels"
 
     def function(self, simulation, period):
@@ -2461,7 +2461,7 @@ class rpns_individu(Variable):
 
 class abat_spe(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Abattements spéciaux"
     url = "http://bofip.impots.gouv.fr/bofip/2036-PGP"
 
@@ -2508,7 +2508,7 @@ class abat_spe(Variable):
 
 class taux_effectif(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"taux_effectif"
     start_date = date(2009, 1, 1)
 
@@ -2531,7 +2531,7 @@ class taux_effectif(Variable):
 
 class taux_moyen_imposition(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Taux moyen d'imposition"
 
     def function(self, simulation, period):
@@ -2550,7 +2550,7 @@ class taux_moyen_imposition(Variable):
 
 class nbptr(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre de parts"
     url = "http://vosdroits.service-public.fr/particuliers/F2705.xhtml"
 
@@ -2662,7 +2662,7 @@ class nbptr(Variable):
 
 class ppe_coef(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Coefficient - Prime pour l'emploi"
 
     def function(self, simulation, period):
@@ -2678,7 +2678,7 @@ class ppe_coef(Variable):
 
 class ppe_elig(Variable):
     column = BoolCol(default = False)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"ppe_elig"
 
     def function(self, simulation, period):
@@ -2703,7 +2703,7 @@ class ppe_elig(Variable):
 
 class ppe_rev(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"ppe_rev"
 
     def function(self, simulation, period):
@@ -2727,7 +2727,7 @@ class ppe_rev(Variable):
 
 class ppe_coef_tp(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"ppe_coef_tp"
 
     def function(self, simulation, period):
@@ -2750,7 +2750,7 @@ class ppe_coef_tp(Variable):
 
 class ppe_base(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"ppe_base"
 
     def function(self, simulation, period):
@@ -2766,7 +2766,7 @@ class ppe_base(Variable):
 
 class ppe_elig_individu(Variable):
     column = BoolCol(default = False)
-    entity_class = Individus
+    entity = Individus
     label = u"ppe_elig_i"
 
     def function(self, simulation, period):
@@ -2785,7 +2785,7 @@ class ppe_elig_individu(Variable):
 
 class ppe_brute(Variable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prime pour l'emploi brute"
 
     def function(self, simulation, period):
@@ -2893,7 +2893,7 @@ class ppe_brute(Variable):
 
 class ppe(DatedVariable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prime pour l'emploi"
     url = "http://vosdroits.service-public.fr/particuliers/F2882.xhtml"
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -146,8 +146,8 @@ class enfant_a_charge(Variable):
         u" revenus, ou né durant la même année, ou handicapés quel que soit son âge"
 
     def function(individu, period):
-        age = individu.calculate('age', period)
-        handicap = individu.calculate('handicap', period)
+        age = individu['age'](period)
+        handicap = individu['handicap'](period)
         is_pac = individu.role_in(FoyersFiscaux) == PERSONNE_A_CHARGE
 
         return period, is_pac * ((age < 18) + handicap)
@@ -216,8 +216,8 @@ class enfant_majeur_celibataire_sans_enfant(Variable):
 
     def function(individu, period):
         period = period.this_year
-        age = individu.calculate('age', period)
-        handicap = individu.calculate('handicap', period)
+        age = individu['age'](period)
+        handicap = individu['handicap'](period)
         is_pac = individu.role_in(FoyersFiscaux) == PERSONNE_A_CHARGE
 
         return period, is_pac * (age >= 18) * not_(handicap)
@@ -230,7 +230,7 @@ class nbJ(Variable):
     column = IntCol
 
     def function(foyer_fiscal, period):
-        enfant_majeur_celibataire_sans_enfant = foyer_fiscal.members.calculate('enfant_majeur_celibataire_sans_enfant', period)
+        enfant_majeur_celibataire_sans_enfant = foyer_fiscal.members['enfant_majeur_celibataire_sans_enfant'](period)
         return period, foyer_fiscal.sum(enfant_majeur_celibataire_sans_enfant)
 
 
@@ -240,7 +240,7 @@ class nombre_enfants_majeurs_celibataires_sans_enfant(Variable):
     column = IntCol
 
     def function(menage, period):
-        enfant_majeur_celibataire_sans_enfant = menage.members.calculate('enfant_majeur_celibataire_sans_enfant', period)
+        enfant_majeur_celibataire_sans_enfant = menage.members['enfant_majeur_celibataire_sans_enfant'](period)
         return period, menage.sum(enfant_majeur_celibataire_sans_enfant)
 
 
@@ -251,7 +251,7 @@ class maries_ou_pacses(Variable):
 
     def function(foyer_fiscal, period):
         period = period.this_year
-        statut_marital = foyer_fiscal.members.calculate('statut_marital', period)
+        statut_marital = foyer_fiscal.members['statut_marital'](period)
         individu_marie_ou_pacse = (statut_marital == 1) | (statut_marital == 5)
 
         return period, foyer_fiscal.value_from_person(individu_marie_ou_pacse, role = DECLARANT)
@@ -264,7 +264,7 @@ class celibataire_ou_divorce(Variable):
 
     def function(foyer_fiscal, period):
         period = period.this_year
-        statut_marital = foyer_fiscal.members.calculate('statut_marital', period)
+        statut_marital = foyer_fiscal.members['statut_marital'](period)
         individu_celibataire_ou_divorce = (statut_marital == 2) | (statut_marital == 3)
 
         return period, foyer_fiscal.value_from_person(individu_celibataire_ou_divorce, role = DECLARANT)
@@ -277,7 +277,7 @@ class veuf(Variable):
 
     def function(foyer_fiscal, period):
         period = period.this_year
-        statut_marital = foyer_fiscal.members.calculate('statut_marital', period)
+        statut_marital = foyer_fiscal.members['statut_marital'](period)
         individu_veuf = (statut_marital == 4)
 
         return period, foyer_fiscal.value_from_person(individu_veuf, role = DECLARANT)
@@ -290,7 +290,7 @@ class jeune_veuf(Variable):
 
     def function(foyer_fiscal, period):
         period = period.this_year
-        statut_marital = foyer_fiscal.members.calculate('statut_marital', period)
+        statut_marital = foyer_fiscal.members['statut_marital'](period)
         individu_jeune_veuf = (statut_marital == 6)
 
         return period, foyer_fiscal.value_from_person(individu_jeune_veuf, role = DECLARANT)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -148,7 +148,7 @@ class enfant_a_charge(Variable):
     def function(individu, period):
         age = individu('age', period)
         handicap = individu('handicap', period)
-        is_pac = individu.role_in(FoyersFiscaux) == PERSONNE_A_CHARGE
+        is_pac = individu.has_role(PERSONNE_A_CHARGE, FoyersFiscaux)
 
         return period, is_pac * ((age < 18) + handicap)
 
@@ -218,7 +218,7 @@ class enfant_majeur_celibataire_sans_enfant(Variable):
         period = period.this_year
         age = individu('age', period)
         handicap = individu('handicap', period)
-        is_pac = individu.role_in(FoyersFiscaux) == PERSONNE_A_CHARGE
+        is_pac = individu.has_role(PERSONNE_A_CHARGE, FoyersFiscaux)
 
         return period, is_pac * (age >= 18) * not_(handicap)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -43,12 +43,12 @@ log = logging.getLogger(__name__)
 
 class jour_xyz(Variable):
     column = IntCol(default = 360)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Jours décomptés au titre de cette déclaration"
 
 class nbptr_n_2(Variable):
     column = PeriodSizeIndependentIntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre de parts année n - 2"
 
 
@@ -62,7 +62,7 @@ class nbptr_n_2(Variable):
 class age(Variable):
     base_function = missing_value
     column = AgeCol(val_type = "age")
-    entity = Individus
+    entity = Individu
     label = u"Âge (en années)"
 
     def function(self, simulation, period):
@@ -89,7 +89,7 @@ class age(Variable):
 class age_en_mois(Variable):
     base_function = missing_value
     column = AgeCol(val_type = "months")
-    entity = Individus
+    entity = Individu
     label = u"Âge (en mois)"
 
     def function(self, simulation, period):
@@ -113,7 +113,7 @@ class age_en_mois(Variable):
 
 class nb_adult(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre d'adulte(s) déclarants dans le foyer fiscal"
 
     def function(self, simulation, period):
@@ -127,7 +127,7 @@ class nb_adult(Variable):
 
 class nb_pac(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre de personnes à charge dans le foyer fiscal"
 
     def function(self, simulation, period):
@@ -141,21 +141,21 @@ class nb_pac(Variable):
 
 class enfant_a_charge(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Enfant à charge non marié, de moins de 18 ans au 1er janvier de l'année de perception des" \
         u" revenus, ou né durant la même année, ou handicapés quel que soit son âge"
 
     def function(individu, period):
         age = individu('age', period)
         handicap = individu('handicap', period)
-        is_pac = individu.has_role(FoyersFiscaux.PERSONNE_A_CHARGE)
+        is_pac = individu.has_role(FoyerFiscal.PERSONNE_A_CHARGE)
 
         return period, is_pac * ((age < 18) + handicap)
 
 
 class nbF(Variable):
     cerfa_field = u'F'
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     column = FloatCol
     label = u"Nombre d'enfants à charge non mariés, qui ne sont pas en résidence alternée, de moins de 18 ans au 1er janvier de l'année de perception des" \
         u" revenus, ou nés durant la même année ou handicapés quel que soit leur âge"
@@ -169,7 +169,7 @@ class nbF(Variable):
 
 class nbG(Variable):
     cerfa_field = u'G'
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     column = FloatCol
     label = u"Nombre d'enfants qui ne sont pas en résidence alternée à charge titulaires de la carte d'invalidité."
 
@@ -183,7 +183,7 @@ class nbG(Variable):
 
 class nbH(Variable):
     cerfa_field = u'H'
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     column = FloatCol
     label = u"Nombre d'enfants à charge en résidence alternée, non mariés de moins de 18 ans au 1er janvier de" \
         u" l'année de perception des revenus, ou nés durant la même année ou handicapés quel que soit leur âge"
@@ -197,7 +197,7 @@ class nbH(Variable):
 
 class nbI(Variable):
     cerfa_field = u'I'
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     column = FloatCol
     label = u"Nombre d'enfants à charge en résidence alternée titulaires de la carte d'invalidité"
 
@@ -211,21 +211,21 @@ class nbI(Variable):
 
 class enfant_majeur_celibataire_sans_enfant(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Enfant majeur célibataire sans enfant"
 
     def function(individu, period):
         period = period.this_year
         age = individu('age', period)
         handicap = individu('handicap', period)
-        is_pac = individu.has_role(FoyersFiscaux.PERSONNE_A_CHARGE)
+        is_pac = individu.has_role(FoyerFiscal.PERSONNE_A_CHARGE)
 
         return period, is_pac * (age >= 18) * not_(handicap)
 
 
 class nbJ(Variable):
     cerfa_field = u'J'
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre d'enfants majeurs célibataires sans enfant"
     column = IntCol
 
@@ -235,7 +235,7 @@ class nbJ(Variable):
 
 
 class nombre_enfants_majeurs_celibataires_sans_enfant(Variable):
-    entity = Menages
+    entity = Menage
     label = u"Nombre d'enfants majeurs célibataires sans enfant"
     column = IntCol
 
@@ -246,7 +246,7 @@ class nombre_enfants_majeurs_celibataires_sans_enfant(Variable):
 
 class maries_ou_pacses(Variable):
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déclarants mariés ou pacsés"
 
     def function(foyer_fiscal, period):
@@ -259,7 +259,7 @@ class maries_ou_pacses(Variable):
 
 class celibataire_ou_divorce(Variable):
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déclarant célibataire ou divorcé"
 
     def function(foyer_fiscal, period):
@@ -271,7 +271,7 @@ class celibataire_ou_divorce(Variable):
 
 class veuf(Variable):
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déclarant veuf"
 
     def function(foyer_fiscal, period):
@@ -283,7 +283,7 @@ class veuf(Variable):
 
 class jeune_veuf(Variable):
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déclarant jeune veuf"
 
     def function(foyer_fiscal, period):
@@ -300,7 +300,7 @@ class jeune_veuf(Variable):
 
 class revenu_assimile_salaire(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenu imposé comme des salaires (salaires, mais aussi 3vj, 3vk)"
 
     def function(self, simulation, period):
@@ -313,7 +313,7 @@ class revenu_assimile_salaire(Variable):
 
 class revenu_assimile_salaire_apres_abattements(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Salaires et chômage imposables après abattements"
 
     def function(self, simulation, period):
@@ -332,7 +332,7 @@ class revenu_assimile_salaire_apres_abattements(Variable):
 
 class revenu_activite_salariee(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenu d'activité salariée"
 
     def function(self, simulation, period):
@@ -344,7 +344,7 @@ class revenu_activite_salariee(Variable):
 
 class revenu_activite_non_salariee(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenu d'activité non salariée"
 
     def function(self, simulation, period):
@@ -356,7 +356,7 @@ class revenu_activite_non_salariee(Variable):
 
 class revenu_activite(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenus d'activités"
 
     def function(self, simulation, period):
@@ -370,7 +370,7 @@ class revenu_activite(Variable):
 
 class revenu_assimile_pension(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenu imposé comme des pensions (retraites, pensions alimentaires, etc.)"
 
     def function(self, simulation, period):
@@ -384,7 +384,7 @@ class revenu_assimile_pension(Variable):
 
 class revenu_assimile_pension_apres_abattements(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Pensions après abattements"
 
     def function(self, simulation, period):
@@ -404,7 +404,7 @@ class revenu_assimile_pension_apres_abattements(Variable):
 
 class indu_plaf_abat_pen(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Plafonnement de l'abattement de 10% sur les pensions du foyer"
 
     def function(self, simulation, period):
@@ -422,7 +422,7 @@ class indu_plaf_abat_pen(Variable):
 
 class abattement_salaires_pensions(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Abattement de 20% sur les salaires et pensions, en vigueur jusqu'à 2006"
     stop_date = date(2005, 12, 31)
 
@@ -442,7 +442,7 @@ class retraite_titre_onereux(Variable):
     """
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Rentes viagères (rentes à titre onéreux)"
     set_input = set_input_divide_by_period
     url = u"http://fr.wikipedia.org/wiki/Rente_viagère"
@@ -460,7 +460,7 @@ class retraite_titre_onereux(Variable):
 
 class retraite_titre_onereux_net(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Rentes viagères après abattements"
     url = u"http://www.lafinancepourtous.fr/Vie-professionnelle-et-retraite/Retraite/Epargne-retraite/La-rente-viagere/La-fiscalite-de-la-rente-viagere"  # noqa
 
@@ -477,7 +477,7 @@ class retraite_titre_onereux_net(Variable):
 
 class traitements_salaires_pensions_rentes(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Traitements salaires pensions et rentes individuelles"
 
     def function(individu, period):
@@ -490,14 +490,14 @@ class traitements_salaires_pensions_rentes(Variable):
         # Quand tspr est calculé sur une année glissante, retraite_titre_onereux_net est calculé sur l'année légale
         # correspondante.
         retraite_titre_onereux_net = individu.foyer_fiscal('retraite_titre_onereux_net', period.offset('first-of'))
-        retraite_titre_onereux_net_declarant1 = retraite_titre_onereux_net * individu.has_role(FoyersFiscaux.DECLARANT_PRINCIPAL)
+        retraite_titre_onereux_net_declarant1 = retraite_titre_onereux_net * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         return period, revenu_assimile_salaire_apres_abattements + revenu_assimile_pension_apres_abattements - abattement_salaires_pensions + retraite_titre_onereux_net_declarant1
 
 
 class rev_cat_pv(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenu catégoriel - Plus-values"
     start_date = date(2013, 1, 1)
     url = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
@@ -512,7 +512,7 @@ class rev_cat_pv(Variable):
 
 class rev_cat_tspr(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenu catégoriel - Traitements, salaires, pensions et rentes"
     url = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
 
@@ -528,7 +528,7 @@ class rev_cat_tspr(Variable):
 
 class deficit_rcm(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Deficit capitaux mobiliers"
     start_date = date(2009, 1, 1)
     url = "http://www.lefigaro.fr/impots/2008/04/25/05003-20080425ARTFIG00254-les-subtilites-des-revenus-de-capitaux-mobiliers-.php"
@@ -548,7 +548,7 @@ class deficit_rcm(Variable):
 
 class rev_cat_rvcm(DatedVariable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenu catégoriel - Capitaux"
     url = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
 
@@ -701,7 +701,7 @@ class rev_cat_rvcm(DatedVariable):
 
 class rfr_rvcm(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"rfr_rvcm"
 
     def function(self, simulation, period):
@@ -741,7 +741,7 @@ class rfr_rvcm(Variable):
 
 class rev_cat_rfon(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenu catégoriel - Foncier"
     url = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
 
@@ -775,7 +775,7 @@ class rev_cat_rfon(Variable):
 
 class rev_cat_rpns(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenu catégoriel - Revenus personnels non salariés"
     url = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
 
@@ -801,7 +801,7 @@ class rev_cat_rpns(Variable):
 
 class rev_cat(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus catégoriels"
     url = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
 
@@ -826,7 +826,7 @@ class rev_cat(Variable):
 
 class deficit_ante(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficit global antérieur"
     url = "http://impotsurlerevenu.org/declaration-de-revenus-fonciers-2044/796-deficits-anterieurs-restant-a-imputer-cadre-450.php"
 
@@ -847,7 +847,7 @@ class deficit_ante(Variable):
 
 class rbg(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenu brut global"
     url = "http://www.documentissime.fr/dossiers-droit-pratique/dossier-19-l-impot-sur-le-revenu-les-modalites-generales-d-imposition/la-determination-du-revenu-imposable/le-revenu-brut-global.html"
 
@@ -871,7 +871,7 @@ class rbg(Variable):
 
 class csg_deduc_patrimoine(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Csg déductible sur le patrimoine"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&typePage=cpr02&sfid=503&espId=1&communaute=1&impot=CS"
 
@@ -888,7 +888,7 @@ class csg_deduc_patrimoine(Variable):
 
 class csg_deduc_patrimoine_simulated(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Csg déductible sur le patrimoine simulée"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&typePage=cpr02&sfid=503&espId=1&communaute=1&impot=CS"
 
@@ -909,7 +909,7 @@ class csg_deduc_patrimoine_simulated(Variable):
 
 class csg_deduc(Variable):  # f6de
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Csg déductible sur le patrimoine"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&typePage=cpr02&sfid=503&espId=1&communaute=1&impot=CS"
 
@@ -925,7 +925,7 @@ class csg_deduc(Variable):  # f6de
 
 class rng(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenu net global"
     url = "http://impotsurlerevenu.org/definitions/114-revenu-net-global.php"
 
@@ -941,7 +941,7 @@ class rng(Variable):
 
 class rni(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenu net imposable"
     url = "http://impotsurlerevenu.org/definitions/115-revenu-net-imposable.php"
 
@@ -956,7 +956,7 @@ class rni(Variable):
 
 class ir_brut(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Impôt sur le revenu brut avant non imposabilité et plafonnement du quotient"
 
     def function(self, simulation, period):
@@ -971,7 +971,7 @@ class ir_brut(Variable):
 
 class ir_ss_qf(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Impôt sans quotient familial"
 
     def function(self, simulation, period):
@@ -989,7 +989,7 @@ class ir_ss_qf(Variable):
 
 class ir_plaf_qf(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Impôt après plafonnement du quotient familial et réduction complémentaire"
 
     def function(self, simulation, period):
@@ -1089,7 +1089,7 @@ class ir_plaf_qf(Variable):
 
 class avantage_qf(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Avantage quotient familial"
 
     def function(self, simulation, period):
@@ -1102,7 +1102,7 @@ class avantage_qf(Variable):
 
 class decote(DatedVariable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"décote"
 
     @dated_function(start = date(2015, 1, 1))
@@ -1140,7 +1140,7 @@ class decote(DatedVariable):
 
 class decote_gain_fiscal(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Gain fiscal de la décote/Décote au sens Dgfip tel que sur la feuille d'impôt"
     start_date = date(1982, 1, 1)
 
@@ -1157,7 +1157,7 @@ class decote_gain_fiscal(Variable):
 
 class nat_imp(Variable):
     column = BoolCol(default = False)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"nat_imp"
 
     def function(self, simulation, period):
@@ -1176,7 +1176,7 @@ class nat_imp(Variable):
 
 class ip_net(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Impôt sur le revenu après décote"
 
     def function(self, simulation, period):
@@ -1194,7 +1194,7 @@ class ip_net(Variable):
 
 class iaidrdi(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Impôt après imputation des réductions d'impôt"
 
     def function(self, simulation, period):
@@ -1210,7 +1210,7 @@ class iaidrdi(Variable):
 
 class cont_rev_loc(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Contribution sur les revenus locatifs"
     start_date = date(2001, 1, 1)
 
@@ -1227,7 +1227,7 @@ class cont_rev_loc(Variable):
 
 class teicaa(Variable):  # f5rm
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Taxe exceptionelle sur l'indemnité compensatrice des agents d'assurance"
 
     def function(self, simulation, period):
@@ -1246,7 +1246,7 @@ class teicaa(Variable):  # f5rm
 
 class assiette_vente(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Assiette régime microsociale pour les ventes"
     start_date = date(2009, 1, 1)
 
@@ -1262,7 +1262,7 @@ class assiette_vente(Variable):
 
 class assiette_service(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Assiette régime microsociale pour les prestations et services"
     start_date = date(2009, 1, 1)
 
@@ -1281,7 +1281,7 @@ class assiette_service(Variable):
 
 class assiette_proflib(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Assiette régime microsociale pour les professions libérales"
     start_date = date(2009, 1, 1)
 
@@ -1302,7 +1302,7 @@ class assiette_proflib(Variable):
 
 class microsocial(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Assiette régime microsociale totale"
     start_date = date(2009, 1, 1)
     url = "http://fr.wikipedia.org/wiki/R%C3%A9gime_micro-social"
@@ -1322,7 +1322,7 @@ class microsocial(Variable):
 
 class microentreprise(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"microentreprise"
     start_date = date(2009, 1, 1)
 
@@ -1343,7 +1343,7 @@ class microentreprise(Variable):
 
 class plus_values(DatedVariable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Taxation des plus_values"
 
     @dated_function(start = date(2007, 1, 1), stop = date(2007, 12, 31))
@@ -1518,7 +1518,7 @@ class plus_values(DatedVariable):
 
 class iai(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Impôt avant imputations de l'impôt sur le revenu"
     url = "http://forum-juridique.net-iris.fr/finances-fiscalite-assurance/43963-declaration-impots.html"
 
@@ -1537,7 +1537,7 @@ class iai(Variable):
 
 class cehr(DatedVariable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Contribution exceptionnelle sur les hauts revenus"
     url = "http://www.legifrance.gouv.fr/affichCode.do?cidTexte=LEGITEXT000006069577&idSectionTA=LEGISCTA000025049019"
 
@@ -1558,7 +1558,7 @@ class cehr(DatedVariable):
 
 class irpp(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Impôt sur le revenu des personnes physiques"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_impot_revenu&espId=1&impot=IR&sfid=50"
 
@@ -1585,7 +1585,7 @@ class irpp(Variable):
 
 class foyer_impose(Variable):
     column = BoolCol(default = False)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Le foyer fiscal est imposé"
 
     def function(self, simulation, period):
@@ -1600,7 +1600,7 @@ class foyer_impose(Variable):
 
 class pensions_alimentaires_versees(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Pensions alimentaires versées"
     url = u"http://vosdroits.service-public.fr/particuliers/F2.xhtml"
 
@@ -1618,7 +1618,7 @@ class pensions_alimentaires_versees(Variable):
 
 class rfr(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenu fiscal de référence"
 
     def function(self, simulation, period):
@@ -1648,7 +1648,7 @@ class rfr(Variable):
 
 class glo(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Gain de levée d'options"
     url = "http://www.officeo.fr/imposition-au-bareme-progressif-de-l-impot-sur-le-revenu-des-gains-de-levee-d-options-sur-actions-et-attributions-d-actions-gratuites"
 
@@ -1674,7 +1674,7 @@ class rev_cap_bar(Variable):
     """
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus du capital imposés au barème"
     set_input = set_input_divide_by_period
     url = "http://fr.wikipedia.org/wiki/Revenu#Revenu_du_Capital"
@@ -1713,7 +1713,7 @@ class rev_cap_lib(DatedVariable):
     '''
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenu du capital imposé au prélèvement libératoire"
     set_input = set_input_divide_by_period
     url = "http://fr.wikipedia.org/wiki/Revenu#Revenu_du_Capital"
@@ -1746,7 +1746,7 @@ class rev_cap_lib(DatedVariable):
 
 class avf(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Avoir fiscal et crédits d'impôt"
 
     def function(self, simulation, period):
@@ -1761,7 +1761,7 @@ class avf(Variable):
 
 class imp_lib(DatedVariable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prelèvement libératoire sur les revenus du capital"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&paf_dm=popup&paf_gm=content&typePage=cpr02&sfid=501&espId=1&impot=CS"
 
@@ -1799,7 +1799,7 @@ class imp_lib(DatedVariable):
 
 class fon(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus fonciers"
     url = "http://impotsurlerevenu.org/definitions/220-revenu-foncier.php"
 
@@ -1820,7 +1820,7 @@ class fon(Variable):
 
 class rpns_pvce(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Plus values de cession - Revenu des professions non salariées"
 
     def function(self, simulation, period):
@@ -1856,7 +1856,7 @@ class rpns_pvce(Variable):
 
 class rpns_exon(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Plus values de cession exonérées -Revenu des professions non salariées"
 
     def function(self, simulation, period):
@@ -1907,7 +1907,7 @@ class rpns_exon(Variable):
 
 class defrag(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficit agricole des années antérieures"
 
     def function(self, simulation, period):
@@ -1936,7 +1936,7 @@ class defrag(Variable):
 
 class defacc(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficit industriels et commerciaux non professionnels des années antérieures"
 
     def function(self, simulation, period):
@@ -1971,7 +1971,7 @@ class defacc(Variable):
 
 class defncn(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficit non commerciaux non professionnels des années antérieures"
 
     def function(self, simulation, period):
@@ -2001,7 +2001,7 @@ class defncn(Variable):
 
 class defmeu(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficit des locations meublées non professionnelles des années antérieures"
 
     def function(self, simulation, period):
@@ -2026,7 +2026,7 @@ class defmeu(Variable):
 
 class rag(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenus agricoles"
     url = "http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&impot=BA&pageId=prof_ba&sfid=50"
 
@@ -2063,7 +2063,7 @@ class rag(Variable):
 
 class ric(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Bénéfices industriels et commerciaux"
     url = "http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?pageId=prof_bic&espId=2&impot=BIC&sfid=50"
 
@@ -2128,7 +2128,7 @@ class ric(Variable):
 
 class rac(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenus accessoires individuels"
     url = "http://vosdroits.service-public.fr/particuliers/F1225.xhtml"
 
@@ -2189,7 +2189,7 @@ class rac(Variable):
 
 class rnc(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenus non commerciaux individuels"
     url = "http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&pageId=prof_bnc&impot=BNC&sfid=50"
 
@@ -2230,7 +2230,7 @@ class rnc(Variable):
 
 class rpns(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenus individuels des professions non salariées"
 
     def function(self, simulation, period):
@@ -2245,7 +2245,7 @@ class rpns(Variable):
 
 class rpns_pvct(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Plus values de court terme -Revenu des professions non salariées"
 
     def function(self, simulation, period):
@@ -2270,7 +2270,7 @@ class rpns_pvct(Variable):
 
 class rpns_mvct(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Moins values de court terme - Revenu des professions non salariées"
 
     def function(self, simulation, period):
@@ -2293,7 +2293,7 @@ class rpns_mvct(Variable):
 
 class rpns_mvlt(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Moins values de long terme - Revenu des professions non salariées"
 
     def function(self, simulation, period):
@@ -2316,7 +2316,7 @@ class rpns_mvlt(Variable):
 
 class rpns_individu(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenus des professions non salariées individuels"
 
     def function(self, simulation, period):
@@ -2461,7 +2461,7 @@ class rpns_individu(Variable):
 
 class abat_spe(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Abattements spéciaux"
     url = "http://bofip.impots.gouv.fr/bofip/2036-PGP"
 
@@ -2508,7 +2508,7 @@ class abat_spe(Variable):
 
 class taux_effectif(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"taux_effectif"
     start_date = date(2009, 1, 1)
 
@@ -2531,7 +2531,7 @@ class taux_effectif(Variable):
 
 class taux_moyen_imposition(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Taux moyen d'imposition"
 
     def function(self, simulation, period):
@@ -2550,7 +2550,7 @@ class taux_moyen_imposition(Variable):
 
 class nbptr(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre de parts"
     url = "http://vosdroits.service-public.fr/particuliers/F2705.xhtml"
 
@@ -2662,7 +2662,7 @@ class nbptr(Variable):
 
 class ppe_coef(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Coefficient - Prime pour l'emploi"
 
     def function(self, simulation, period):
@@ -2678,7 +2678,7 @@ class ppe_coef(Variable):
 
 class ppe_elig(Variable):
     column = BoolCol(default = False)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"ppe_elig"
 
     def function(self, simulation, period):
@@ -2703,7 +2703,7 @@ class ppe_elig(Variable):
 
 class ppe_rev(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"ppe_rev"
 
     def function(self, simulation, period):
@@ -2727,7 +2727,7 @@ class ppe_rev(Variable):
 
 class ppe_coef_tp(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"ppe_coef_tp"
 
     def function(self, simulation, period):
@@ -2750,7 +2750,7 @@ class ppe_coef_tp(Variable):
 
 class ppe_base(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"ppe_base"
 
     def function(self, simulation, period):
@@ -2766,7 +2766,7 @@ class ppe_base(Variable):
 
 class ppe_elig_individu(Variable):
     column = BoolCol(default = False)
-    entity = Individus
+    entity = Individu
     label = u"ppe_elig_i"
 
     def function(self, simulation, period):
@@ -2785,7 +2785,7 @@ class ppe_elig_individu(Variable):
 
 class ppe_brute(Variable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prime pour l'emploi brute"
 
     def function(self, simulation, period):
@@ -2893,7 +2893,7 @@ class ppe_brute(Variable):
 
 class ppe(DatedVariable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prime pour l'emploi"
     url = "http://vosdroits.service-public.fr/particuliers/F2882.xhtml"
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -146,8 +146,8 @@ class enfant_a_charge(Variable):
         u" revenus, ou né durant la même année, ou handicapés quel que soit son âge"
 
     def function(individu, period):
-        age = individu['age'](period)
-        handicap = individu['handicap'](period)
+        age = individu('age', period)
+        handicap = individu('handicap', period)
         is_pac = individu.role_in(FoyersFiscaux) == PERSONNE_A_CHARGE
 
         return period, is_pac * ((age < 18) + handicap)
@@ -216,8 +216,8 @@ class enfant_majeur_celibataire_sans_enfant(Variable):
 
     def function(individu, period):
         period = period.this_year
-        age = individu['age'](period)
-        handicap = individu['handicap'](period)
+        age = individu('age', period)
+        handicap = individu('handicap', period)
         is_pac = individu.role_in(FoyersFiscaux) == PERSONNE_A_CHARGE
 
         return period, is_pac * (age >= 18) * not_(handicap)
@@ -230,7 +230,7 @@ class nbJ(Variable):
     column = IntCol
 
     def function(foyer_fiscal, period):
-        enfant_majeur_celibataire_sans_enfant = foyer_fiscal.members['enfant_majeur_celibataire_sans_enfant'](period)
+        enfant_majeur_celibataire_sans_enfant = foyer_fiscal.members('enfant_majeur_celibataire_sans_enfant', period)
         return period, foyer_fiscal.sum(enfant_majeur_celibataire_sans_enfant)
 
 
@@ -240,7 +240,7 @@ class nombre_enfants_majeurs_celibataires_sans_enfant(Variable):
     column = IntCol
 
     def function(menage, period):
-        enfant_majeur_celibataire_sans_enfant = menage.members['enfant_majeur_celibataire_sans_enfant'](period)
+        enfant_majeur_celibataire_sans_enfant = menage.members('enfant_majeur_celibataire_sans_enfant', period)
         return period, menage.sum(enfant_majeur_celibataire_sans_enfant)
 
 
@@ -251,7 +251,7 @@ class maries_ou_pacses(Variable):
 
     def function(foyer_fiscal, period):
         period = period.this_year
-        statut_marital = foyer_fiscal.members['statut_marital'](period)
+        statut_marital = foyer_fiscal.members('statut_marital', period)
         individu_marie_ou_pacse = (statut_marital == 1) | (statut_marital == 5)
 
         return period, foyer_fiscal.value_from_person(individu_marie_ou_pacse, role = DECLARANT)
@@ -264,7 +264,7 @@ class celibataire_ou_divorce(Variable):
 
     def function(foyer_fiscal, period):
         period = period.this_year
-        statut_marital = foyer_fiscal.members['statut_marital'](period)
+        statut_marital = foyer_fiscal.members('statut_marital', period)
         individu_celibataire_ou_divorce = (statut_marital == 2) | (statut_marital == 3)
 
         return period, foyer_fiscal.value_from_person(individu_celibataire_ou_divorce, role = DECLARANT)
@@ -277,7 +277,7 @@ class veuf(Variable):
 
     def function(foyer_fiscal, period):
         period = period.this_year
-        statut_marital = foyer_fiscal.members['statut_marital'](period)
+        statut_marital = foyer_fiscal.members('statut_marital', period)
         individu_veuf = (statut_marital == 4)
 
         return period, foyer_fiscal.value_from_person(individu_veuf, role = DECLARANT)
@@ -290,7 +290,7 @@ class jeune_veuf(Variable):
 
     def function(foyer_fiscal, period):
         period = period.this_year
-        statut_marital = foyer_fiscal.members['statut_marital'](period)
+        statut_marital = foyer_fiscal.members('statut_marital', period)
         individu_jeune_veuf = (statut_marital == 6)
 
         return period, foyer_fiscal.value_from_person(individu_jeune_veuf, role = DECLARANT)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -480,17 +480,17 @@ class traitements_salaires_pensions_rentes(Variable):
     entity_class = Individus
     label = u"Traitements salaires pensions et rentes individuelles"
 
-    def function(self, simulation, period):
+    def function(individu, period):
         period = period.this_year
 
-        revenu_assimile_salaire_apres_abattements = simulation.calculate('revenu_assimile_salaire_apres_abattements', period)
-        revenu_assimile_pension_apres_abattements = simulation.calculate('revenu_assimile_pension_apres_abattements', period)
-        abattement_salaires_pensions = simulation.calculate('abattement_salaires_pensions', period)
+        revenu_assimile_salaire_apres_abattements = individu('revenu_assimile_salaire_apres_abattements', period)
+        revenu_assimile_pension_apres_abattements = individu('revenu_assimile_pension_apres_abattements', period)
+        abattement_salaires_pensions = individu('abattement_salaires_pensions', period)
 
         # Quand tspr est calculé sur une année glissante, retraite_titre_onereux_net est calculé sur l'année légale
         # correspondante.
-        retraite_titre_onereux_net = simulation.calculate('retraite_titre_onereux_net', period.offset('first-of'))
-        retraite_titre_onereux_net_declarant1 = simulation.foyer_fiscal.project_on_first_person(retraite_titre_onereux_net)
+        retraite_titre_onereux_net = individu.foyer_fiscal('retraite_titre_onereux_net', period.offset('first-of'))
+        retraite_titre_onereux_net_declarant1 = retraite_titre_onereux_net * individu.has_role(FoyersFiscaux.DECLARANT_PRINCIPAL)
 
         return period, revenu_assimile_salaire_apres_abattements + revenu_assimile_pension_apres_abattements - abattement_salaires_pensions + retraite_titre_onereux_net_declarant1
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/plus_values_immobilieres.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/plus_values_immobilieres.py
@@ -74,7 +74,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class ir_pv_immo(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Impôt sur le revenu afférent à la plus-value immobilière"
     url = "http://www.impots.gouv.fr/portal/dgi/public/popup?espId=1&typePage=cpr02&docOid=documentstandard_2157"
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/plus_values_immobilieres.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/plus_values_immobilieres.py
@@ -74,7 +74,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class ir_pv_immo(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Impôt sur le revenu afférent à la plus-value immobilière"
     url = "http://www.impots.gouv.fr/portal/dgi/public/popup?espId=1&typePage=cpr02&docOid=documentstandard_2157"
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 class reductions(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"reductions"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -458,7 +458,7 @@ class reductions(DatedVariable):
 
 class adhcga(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"adhcga"
 
     def function(self, simulation, period):
@@ -476,7 +476,7 @@ class adhcga(Variable):
 
 class assvie(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"assvie"
     start_date = date(2002, 1, 1)
     stop_date = date(2004, 12, 31)
@@ -499,7 +499,7 @@ class assvie(Variable):
 
 class cappme(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"cappme"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -668,7 +668,7 @@ class cappme(DatedVariable):
 
 class cotsyn(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"cotsyn"
 
     def function(self, simulation, period):
@@ -704,7 +704,7 @@ class cotsyn(Variable):
 
 class creaen(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"creaen"
 
     @dated_function(start = date(2006, 1, 1), stop = date(2008, 12, 31))
@@ -779,7 +779,7 @@ class creaen(DatedVariable):
 
 class deffor(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"deffor"
     start_date = date(2006, 1, 1)
 
@@ -797,7 +797,7 @@ class deffor(Variable):
 
 class daepad(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"daepad"
 
     def function(self, simulation, period):
@@ -815,7 +815,7 @@ class daepad(Variable):
 
 class dfppce(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"dfppce"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2003, 12, 31))
@@ -1024,7 +1024,7 @@ class dfppce(DatedVariable):
 # Outre-mer : TODO: plafonnement, cf. 2041-GE 2042-IOM
 class doment(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"doment"
 
     @dated_function(start = date(2005, 1, 1), stop = date(2005, 12, 31))
@@ -1329,7 +1329,7 @@ class doment(DatedVariable):
 
 class domlog(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"domlog"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -1536,7 +1536,7 @@ class domlog(DatedVariable):
 
 class domsoc(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"domsoc"
 
     @dated_function(start = date(2010, 1, 1), stop = date(2012, 12, 31))
@@ -1588,7 +1588,7 @@ class domsoc(DatedVariable):
 
 class donapd(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"donapd"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2010, 12, 31))
@@ -1617,7 +1617,7 @@ class donapd(DatedVariable):
 
 class duflot(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"duflot"
     start_date = date(2013, 1, 1)
 
@@ -1638,7 +1638,7 @@ class duflot(Variable):
 
 class ecodev(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"ecodev"
     start_date = date(2009, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -1658,7 +1658,7 @@ class ecodev(Variable):
 
 class ecpess(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"ecpess"
 
     def function(self, simulation, period):
@@ -1681,7 +1681,7 @@ class ecpess(Variable):
 
 class garext(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"garext"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -1730,7 +1730,7 @@ class garext(DatedVariable):
 
 class intagr(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"intagr"
     start_date = date(2005, 1, 1)
 
@@ -1750,7 +1750,7 @@ class intagr(Variable):
 
 class intcon(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"intcon"
     start_date = date(2004, 1, 1)
     stop_date = date(2005, 12, 31)
@@ -1770,7 +1770,7 @@ class intcon(Variable):
 
 class intemp(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"intemp"
     start_date = date(2002, 1, 1)
     stop_date = date(2003, 12, 31)
@@ -1791,7 +1791,7 @@ class intemp(Variable):
 
 class invfor(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"invfor"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2005, 12, 31))
@@ -1952,7 +1952,7 @@ class invfor(DatedVariable):
 
 class invlst(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"invlst"
 
     @dated_function(start = date(2004, 1, 1), stop = date(2004, 12, 31))
@@ -2171,7 +2171,7 @@ class invlst(DatedVariable):
 
 class invrev(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"invrev"
     start_date = date(2002, 1, 1)
     stop_date = date(2003, 12, 31)
@@ -2200,7 +2200,7 @@ class invrev(Variable):
 
 class locmeu(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"locmeu"
 
     @dated_function(start = date(2009, 1, 1), stop = date(2009, 12, 31))
@@ -2357,7 +2357,7 @@ class locmeu(DatedVariable):
 
 class mohist(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"mohist"
     start_date = date(2008, 1, 1)
 
@@ -2375,7 +2375,7 @@ class mohist(Variable):
 
 class patnat(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"patnat"
 
     @dated_function(start = date(2010, 1, 1), stop = date(2010, 12, 31))
@@ -2439,7 +2439,7 @@ class patnat(DatedVariable):
 
 class prcomp(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"prcomp"
 
     def function(self, simulation, period):
@@ -2468,7 +2468,7 @@ class prcomp(Variable):
 
 class reduction_impot_exceptionnelle(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Réduction d'impôt exceptionnelle"
     url = "https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=2342AB1B1727908BFF5295A7F51A5A65.\
         tpdjo13v_1?cidTexte=JORFTEXT000029349482&idArticle=LEGIARTI000029350526&dateTexte=20140809&categorieLien=cid"
@@ -2487,7 +2487,7 @@ class reduction_impot_exceptionnelle(DatedVariable):
 
 class repsoc(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"repsoc"
     start_date = date(2003, 1, 1)
 
@@ -2507,7 +2507,7 @@ class repsoc(Variable):
 
 class resimm(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"resimm"
 
     @dated_function(start = date(2009, 1, 1), stop = date(2010, 12, 31))
@@ -2596,7 +2596,7 @@ class resimm(DatedVariable):
 
 class rsceha(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"rsceha"
 
     def function(self, simulation, period):
@@ -2616,7 +2616,7 @@ class rsceha(Variable):
 
 class saldom(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"saldom"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2004, 12, 31))
@@ -2710,7 +2710,7 @@ class saldom(DatedVariable):
 
 class scelli(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"scelli"
 
     @dated_function(start = date(2009, 1, 1), stop = date(2009, 12, 31))
@@ -3032,7 +3032,7 @@ class scelli(DatedVariable):
 
 class sofica(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"sofica"
     start_date = date(2006, 1, 1)
 
@@ -3054,7 +3054,7 @@ class sofica(Variable):
 
 class sofipe(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"sofipe"
     start_date = date(2009, 1, 1)
     stop_date = date(2011, 1, 1)
@@ -3077,7 +3077,7 @@ class sofipe(Variable):
 
 class spfcpi(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"spfcpi"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 class reductions(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"reductions"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -458,7 +458,7 @@ class reductions(DatedVariable):
 
 class adhcga(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"adhcga"
 
     def function(self, simulation, period):
@@ -476,7 +476,7 @@ class adhcga(Variable):
 
 class assvie(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"assvie"
     start_date = date(2002, 1, 1)
     stop_date = date(2004, 12, 31)
@@ -499,7 +499,7 @@ class assvie(Variable):
 
 class cappme(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"cappme"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -668,7 +668,7 @@ class cappme(DatedVariable):
 
 class cotsyn(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"cotsyn"
 
     def function(self, simulation, period):
@@ -704,7 +704,7 @@ class cotsyn(Variable):
 
 class creaen(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"creaen"
 
     @dated_function(start = date(2006, 1, 1), stop = date(2008, 12, 31))
@@ -779,7 +779,7 @@ class creaen(DatedVariable):
 
 class deffor(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"deffor"
     start_date = date(2006, 1, 1)
 
@@ -797,7 +797,7 @@ class deffor(Variable):
 
 class daepad(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"daepad"
 
     def function(self, simulation, period):
@@ -815,7 +815,7 @@ class daepad(Variable):
 
 class dfppce(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"dfppce"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2003, 12, 31))
@@ -1024,7 +1024,7 @@ class dfppce(DatedVariable):
 # Outre-mer : TODO: plafonnement, cf. 2041-GE 2042-IOM
 class doment(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"doment"
 
     @dated_function(start = date(2005, 1, 1), stop = date(2005, 12, 31))
@@ -1329,7 +1329,7 @@ class doment(DatedVariable):
 
 class domlog(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"domlog"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -1536,7 +1536,7 @@ class domlog(DatedVariable):
 
 class domsoc(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"domsoc"
 
     @dated_function(start = date(2010, 1, 1), stop = date(2012, 12, 31))
@@ -1588,7 +1588,7 @@ class domsoc(DatedVariable):
 
 class donapd(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"donapd"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2010, 12, 31))
@@ -1617,7 +1617,7 @@ class donapd(DatedVariable):
 
 class duflot(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"duflot"
     start_date = date(2013, 1, 1)
 
@@ -1638,7 +1638,7 @@ class duflot(Variable):
 
 class ecodev(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"ecodev"
     start_date = date(2009, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -1658,7 +1658,7 @@ class ecodev(Variable):
 
 class ecpess(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"ecpess"
 
     def function(self, simulation, period):
@@ -1681,7 +1681,7 @@ class ecpess(Variable):
 
 class garext(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"garext"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))
@@ -1730,7 +1730,7 @@ class garext(DatedVariable):
 
 class intagr(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"intagr"
     start_date = date(2005, 1, 1)
 
@@ -1750,7 +1750,7 @@ class intagr(Variable):
 
 class intcon(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"intcon"
     start_date = date(2004, 1, 1)
     stop_date = date(2005, 12, 31)
@@ -1770,7 +1770,7 @@ class intcon(Variable):
 
 class intemp(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"intemp"
     start_date = date(2002, 1, 1)
     stop_date = date(2003, 12, 31)
@@ -1791,7 +1791,7 @@ class intemp(Variable):
 
 class invfor(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"invfor"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2005, 12, 31))
@@ -1952,7 +1952,7 @@ class invfor(DatedVariable):
 
 class invlst(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"invlst"
 
     @dated_function(start = date(2004, 1, 1), stop = date(2004, 12, 31))
@@ -2171,7 +2171,7 @@ class invlst(DatedVariable):
 
 class invrev(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"invrev"
     start_date = date(2002, 1, 1)
     stop_date = date(2003, 12, 31)
@@ -2200,7 +2200,7 @@ class invrev(Variable):
 
 class locmeu(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"locmeu"
 
     @dated_function(start = date(2009, 1, 1), stop = date(2009, 12, 31))
@@ -2357,7 +2357,7 @@ class locmeu(DatedVariable):
 
 class mohist(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"mohist"
     start_date = date(2008, 1, 1)
 
@@ -2375,7 +2375,7 @@ class mohist(Variable):
 
 class patnat(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"patnat"
 
     @dated_function(start = date(2010, 1, 1), stop = date(2010, 12, 31))
@@ -2439,7 +2439,7 @@ class patnat(DatedVariable):
 
 class prcomp(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"prcomp"
 
     def function(self, simulation, period):
@@ -2468,7 +2468,7 @@ class prcomp(Variable):
 
 class reduction_impot_exceptionnelle(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Réduction d'impôt exceptionnelle"
     url = "https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=2342AB1B1727908BFF5295A7F51A5A65.\
         tpdjo13v_1?cidTexte=JORFTEXT000029349482&idArticle=LEGIARTI000029350526&dateTexte=20140809&categorieLien=cid"
@@ -2487,7 +2487,7 @@ class reduction_impot_exceptionnelle(DatedVariable):
 
 class repsoc(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"repsoc"
     start_date = date(2003, 1, 1)
 
@@ -2507,7 +2507,7 @@ class repsoc(Variable):
 
 class resimm(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"resimm"
 
     @dated_function(start = date(2009, 1, 1), stop = date(2010, 12, 31))
@@ -2596,7 +2596,7 @@ class resimm(DatedVariable):
 
 class rsceha(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"rsceha"
 
     def function(self, simulation, period):
@@ -2616,7 +2616,7 @@ class rsceha(Variable):
 
 class saldom(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"saldom"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2004, 12, 31))
@@ -2710,7 +2710,7 @@ class saldom(DatedVariable):
 
 class scelli(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"scelli"
 
     @dated_function(start = date(2009, 1, 1), stop = date(2009, 12, 31))
@@ -3032,7 +3032,7 @@ class scelli(DatedVariable):
 
 class sofica(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"sofica"
     start_date = date(2006, 1, 1)
 
@@ -3054,7 +3054,7 @@ class sofica(Variable):
 
 class sofipe(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"sofipe"
     start_date = date(2009, 1, 1)
     stop_date = date(2011, 1, 1)
@@ -3077,7 +3077,7 @@ class sofipe(Variable):
 
 class spfcpi(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"spfcpi"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2002, 12, 31))

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -7,7 +7,7 @@ from openfisca_france.model.base import *  # noqa
 class f7ud(Variable):
     cerfa_field = u"7UD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dons à des organismes d'aide aux personnes en difficulté"
 
 
@@ -15,7 +15,7 @@ class f7ud(Variable):
 class f7uf(Variable):
     cerfa_field = u"7UF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dons à d'autres oeuvres d'utilité publique ou fiscalement assimilables aux oeuvres d'intérêt général"
 
  # début/fin ?
@@ -23,7 +23,7 @@ class f7uf(Variable):
 class f7xs(Variable):
     cerfa_field = u"7XS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -5"
 
 
@@ -31,7 +31,7 @@ class f7xs(Variable):
 class f7xt(Variable):
     cerfa_field = u"7XT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -4"
 
 
@@ -39,7 +39,7 @@ class f7xt(Variable):
 class f7xu(Variable):
     cerfa_field = u"7XU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -3"
     start_date = date(2006, 1, 1)
 
@@ -48,7 +48,7 @@ class f7xu(Variable):
 class f7xw(Variable):
     cerfa_field = u"7XW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -2"
     start_date = date(2007, 1, 1)
 
@@ -57,7 +57,7 @@ class f7xw(Variable):
 class f7xy(Variable):
     cerfa_field = u"7XY"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -1"
     start_date = date(2008, 1, 1)
 
@@ -66,7 +66,7 @@ class f7xy(Variable):
 class f7va(Variable):
     cerfa_field = u"7VA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dons à des organismes d'aides aux personnes établis dans un Etat européen"
     start_date = date(2011, 1, 1)
 
@@ -75,7 +75,7 @@ class f7va(Variable):
 class f7vc(Variable):
     cerfa_field = u"7VC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dons à des autres organismes établis dans un Etat européen"
     start_date = date(2011, 1, 1)
 
@@ -88,7 +88,7 @@ class f7ac(Variable):
         QUIFOY['pac1']: u"7AG",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisations syndicales des salariées et pensionnés"
     start_date = date(2013, 1, 1)
 
@@ -98,7 +98,7 @@ class f7ac(Variable):
 class f7db(Variable):
     cerfa_field = u"7DB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Sommes versées pour l'emploi d'un salarié à domicile par les personnes ayant excercé une activité professionnelle ou ayant été demandeur d'emploi l'année de perception des revenus déclarés"
     start_date = date(2007, 1, 1)
 
@@ -107,7 +107,7 @@ class f7db(Variable):
 class f7df(Variable):
     cerfa_field = u"7DF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Sommes versées pour l'emploi d'un salarié à domicile par les personnes retraités, ou inactives l'année de perception des revenus déclarés"
 
 
@@ -115,7 +115,7 @@ class f7df(Variable):
 class f7dq(Variable):
     cerfa_field = u"7DQ"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Emploi direct pour la première fois d'un salarié à domicile durant l'année de perception des revenus déclarés"
     start_date = date(2009, 1, 1)
 
@@ -124,7 +124,7 @@ class f7dq(Variable):
 class f7dg(Variable):
     cerfa_field = u"7DG"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Vous, votre conjoint ou une personne à votre charge à une carte d'invalidité d'au moins 80 % l'année de perception des revenus déclarés"
 
 
@@ -132,7 +132,7 @@ class f7dg(Variable):
 class f7dl(Variable):
     cerfa_field = u"7DL"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre d'ascendants bénéficiaires de l'APA, âgés de plus de 65 ans, pour lesquels des dépenses ont été engagées l'année de perception des revenus déclarés"
 
 
@@ -141,7 +141,7 @@ class f7dl(Variable):
 class f7uh_2007(Variable):
     cerfa_field = u"7UH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Intérêts payés la première année de remboursement du prêt pour l'habitation principale"
     start_date = date(2007, 1, 1)
     stop_date = date(2007, 12, 31)
@@ -151,7 +151,7 @@ class f7uh_2007(Variable):
 class f7vy(Variable):
     cerfa_field = u"7VY"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements anciens (acquis entre le 06/05/2007 et le 30/09/2011) ou neufs (acquis entre le 06/05/2007 et le 31/12/2009): Première annuité"
     start_date = date(2008, 1, 1)
 
@@ -160,7 +160,7 @@ class f7vy(Variable):
 class f7vz(Variable):
     cerfa_field = u"7VZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements anciens (acquis entre le 06/05/2007 et le 30/09/2011) ou neufs (acquis entre le 06/05/2007 et le 31/12/2009): annuités suivantes"
     start_date = date(2008, 1, 1)
 
@@ -169,7 +169,7 @@ class f7vz(Variable):
 class f7vx(Variable):
     cerfa_field = u"7VX"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs BBC acquis ou construits du 01/01/2009 au 30/09/2011"
 
 
@@ -177,7 +177,7 @@ class f7vx(Variable):
 class f7vw(Variable):
     cerfa_field = u"7VW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2010 au 31/12/2010: première annuité"
     start_date = date(2010, 1, 1)
 
@@ -186,7 +186,7 @@ class f7vw(Variable):
 class f7vv(Variable):
     cerfa_field = u"7VV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2010 au 31/12/2010: annuités suivantes"
     start_date = date(2011, 1, 1)
 
@@ -195,7 +195,7 @@ class f7vv(Variable):
 class f7vu(Variable):
     cerfa_field = u"7VU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2011 au 30/09/2011: première annuité"
     start_date = date(2011, 1, 1)
 
@@ -204,7 +204,7 @@ class f7vu(Variable):
 class f7vt(Variable):
     cerfa_field = u"7VT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2011 au 30/09/2011: annuités suivantes"
     start_date = date(2012, 1, 1)
 
@@ -214,7 +214,7 @@ class f7vt(Variable):
 class f7cd(Variable):
     cerfa_field = u"7CD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses d'accueil dans un établissement pour personnes âgées dépendantes: 1ere personne"
 
 
@@ -222,7 +222,7 @@ class f7cd(Variable):
 class f7ce(Variable):
     cerfa_field = u"7CE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses d'accueil dans un établissement pour personnes âgées dépendantes: 2éme personne"
 
 
@@ -231,7 +231,7 @@ class f7ce(Variable):
 class f7ga(Variable):
     cerfa_field = u"7GA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 1er enfant à charge"
 
 
@@ -239,7 +239,7 @@ class f7ga(Variable):
 class f7gb(Variable):
     cerfa_field = u"7GB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 2ème enfant à charge"
 
 
@@ -247,7 +247,7 @@ class f7gb(Variable):
 class f7gc(Variable):
     cerfa_field = u"7GC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 3ème enfant à charge"
 
 
@@ -255,7 +255,7 @@ class f7gc(Variable):
 class f7ge(Variable):
     cerfa_field = u"7GE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 1er enfant à charge en résidence alternée"
 
 
@@ -263,7 +263,7 @@ class f7ge(Variable):
 class f7gf(Variable):
     cerfa_field = u"7GF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 2ème enfant à charge en résidence alternée"
 
 
@@ -271,7 +271,7 @@ class f7gf(Variable):
 class f7gg(Variable):
     cerfa_field = u"7GG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 3ème enfant à charge en résidence alternée"
 
 
@@ -280,7 +280,7 @@ class f7gg(Variable):
 class f7ea(Variable):
     cerfa_field = u"7EA"
     column = PeriodSizeIndependentIntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre d'enfants à charge poursuivant leurs études au collège"
 
 
@@ -288,7 +288,7 @@ class f7ea(Variable):
 class f7eb(Variable):
     cerfa_field = u"7EB"
     column = PeriodSizeIndependentIntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre d'enfants à charge en résidence alternée poursuivant leurs études au collège"
 
 
@@ -296,7 +296,7 @@ class f7eb(Variable):
 class f7ec(Variable):
     cerfa_field = u"7EC"
     column = PeriodSizeIndependentIntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre d'enfants à charge poursuivant leurs études au lycée"
 
 
@@ -304,7 +304,7 @@ class f7ec(Variable):
 class f7ed(Variable):
     cerfa_field = u"7ED"
     column = PeriodSizeIndependentIntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre d'enfants à charge en résidence alternée poursuivant leurs études au lycée"
 
 
@@ -312,7 +312,7 @@ class f7ed(Variable):
 class f7ef(Variable):
     cerfa_field = u"7EF"
     column = PeriodSizeIndependentIntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre d'enfants à charge poursuivant leurs études dans l'enseignement supérieur"
 
 
@@ -320,7 +320,7 @@ class f7ef(Variable):
 class f7eg(Variable):
     cerfa_field = u"7EG"
     column = PeriodSizeIndependentIntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre d'enfants à charge en résidence alternée poursuivant leurs études dans l'enseignement supérieur"
 
 
@@ -329,7 +329,7 @@ class f7eg(Variable):
 class f7td(Variable):
     cerfa_field = u"7TD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Intérêts des prêts étudiants versés avant l'année de perception des revenus déclarés"
     start_date = date(2008, 1, 1)
 
@@ -338,7 +338,7 @@ class f7td(Variable):
 class f7vo(Variable):
     cerfa_field = u"7VO"
     column = PeriodSizeIndependentIntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Nombre d'années de remboursement du prêt étudiant avant l'année de perception des revenus déclarés"
     start_date = date(2006, 1, 1)
 
@@ -347,7 +347,7 @@ class f7vo(Variable):
 class f7uk(Variable):
     cerfa_field = u"7UK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Intérêts des prêts étudiants versés durant l'année de perception des revenus déclarés"
 
 
@@ -356,7 +356,7 @@ class f7uk(Variable):
 class f7gz(Variable):
     cerfa_field = u"7GZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Primes de rente survie, contrats d'épargne handicap"
 
 
@@ -365,7 +365,7 @@ class f7gz(Variable):
 class f7wm(Variable):
     cerfa_field = u"7WM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prestations compensatoires: Capital fixé en substitution de rente"
 
 
@@ -373,7 +373,7 @@ class f7wm(Variable):
 class f7wn(Variable):
     cerfa_field = u"7WN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prestations compensatoires: Sommes versées l'année de perception des revenus déclarés"
 
 
@@ -381,7 +381,7 @@ class f7wn(Variable):
 class f7wo(Variable):
     cerfa_field = u"7WO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prestations compensatoires: Sommes totales décidées par jugement l'année de perception des revenus déclarés ou capital reconstitué"
 
 
@@ -389,7 +389,7 @@ class f7wo(Variable):
 class f7wp(Variable):
     cerfa_field = u"7WP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prestations compensatoires: Report des sommes décidées l'année de perception des revenus -1"
 
 
@@ -398,7 +398,7 @@ class f7wp(Variable):
 class f7we(Variable):
     cerfa_field = u"7WE"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: éco-prêt à taux zéro avec offre de prêt émise l'année de perception des revenus déclarés"
     start_date = date(2009, 1, 1)
 
@@ -407,7 +407,7 @@ class f7we(Variable):
 class f7wg(Variable):
     cerfa_field = u"7WG"
     column = BoolCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: éco-prêt à taux zéro avec offre de prêt émise l'année de perception des revenus déclarés -1"
     start_date = date(2012, 1, 1)
 
@@ -416,7 +416,7 @@ class f7wg(Variable):
 class f7wa(Variable):
     cerfa_field = u"7WA"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique des murs avant le 03/04/2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -426,7 +426,7 @@ class f7wa(Variable):
 class f7wb(Variable):
     cerfa_field = u"7WB"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique des murs à compter du 04/04/2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -436,7 +436,7 @@ class f7wb(Variable):
 class f7wc(Variable):
     cerfa_field = u"7WC"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique sur plus de la moitié de la surface des murs extérieurs"
     start_date = date(2012, 1, 1)
 
@@ -445,7 +445,7 @@ class f7wc(Variable):
 class f7ve(Variable):
     cerfa_field = u"7VE"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de la toiture avant le 04/04/2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -455,7 +455,7 @@ class f7ve(Variable):
 class f7vf(Variable):
     cerfa_field = u"7VF"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de la toiture à compter du 04/04/2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -465,7 +465,7 @@ class f7vf(Variable):
 class f7vg(Variable):
     cerfa_field = u"7VG"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de toute la toiture"
     start_date = date(2012, 1, 1)
 
@@ -474,7 +474,7 @@ class f7vg(Variable):
 class f7sg(Variable):
     cerfa_field = u"7SG"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Matériaux d'isolation thermique des murs (acquisitionn et pose)"
     start_date = date(2012, 1, 1)
 
@@ -483,7 +483,7 @@ class f7sg(Variable):
 class f7sj(Variable):
     cerfa_field = u"7SJ"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Matériaux d'isolation thermique des parois vitrées"
     start_date = date(2012, 1, 1)
 
@@ -492,7 +492,7 @@ class f7sj(Variable):
 class f7sk(Variable):
     cerfa_field = u"7SK"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Volets isolants"
     start_date = date(2012, 1, 1)
 
@@ -501,7 +501,7 @@ class f7sk(Variable):
 class f7sl(Variable):
     cerfa_field = u"7SL"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Portes d'entrées donnant sur l'extérieur"
     start_date = date(2012, 1, 1)
 
@@ -510,7 +510,7 @@ class f7sl(Variable):
 class f7sm(Variable):
     cerfa_field = u"7SM"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de production d'électricité utilisant l'énergie radiative du soleil"
     start_date = date(2012, 1, 1)
 
@@ -519,7 +519,7 @@ class f7sm(Variable):
 class f7sn(Variable):
     cerfa_field = u"7SN"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Appareils de chauffage au bois ou autres biomasses remplaçant un appareil équivalent"
     start_date = date(2012, 1, 1)
 
@@ -528,7 +528,7 @@ class f7sn(Variable):
 class f7so(Variable):
     cerfa_field = u"7SO"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Appareils de chauffage au bois ou autres biomasses ne remplaçant pas un appareil équivalent"
     start_date = date(2012, 1, 1)
 
@@ -537,7 +537,7 @@ class f7so(Variable):
 class f7sp(Variable):
     cerfa_field = u"7SP"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Pompes à chaleur autres que air/air et autres que géothermiques dont la finalité essentielle est la production de chaleur"
     start_date = date(2012, 1, 1)
 
@@ -546,7 +546,7 @@ class f7sp(Variable):
 class f7sq(Variable):
     cerfa_field = u"7SQ"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Pompes à chaleur géothermiques dont la finalité essentielle est la production de chaleur"
     start_date = date(2012, 1, 1)
 
@@ -555,7 +555,7 @@ class f7sq(Variable):
 class f7sr(Variable):
     cerfa_field = u"7SR"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Pompes à chaleur (autres que air/air) dédiées à la production d'eau chaude sanitaire (chauffe-eaux thermodynamiques)"
     start_date = date(2012, 1, 1)
 
@@ -564,7 +564,7 @@ class f7sr(Variable):
 class f7ss(Variable):
     cerfa_field = u"7SS"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de fourniture d'eau chaude sanitaire fonctionnant à l'énergie solaire et dotés de capteurs solaires"
     start_date = date(2012, 1, 1)
 
@@ -573,7 +573,7 @@ class f7ss(Variable):
 class f7st(Variable):
     cerfa_field = u"7ST"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Autres équipements de production d'énergie utilisant une source d'énergie renouvelable (éolien, hydraulique)"
     start_date = date(2012, 1, 1)
 
@@ -582,7 +582,7 @@ class f7st(Variable):
 class f7su(Variable):
     cerfa_field = u"7SU"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de récupération et de traitement des eaux pluviales"
     start_date = date(2012, 1, 1)
 
@@ -591,7 +591,7 @@ class f7su(Variable):
 class f7sv(Variable):
     cerfa_field = u"7SV"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Diagnostic de performance énergétique"
     start_date = date(2012, 1, 1)
 
@@ -600,7 +600,7 @@ class f7sv(Variable):
 class f7sw(Variable):
     cerfa_field = u"7SW"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de raccordement à un réseau de chaleur"
     start_date = date(2012, 1, 1)
 
@@ -615,7 +615,7 @@ class f7sw(Variable):
 class f7wq(Variable):
     cerfa_field = u"7WQ"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolation thermique des parois vitrées du 01/01/2012 au 03/04/2012"
     start_date = date(2010, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -625,7 +625,7 @@ class f7wq(Variable):
 class f7ws(Variable):
     cerfa_field = u"7WS"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolations des parois vitrées à compter du 04/04/2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -635,7 +635,7 @@ class f7ws(Variable):
 class f7wt(Variable):
     cerfa_field = u"7WT"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolation thermique des parois vitrées réalisées sur au moins la moitié des fenêtres du logement "
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -645,7 +645,7 @@ class f7wt(Variable):
 class f7wu(Variable):
     cerfa_field = u"7WU"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de volets avant 2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -655,7 +655,7 @@ class f7wu(Variable):
 class f7wv(Variable):
     cerfa_field = u"7WV"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de volets en 2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -665,7 +665,7 @@ class f7wv(Variable):
 class f7ww(Variable):
     cerfa_field = u"7WW"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de portes avant 2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -675,7 +675,7 @@ class f7ww(Variable):
 class f7wx(Variable):
     cerfa_field = u"7WX"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de portes en 2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -685,7 +685,7 @@ class f7wx(Variable):
 class f7wh(Variable):
     cerfa_field = u"7WH"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (logement achevé depuis plus de 2 ans): bouquet de travaux réalisé pendant l'année de perception des revenus"
     start_date = date(2013, 1, 1)
 
@@ -694,7 +694,7 @@ class f7wh(Variable):
 class f7wk(Variable):
     cerfa_field = u"7WK"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Votre habitation principale est une maison individuelle"
     start_date = date(2009, 1, 1)
 
@@ -703,7 +703,7 @@ class f7wk(Variable):
 class f7wf(Variable):
     cerfa_field = u"7WF"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolation thermique des parois vitrées avant le 01/01/n-1"
     stop_date = date(2013, 12, 31)
 
@@ -713,7 +713,7 @@ class f7wf(Variable):
 class f7wi(Variable):
     cerfa_field = u"7WI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: Ascenseurs électriques à traction"
     stop_date = date(2012, 12, 31)
 
@@ -722,7 +722,7 @@ class f7wi(Variable):
 class f7wj(Variable):
     cerfa_field = u"7WJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: équipements spécialement conçus pour les personnes âgées ou handicapées"
 
 
@@ -730,7 +730,7 @@ class f7wj(Variable):
 class f7wl(Variable):
     cerfa_field = u"7WL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: travaux de prévention des risques technologiques"
     start_date = date(2010, 1, 1)
 
@@ -739,7 +739,7 @@ class f7wl(Variable):
 class f7wr(Variable):
     cerfa_field = u"7WR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de l'aide aux personnes réalisées dans des habitations données en location : travaux de prévention des risques technologiques"
     start_date = date(2013, 1, 1)
 
@@ -749,7 +749,7 @@ class f7wr(Variable):
 class f7ur(Variable):
     cerfa_field = u"7UR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements réalisés en n-1, total réduction d’impôt"
     stop_date = date(2008, 12, 31)
 
@@ -758,7 +758,7 @@ class f7ur(Variable):
 class f7oz(Variable):
     cerfa_field = u"7OZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer: report de réduction d'impôt non imputée les années antérieures année n-6"
     stop_date = date(2011, 12, 31)
 
@@ -767,7 +767,7 @@ class f7oz(Variable):
 class f7pz(Variable):
     cerfa_field = u"7PZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer réalisés en 2007 dans le cadre d'une entreprise: report de réduction d'impôt non imputée les années antérieures"
     stop_date = date(2013, 12, 31)
 
@@ -776,7 +776,7 @@ class f7pz(Variable):
 class f7qz(Variable):
     cerfa_field = u"7QZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer réalisés en 2008 dans le casdre d'une entreprise: report de réduction d'impôt non imputée les années antérieures"
     stop_date = date(2012, 12, 31)
 
@@ -785,7 +785,7 @@ class f7qz(Variable):
 class f7rz(Variable):
     cerfa_field = u"7RZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer: report de réduction d'impôt non imputée les années antérieures année n-3"
     stop_date = date(2010, 12, 31)
 
@@ -794,7 +794,7 @@ class f7rz(Variable):
 class f7qv(Variable):
     cerfa_field = u"7QV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010, nvestissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
     stop_date = date(2011, 12, 31)
 
@@ -803,7 +803,7 @@ class f7qv(Variable):
 class f7qo(Variable):
     cerfa_field = u"7QO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010 à hauteur de 50%"
     stop_date = date(2009, 12, 31)
 
@@ -812,7 +812,7 @@ class f7qo(Variable):
 class f7qp(Variable):
     cerfa_field = u"7QP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010 à hauteur de 60%"
     stop_date = date(2009, 12, 31)
 
@@ -821,7 +821,7 @@ class f7qp(Variable):
 class f7pa(Variable):
     cerfa_field = u"7PA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
     stop_date = date(2011, 12, 31)
 
@@ -830,7 +830,7 @@ class f7pa(Variable):
 class f7pb(Variable):
     cerfa_field = u"7PB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
     stop_date = date(2011, 12, 31)
 
@@ -839,7 +839,7 @@ class f7pb(Variable):
 class f7pc(Variable):
     cerfa_field = u"7PC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
     stop_date = date(2011, 12, 31)
 
@@ -848,7 +848,7 @@ class f7pc(Variable):
 class f7pd(Variable):
     cerfa_field = u"7PD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
     stop_date = date(2011, 12, 31)
 
@@ -857,7 +857,7 @@ class f7pd(Variable):
 class f7qe(Variable):
     cerfa_field = u"7QE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet avant 1.1.2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
     stop_date = date(2009, 12, 31)
 
@@ -866,7 +866,7 @@ class f7qe(Variable):
 class f7pe(Variable):
     cerfa_field = u"7PE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
     stop_date = date(2011, 12, 31)
 
@@ -875,7 +875,7 @@ class f7pe(Variable):
 class f7pf(Variable):
     cerfa_field = u"7PF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
     stop_date = date(2011, 12, 31)
 
@@ -884,7 +884,7 @@ class f7pf(Variable):
 class f7pg(Variable):
     cerfa_field = u"7PG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
     stop_date = date(2011, 12, 31)
 
@@ -893,7 +893,7 @@ class f7pg(Variable):
 class f7ph(Variable):
     cerfa_field = u"7PH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
     stop_date = date(2011, 12, 31)
 
@@ -902,7 +902,7 @@ class f7ph(Variable):
 class f7pi(Variable):
     cerfa_field = u"7PI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
     stop_date = date(2011, 12, 31)
 
@@ -911,7 +911,7 @@ class f7pi(Variable):
 class f7pj(Variable):
     cerfa_field = u"7PJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
     stop_date = date(2011, 12, 31)
 
@@ -920,7 +920,7 @@ class f7pj(Variable):
 class f7pk(Variable):
     cerfa_field = u"7PK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
     stop_date = date(2011, 12, 31)
 
@@ -929,7 +929,7 @@ class f7pk(Variable):
 class f7pl(Variable):
     cerfa_field = u"7PL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
     stop_date = date(2011, 12, 31)
 
@@ -938,7 +938,7 @@ class f7pl(Variable):
 class f7pm(Variable):
     cerfa_field = u"7PM"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%"
     stop_date = date(2013, 12, 31)
 
@@ -947,7 +947,7 @@ class f7pm(Variable):
 class f7pn(Variable):
     cerfa_field = u"7PN"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50 %"
     stop_date = date(2013, 12, 31)
 
@@ -956,7 +956,7 @@ class f7pn(Variable):
 class f7po(Variable):
     cerfa_field = u"7PO"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60 %"
     stop_date = date(2013, 12, 31)
 
@@ -965,7 +965,7 @@ class f7po(Variable):
 class f7pp(Variable):
     cerfa_field = u"7PP"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
     stop_date = date(2013, 12, 31)
 
@@ -974,7 +974,7 @@ class f7pp(Variable):
 class f7pq(Variable):
     cerfa_field = u"7PQ"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     stop_date = date(2013, 12, 31)
 
@@ -983,7 +983,7 @@ class f7pq(Variable):
 class f7pr(Variable):
     cerfa_field = u"7PR"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     stop_date = date(2013, 12, 31)
 
@@ -992,7 +992,7 @@ class f7pr(Variable):
 class f7ps(Variable):
     cerfa_field = u"7PS"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50 %"
     stop_date = date(2013, 12, 31)
 
@@ -1001,7 +1001,7 @@ class f7ps(Variable):
 class f7pt(Variable):
     cerfa_field = u"7PT"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60 %"
     stop_date = date(2013, 12, 31)
 
@@ -1010,7 +1010,7 @@ class f7pt(Variable):
 class f7pu(Variable):
     cerfa_field = u"7PU"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
     stop_date = date(2013, 12, 31)
 
@@ -1019,7 +1019,7 @@ class f7pu(Variable):
 class f7pv(Variable):
     cerfa_field = u"7PV"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     stop_date = date(2013, 12, 31)
 
@@ -1028,7 +1028,7 @@ class f7pv(Variable):
 class f7pw(Variable):
     cerfa_field = u"7PW"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     stop_date = date(2013, 12, 31)
 
@@ -1037,7 +1037,7 @@ class f7pw(Variable):
 class f7px(Variable):
     cerfa_field = u"7PX"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt  à hauteur de 52,63 %"
     stop_date = date(2013, 12, 31)
 
@@ -1046,7 +1046,7 @@ class f7px(Variable):
 class f7py(Variable):
     cerfa_field = u"7PY"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     start_date = date(2012, 1, 1)
 
@@ -1055,7 +1055,7 @@ class f7py(Variable):
 class f7rg(Variable):
     cerfa_field = u"7RG"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
     start_date = date(2012, 1, 1)
 
@@ -1064,7 +1064,7 @@ class f7rg(Variable):
 class f7rh(Variable):
     cerfa_field = u"7RH"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     start_date = date(2012, 1, 1)
 
@@ -1073,7 +1073,7 @@ class f7rh(Variable):
 class f7ri(Variable):
     cerfa_field = u"7RI"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     start_date = date(2012, 1, 1)
 
@@ -1082,7 +1082,7 @@ class f7ri(Variable):
 class f7rj(Variable):
     cerfa_field = u"7RJ"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %"
     start_date = date(2012, 1, 1)
 
@@ -1091,7 +1091,7 @@ class f7rj(Variable):
 class f7rk(Variable):
     cerfa_field = u"7RK"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     start_date = date(2012, 1, 1)
 
@@ -1100,7 +1100,7 @@ class f7rk(Variable):
 class f7rl(Variable):
     cerfa_field = u"7RL"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     start_date = date(2012, 1, 1)
 
@@ -1109,7 +1109,7 @@ class f7rl(Variable):
 class f7rm(Variable):
     cerfa_field = u"7RM"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
     start_date = date(2012, 1, 1)
 
@@ -1118,7 +1118,7 @@ class f7rm(Variable):
 class f7rn(Variable):
     cerfa_field = u"7RN"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     start_date = date(2012, 1, 1)
 
@@ -1127,7 +1127,7 @@ class f7rn(Variable):
 class f7ro(Variable):
     cerfa_field = u"7RO"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     start_date = date(2012, 1, 1)
 
@@ -1136,7 +1136,7 @@ class f7ro(Variable):
 class f7rp(Variable):
     cerfa_field = u"7RP"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     start_date = date(2012, 1, 1)
 
@@ -1145,7 +1145,7 @@ class f7rp(Variable):
 class f7rq(Variable):
     cerfa_field = u"7RQ"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     start_date = date(2012, 1, 1)
 
@@ -1154,7 +1154,7 @@ class f7rq(Variable):
 class f7rr(Variable):
     cerfa_field = u"7RR"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
     start_date = date(2012, 1, 1)
 
@@ -1163,7 +1163,7 @@ class f7rr(Variable):
 class f7rs(Variable):
     cerfa_field = u"7RS"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     start_date = date(2012, 1, 1)
 
@@ -1172,7 +1172,7 @@ class f7rs(Variable):
 class f7rt(Variable):
     cerfa_field = u"7RT"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     start_date = date(2012, 1, 1)
 
@@ -1181,7 +1181,7 @@ class f7rt(Variable):
 class f7ru(Variable):
     cerfa_field = u"7RU"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     start_date = date(2012, 1, 1)
 
@@ -1190,7 +1190,7 @@ class f7ru(Variable):
 class f7rv(Variable):
     cerfa_field = u"7RV"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     start_date = date(2012, 1, 1)
 
@@ -1199,7 +1199,7 @@ class f7rv(Variable):
 class f7rw(Variable):
     cerfa_field = u"7RW"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
     start_date = date(2012, 1, 1)
 
@@ -1208,7 +1208,7 @@ class f7rw(Variable):
 class f7rx(Variable):
     cerfa_field = u"7RX"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     start_date = date(2012, 1, 1)
 
@@ -1217,7 +1217,7 @@ class f7rx(Variable):
 class f7ry(Variable):
     cerfa_field = u"7RY"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     start_date = date(2012, 1, 1)
 
@@ -1226,7 +1226,7 @@ class f7ry(Variable):
 class f7nu(Variable):
     cerfa_field = u"7NU"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     start_date = date(2012, 1, 1)
 
@@ -1235,7 +1235,7 @@ class f7nu(Variable):
 class f7nv(Variable):
     cerfa_field = u"7NV"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     start_date = date(2012, 1, 1)
 
@@ -1244,7 +1244,7 @@ class f7nv(Variable):
 class f7nw(Variable):
     cerfa_field = u"7NW"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise"
     start_date = date(2012, 1, 1)
 
@@ -1253,7 +1253,7 @@ class f7nw(Variable):
 class f7nx(Variable):
     cerfa_field = u"7NX"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     start_date = date(2012, 1, 1)
 
@@ -1262,7 +1262,7 @@ class f7nx(Variable):
 class f7ny(Variable):
     cerfa_field = u"7NY"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     start_date = date(2012, 1, 1)
 
@@ -1271,7 +1271,7 @@ class f7ny(Variable):
 class f7mn(Variable):
     cerfa_field = u"7MN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
     start_date = date(2011, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1281,7 +1281,7 @@ class f7mn(Variable):
 class f7lh(Variable):
     cerfa_field = u"7LH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
     stop_date = date(2011, 12, 31)
 
@@ -1290,7 +1290,7 @@ class f7lh(Variable):
 class f7mb(Variable):
     cerfa_field = u"7MB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60%"
     start_date = date(2011, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1300,7 +1300,7 @@ class f7mb(Variable):
 class f7kt(Variable):
     cerfa_field = u"7KT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt, Investissements dans votre entreprise"
     start_date = date(2011, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1310,7 +1310,7 @@ class f7kt(Variable):
 class f7li(Variable):
     cerfa_field = u"7LI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Autres investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
     start_date = date(2011, 1, 1)
 
@@ -1319,7 +1319,7 @@ class f7li(Variable):
 class f7mc(Variable):
     cerfa_field = u"7MC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Autres investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60%"
     start_date = date(2011, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1329,7 +1329,7 @@ class f7mc(Variable):
 class f7ku(Variable):
     cerfa_field = u"7KU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements dans votre entreprise"
     start_date = date(2011, 1, 1)
     stop_date = date(2011, 12, 31)
@@ -1341,7 +1341,7 @@ class f7ku(Variable):
 class f7sz(Variable):
     cerfa_field = u"7SZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location"
     start_date = date(2006, 1, 1)
 
@@ -1350,7 +1350,7 @@ class f7sz(Variable):
 class fhsa(Variable):
     cerfa_field = u"HSA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 52,63%"
     start_date = date(2013, 1, 1)
 
@@ -1359,7 +1359,7 @@ class fhsa(Variable):
 class fhsb(Variable):
     cerfa_field = u"HSB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 62,5%"
     start_date = date(2013, 1, 1)
 
@@ -1368,7 +1368,7 @@ class fhsb(Variable):
 class fhsf(Variable):
     cerfa_field = u"HSF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 52,63%"
     start_date = date(2013, 1, 1)
 
@@ -1377,7 +1377,7 @@ class fhsf(Variable):
 class fhsg(Variable):
     cerfa_field = u"HSG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 62,5%"
     start_date = date(2013, 1, 1)
 
@@ -1386,7 +1386,7 @@ class fhsg(Variable):
 class fhsc(Variable):
     cerfa_field = u"HSC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise en 2010"
     start_date = date(2013, 1, 1)
 
@@ -1395,7 +1395,7 @@ class fhsc(Variable):
 class fhsh(Variable):
     cerfa_field = u"HSH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise en 2011"
     start_date = date(2013, 1, 1)
 
@@ -1404,7 +1404,7 @@ class fhsh(Variable):
 class fhsd(Variable):
     cerfa_field = u"HSD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2010"
     start_date = date(2013, 1, 1)
 
@@ -1413,7 +1413,7 @@ class fhsd(Variable):
 class fhsi(Variable):
     cerfa_field = u"HSI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2011"
     start_date = date(2013, 1, 1)
 
@@ -1422,7 +1422,7 @@ class fhsi(Variable):
 class fhse(Variable):
     cerfa_field = u"HSE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
     start_date = date(2013, 1, 1)
 
@@ -1431,7 +1431,7 @@ class fhse(Variable):
 class fhsj(Variable):
     cerfa_field = u"HSJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
     start_date = date(2013, 1, 1)
 
@@ -1440,7 +1440,7 @@ class fhsj(Variable):
 class fhsk(Variable):
     cerfa_field = u"HSK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2010 à hauteur de 52,63%"
     start_date = date(2013, 1, 1)
 
@@ -1449,7 +1449,7 @@ class fhsk(Variable):
 class fhsl(Variable):
     cerfa_field = u"HSL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2010 à hauteur de 62,5%"
     start_date = date(2013, 1, 1)
 
@@ -1458,7 +1458,7 @@ class fhsl(Variable):
 class fhsp(Variable):
     cerfa_field = u"HSP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2011 à hauteur de 52,63%"
     start_date = date(2013, 1, 1)
 
@@ -1467,7 +1467,7 @@ class fhsp(Variable):
 class fhsq(Variable):
     cerfa_field = u"HSQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2011 à hauteur de 62,5%"
     start_date = date(2013, 1, 1)
 
@@ -1476,7 +1476,7 @@ class fhsq(Variable):
 class fhsm(Variable):
     cerfa_field = u"HSM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2010"
     start_date = date(2013, 1, 1)
 
@@ -1485,7 +1485,7 @@ class fhsm(Variable):
 class fhsr(Variable):
     cerfa_field = u"HSR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2011"
     start_date = date(2013, 1, 1)
 
@@ -1494,7 +1494,7 @@ class fhsr(Variable):
 class fhsn(Variable):
     cerfa_field = u"HSN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2010"
     start_date = date(2013, 1, 1)
 
@@ -1503,7 +1503,7 @@ class fhsn(Variable):
 class fhss(Variable):
     cerfa_field = u"HSS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2011"
     start_date = date(2013, 1, 1)
 
@@ -1512,7 +1512,7 @@ class fhss(Variable):
 class fhso(Variable):
     cerfa_field = u"HSO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
     start_date = date(2013, 1, 1)
 
@@ -1521,7 +1521,7 @@ class fhso(Variable):
 class fhst(Variable):
     cerfa_field = u"HST"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
     start_date = date(2013, 1, 1)
 
@@ -1530,7 +1530,7 @@ class fhst(Variable):
 class fhsu(Variable):
     cerfa_field = u"HSU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 52,63%"
     start_date = date(2013, 1, 1)
 
@@ -1539,7 +1539,7 @@ class fhsu(Variable):
 class fhsv(Variable):
     cerfa_field = u"HSV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 62,5%"
     start_date = date(2013, 1, 1)
 
@@ -1548,7 +1548,7 @@ class fhsv(Variable):
 class fhsw(Variable):
     cerfa_field = u"HSW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise"
     start_date = date(2013, 1, 1)
 
@@ -1557,7 +1557,7 @@ class fhsw(Variable):
 class fhsx(Variable):
     cerfa_field = u"HSX"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
     start_date = date(2013, 1, 1)
 
@@ -1566,7 +1566,7 @@ class fhsx(Variable):
 class fhsy(Variable):
     cerfa_field = u"HS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
     start_date = date(2013, 1, 1)
 
@@ -1575,7 +1575,7 @@ class fhsy(Variable):
 class fhsz(Variable):
     cerfa_field = u"HSZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 52,63%"
     start_date = date(2013, 1, 1)
 
@@ -1584,7 +1584,7 @@ class fhsz(Variable):
 class fhta(Variable):
     cerfa_field = u"HTA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 62,5%"
     start_date = date(2013, 1, 1)
 
@@ -1593,7 +1593,7 @@ class fhta(Variable):
 class fhtb(Variable):
     cerfa_field = u"HTB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise"
     start_date = date(2013, 1, 1)
 
@@ -1602,7 +1602,7 @@ class fhtb(Variable):
 class fhtc(Variable):
     cerfa_field = u"HTC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
     start_date = date(2013, 1, 1)
 
@@ -1611,7 +1611,7 @@ class fhtc(Variable):
 class fhtd(Variable):
     cerfa_field = u"HTD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
     start_date = date(2013, 1, 1)
 
@@ -1621,7 +1621,7 @@ class fhtd(Variable):
 class f7fy(Variable):
     cerfa_field = u"7FY"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés: conventions signées avant l'année n-1 et ayant pris fin en année n-1"
     stop_date = date(2011, 12, 31)
 
@@ -1630,7 +1630,7 @@ class f7fy(Variable):
 class f7gy(Variable):
     cerfa_field = u"7GY"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés dont handicapés: conventions signées avant l'année n-1 et ayant pris fin en année n-1"
     start_date = date(2006, 1, 1)
     stop_date = date(2011, 12, 31)
@@ -1640,7 +1640,7 @@ class f7gy(Variable):
 class f7hy(Variable):
     cerfa_field = u"7HY"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés: conventions signées en n-1 et n'ayant pas pris fin en n-1"
     start_date = date(2009, 1, 1)
     stop_date = date(2011, 12, 31)
@@ -1650,7 +1650,7 @@ class f7hy(Variable):
 class f7ky(Variable):
     cerfa_field = u"7KY"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés dont handicapés: conventions signées en n-1 et ayant pris fin en n-1"
     start_date = date(2009, 1, 1)
     stop_date = date(2011, 12, 31)
@@ -1660,7 +1660,7 @@ class f7ky(Variable):
 class f7iy(Variable):
     cerfa_field = u"7IY"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Report du solde de réduction d'impôt non encore imputé sur les investissements réalisés"
     start_date = date(2013, 1, 1)
 
@@ -1669,7 +1669,7 @@ class f7iy(Variable):
 class f7ly(Variable):
     cerfa_field = u"7LY"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés: conventions ayant pas pris fin l'année de perception des revenus déclarés"
     start_date = date(2010, 1, 1)
 
@@ -1678,7 +1678,7 @@ class f7ly(Variable):
 class f7my(Variable):
     cerfa_field = u"7MY"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés dont handicapés: conventions ayant pas pris fin l'année de perception des revenus déclarés"
     start_date = date(2010, 1, 1)
 
@@ -1688,7 +1688,7 @@ class f7my(Variable):
 class f7ra(Variable):
     cerfa_field = u"7RA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Travaux de restauration immobilière dans une zone de protection du patrimoine architectural, urbain et paysager"
     start_date = date(2009, 1, 1)
 
@@ -1697,7 +1697,7 @@ class f7ra(Variable):
 class f7rb(Variable):
     cerfa_field = u"7RB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2009, 1, 1)
 
@@ -1706,7 +1706,7 @@ class f7rb(Variable):
 class f7rc(Variable):
     cerfa_field = u"7RC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2011, 1, 1)
 
@@ -1715,7 +1715,7 @@ class f7rc(Variable):
 class f7rd(Variable):
     cerfa_field = u"7RD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2011, 1, 1)
 
@@ -1724,7 +1724,7 @@ class f7rd(Variable):
 class f7re(Variable):
     cerfa_field = u"7RE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2012, 1, 1)
 
@@ -1733,7 +1733,7 @@ class f7re(Variable):
 class f7rf(Variable):
     cerfa_field = u"7RF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2012, 1, 1)
 
@@ -1742,7 +1742,7 @@ class f7rf(Variable):
 class f7sx(Variable):
     cerfa_field = u"7SX"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2013, 1, 1)
 
@@ -1751,7 +1751,7 @@ class f7sx(Variable):
 class f7sy(Variable):
     cerfa_field = u"7SY"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2013, 1, 1)
 
@@ -1760,7 +1760,7 @@ class f7sy(Variable):
 class f7gw(Variable):
     cerfa_field = u"7GW"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements achevés en n-2 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna : report de 1/5 de la réduction d'impôt"
     start_date = date(2013, 1, 1)
 
@@ -1769,7 +1769,7 @@ class f7gw(Variable):
 class f7gx(Variable):
     cerfa_field = u"7GX"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements achevés en n-2 avec promesse d'achat en n-3 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna : report de 1/5 de la réduction d'impôt"
     start_date = date(2013, 1, 1)
 
@@ -1779,7 +1779,7 @@ class f7gx(Variable):
 class f7xa(Variable):
     cerfa_field = u"7XA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: travaux engagés avant 2011 dans un village résidentiel de tourisme"
     start_date = date(2011, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1789,7 +1789,7 @@ class f7xa(Variable):
 class f7xb(Variable):
     cerfa_field = u"7XB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: travaux engagés avant 2011 dans une résidence de tourisme classée ou meublée"
     start_date = date(2011, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1799,7 +1799,7 @@ class f7xb(Variable):
 class f7xc(Variable):
     cerfa_field = u"7XC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: prix d'acquisition ou de revient d'un logement neuf acquis ou achevé en n-1"
     stop_date = date(2012, 12, 31)
 
@@ -1808,7 +1808,7 @@ class f7xc(Variable):
 class f7xd(Variable):
     cerfa_field = u"7XD"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: logement neuf, demande d'étalement du solde de la réduction d'impôt sur 6 ans"
     start_date = date(2009, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1818,7 +1818,7 @@ class f7xd(Variable):
 class f7xe(Variable):
     cerfa_field = u"7XE"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, demande d'étalement du solde de la réduction d'impôt sur 6 ans"
     start_date = date(2009, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1828,7 +1828,7 @@ class f7xe(Variable):
 class f7xf(Variable):
     cerfa_field = u"7XF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique, logement neuf: report des dépenses d'investissement des années antérieures"
 
 
@@ -1836,7 +1836,7 @@ class f7xf(Variable):
 class f7xh(Variable):
     cerfa_field = u"7XH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: travaux de reconstruction, agrandissement, réparation dans une résidence de tourisme classée ou un meublé de tourisme"
     stop_date = date(2012, 12, 31)
 
@@ -1845,7 +1845,7 @@ class f7xh(Variable):
 class f7xi(Variable):
     cerfa_field = u"7XI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique, logement neuf: report des dépenses d'investissement des années antérieures"
     start_date = date(2010, 1, 1)
 
@@ -1854,7 +1854,7 @@ class f7xi(Variable):
 class f7xj(Variable):
     cerfa_field = u"7XJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, report des dépenses d'investissement des années antérieures"
     start_date = date(2010, 1, 1)
 
@@ -1863,7 +1863,7 @@ class f7xj(Variable):
 class f7xk(Variable):
     cerfa_field = u"7XK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     start_date = date(2010, 1, 1)
 
@@ -1872,7 +1872,7 @@ class f7xk(Variable):
 class f7xl(Variable):
     cerfa_field = u"7XL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, prix de revient d'un logement réhabilité en n-1 et achevé depuis moins de 15 ans"
     stop_date = date(2012, 12, 31)
 
@@ -1881,7 +1881,7 @@ class f7xl(Variable):
 class f7xm(Variable):
     cerfa_field = u"7XM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, report de dépenses des travaux de réhabilitation achevés les années antérieures"
 
 
@@ -1890,7 +1890,7 @@ class f7xm(Variable):
 class f7xn(Variable):
     cerfa_field = u"7XN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique, logement neuf: report des dépenses d'investissement des années antérieures"
     start_date = date(2012, 1, 1)
 
@@ -1899,7 +1899,7 @@ class f7xn(Variable):
 class f7xo(Variable):
     cerfa_field = u"7XO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     start_date = date(2008, 1, 1)
 
@@ -1908,7 +1908,7 @@ class f7xo(Variable):
 class f7xp(Variable):
     cerfa_field = u"7XP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     start_date = date(2011, 1, 1)
 
@@ -1917,7 +1917,7 @@ class f7xp(Variable):
 class f7xq(Variable):
     cerfa_field = u"7XQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     start_date = date(2011, 1, 1)
 
@@ -1926,7 +1926,7 @@ class f7xq(Variable):
 class f7xr(Variable):
     cerfa_field = u"7XR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     start_date = date(2011, 1, 1)
 
@@ -1935,7 +1935,7 @@ class f7xr(Variable):
 class f7xv(Variable):
     cerfa_field = u"7XV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: Report des dépenses d'investissement des années antérieures"
     start_date = date(2012, 1, 1)
 
@@ -1944,7 +1944,7 @@ class f7xv(Variable):
 class f7xx(Variable):
     cerfa_field = u"7XX"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: travaux engagés après 2012 dans un village résidentiel de tourisme"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1954,7 +1954,7 @@ class f7xx(Variable):
 class f7xz(Variable):
     cerfa_field = u"7XZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: travaux engagés après 2012 dans une résidence de tourisme classée ou un meublé tourisme"
     start_date = date(2012, 1, 1)
 
@@ -1963,7 +1963,7 @@ class f7xz(Variable):
 class f7uy(Variable):
     cerfa_field = u"7UY"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: Report des dépenses d'investissement des années antérieures"
     start_date = date(2013, 1, 1)
 
@@ -1972,7 +1972,7 @@ class f7uy(Variable):
 class f7uz(Variable):
     cerfa_field = u"7UZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs dans le secteur de touristique: Report des dépenses d'investissement des années antérieures"
     start_date = date(2013, 1, 1)
 
@@ -1982,7 +1982,7 @@ class f7uz(Variable):
 class f7cf(Variable):
     cerfa_field = u"7CF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscriptions au capital des PME non cotées, petites entreprises en phase de démarrage, ou d'expansion"
 
 
@@ -1990,7 +1990,7 @@ class f7cf(Variable):
 class f7cl(Variable):
     cerfa_field = u"7CL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -4"
 
 
@@ -1998,7 +1998,7 @@ class f7cl(Variable):
 class f7cm(Variable):
     cerfa_field = u"7CM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -3"
 
 
@@ -2006,7 +2006,7 @@ class f7cm(Variable):
 class f7cn(Variable):
     cerfa_field = u"7CN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -2"
 
 
@@ -2014,7 +2014,7 @@ class f7cn(Variable):
 class f7cc(Variable):
     cerfa_field = u"7CC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1"
     start_date = date(2013, 1, 1)
 
@@ -2023,7 +2023,7 @@ class f7cc(Variable):
 class f7cq(Variable):
     cerfa_field = u"7CQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1pour les start-up"
     start_date = date(2011, 1, 1)
 
@@ -2032,7 +2032,7 @@ class f7cq(Variable):
 class f7cu(Variable):
     cerfa_field = u"7CU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscriptions au capital des PME non cotées, montant versé au titre de souscriptions antérieures"
 
 
@@ -2042,7 +2042,7 @@ class f7cu(Variable):
 class f7gs(Variable):
     cerfa_field = u"7GS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Reports concernant les investissements achevés ou acquis au cours des années antérieures: Investissements réalisés en n-3 en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2013, 1, 1)
 
@@ -2052,14 +2052,14 @@ class f7gs(Variable):
 class f7ua(Variable):
     cerfa_field = u"7UA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2007, 12, 31)
 
 
 class f7ub(Variable):
     cerfa_field = u"7UB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2007, 12, 31)
 
 
@@ -2071,7 +2071,7 @@ class f7ub(Variable):
 class f7uc(Variable):
     cerfa_field = u"7UC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Cotisations pour la défense des forêts contre l'incendie "
 
 
@@ -2079,156 +2079,156 @@ class f7uc(Variable):
 class f7ui(Variable):
     cerfa_field = u"7UI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2008, 12, 31)
 
 
 class f7uj(Variable):
     cerfa_field = u"7UJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2007, 12, 31)
 
 
 class f7qb(Variable):
     cerfa_field = u"7QB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2011, 12, 31)
 
 
 class f7qc(Variable):
     cerfa_field = u"7QC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2011, 12, 31)
 
 
 class f7qd(Variable):
     cerfa_field = u"7QD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2011, 12, 31)
 
 
 class f7qk(Variable):
     cerfa_field = u"7QK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2009, 12, 31)
 
 
 class f7qn(Variable):
     cerfa_field = u"7QN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2010, 12, 31)
 
 
 class f7kg(Variable):
     cerfa_field = u"7KG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2010, 12, 31)
 
 
 class f7ql(Variable):
     cerfa_field = u"7QL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2011, 12, 31)
 
 
 class f7qt(Variable):
     cerfa_field = u"7QT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2011, 12, 31)
 
 
 class f7qm(Variable):
     cerfa_field = u"7QM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2011, 12, 31)
 
 
 class f7qu(Variable):
     cerfa_field = u"7QU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7ki(Variable):
     cerfa_field = u"7KI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7qj(Variable):
     cerfa_field = u"7QJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7qw(Variable):
     cerfa_field = u"7QW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7qx(Variable):
     cerfa_field = u"7QX"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7qf(Variable):
     cerfa_field = u"7QF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7qg(Variable):
     cerfa_field = u"7QG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7qh(Variable):
     cerfa_field = u"7QH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7qi(Variable):
     cerfa_field = u"7QI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7qq(Variable):
     cerfa_field = u"7QQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7qr(Variable):
     cerfa_field = u"7QR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7qs(Variable):
     cerfa_field = u"7QS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7mm(Variable):
     cerfa_field = u"7MM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     start_date = date(2010, 1, 1)
     stop_date = date(2012, 12, 31)
 
@@ -2236,34 +2236,34 @@ class f7mm(Variable):
 class f7lg(Variable):
     cerfa_field = u"7LG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     start_date = date(2010, 1, 1)
 
 
 class f7ma(Variable):
     cerfa_field = u"7MA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     start_date = date(2010, 1, 1)
 
 
 class f7ks(Variable):
     cerfa_field = u"7KS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class f7kh(Variable):
     cerfa_field = u"7KH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 
 class f7oa(Variable):
     cerfa_field = u"7OA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% avant 2009"
     start_date = date(2011, 1, 1)
 
@@ -2272,7 +2272,7 @@ class f7oa(Variable):
 class f7ob(Variable):
     cerfa_field = u"7OB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2009"
     start_date = date(2011, 1, 1)
 
@@ -2281,7 +2281,7 @@ class f7ob(Variable):
 class f7oc(Variable):
     cerfa_field = u"7OC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     start_date = date(2011, 1, 1)
 
@@ -2290,7 +2290,7 @@ class f7oc(Variable):
 class f7oh(Variable):
     cerfa_field = u"7OH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% avant 2009"
     start_date = date(2011, 1, 1)
 
@@ -2299,7 +2299,7 @@ class f7oh(Variable):
 class f7oi(Variable):
     cerfa_field = u"7OI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2009"
     start_date = date(2011, 1, 1)
 
@@ -2308,7 +2308,7 @@ class f7oi(Variable):
 class f7oj(Variable):
     cerfa_field = u"7OJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     start_date = date(2011, 1, 1)
 
@@ -2317,7 +2317,7 @@ class f7oj(Variable):
 class f7ok(Variable):
     cerfa_field = u"7OK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Autres investissements"
     start_date = date(2011, 1, 1)
 
@@ -2326,7 +2326,7 @@ class f7ok(Variable):
 class f7ol(Variable):
     cerfa_field = u"7OL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
     start_date = date(2012, 1, 1)
 
@@ -2335,7 +2335,7 @@ class f7ol(Variable):
 class f7om(Variable):
     cerfa_field = u"7OM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
     start_date = date(2012, 1, 1)
 
@@ -2344,7 +2344,7 @@ class f7om(Variable):
 class f7on(Variable):
     cerfa_field = u"7ON"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     start_date = date(2012, 1, 1)
 
@@ -2353,7 +2353,7 @@ class f7on(Variable):
 class f7oo(Variable):
     cerfa_field = u"7OO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
     start_date = date(2012, 1, 1)
 
@@ -2362,7 +2362,7 @@ class f7oo(Variable):
 class f7op(Variable):
     cerfa_field = u"7OP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
     start_date = date(2012, 1, 1)
 
@@ -2371,7 +2371,7 @@ class f7op(Variable):
 class f7oq(Variable):
     cerfa_field = u"7OQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     start_date = date(2012, 1, 1)
 
@@ -2380,7 +2380,7 @@ class f7oq(Variable):
 class f7or(Variable):
     cerfa_field = u"7OR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     start_date = date(2012, 1, 1)
 
@@ -2389,7 +2389,7 @@ class f7or(Variable):
 class f7os(Variable):
     cerfa_field = u"7OS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
     start_date = date(2012, 1, 1)
 
@@ -2398,7 +2398,7 @@ class f7os(Variable):
 class f7ot(Variable):
     cerfa_field = u"7OT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
     start_date = date(2012, 1, 1)
 
@@ -2407,7 +2407,7 @@ class f7ot(Variable):
 class f7ou(Variable):
     cerfa_field = u"7OU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     start_date = date(2012, 1, 1)
 
@@ -2416,7 +2416,7 @@ class f7ou(Variable):
 class f7ov(Variable):
     cerfa_field = u"7OV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     start_date = date(2012, 1, 1)
 
@@ -2425,7 +2425,7 @@ class f7ov(Variable):
 class f7ow(Variable):
     cerfa_field = u"7OW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, "
     start_date = date(2012, 1, 1)
 
@@ -2434,7 +2434,7 @@ class f7ow(Variable):
 class fhod(Variable):
     cerfa_field = u"HOD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés avant le 1.1.2011"
     start_date = date(2013, 1, 1)
 
@@ -2443,7 +2443,7 @@ class fhod(Variable):
 class fhoe(Variable):
     cerfa_field = u"HOE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     start_date = date(2013, 1, 1)
 
@@ -2452,7 +2452,7 @@ class fhoe(Variable):
 class fhof(Variable):
     cerfa_field = u"HOF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     start_date = date(2013, 1, 1)
 
@@ -2462,7 +2462,7 @@ class fhof(Variable):
 class fhog(Variable):
     cerfa_field = u"HOG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     start_date = date(2013, 1, 1)
 
@@ -2472,7 +2472,7 @@ class fhog(Variable):
 class fhox(Variable):
     cerfa_field = u"HOX"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2011"
     start_date = date(2013, 1, 1)
 
@@ -2482,7 +2482,7 @@ class fhox(Variable):
 class fhoy(Variable):
     cerfa_field = u"HOY"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2012"
     start_date = date(2013, 1, 1)
 
@@ -2492,7 +2492,7 @@ class fhoy(Variable):
 class fhoz(Variable):
     cerfa_field = u"HOZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Autres investissements"
     start_date = date(2013, 1, 1)
 
@@ -2503,7 +2503,7 @@ class fhoz(Variable):
 class fhra(Variable):
     cerfa_field = u"HRA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Investissements ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     start_date = date(2013, 1, 1)
 
@@ -2512,7 +2512,7 @@ class fhra(Variable):
 class fhrb(Variable):
     cerfa_field = u"HRB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Investissements ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     start_date = date(2013, 1, 1)
 
@@ -2521,7 +2521,7 @@ class fhrb(Variable):
 class fhrc(Variable):
     cerfa_field = u"HRC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Investissements ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2012"
     start_date = date(2013, 1, 1)
 
@@ -2530,7 +2530,7 @@ class fhrc(Variable):
 class fhrd(Variable):
     cerfa_field = u"HRD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Autres investissements"
     start_date = date(2013, 1, 1)
 
@@ -2541,7 +2541,7 @@ class fhrd(Variable):
 class f7gq(Variable):
     cerfa_field = u"7GQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscription de parts de fonds communs de placement dans l'innovation"
 
 
@@ -2549,7 +2549,7 @@ class f7gq(Variable):
 class f7fq(Variable):
     cerfa_field = u"7FQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscription de parts de fonds d'investissement de proximité"
 
 
@@ -2557,7 +2557,7 @@ class f7fq(Variable):
 class f7fm(Variable):
     cerfa_field = u"7FM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscription de parts de fonds d'investissement de proximité investis en Corse"
     start_date = date(2007, 1, 1)
 
@@ -2566,7 +2566,7 @@ class f7fm(Variable):
 class f7fl(Variable):
     cerfa_field = u"7FL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscription de parts de fonds d'investissement de proximité investis outre-mer par des personnes domiciliées outre-mer"
     start_date = date(2011, 1, 1)
 
@@ -2576,7 +2576,7 @@ class f7fl(Variable):
 class f7gn(Variable):
     cerfa_field = u"7GN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscriptions au capital de SOFICA 36 %"
     start_date = date(2006, 1, 1)
 
@@ -2585,7 +2585,7 @@ class f7gn(Variable):
 class f7fn(Variable):
     cerfa_field = u"7FN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Souscriptions au capital de SOFICA 30 %"
     start_date = date(2006, 1, 1)
 
@@ -2595,7 +2595,7 @@ class f7fn(Variable):
 class f7fh(Variable):
     cerfa_field = u"7FH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Intérêts d'emprunt pour reprise de société"
 
 
@@ -2604,7 +2604,7 @@ class f7fh(Variable):
 class f7ff(Variable):
     cerfa_field = u"7FF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Frais de comptabilité et d'adhésion à un CGA (centre de gestion agréée) ou à une AA (association agréée)"
 
 
@@ -2612,7 +2612,7 @@ class f7ff(Variable):
 class f7fg(Variable):
     cerfa_field = u"7FG"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Frais de comptabilité et d'adhésion à un CGA ou à une AA: nombre d'exploitations"
 
 
@@ -2621,7 +2621,7 @@ class f7fg(Variable):
 class f7nz(Variable):
     cerfa_field = u"7NZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Travaux de conservation et de restauration d’objets classés monuments historiques"
     start_date = date(2008, 1, 1)
 
@@ -2631,7 +2631,7 @@ class f7nz(Variable):
 class f7ka(Variable):
     cerfa_field = u"7KA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de protection du patrimoine naturel"
     start_date = date(2010, 1, 1)
 
@@ -2640,7 +2640,7 @@ class f7ka(Variable):
 class f7kb(Variable):
     cerfa_field = u"7KB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
     start_date = date(2011, 1, 1)
 
@@ -2649,7 +2649,7 @@ class f7kb(Variable):
 class f7kc(Variable):
     cerfa_field = u"7KC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
     start_date = date(2012, 1, 1)
 
@@ -2658,7 +2658,7 @@ class f7kc(Variable):
 class f7kd(Variable):
     cerfa_field = u"7KD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
     start_date = date(2013, 1, 1)
 
@@ -2667,7 +2667,7 @@ class f7kd(Variable):
 class f7uh(Variable):
     cerfa_field = u"7UH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dons et cotisations versés aux partis politiques"
     start_date = date(2007, 1, 1)
 
@@ -2677,7 +2677,7 @@ class f7uh(Variable):
 class f7un(Variable):
     cerfa_field = u"7UN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements forestiers: acquisition"
 
 
@@ -2685,7 +2685,7 @@ class f7un(Variable):
 class f7ul(Variable):
     cerfa_field = u"7UL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements forestiers"
     start_date = date(2011, 1, 1)
 
@@ -2694,7 +2694,7 @@ class f7ul(Variable):
 class f7uu(Variable):
     cerfa_field = u"7UU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements forestiers"
     start_date = date(2010, 1, 1)
 
@@ -2703,7 +2703,7 @@ class f7uu(Variable):
 class f7uv(Variable):
     cerfa_field = u"7UV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements forestiers"
     start_date = date(2011, 1, 1)
 
@@ -2712,7 +2712,7 @@ class f7uv(Variable):
 class f7uw(Variable):
     cerfa_field = u"7UW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements forestiers"
     start_date = date(2012, 1, 1)
 
@@ -2721,7 +2721,7 @@ class f7uw(Variable):
 class f7th(Variable):
     cerfa_field = u"7TH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements forestiers"
     start_date = date(2013, 1, 1)
 
@@ -2730,7 +2730,7 @@ class f7th(Variable):
 class f7ux(Variable):
     cerfa_field = u"7UX"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements forestiers"
     start_date = date(2013, 1, 1)
 
@@ -2739,7 +2739,7 @@ class f7ux(Variable):
 class f7tg(Variable):
     cerfa_field = u"7TG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements forestiers"
     start_date = date(2012, 1, 1)
 
@@ -2748,7 +2748,7 @@ class f7tg(Variable):
 class f7tf(Variable):
     cerfa_field = u"7TF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements forestiers"
     start_date = date(2011, 1, 1)
     stop_date = date(2013, 12, 31)
@@ -2758,7 +2758,7 @@ class f7tf(Variable):
 class f7ut(Variable):
     cerfa_field = u"7UT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements forestiers"
     start_date = date(2009, 1, 1)
 
@@ -2768,7 +2768,7 @@ class f7ut(Variable):
 class f7um(Variable):
     cerfa_field = u"7UM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Intérêts pour paiement différé accordé aux agriculteurs"
 
 
@@ -2777,7 +2777,7 @@ class f7um(Variable):
 class f7hj(Variable):
     cerfa_field = u"7HJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 en métropole"
     start_date = date(2009, 1, 1)
 
@@ -2786,7 +2786,7 @@ class f7hj(Variable):
 class f7hk(Variable):
     cerfa_field = u"7HK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 dans les DOM-COM"
     start_date = date(2009, 1, 1)
 
@@ -2795,7 +2795,7 @@ class f7hk(Variable):
 class f7hn(Variable):
     cerfa_field = u"7HN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 en métropole avec promesse d'achat avant le 1er janvier 2010"
     start_date = date(2010, 1, 1)
 
@@ -2804,7 +2804,7 @@ class f7hn(Variable):
 class f7ho(Variable):
     cerfa_field = u"7HO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 dans les DOM-COM avec promesse d'achat avant le 1er janvier 2010"
     start_date = date(2010, 1, 1)
 
@@ -2813,7 +2813,7 @@ class f7ho(Variable):
 class f7hl(Variable):
     cerfa_field = u"7HL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2009 (métropole et DOM ne respectant pas les plafonds)"
     start_date = date(2010, 1, 1)
 
@@ -2822,7 +2822,7 @@ class f7hl(Variable):
 class f7hm(Variable):
     cerfa_field = u"7HM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2009 dans les DOM et respectant les plafonds"
     start_date = date(2010, 1, 1)
 
@@ -2831,7 +2831,7 @@ class f7hm(Variable):
 class f7hr(Variable):
     cerfa_field = u"7HR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés et achevés en 2009, en métropole en 2009; dans les DOM du 1.1.2009 au 26.5.2009 ; dans les DOM du 27.5.2009 au 30.12.2009 lorsqu'ils ne respectent pas les plafonds spécifiques"
     start_date = date(2010, 1, 1)
 
@@ -2840,7 +2840,7 @@ class f7hr(Variable):
 class f7hs(Variable):
     cerfa_field = u"7HS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés et achevés en 2009 dans les DOM COM du 27.5.2009 au 31.12.2009 respectant les plafonds spécifiques"
     start_date = date(2010, 1, 1)
 
@@ -2849,7 +2849,7 @@ class f7hs(Variable):
 class f7la(Variable):
     cerfa_field = u"7LA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2009"
     start_date = date(2010, 1, 1)
 
@@ -2858,7 +2858,7 @@ class f7la(Variable):
 class f7lb(Variable):
     cerfa_field = u"7LB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2010"
     start_date = date(2011, 1, 1)
 
@@ -2867,7 +2867,7 @@ class f7lb(Variable):
 class f7lc(Variable):
     cerfa_field = u"7LC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report de l'année 2010"
     start_date = date(2011, 1, 1)
 
@@ -2876,7 +2876,7 @@ class f7lc(Variable):
 class f7ld(Variable):
     cerfa_field = u"7LD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report de l'année 2011"
     start_date = date(2012, 1, 1)
 
@@ -2885,7 +2885,7 @@ class f7ld(Variable):
 class f7le(Variable):
     cerfa_field = u"7LE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2011"
     start_date = date(2012, 1, 1)
 
@@ -2894,7 +2894,7 @@ class f7le(Variable):
 class f7lf(Variable):
     cerfa_field = u"7LF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2011 : report du solde de réduction d'impôt de l'année 2011"
     start_date = date(2012, 1, 1)
 
@@ -2903,7 +2903,7 @@ class f7lf(Variable):
 class f7ls(Variable):
     cerfa_field = u"7LS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010"
     start_date = date(2013, 1, 1)
 
@@ -2912,7 +2912,7 @@ class f7ls(Variable):
 class f7lm(Variable):
     cerfa_field = u"7LM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010"
     start_date = date(2013, 1, 1)
 
@@ -2921,7 +2921,7 @@ class f7lm(Variable):
 class f7lz(Variable):
     cerfa_field = u"7LZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Report du solde de réduction d'impôt de l'année 2012"
     start_date = date(2013, 1, 1)
 
@@ -2930,7 +2930,7 @@ class f7lz(Variable):
 class f7mg(Variable):
     cerfa_field = u"7MG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2012 : report du solde de réduction d'impôt de l'année 2012"
     start_date = date(2013, 1, 1)
 
@@ -2939,7 +2939,7 @@ class f7mg(Variable):
 class f7na(Variable):
     cerfa_field = u"7NA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, métropole, BBC"
     start_date = date(2011, 1, 1)
 
@@ -2948,7 +2948,7 @@ class f7na(Variable):
 class f7nb(Variable):
     cerfa_field = u"7NB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, "
     start_date = date(2011, 1, 1)
 
@@ -2957,7 +2957,7 @@ class f7nb(Variable):
 class f7nc(Variable):
     cerfa_field = u"7NC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, métropole, BBC"
     start_date = date(2011, 1, 1)
 
@@ -2966,7 +2966,7 @@ class f7nc(Variable):
 class f7nd(Variable):
     cerfa_field = u"7ND"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, métropole, BBC"
     start_date = date(2011, 1, 1)
 
@@ -2975,7 +2975,7 @@ class f7nd(Variable):
 class f7ne(Variable):
     cerfa_field = u"7NE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, métropole, BBC"
     start_date = date(2011, 1, 1)
 
@@ -2984,7 +2984,7 @@ class f7ne(Variable):
 class f7nf(Variable):
     cerfa_field = u"7NF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, "
     start_date = date(2011, 1, 1)
 
@@ -2993,7 +2993,7 @@ class f7nf(Variable):
 class f7ng(Variable):
     cerfa_field = u"7NG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, "
     start_date = date(2011, 1, 1)
 
@@ -3002,7 +3002,7 @@ class f7ng(Variable):
 class f7nh(Variable):
     cerfa_field = u"7NH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, Investissement réalisé du 1.1.2011 au 31.1.2011, métropole, non-BBC"
     start_date = date(2011, 1, 1)
 
@@ -3011,7 +3011,7 @@ class f7nh(Variable):
 class f7ni(Variable):
     cerfa_field = u"7NI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, métropole, non-BBC"
     start_date = date(2011, 1, 1)
 
@@ -3020,7 +3020,7 @@ class f7ni(Variable):
 class f7nj(Variable):
     cerfa_field = u"7NJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, métropole, non-BBC"
     start_date = date(2011, 1, 1)
 
@@ -3029,7 +3029,7 @@ class f7nj(Variable):
 class f7nk(Variable):
     cerfa_field = u"7NK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2011, 1, 1)
 
@@ -3038,7 +3038,7 @@ class f7nk(Variable):
 class f7nl(Variable):
     cerfa_field = u"7NL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2011, 1, 1)
 
@@ -3047,7 +3047,7 @@ class f7nl(Variable):
 class f7nm(Variable):
     cerfa_field = u"7NM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, Investissement réalisé du 1.1.2011 au 31.1.2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2011, 1, 1)
 
@@ -3056,7 +3056,7 @@ class f7nm(Variable):
 class f7nn(Variable):
     cerfa_field = u"7NN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2011, 1, 1)
 
@@ -3065,7 +3065,7 @@ class f7nn(Variable):
 class f7no(Variable):
     cerfa_field = u"7NO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2011, 1, 1)
 
@@ -3074,7 +3074,7 @@ class f7no(Variable):
 class f7np(Variable):
     cerfa_field = u"7NP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2011, 1, 1)
 
@@ -3083,7 +3083,7 @@ class f7np(Variable):
 class f7nq(Variable):
     cerfa_field = u"7NQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2011, 1, 1)
 
@@ -3092,7 +3092,7 @@ class f7nq(Variable):
 class f7nr(Variable):
     cerfa_field = u"7NR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, Investissement réalisé du 1.1.2011 au 31.1.2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2011, 1, 1)
 
@@ -3101,7 +3101,7 @@ class f7nr(Variable):
 class f7ns(Variable):
     cerfa_field = u"7NS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2011, 1, 1)
 
@@ -3110,7 +3110,7 @@ class f7ns(Variable):
 class f7nt(Variable):
     cerfa_field = u"7NT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2011, 1, 1)
 
@@ -3119,7 +3119,7 @@ class f7nt(Variable):
 class f7hv(Variable):
     cerfa_field = u"7HV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 en métropole"
     start_date = date(2011, 1, 1)
 
@@ -3128,7 +3128,7 @@ class f7hv(Variable):
 class f7hw(Variable):
     cerfa_field = u"7HW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 dans les DOM COM"
     start_date = date(2011, 1, 1)
 
@@ -3137,7 +3137,7 @@ class f7hw(Variable):
 class f7hx(Variable):
     cerfa_field = u"7HX"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 en métropole avec promesse d'achat avant le 1.1.2010"
     start_date = date(2011, 1, 1)
 
@@ -3146,7 +3146,7 @@ class f7hx(Variable):
 class f7hz(Variable):
     cerfa_field = u"7HZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 dans les DOM COM avec promesse d'achat avant le 1.1.2010"
     start_date = date(2011, 1, 1)
 
@@ -3155,7 +3155,7 @@ class f7hz(Variable):
 class f7ht(Variable):
     cerfa_field = u"7HT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2009, Investissements réalisés en 2009 et achevés en 2010, en métropole en 2009; dans les DOM du 1.1.2009 au 26.5.2009 ; dans les DOM du 27.5.2009 au 30.12.2009 lorsqu'ils ne respectent pas les plafonds spécifiques"
     start_date = date(2011, 1, 1)
 
@@ -3164,7 +3164,7 @@ class f7ht(Variable):
 class f7hu(Variable):
     cerfa_field = u"7HU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2009, Investissements réalisés en 2009 et achevés en 2010, dans les DOM COM du 27.5.2009 au 31.12.2009 respectant les plafonds spécifiques"
     start_date = date(2011, 1, 1)
 
@@ -3173,7 +3173,7 @@ class f7hu(Variable):
 class f7ha(Variable):
     cerfa_field = u"7HA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés et réalisés en 2011"
     start_date = date(2012, 1, 1)
 
@@ -3182,7 +3182,7 @@ class f7ha(Variable):
 class f7hb(Variable):
     cerfa_field = u"7HB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés et réalisés en 2011, avec promesse d'achat en 2010"
     start_date = date(2012, 1, 1)
 
@@ -3191,7 +3191,7 @@ class f7hb(Variable):
 class f7hg(Variable):
     cerfa_field = u"7HG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2011 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna"
     start_date = date(2012, 1, 1)
 
@@ -3200,7 +3200,7 @@ class f7hg(Variable):
 class f7hh(Variable):
     cerfa_field = u"7HH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2011 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna avec promesse d'achat en 2010"
     start_date = date(2012, 1, 1)
 
@@ -3209,7 +3209,7 @@ class f7hh(Variable):
 class f7hd(Variable):
     cerfa_field = u"7HD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés en 2011, réalisés en 2010, en métropole et dans les DOM-COM"
     start_date = date(2012, 1, 1)
 
@@ -3218,7 +3218,7 @@ class f7hd(Variable):
 class f7he(Variable):
     cerfa_field = u"7HE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés en 2011, en métropole et dans les DOM-COM avec promesse d'achat avant le 1.1.2010"
     start_date = date(2012, 1, 1)
 
@@ -3227,7 +3227,7 @@ class f7he(Variable):
 class f7hf(Variable):
     cerfa_field = u"7HF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés en 2011, Investissements réalisés en 2009 en métropole et dans les DOM-COM"
     start_date = date(2012, 1, 1)
 
@@ -3236,7 +3236,7 @@ class f7hf(Variable):
 class f7ja(Variable):
     cerfa_field = u"7JA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2012, métropole, BBC"
     start_date = date(2012, 1, 1)
 
@@ -3245,7 +3245,7 @@ class f7ja(Variable):
 class f7jb(Variable):
     cerfa_field = u"7JB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, métropole, BBC"
     start_date = date(2012, 1, 1)
 
@@ -3254,7 +3254,7 @@ class f7jb(Variable):
 class f7jd(Variable):
     cerfa_field = u"7JD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, métropole, BBC"
     start_date = date(2012, 1, 1)
 
@@ -3263,7 +3263,7 @@ class f7jd(Variable):
 class f7je(Variable):
     cerfa_field = u"7JE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, métropole, BBC "
     start_date = date(2012, 1, 1)
 
@@ -3272,7 +3272,7 @@ class f7je(Variable):
 class f7jf(Variable):
     cerfa_field = u"7JF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2012, métropole, non-BBC"
     start_date = date(2012, 1, 1)
 
@@ -3281,7 +3281,7 @@ class f7jf(Variable):
 class f7jg(Variable):
     cerfa_field = u"7JG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, métropole, non-BBC"
     start_date = date(2012, 1, 1)
 
@@ -3290,7 +3290,7 @@ class f7jg(Variable):
 class f7jh(Variable):
     cerfa_field = u"7JH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, métropole, non-BBC"
     start_date = date(2012, 1, 1)
 
@@ -3299,7 +3299,7 @@ class f7jh(Variable):
 class f7jj(Variable):
     cerfa_field = u"7JJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, métropole, non-BBC"
     start_date = date(2012, 1, 1)
 
@@ -3308,7 +3308,7 @@ class f7jj(Variable):
 class f7jk(Variable):
     cerfa_field = u"7JK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2012, 1, 1)
 
@@ -3317,7 +3317,7 @@ class f7jk(Variable):
 class f7jl(Variable):
     cerfa_field = u"7JL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2012, 1, 1)
 
@@ -3326,7 +3326,7 @@ class f7jl(Variable):
 class f7jm(Variable):
     cerfa_field = u"7JM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2012, 1, 1)
 
@@ -3335,7 +3335,7 @@ class f7jm(Variable):
 class f7jn(Variable):
     cerfa_field = u"7JN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2012, 1, 1)
 
@@ -3344,7 +3344,7 @@ class f7jn(Variable):
 class f7jo(Variable):
     cerfa_field = u"7JO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2012, 1, 1)
 
@@ -3353,7 +3353,7 @@ class f7jo(Variable):
 class f7jp(Variable):
     cerfa_field = u"7JP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2012, 1, 1)
 
@@ -3362,7 +3362,7 @@ class f7jp(Variable):
 class f7jq(Variable):
     cerfa_field = u"7JQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2012, 1, 1)
 
@@ -3371,7 +3371,7 @@ class f7jq(Variable):
 class f7jr(Variable):
     cerfa_field = u"7JR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2012, 1, 1)
 
@@ -3380,7 +3380,7 @@ class f7jr(Variable):
 class f7gj(Variable):
     cerfa_field = u"7GJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés et réalisés en 2012, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2013, 1, 1)
 
@@ -3389,7 +3389,7 @@ class f7gj(Variable):
 class f7gk(Variable):
     cerfa_field = u"7GK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés et réalisés en 2012, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon, avec promesse d'achat en 2011"
     start_date = date(2013, 1, 1)
 
@@ -3398,7 +3398,7 @@ class f7gk(Variable):
 class f7gl(Variable):
     cerfa_field = u"7GL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2012 et réalisés en 2011, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2013, 1, 1)
 
@@ -3407,7 +3407,7 @@ class f7gl(Variable):
 class f7gp(Variable):
     cerfa_field = u"7GP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2012 et réalisés en 2011, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon, avec promesse d'achat en 2010s"
     start_date = date(2013, 1, 1)
 
@@ -3416,7 +3416,7 @@ class f7gp(Variable):
 class f7fa(Variable):
     cerfa_field = u"7FA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013, métropole, BBC"
     start_date = date(2013, 1, 1)
 
@@ -3425,7 +3425,7 @@ class f7fa(Variable):
 class f7fb(Variable):
     cerfa_field = u"7FB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013, métropole, non-BBC"
     start_date = date(2013, 1, 1)
 
@@ -3434,7 +3434,7 @@ class f7fb(Variable):
 class f7fc(Variable):
     cerfa_field = u"7FC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013, DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2013, 1, 1)
 
@@ -3443,7 +3443,7 @@ class f7fc(Variable):
 class f7fd(Variable):
     cerfa_field = u"7FD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna"
     start_date = date(2013, 1, 1)
 
@@ -3453,7 +3453,7 @@ class f7fd(Variable):
 class f7ij(Variable):
     cerfa_field = u"7IJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissement destinés à la location meublée non professionnelle: Investissements réalisés en 2011 et achevés en 2012, engagement de réalisation de l'investissement en 2011"
     start_date = date(2009, 1, 1)
 
@@ -3462,7 +3462,7 @@ class f7ij(Variable):
 class f7il(Variable):
     cerfa_field = u"7IL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissement destinés à la location meublée non professionnelle: Investissements réalisés en 2011 et achevés en 2012, promesse d'achat en 2010"
     start_date = date(2010, 1, 1)
 
@@ -3471,7 +3471,7 @@ class f7il(Variable):
 class f7im(Variable):
     cerfa_field = u"7IM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissement destinés à la location meublée non professionnelle: Investissements réalisés en 2010 et achevés en 2012 avec promesse d'achat en 2009"
     start_date = date(2010, 1, 1)
 
@@ -3480,7 +3480,7 @@ class f7im(Variable):
 class f7ik(Variable):
     cerfa_field = u"7IK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Reports de 1/9 de l'investissement réalisé et achevé en 2009"
     start_date = date(2010, 1, 1)
 
@@ -3489,7 +3489,7 @@ class f7ik(Variable):
 class f7in(Variable):
     cerfa_field = u"7IN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, investissement réalisé du 1.1.2011 au 31.3.2011"
     start_date = date(2011, 1, 1)
 
@@ -3498,7 +3498,7 @@ class f7in(Variable):
 class f7iv(Variable):
     cerfa_field = u"7IV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, investissement réalisé du 1.4.2011 au 31.12.2011"
     start_date = date(2011, 1, 1)
 
@@ -3507,7 +3507,7 @@ class f7iv(Variable):
 class f7iw(Variable):
     cerfa_field = u"7IW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2010 et achevés en 2012"
     start_date = date(2011, 1, 1)
 
@@ -3516,7 +3516,7 @@ class f7iw(Variable):
 class f7io(Variable):
     cerfa_field = u"7IO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : "
     start_date = date(2011, 1, 1)
 
@@ -3525,7 +3525,7 @@ class f7io(Variable):
 class f7ip(Variable):
     cerfa_field = u"7IP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : "
     start_date = date(2011, 1, 1)
 
@@ -3534,7 +3534,7 @@ class f7ip(Variable):
 class f7ir(Variable):
     cerfa_field = u"7IR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : "
     start_date = date(2011, 1, 1)
 
@@ -3543,7 +3543,7 @@ class f7ir(Variable):
 class f7iq(Variable):
     cerfa_field = u"7IQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : "
     start_date = date(2011, 1, 1)
 
@@ -3552,7 +3552,7 @@ class f7iq(Variable):
 class f7iu(Variable):
     cerfa_field = u"7IU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : "
     start_date = date(2011, 1, 1)
 
@@ -3561,7 +3561,7 @@ class f7iu(Variable):
 class f7it(Variable):
     cerfa_field = u"7IT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : "
     start_date = date(2011, 1, 1)
 
@@ -3570,7 +3570,7 @@ class f7it(Variable):
 class f7is(Variable):
     cerfa_field = u"7IS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé: année  n-4"
     start_date = date(2010, 1, 1)
 
@@ -3579,7 +3579,7 @@ class f7is(Variable):
 class f7ia(Variable):
     cerfa_field = u"7IA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011"
     start_date = date(2012, 1, 1)
 
@@ -3588,7 +3588,7 @@ class f7ia(Variable):
 class f7ib(Variable):
     cerfa_field = u"7IB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 avec promesse d'achat en 2010 ou réalisés en 2010"
     start_date = date(2012, 1, 1)
 
@@ -3597,7 +3597,7 @@ class f7ib(Variable):
 class f7ic(Variable):
     cerfa_field = u"7IC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2010 et achevés en 2011 avec promesse d'achat en 2009 ou réalisés en 2009"
     start_date = date(2012, 1, 1)
 
@@ -3606,7 +3606,7 @@ class f7ic(Variable):
 class f7id(Variable):
     cerfa_field = u"7ID"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, Engagement de réalisation de l'investissement en 2012"
     start_date = date(2012, 1, 1)
 
@@ -3615,7 +3615,7 @@ class f7id(Variable):
 class f7ie(Variable):
     cerfa_field = u"7IE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, Promesse d'achat en 2011"
     start_date = date(2012, 1, 1)
 
@@ -3624,7 +3624,7 @@ class f7ie(Variable):
 class f7if(Variable):
     cerfa_field = u"7IF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, investissement réalisé du 1.1.2012 au 31.3.2012, investissement réalisé du 1.1.2012 au 31.3.2012"
     start_date = date(2012, 1, 1)
 
@@ -3633,7 +3633,7 @@ class f7if(Variable):
 class f7ig(Variable):
     cerfa_field = u"7IG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, Investissements destinés à la location meublée non professionnelle : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, investissement réalisé du 1.4.2012 au 31.12.2012"
     start_date = date(2012, 1, 1)
 
@@ -3642,7 +3642,7 @@ class f7ig(Variable):
 class f7ix(Variable):
     cerfa_field = u"7IX"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2009; réalisés en 2009 et achevés en 2010; réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report du solde de réduction d'impôt de l'année 2011"
     start_date = date(2012, 1, 1)
 
@@ -3651,7 +3651,7 @@ class f7ix(Variable):
 class f7ih(Variable):
     cerfa_field = u"7IH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report du solde de réduction d'impôt de l'année 2011"
     start_date = date(2012, 1, 1)
 
@@ -3660,7 +3660,7 @@ class f7ih(Variable):
 class f7iz(Variable):
     cerfa_field = u"7IZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 : report du solde de réduction d'impôt de l'année 2011"
     start_date = date(2012, 1, 1)
 
@@ -3669,7 +3669,7 @@ class f7iz(Variable):
 class f7jt(Variable):
     cerfa_field = u"7JT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2013, Engagement de réalisation de l'investissement en 2013"
     start_date = date(2013, 1, 1)
 
@@ -3678,7 +3678,7 @@ class f7jt(Variable):
 class f7ju(Variable):
     cerfa_field = u"7JU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2013, Engagement de réalisation de l'investissement en 2012"
     start_date = date(2013, 1, 1)
 
@@ -3687,7 +3687,7 @@ class f7ju(Variable):
 class f7jv(Variable):
     cerfa_field = u"7JV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2012"
     start_date = date(2013, 1, 1)
 
@@ -3696,7 +3696,7 @@ class f7jv(Variable):
 class f7jw(Variable):
     cerfa_field = u"7JW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011"
     start_date = date(2013, 1, 1)
 
@@ -3705,7 +3705,7 @@ class f7jw(Variable):
 class f7jx(Variable):
     cerfa_field = u"7JX"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2011 avec promesse d'achat en 2010 ou réalisés en 2010"
     start_date = date(2013, 1, 1)
 
@@ -3714,7 +3714,7 @@ class f7jx(Variable):
 class f7jy(Variable):
     cerfa_field = u"7JY"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2010 avec promesse d'achat en 2009 ou réalisés en 2009"
     start_date = date(2013, 1, 1)
 
@@ -3723,7 +3723,7 @@ class f7jy(Variable):
 class f7jc(Variable):
     cerfa_field = u"7JC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report du solde de réduction d'impôt de l'année 2012"
     start_date = date(2013, 1, 1)
 
@@ -3732,7 +3732,7 @@ class f7jc(Variable):
 class f7ji(Variable):
     cerfa_field = u"7JI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 ; réalisés en 2011 et achevés en 2011 ou 2012 ; réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2012, Report du solde de réduction d'impôt de l'année 2012"
     start_date = date(2013, 1, 1)
 
@@ -3741,7 +3741,7 @@ class f7ji(Variable):
 class f7js(Variable):
     cerfa_field = u"7JS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 ; réalisés en 2011 et achevés en 2011 ou 2012 ; réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2012, Report du solde de réduction d’impôt de l’année 2012"
     start_date = date(2013, 1, 1)
 
@@ -3757,7 +3757,7 @@ class f7js(Variable):
 class f7gt(Variable):
     cerfa_field = u"7GT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements achevés en 2012 avec promesse d'achat en 2010"
     start_date = date(2013, 1, 1)
 
@@ -3766,7 +3766,7 @@ class f7gt(Variable):
 class f7gu(Variable):
     cerfa_field = u"7GU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements achevés en 2012 avec promesse d'achat en 2009"
     start_date = date(2013, 1, 1)
 
@@ -3775,7 +3775,7 @@ class f7gu(Variable):
 class f7gv(Variable):
     cerfa_field = u"7GV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés et achevés en 2012 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
     start_date = date(2013, 1, 1)
 
@@ -3784,7 +3784,7 @@ class f7gv(Variable):
 class f7xg(Variable):
     cerfa_field = u"7XG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissement locatif dans le secteur touristique, travaux réalisés dans un village résidentiel de tourisme"
     stop_date = date(2012, 12, 1)
 
@@ -3795,7 +3795,7 @@ class f7xg(Variable):
 class f7uo(Variable):
     cerfa_field = u"7UO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Acquisition de biens culturels"
 
 
@@ -3804,7 +3804,7 @@ class f7uo(Variable):
 class f7us(Variable):
     cerfa_field = u"7US"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Réduction d'impôt mécénat d'entreprise"
 
 
@@ -3814,7 +3814,7 @@ class f7us(Variable):
 class f7sb(Variable):
     cerfa_field = u"7SB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location: crédit à 25 %"
     start_date = date(2009, 1, 1)
     stop_date = date(2011, 12, 31)
@@ -3824,7 +3824,7 @@ class f7sb(Variable):
 class f7sc(Variable):
     cerfa_field = u"7SC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédits d’impôt pour dépenses en faveur de la qualité environnementale"
     start_date = date(2009, 1, 1)
     stop_date = date(2009, 12, 1)
@@ -3837,7 +3837,7 @@ class f7sc(Variable):
 class f7sd(Variable):
     cerfa_field = u"7SD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale, économie d'énergie: chaudières à condensation"
     start_date = date(2009, 1, 1)
 
@@ -3846,7 +3846,7 @@ class f7sd(Variable):
 class f7se(Variable):
     cerfa_field = u"7SE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale, économie d'énergie: chaudières à micro-cogénération gaz"
     start_date = date(2009, 1, 1)
 
@@ -3855,7 +3855,7 @@ class f7se(Variable):
 class f7sh(Variable):
     cerfa_field = u"7SH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale, isolation thermique: matériaux d'isolation des toitures (acquisition et pose)"
     start_date = date(2010, 1, 1)
 
@@ -3867,7 +3867,7 @@ class f7sh(Variable):
 class f7up(Variable):
     cerfa_field = u"7UP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt pour investissements forestiers: travaux"
     start_date = date(2009, 1, 1)
 
@@ -3876,7 +3876,7 @@ class f7up(Variable):
 class f7uq(Variable):
     cerfa_field = u"7UQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt pour investissements forestiers: contrat de gestion"
     start_date = date(2009, 1, 1)
 
@@ -3886,7 +3886,7 @@ class f7uq(Variable):
 class f1ar(Variable):
     cerfa_field = u"1AR"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt aide à la mobilité : le déclarant déménage à plus de 200 km pour son emploi"
     stop_date = date(2080, 12, 31)
 
@@ -3895,7 +3895,7 @@ class f1ar(Variable):
 class f1br(Variable):
     cerfa_field = u"1BR"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt aide à la mobilité : le conjoint déménage à plus de 200 km pour son emploi"
     stop_date = date(2008, 12, 31)
 
@@ -3904,7 +3904,7 @@ class f1br(Variable):
 class f1cr(Variable):
     cerfa_field = u"1CR"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt aide à la mobilité : la 1ère personne à charge déménage à plus de 200 km pour son emploi"
     stop_date = date(2008, 12, 31)
 
@@ -3913,7 +3913,7 @@ class f1cr(Variable):
 class f1dr(Variable):
     cerfa_field = u"1DR"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt aide à la mobilité : la 2è personne à charge déménage à plus de 200 km pour son emploi"
     stop_date = date(2008, 12, 31)
 
@@ -3922,7 +3922,7 @@ class f1dr(Variable):
 class f1er(Variable):
     cerfa_field = u"1ER"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt aide à la mobilité : la 3è personne à charge déménage à plus de 200 km pour son emploi"
     stop_date = date(2006, 12, 31)
 
@@ -3932,7 +3932,7 @@ class f1er(Variable):
 class f4tq(Variable):
     cerfa_field = u"4TQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d’impôt représentatif de la taxe additionnelle au droit de bail"
 
   # vérif libéllé, en 2013=Montant des loyers courus du 01/01/1998 au 30/09/1998 provenant des immeubles
@@ -3944,7 +3944,7 @@ class f4tq(Variable):
 class f7sf(Variable):
     cerfa_field = u"7SF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit de travaux en faveur d'aides aux personnes pour des logements en location (avant 2012 ) / Appareils de régulation du chauffage, matériaux de calorifugeage (après 2011)"
     start_date = date(2012, 1, 1)
 
@@ -3953,7 +3953,7 @@ class f7sf(Variable):
 class f7si(Variable):
     cerfa_field = u"7SI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Matériaux d’isolation des planchers bas sur sous-sol, sur vide sanitaire ou sur passage couvert (acquisition et pose)"
     start_date = date(2012, 1, 1)
 
@@ -3962,7 +3962,7 @@ class f7si(Variable):
 class f7te(Variable):
     cerfa_field = u"7TE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses d'investissement forestier"
     start_date = date(2010, 1, 1)
 
@@ -3971,7 +3971,7 @@ class f7te(Variable):
 class f7tu(Variable):
     cerfa_field = u"7TU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de travaux dans l'habitation principale"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -3981,7 +3981,7 @@ class f7tu(Variable):
 class f7tt(Variable):
     cerfa_field = u"7TT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de travaux dans l'habitation principale"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -3991,7 +3991,7 @@ class f7tt(Variable):
 class f7tv(Variable):
     cerfa_field = u"7TV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de travaux dans l'habitation principale"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -4001,7 +4001,7 @@ class f7tv(Variable):
 class f7tx(Variable):
     cerfa_field = u"7TX"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de travaux dans l'habitation principale"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -4011,7 +4011,7 @@ class f7tx(Variable):
 class f7ty(Variable):
     cerfa_field = u"7TY"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de travaux dans l'habitation principale"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -4021,7 +4021,7 @@ class f7ty(Variable):
 class f7tw(Variable):
     cerfa_field = u"7TW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Dépenses de travaux dans l'habitation principale"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -4033,7 +4033,7 @@ class f7tw(Variable):
 class f7gh(Variable):
     cerfa_field = u"7GH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs intermédiaires en métropole"
     start_date = date(2013, 1, 1)
 
@@ -4042,7 +4042,7 @@ class f7gh(Variable):
 class f7gi(Variable):
     cerfa_field = u"7GI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Investissements locatifs intermédiaires outre-mer"
     start_date = date(2013, 1, 1)
 
@@ -4054,7 +4054,7 @@ class f7gi(Variable):
 class f8tc(Variable):
     cerfa_field = u"8TC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt autres entreprises (recherche non encore remboursé (années antérieures))"
     stop_date = date(2008, 12, 31)
 
@@ -4063,7 +4063,7 @@ class f8tc(Variable):
 class f8tb(Variable):
     cerfa_field = u"8TB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt recherche (entreprises bénéficiant de la restitution immédiate)"
 
 
@@ -4071,7 +4071,7 @@ class f8tb(Variable):
 class f8te(Variable):
     cerfa_field = u"8TE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: adhésion à un groupement de prévention agréé"
 
 
@@ -4079,7 +4079,7 @@ class f8te(Variable):
 class f8tf(Variable):
     cerfa_field = u"8TF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Reprises de réductions ou de crédits d'impôt"
 
 
@@ -4087,7 +4087,7 @@ class f8tf(Variable):
 class f8tg(Variable):
     cerfa_field = u"8TG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédits d'impôt en faveur des entreprises: Investissement en Corse"
 
 
@@ -4095,7 +4095,7 @@ class f8tg(Variable):
 class f8tl(Variable):
     cerfa_field = u"8TL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt compétitivité emploi (CICE), entreprises bénéficiant de la restitution immédiate"
 
 
@@ -4103,7 +4103,7 @@ class f8tl(Variable):
 class f8to(Variable):
     cerfa_field = u"8TO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: investissement en Corse, report non imputé les années antérieures"
 
 
@@ -4111,7 +4111,7 @@ class f8to(Variable):
 class f8tp(Variable):
     cerfa_field = u"8TP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: investissement en Corse, reprise de crédit d'impôt"
 
 
@@ -4119,7 +4119,7 @@ class f8tp(Variable):
 class f8ts(Variable):
     cerfa_field = u"8TS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: investissement en Corse, crédit d'impôt"
     start_date = date(2012, 1, 1)
 
@@ -4128,7 +4128,7 @@ class f8ts(Variable):
 class f8uz(Variable):
     cerfa_field = u"8UZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Famille"
 
 
@@ -4136,7 +4136,7 @@ class f8uz(Variable):
 class f8uw(Variable):
     cerfa_field = u"8UW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt compétitivité emploi (CICE), autres entreprises"
     start_date = date(2013, 1, 1)
 
@@ -4145,7 +4145,7 @@ class f8uw(Variable):
 class f8tz(Variable):
     cerfa_field = u"8TZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Apprentissage"
 
 
@@ -4153,7 +4153,7 @@ class f8tz(Variable):
 class f8wa(Variable):
     cerfa_field = u"8WA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Agriculture biologique"
 
 
@@ -4161,7 +4161,7 @@ class f8wa(Variable):
 class f8wb(Variable):
     cerfa_field = u"8WB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Prospection commerciale"
 
 
@@ -4169,7 +4169,7 @@ class f8wb(Variable):
 class f8wc__2008(Variable):
     cerfa_field = u"8WC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Nouvelles technologies"
     stop_date = date(2008, 12, 31)
 
@@ -4178,7 +4178,7 @@ class f8wc__2008(Variable):
 class f8wc(Variable):
     cerfa_field = u"8WC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Prêts sans intérêt"
     start_date = date(2012, 1, 1)
 
@@ -4187,7 +4187,7 @@ class f8wc(Variable):
 class f8wd(Variable):
     cerfa_field = u"8WD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Formation des chefs d'entreprise"
     start_date = date(2006, 1, 1)
 
@@ -4196,7 +4196,7 @@ class f8wd(Variable):
 class f8we(Variable):
     cerfa_field = u"8WE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Intéressement"
     start_date = date(2008, 1, 1)
 
@@ -4205,7 +4205,7 @@ class f8we(Variable):
 class f8wr(Variable):
     cerfa_field = u"8WR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Métiers d'art"
     start_date = date(2006, 1, 1)
 
@@ -4214,7 +4214,7 @@ class f8wr(Variable):
 class f8ws(Variable):
     cerfa_field = u"8WS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Emploi de salariés réservistes"
     start_date = date(2006, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -4224,7 +4224,7 @@ class f8ws(Variable):
 class f8wt(Variable):
     cerfa_field = u"8WT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Remplacement pour congé des agriculteurs"
     start_date = date(2006, 1, 1)
 
@@ -4233,7 +4233,7 @@ class f8wt(Variable):
 class f8wu(Variable):
     cerfa_field = u"8WU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Maître restaurateur"
     start_date = date(2006, 1, 1)
 
@@ -4242,7 +4242,7 @@ class f8wu(Variable):
 class f8wv(Variable):
     cerfa_field = u"8WV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Débitants de tabac"
     start_date = date(2007, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -4252,7 +4252,7 @@ class f8wv(Variable):
 class f8wx(Variable):
     cerfa_field = u"8WX"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt en faveur des entreprises: Formation des salariés à l'économie d'entreprise"
     start_date = date(2007, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -4264,7 +4264,7 @@ class elig_creimp_exc_2008(Variable):
         default = 1,
         val_type = "monetary",
         )
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Éligibilité au crédit d'impôt exceptionnel sur les revenus 2008"
     start_date = date(2008, 1, 1)
     stop_date = date(2008, 12, 31)
@@ -4273,7 +4273,7 @@ class elig_creimp_exc_2008(Variable):
 
 class elig_creimp_jeunes(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Éligible au crédit d'impôt jeunes"
     start_date = date(2005, 1, 1)
     stop_date = date(2008, 1, 1)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -7,7 +7,7 @@ from openfisca_france.model.base import *  # noqa
 class f7ud(Variable):
     cerfa_field = u"7UD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dons à des organismes d'aide aux personnes en difficulté"
 
 
@@ -15,7 +15,7 @@ class f7ud(Variable):
 class f7uf(Variable):
     cerfa_field = u"7UF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dons à d'autres oeuvres d'utilité publique ou fiscalement assimilables aux oeuvres d'intérêt général"
 
  # début/fin ?
@@ -23,7 +23,7 @@ class f7uf(Variable):
 class f7xs(Variable):
     cerfa_field = u"7XS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -5"
 
 
@@ -31,7 +31,7 @@ class f7xs(Variable):
 class f7xt(Variable):
     cerfa_field = u"7XT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -4"
 
 
@@ -39,7 +39,7 @@ class f7xt(Variable):
 class f7xu(Variable):
     cerfa_field = u"7XU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -3"
     start_date = date(2006, 1, 1)
 
@@ -48,7 +48,7 @@ class f7xu(Variable):
 class f7xw(Variable):
     cerfa_field = u"7XW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -2"
     start_date = date(2007, 1, 1)
 
@@ -57,7 +57,7 @@ class f7xw(Variable):
 class f7xy(Variable):
     cerfa_field = u"7XY"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -1"
     start_date = date(2008, 1, 1)
 
@@ -66,7 +66,7 @@ class f7xy(Variable):
 class f7va(Variable):
     cerfa_field = u"7VA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dons à des organismes d'aides aux personnes établis dans un Etat européen"
     start_date = date(2011, 1, 1)
 
@@ -75,7 +75,7 @@ class f7va(Variable):
 class f7vc(Variable):
     cerfa_field = u"7VC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dons à des autres organismes établis dans un Etat européen"
     start_date = date(2011, 1, 1)
 
@@ -88,7 +88,7 @@ class f7ac(Variable):
         QUIFOY['pac1']: u"7AG",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Cotisations syndicales des salariées et pensionnés"
     start_date = date(2013, 1, 1)
 
@@ -98,7 +98,7 @@ class f7ac(Variable):
 class f7db(Variable):
     cerfa_field = u"7DB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Sommes versées pour l'emploi d'un salarié à domicile par les personnes ayant excercé une activité professionnelle ou ayant été demandeur d'emploi l'année de perception des revenus déclarés"
     start_date = date(2007, 1, 1)
 
@@ -107,7 +107,7 @@ class f7db(Variable):
 class f7df(Variable):
     cerfa_field = u"7DF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Sommes versées pour l'emploi d'un salarié à domicile par les personnes retraités, ou inactives l'année de perception des revenus déclarés"
 
 
@@ -115,7 +115,7 @@ class f7df(Variable):
 class f7dq(Variable):
     cerfa_field = u"7DQ"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Emploi direct pour la première fois d'un salarié à domicile durant l'année de perception des revenus déclarés"
     start_date = date(2009, 1, 1)
 
@@ -124,7 +124,7 @@ class f7dq(Variable):
 class f7dg(Variable):
     cerfa_field = u"7DG"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Vous, votre conjoint ou une personne à votre charge à une carte d'invalidité d'au moins 80 % l'année de perception des revenus déclarés"
 
 
@@ -132,7 +132,7 @@ class f7dg(Variable):
 class f7dl(Variable):
     cerfa_field = u"7DL"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre d'ascendants bénéficiaires de l'APA, âgés de plus de 65 ans, pour lesquels des dépenses ont été engagées l'année de perception des revenus déclarés"
 
 
@@ -141,7 +141,7 @@ class f7dl(Variable):
 class f7uh_2007(Variable):
     cerfa_field = u"7UH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Intérêts payés la première année de remboursement du prêt pour l'habitation principale"
     start_date = date(2007, 1, 1)
     stop_date = date(2007, 12, 31)
@@ -151,7 +151,7 @@ class f7uh_2007(Variable):
 class f7vy(Variable):
     cerfa_field = u"7VY"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements anciens (acquis entre le 06/05/2007 et le 30/09/2011) ou neufs (acquis entre le 06/05/2007 et le 31/12/2009): Première annuité"
     start_date = date(2008, 1, 1)
 
@@ -160,7 +160,7 @@ class f7vy(Variable):
 class f7vz(Variable):
     cerfa_field = u"7VZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements anciens (acquis entre le 06/05/2007 et le 30/09/2011) ou neufs (acquis entre le 06/05/2007 et le 31/12/2009): annuités suivantes"
     start_date = date(2008, 1, 1)
 
@@ -169,7 +169,7 @@ class f7vz(Variable):
 class f7vx(Variable):
     cerfa_field = u"7VX"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs BBC acquis ou construits du 01/01/2009 au 30/09/2011"
 
 
@@ -177,7 +177,7 @@ class f7vx(Variable):
 class f7vw(Variable):
     cerfa_field = u"7VW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2010 au 31/12/2010: première annuité"
     start_date = date(2010, 1, 1)
 
@@ -186,7 +186,7 @@ class f7vw(Variable):
 class f7vv(Variable):
     cerfa_field = u"7VV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2010 au 31/12/2010: annuités suivantes"
     start_date = date(2011, 1, 1)
 
@@ -195,7 +195,7 @@ class f7vv(Variable):
 class f7vu(Variable):
     cerfa_field = u"7VU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2011 au 30/09/2011: première annuité"
     start_date = date(2011, 1, 1)
 
@@ -204,7 +204,7 @@ class f7vu(Variable):
 class f7vt(Variable):
     cerfa_field = u"7VT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2011 au 30/09/2011: annuités suivantes"
     start_date = date(2012, 1, 1)
 
@@ -214,7 +214,7 @@ class f7vt(Variable):
 class f7cd(Variable):
     cerfa_field = u"7CD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses d'accueil dans un établissement pour personnes âgées dépendantes: 1ere personne"
 
 
@@ -222,7 +222,7 @@ class f7cd(Variable):
 class f7ce(Variable):
     cerfa_field = u"7CE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses d'accueil dans un établissement pour personnes âgées dépendantes: 2éme personne"
 
 
@@ -231,7 +231,7 @@ class f7ce(Variable):
 class f7ga(Variable):
     cerfa_field = u"7GA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 1er enfant à charge"
 
 
@@ -239,7 +239,7 @@ class f7ga(Variable):
 class f7gb(Variable):
     cerfa_field = u"7GB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 2ème enfant à charge"
 
 
@@ -247,7 +247,7 @@ class f7gb(Variable):
 class f7gc(Variable):
     cerfa_field = u"7GC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 3ème enfant à charge"
 
 
@@ -255,7 +255,7 @@ class f7gc(Variable):
 class f7ge(Variable):
     cerfa_field = u"7GE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 1er enfant à charge en résidence alternée"
 
 
@@ -263,7 +263,7 @@ class f7ge(Variable):
 class f7gf(Variable):
     cerfa_field = u"7GF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 2ème enfant à charge en résidence alternée"
 
 
@@ -271,7 +271,7 @@ class f7gf(Variable):
 class f7gg(Variable):
     cerfa_field = u"7GG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 3ème enfant à charge en résidence alternée"
 
 
@@ -280,7 +280,7 @@ class f7gg(Variable):
 class f7ea(Variable):
     cerfa_field = u"7EA"
     column = PeriodSizeIndependentIntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre d'enfants à charge poursuivant leurs études au collège"
 
 
@@ -288,7 +288,7 @@ class f7ea(Variable):
 class f7eb(Variable):
     cerfa_field = u"7EB"
     column = PeriodSizeIndependentIntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre d'enfants à charge en résidence alternée poursuivant leurs études au collège"
 
 
@@ -296,7 +296,7 @@ class f7eb(Variable):
 class f7ec(Variable):
     cerfa_field = u"7EC"
     column = PeriodSizeIndependentIntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre d'enfants à charge poursuivant leurs études au lycée"
 
 
@@ -304,7 +304,7 @@ class f7ec(Variable):
 class f7ed(Variable):
     cerfa_field = u"7ED"
     column = PeriodSizeIndependentIntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre d'enfants à charge en résidence alternée poursuivant leurs études au lycée"
 
 
@@ -312,7 +312,7 @@ class f7ed(Variable):
 class f7ef(Variable):
     cerfa_field = u"7EF"
     column = PeriodSizeIndependentIntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre d'enfants à charge poursuivant leurs études dans l'enseignement supérieur"
 
 
@@ -320,7 +320,7 @@ class f7ef(Variable):
 class f7eg(Variable):
     cerfa_field = u"7EG"
     column = PeriodSizeIndependentIntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre d'enfants à charge en résidence alternée poursuivant leurs études dans l'enseignement supérieur"
 
 
@@ -329,7 +329,7 @@ class f7eg(Variable):
 class f7td(Variable):
     cerfa_field = u"7TD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Intérêts des prêts étudiants versés avant l'année de perception des revenus déclarés"
     start_date = date(2008, 1, 1)
 
@@ -338,7 +338,7 @@ class f7td(Variable):
 class f7vo(Variable):
     cerfa_field = u"7VO"
     column = PeriodSizeIndependentIntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Nombre d'années de remboursement du prêt étudiant avant l'année de perception des revenus déclarés"
     start_date = date(2006, 1, 1)
 
@@ -347,7 +347,7 @@ class f7vo(Variable):
 class f7uk(Variable):
     cerfa_field = u"7UK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Intérêts des prêts étudiants versés durant l'année de perception des revenus déclarés"
 
 
@@ -356,7 +356,7 @@ class f7uk(Variable):
 class f7gz(Variable):
     cerfa_field = u"7GZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Primes de rente survie, contrats d'épargne handicap"
 
 
@@ -365,7 +365,7 @@ class f7gz(Variable):
 class f7wm(Variable):
     cerfa_field = u"7WM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prestations compensatoires: Capital fixé en substitution de rente"
 
 
@@ -373,7 +373,7 @@ class f7wm(Variable):
 class f7wn(Variable):
     cerfa_field = u"7WN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prestations compensatoires: Sommes versées l'année de perception des revenus déclarés"
 
 
@@ -381,7 +381,7 @@ class f7wn(Variable):
 class f7wo(Variable):
     cerfa_field = u"7WO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prestations compensatoires: Sommes totales décidées par jugement l'année de perception des revenus déclarés ou capital reconstitué"
 
 
@@ -389,7 +389,7 @@ class f7wo(Variable):
 class f7wp(Variable):
     cerfa_field = u"7WP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prestations compensatoires: Report des sommes décidées l'année de perception des revenus -1"
 
 
@@ -398,7 +398,7 @@ class f7wp(Variable):
 class f7we(Variable):
     cerfa_field = u"7WE"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: éco-prêt à taux zéro avec offre de prêt émise l'année de perception des revenus déclarés"
     start_date = date(2009, 1, 1)
 
@@ -407,7 +407,7 @@ class f7we(Variable):
 class f7wg(Variable):
     cerfa_field = u"7WG"
     column = BoolCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: éco-prêt à taux zéro avec offre de prêt émise l'année de perception des revenus déclarés -1"
     start_date = date(2012, 1, 1)
 
@@ -416,7 +416,7 @@ class f7wg(Variable):
 class f7wa(Variable):
     cerfa_field = u"7WA"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique des murs avant le 03/04/2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -426,7 +426,7 @@ class f7wa(Variable):
 class f7wb(Variable):
     cerfa_field = u"7WB"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique des murs à compter du 04/04/2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -436,7 +436,7 @@ class f7wb(Variable):
 class f7wc(Variable):
     cerfa_field = u"7WC"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique sur plus de la moitié de la surface des murs extérieurs"
     start_date = date(2012, 1, 1)
 
@@ -445,7 +445,7 @@ class f7wc(Variable):
 class f7ve(Variable):
     cerfa_field = u"7VE"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de la toiture avant le 04/04/2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -455,7 +455,7 @@ class f7ve(Variable):
 class f7vf(Variable):
     cerfa_field = u"7VF"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de la toiture à compter du 04/04/2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -465,7 +465,7 @@ class f7vf(Variable):
 class f7vg(Variable):
     cerfa_field = u"7VG"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de toute la toiture"
     start_date = date(2012, 1, 1)
 
@@ -474,7 +474,7 @@ class f7vg(Variable):
 class f7sg(Variable):
     cerfa_field = u"7SG"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Matériaux d'isolation thermique des murs (acquisitionn et pose)"
     start_date = date(2012, 1, 1)
 
@@ -483,7 +483,7 @@ class f7sg(Variable):
 class f7sj(Variable):
     cerfa_field = u"7SJ"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Matériaux d'isolation thermique des parois vitrées"
     start_date = date(2012, 1, 1)
 
@@ -492,7 +492,7 @@ class f7sj(Variable):
 class f7sk(Variable):
     cerfa_field = u"7SK"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Volets isolants"
     start_date = date(2012, 1, 1)
 
@@ -501,7 +501,7 @@ class f7sk(Variable):
 class f7sl(Variable):
     cerfa_field = u"7SL"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Portes d'entrées donnant sur l'extérieur"
     start_date = date(2012, 1, 1)
 
@@ -510,7 +510,7 @@ class f7sl(Variable):
 class f7sm(Variable):
     cerfa_field = u"7SM"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de production d'électricité utilisant l'énergie radiative du soleil"
     start_date = date(2012, 1, 1)
 
@@ -519,7 +519,7 @@ class f7sm(Variable):
 class f7sn(Variable):
     cerfa_field = u"7SN"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Appareils de chauffage au bois ou autres biomasses remplaçant un appareil équivalent"
     start_date = date(2012, 1, 1)
 
@@ -528,7 +528,7 @@ class f7sn(Variable):
 class f7so(Variable):
     cerfa_field = u"7SO"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Appareils de chauffage au bois ou autres biomasses ne remplaçant pas un appareil équivalent"
     start_date = date(2012, 1, 1)
 
@@ -537,7 +537,7 @@ class f7so(Variable):
 class f7sp(Variable):
     cerfa_field = u"7SP"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Pompes à chaleur autres que air/air et autres que géothermiques dont la finalité essentielle est la production de chaleur"
     start_date = date(2012, 1, 1)
 
@@ -546,7 +546,7 @@ class f7sp(Variable):
 class f7sq(Variable):
     cerfa_field = u"7SQ"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Pompes à chaleur géothermiques dont la finalité essentielle est la production de chaleur"
     start_date = date(2012, 1, 1)
 
@@ -555,7 +555,7 @@ class f7sq(Variable):
 class f7sr(Variable):
     cerfa_field = u"7SR"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Pompes à chaleur (autres que air/air) dédiées à la production d'eau chaude sanitaire (chauffe-eaux thermodynamiques)"
     start_date = date(2012, 1, 1)
 
@@ -564,7 +564,7 @@ class f7sr(Variable):
 class f7ss(Variable):
     cerfa_field = u"7SS"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de fourniture d'eau chaude sanitaire fonctionnant à l'énergie solaire et dotés de capteurs solaires"
     start_date = date(2012, 1, 1)
 
@@ -573,7 +573,7 @@ class f7ss(Variable):
 class f7st(Variable):
     cerfa_field = u"7ST"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Autres équipements de production d'énergie utilisant une source d'énergie renouvelable (éolien, hydraulique)"
     start_date = date(2012, 1, 1)
 
@@ -582,7 +582,7 @@ class f7st(Variable):
 class f7su(Variable):
     cerfa_field = u"7SU"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de récupération et de traitement des eaux pluviales"
     start_date = date(2012, 1, 1)
 
@@ -591,7 +591,7 @@ class f7su(Variable):
 class f7sv(Variable):
     cerfa_field = u"7SV"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Diagnostic de performance énergétique"
     start_date = date(2012, 1, 1)
 
@@ -600,7 +600,7 @@ class f7sv(Variable):
 class f7sw(Variable):
     cerfa_field = u"7SW"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de raccordement à un réseau de chaleur"
     start_date = date(2012, 1, 1)
 
@@ -615,7 +615,7 @@ class f7sw(Variable):
 class f7wq(Variable):
     cerfa_field = u"7WQ"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolation thermique des parois vitrées du 01/01/2012 au 03/04/2012"
     start_date = date(2010, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -625,7 +625,7 @@ class f7wq(Variable):
 class f7ws(Variable):
     cerfa_field = u"7WS"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolations des parois vitrées à compter du 04/04/2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -635,7 +635,7 @@ class f7ws(Variable):
 class f7wt(Variable):
     cerfa_field = u"7WT"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolation thermique des parois vitrées réalisées sur au moins la moitié des fenêtres du logement "
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -645,7 +645,7 @@ class f7wt(Variable):
 class f7wu(Variable):
     cerfa_field = u"7WU"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de volets avant 2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -655,7 +655,7 @@ class f7wu(Variable):
 class f7wv(Variable):
     cerfa_field = u"7WV"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de volets en 2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -665,7 +665,7 @@ class f7wv(Variable):
 class f7ww(Variable):
     cerfa_field = u"7WW"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de portes avant 2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -675,7 +675,7 @@ class f7ww(Variable):
 class f7wx(Variable):
     cerfa_field = u"7WX"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de portes en 2012"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -685,7 +685,7 @@ class f7wx(Variable):
 class f7wh(Variable):
     cerfa_field = u"7WH"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (logement achevé depuis plus de 2 ans): bouquet de travaux réalisé pendant l'année de perception des revenus"
     start_date = date(2013, 1, 1)
 
@@ -694,7 +694,7 @@ class f7wh(Variable):
 class f7wk(Variable):
     cerfa_field = u"7WK"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Votre habitation principale est une maison individuelle"
     start_date = date(2009, 1, 1)
 
@@ -703,7 +703,7 @@ class f7wk(Variable):
 class f7wf(Variable):
     cerfa_field = u"7WF"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolation thermique des parois vitrées avant le 01/01/n-1"
     stop_date = date(2013, 12, 31)
 
@@ -713,7 +713,7 @@ class f7wf(Variable):
 class f7wi(Variable):
     cerfa_field = u"7WI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: Ascenseurs électriques à traction"
     stop_date = date(2012, 12, 31)
 
@@ -722,7 +722,7 @@ class f7wi(Variable):
 class f7wj(Variable):
     cerfa_field = u"7WJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: équipements spécialement conçus pour les personnes âgées ou handicapées"
 
 
@@ -730,7 +730,7 @@ class f7wj(Variable):
 class f7wl(Variable):
     cerfa_field = u"7WL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: travaux de prévention des risques technologiques"
     start_date = date(2010, 1, 1)
 
@@ -739,7 +739,7 @@ class f7wl(Variable):
 class f7wr(Variable):
     cerfa_field = u"7WR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de l'aide aux personnes réalisées dans des habitations données en location : travaux de prévention des risques technologiques"
     start_date = date(2013, 1, 1)
 
@@ -749,7 +749,7 @@ class f7wr(Variable):
 class f7ur(Variable):
     cerfa_field = u"7UR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements réalisés en n-1, total réduction d’impôt"
     stop_date = date(2008, 12, 31)
 
@@ -758,7 +758,7 @@ class f7ur(Variable):
 class f7oz(Variable):
     cerfa_field = u"7OZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer: report de réduction d'impôt non imputée les années antérieures année n-6"
     stop_date = date(2011, 12, 31)
 
@@ -767,7 +767,7 @@ class f7oz(Variable):
 class f7pz(Variable):
     cerfa_field = u"7PZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer réalisés en 2007 dans le cadre d'une entreprise: report de réduction d'impôt non imputée les années antérieures"
     stop_date = date(2013, 12, 31)
 
@@ -776,7 +776,7 @@ class f7pz(Variable):
 class f7qz(Variable):
     cerfa_field = u"7QZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer réalisés en 2008 dans le casdre d'une entreprise: report de réduction d'impôt non imputée les années antérieures"
     stop_date = date(2012, 12, 31)
 
@@ -785,7 +785,7 @@ class f7qz(Variable):
 class f7rz(Variable):
     cerfa_field = u"7RZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer: report de réduction d'impôt non imputée les années antérieures année n-3"
     stop_date = date(2010, 12, 31)
 
@@ -794,7 +794,7 @@ class f7rz(Variable):
 class f7qv(Variable):
     cerfa_field = u"7QV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010, nvestissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
     stop_date = date(2011, 12, 31)
 
@@ -803,7 +803,7 @@ class f7qv(Variable):
 class f7qo(Variable):
     cerfa_field = u"7QO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010 à hauteur de 50%"
     stop_date = date(2009, 12, 31)
 
@@ -812,7 +812,7 @@ class f7qo(Variable):
 class f7qp(Variable):
     cerfa_field = u"7QP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010 à hauteur de 60%"
     stop_date = date(2009, 12, 31)
 
@@ -821,7 +821,7 @@ class f7qp(Variable):
 class f7pa(Variable):
     cerfa_field = u"7PA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
     stop_date = date(2011, 12, 31)
 
@@ -830,7 +830,7 @@ class f7pa(Variable):
 class f7pb(Variable):
     cerfa_field = u"7PB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
     stop_date = date(2011, 12, 31)
 
@@ -839,7 +839,7 @@ class f7pb(Variable):
 class f7pc(Variable):
     cerfa_field = u"7PC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
     stop_date = date(2011, 12, 31)
 
@@ -848,7 +848,7 @@ class f7pc(Variable):
 class f7pd(Variable):
     cerfa_field = u"7PD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
     stop_date = date(2011, 12, 31)
 
@@ -857,7 +857,7 @@ class f7pd(Variable):
 class f7qe(Variable):
     cerfa_field = u"7QE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet avant 1.1.2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
     stop_date = date(2009, 12, 31)
 
@@ -866,7 +866,7 @@ class f7qe(Variable):
 class f7pe(Variable):
     cerfa_field = u"7PE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
     stop_date = date(2011, 12, 31)
 
@@ -875,7 +875,7 @@ class f7pe(Variable):
 class f7pf(Variable):
     cerfa_field = u"7PF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
     stop_date = date(2011, 12, 31)
 
@@ -884,7 +884,7 @@ class f7pf(Variable):
 class f7pg(Variable):
     cerfa_field = u"7PG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
     stop_date = date(2011, 12, 31)
 
@@ -893,7 +893,7 @@ class f7pg(Variable):
 class f7ph(Variable):
     cerfa_field = u"7PH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
     stop_date = date(2011, 12, 31)
 
@@ -902,7 +902,7 @@ class f7ph(Variable):
 class f7pi(Variable):
     cerfa_field = u"7PI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
     stop_date = date(2011, 12, 31)
 
@@ -911,7 +911,7 @@ class f7pi(Variable):
 class f7pj(Variable):
     cerfa_field = u"7PJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
     stop_date = date(2011, 12, 31)
 
@@ -920,7 +920,7 @@ class f7pj(Variable):
 class f7pk(Variable):
     cerfa_field = u"7PK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
     stop_date = date(2011, 12, 31)
 
@@ -929,7 +929,7 @@ class f7pk(Variable):
 class f7pl(Variable):
     cerfa_field = u"7PL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
     stop_date = date(2011, 12, 31)
 
@@ -938,7 +938,7 @@ class f7pl(Variable):
 class f7pm(Variable):
     cerfa_field = u"7PM"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%"
     stop_date = date(2013, 12, 31)
 
@@ -947,7 +947,7 @@ class f7pm(Variable):
 class f7pn(Variable):
     cerfa_field = u"7PN"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50 %"
     stop_date = date(2013, 12, 31)
 
@@ -956,7 +956,7 @@ class f7pn(Variable):
 class f7po(Variable):
     cerfa_field = u"7PO"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60 %"
     stop_date = date(2013, 12, 31)
 
@@ -965,7 +965,7 @@ class f7po(Variable):
 class f7pp(Variable):
     cerfa_field = u"7PP"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
     stop_date = date(2013, 12, 31)
 
@@ -974,7 +974,7 @@ class f7pp(Variable):
 class f7pq(Variable):
     cerfa_field = u"7PQ"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     stop_date = date(2013, 12, 31)
 
@@ -983,7 +983,7 @@ class f7pq(Variable):
 class f7pr(Variable):
     cerfa_field = u"7PR"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     stop_date = date(2013, 12, 31)
 
@@ -992,7 +992,7 @@ class f7pr(Variable):
 class f7ps(Variable):
     cerfa_field = u"7PS"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50 %"
     stop_date = date(2013, 12, 31)
 
@@ -1001,7 +1001,7 @@ class f7ps(Variable):
 class f7pt(Variable):
     cerfa_field = u"7PT"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60 %"
     stop_date = date(2013, 12, 31)
 
@@ -1010,7 +1010,7 @@ class f7pt(Variable):
 class f7pu(Variable):
     cerfa_field = u"7PU"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
     stop_date = date(2013, 12, 31)
 
@@ -1019,7 +1019,7 @@ class f7pu(Variable):
 class f7pv(Variable):
     cerfa_field = u"7PV"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     stop_date = date(2013, 12, 31)
 
@@ -1028,7 +1028,7 @@ class f7pv(Variable):
 class f7pw(Variable):
     cerfa_field = u"7PW"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     stop_date = date(2013, 12, 31)
 
@@ -1037,7 +1037,7 @@ class f7pw(Variable):
 class f7px(Variable):
     cerfa_field = u"7PX"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt  à hauteur de 52,63 %"
     stop_date = date(2013, 12, 31)
 
@@ -1046,7 +1046,7 @@ class f7px(Variable):
 class f7py(Variable):
     cerfa_field = u"7PY"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     start_date = date(2012, 1, 1)
 
@@ -1055,7 +1055,7 @@ class f7py(Variable):
 class f7rg(Variable):
     cerfa_field = u"7RG"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
     start_date = date(2012, 1, 1)
 
@@ -1064,7 +1064,7 @@ class f7rg(Variable):
 class f7rh(Variable):
     cerfa_field = u"7RH"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     start_date = date(2012, 1, 1)
 
@@ -1073,7 +1073,7 @@ class f7rh(Variable):
 class f7ri(Variable):
     cerfa_field = u"7RI"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     start_date = date(2012, 1, 1)
 
@@ -1082,7 +1082,7 @@ class f7ri(Variable):
 class f7rj(Variable):
     cerfa_field = u"7RJ"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %"
     start_date = date(2012, 1, 1)
 
@@ -1091,7 +1091,7 @@ class f7rj(Variable):
 class f7rk(Variable):
     cerfa_field = u"7RK"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     start_date = date(2012, 1, 1)
 
@@ -1100,7 +1100,7 @@ class f7rk(Variable):
 class f7rl(Variable):
     cerfa_field = u"7RL"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     start_date = date(2012, 1, 1)
 
@@ -1109,7 +1109,7 @@ class f7rl(Variable):
 class f7rm(Variable):
     cerfa_field = u"7RM"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
     start_date = date(2012, 1, 1)
 
@@ -1118,7 +1118,7 @@ class f7rm(Variable):
 class f7rn(Variable):
     cerfa_field = u"7RN"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     start_date = date(2012, 1, 1)
 
@@ -1127,7 +1127,7 @@ class f7rn(Variable):
 class f7ro(Variable):
     cerfa_field = u"7RO"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     start_date = date(2012, 1, 1)
 
@@ -1136,7 +1136,7 @@ class f7ro(Variable):
 class f7rp(Variable):
     cerfa_field = u"7RP"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     start_date = date(2012, 1, 1)
 
@@ -1145,7 +1145,7 @@ class f7rp(Variable):
 class f7rq(Variable):
     cerfa_field = u"7RQ"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     start_date = date(2012, 1, 1)
 
@@ -1154,7 +1154,7 @@ class f7rq(Variable):
 class f7rr(Variable):
     cerfa_field = u"7RR"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
     start_date = date(2012, 1, 1)
 
@@ -1163,7 +1163,7 @@ class f7rr(Variable):
 class f7rs(Variable):
     cerfa_field = u"7RS"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     start_date = date(2012, 1, 1)
 
@@ -1172,7 +1172,7 @@ class f7rs(Variable):
 class f7rt(Variable):
     cerfa_field = u"7RT"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     start_date = date(2012, 1, 1)
 
@@ -1181,7 +1181,7 @@ class f7rt(Variable):
 class f7ru(Variable):
     cerfa_field = u"7RU"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     start_date = date(2012, 1, 1)
 
@@ -1190,7 +1190,7 @@ class f7ru(Variable):
 class f7rv(Variable):
     cerfa_field = u"7RV"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     start_date = date(2012, 1, 1)
 
@@ -1199,7 +1199,7 @@ class f7rv(Variable):
 class f7rw(Variable):
     cerfa_field = u"7RW"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
     start_date = date(2012, 1, 1)
 
@@ -1208,7 +1208,7 @@ class f7rw(Variable):
 class f7rx(Variable):
     cerfa_field = u"7RX"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     start_date = date(2012, 1, 1)
 
@@ -1217,7 +1217,7 @@ class f7rx(Variable):
 class f7ry(Variable):
     cerfa_field = u"7RY"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     start_date = date(2012, 1, 1)
 
@@ -1226,7 +1226,7 @@ class f7ry(Variable):
 class f7nu(Variable):
     cerfa_field = u"7NU"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     start_date = date(2012, 1, 1)
 
@@ -1235,7 +1235,7 @@ class f7nu(Variable):
 class f7nv(Variable):
     cerfa_field = u"7NV"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     start_date = date(2012, 1, 1)
 
@@ -1244,7 +1244,7 @@ class f7nv(Variable):
 class f7nw(Variable):
     cerfa_field = u"7NW"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise"
     start_date = date(2012, 1, 1)
 
@@ -1253,7 +1253,7 @@ class f7nw(Variable):
 class f7nx(Variable):
     cerfa_field = u"7NX"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     start_date = date(2012, 1, 1)
 
@@ -1262,7 +1262,7 @@ class f7nx(Variable):
 class f7ny(Variable):
     cerfa_field = u"7NY"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     start_date = date(2012, 1, 1)
 
@@ -1271,7 +1271,7 @@ class f7ny(Variable):
 class f7mn(Variable):
     cerfa_field = u"7MN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
     start_date = date(2011, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1281,7 +1281,7 @@ class f7mn(Variable):
 class f7lh(Variable):
     cerfa_field = u"7LH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
     stop_date = date(2011, 12, 31)
 
@@ -1290,7 +1290,7 @@ class f7lh(Variable):
 class f7mb(Variable):
     cerfa_field = u"7MB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60%"
     start_date = date(2011, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1300,7 +1300,7 @@ class f7mb(Variable):
 class f7kt(Variable):
     cerfa_field = u"7KT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt, Investissements dans votre entreprise"
     start_date = date(2011, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1310,7 +1310,7 @@ class f7kt(Variable):
 class f7li(Variable):
     cerfa_field = u"7LI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Autres investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
     start_date = date(2011, 1, 1)
 
@@ -1319,7 +1319,7 @@ class f7li(Variable):
 class f7mc(Variable):
     cerfa_field = u"7MC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Autres investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60%"
     start_date = date(2011, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1329,7 +1329,7 @@ class f7mc(Variable):
 class f7ku(Variable):
     cerfa_field = u"7KU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements dans votre entreprise"
     start_date = date(2011, 1, 1)
     stop_date = date(2011, 12, 31)
@@ -1341,7 +1341,7 @@ class f7ku(Variable):
 class f7sz(Variable):
     cerfa_field = u"7SZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location"
     start_date = date(2006, 1, 1)
 
@@ -1350,7 +1350,7 @@ class f7sz(Variable):
 class fhsa(Variable):
     cerfa_field = u"HSA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 52,63%"
     start_date = date(2013, 1, 1)
 
@@ -1359,7 +1359,7 @@ class fhsa(Variable):
 class fhsb(Variable):
     cerfa_field = u"HSB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 62,5%"
     start_date = date(2013, 1, 1)
 
@@ -1368,7 +1368,7 @@ class fhsb(Variable):
 class fhsf(Variable):
     cerfa_field = u"HSF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 52,63%"
     start_date = date(2013, 1, 1)
 
@@ -1377,7 +1377,7 @@ class fhsf(Variable):
 class fhsg(Variable):
     cerfa_field = u"HSG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 62,5%"
     start_date = date(2013, 1, 1)
 
@@ -1386,7 +1386,7 @@ class fhsg(Variable):
 class fhsc(Variable):
     cerfa_field = u"HSC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise en 2010"
     start_date = date(2013, 1, 1)
 
@@ -1395,7 +1395,7 @@ class fhsc(Variable):
 class fhsh(Variable):
     cerfa_field = u"HSH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise en 2011"
     start_date = date(2013, 1, 1)
 
@@ -1404,7 +1404,7 @@ class fhsh(Variable):
 class fhsd(Variable):
     cerfa_field = u"HSD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2010"
     start_date = date(2013, 1, 1)
 
@@ -1413,7 +1413,7 @@ class fhsd(Variable):
 class fhsi(Variable):
     cerfa_field = u"HSI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2011"
     start_date = date(2013, 1, 1)
 
@@ -1422,7 +1422,7 @@ class fhsi(Variable):
 class fhse(Variable):
     cerfa_field = u"HSE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
     start_date = date(2013, 1, 1)
 
@@ -1431,7 +1431,7 @@ class fhse(Variable):
 class fhsj(Variable):
     cerfa_field = u"HSJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
     start_date = date(2013, 1, 1)
 
@@ -1440,7 +1440,7 @@ class fhsj(Variable):
 class fhsk(Variable):
     cerfa_field = u"HSK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2010 à hauteur de 52,63%"
     start_date = date(2013, 1, 1)
 
@@ -1449,7 +1449,7 @@ class fhsk(Variable):
 class fhsl(Variable):
     cerfa_field = u"HSL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2010 à hauteur de 62,5%"
     start_date = date(2013, 1, 1)
 
@@ -1458,7 +1458,7 @@ class fhsl(Variable):
 class fhsp(Variable):
     cerfa_field = u"HSP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2011 à hauteur de 52,63%"
     start_date = date(2013, 1, 1)
 
@@ -1467,7 +1467,7 @@ class fhsp(Variable):
 class fhsq(Variable):
     cerfa_field = u"HSQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2011 à hauteur de 62,5%"
     start_date = date(2013, 1, 1)
 
@@ -1476,7 +1476,7 @@ class fhsq(Variable):
 class fhsm(Variable):
     cerfa_field = u"HSM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2010"
     start_date = date(2013, 1, 1)
 
@@ -1485,7 +1485,7 @@ class fhsm(Variable):
 class fhsr(Variable):
     cerfa_field = u"HSR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2011"
     start_date = date(2013, 1, 1)
 
@@ -1494,7 +1494,7 @@ class fhsr(Variable):
 class fhsn(Variable):
     cerfa_field = u"HSN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2010"
     start_date = date(2013, 1, 1)
 
@@ -1503,7 +1503,7 @@ class fhsn(Variable):
 class fhss(Variable):
     cerfa_field = u"HSS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2011"
     start_date = date(2013, 1, 1)
 
@@ -1512,7 +1512,7 @@ class fhss(Variable):
 class fhso(Variable):
     cerfa_field = u"HSO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
     start_date = date(2013, 1, 1)
 
@@ -1521,7 +1521,7 @@ class fhso(Variable):
 class fhst(Variable):
     cerfa_field = u"HST"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
     start_date = date(2013, 1, 1)
 
@@ -1530,7 +1530,7 @@ class fhst(Variable):
 class fhsu(Variable):
     cerfa_field = u"HSU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 52,63%"
     start_date = date(2013, 1, 1)
 
@@ -1539,7 +1539,7 @@ class fhsu(Variable):
 class fhsv(Variable):
     cerfa_field = u"HSV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 62,5%"
     start_date = date(2013, 1, 1)
 
@@ -1548,7 +1548,7 @@ class fhsv(Variable):
 class fhsw(Variable):
     cerfa_field = u"HSW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise"
     start_date = date(2013, 1, 1)
 
@@ -1557,7 +1557,7 @@ class fhsw(Variable):
 class fhsx(Variable):
     cerfa_field = u"HSX"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
     start_date = date(2013, 1, 1)
 
@@ -1566,7 +1566,7 @@ class fhsx(Variable):
 class fhsy(Variable):
     cerfa_field = u"HS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
     start_date = date(2013, 1, 1)
 
@@ -1575,7 +1575,7 @@ class fhsy(Variable):
 class fhsz(Variable):
     cerfa_field = u"HSZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 52,63%"
     start_date = date(2013, 1, 1)
 
@@ -1584,7 +1584,7 @@ class fhsz(Variable):
 class fhta(Variable):
     cerfa_field = u"HTA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 62,5%"
     start_date = date(2013, 1, 1)
 
@@ -1593,7 +1593,7 @@ class fhta(Variable):
 class fhtb(Variable):
     cerfa_field = u"HTB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise"
     start_date = date(2013, 1, 1)
 
@@ -1602,7 +1602,7 @@ class fhtb(Variable):
 class fhtc(Variable):
     cerfa_field = u"HTC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
     start_date = date(2013, 1, 1)
 
@@ -1611,7 +1611,7 @@ class fhtc(Variable):
 class fhtd(Variable):
     cerfa_field = u"HTD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
     start_date = date(2013, 1, 1)
 
@@ -1621,7 +1621,7 @@ class fhtd(Variable):
 class f7fy(Variable):
     cerfa_field = u"7FY"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés: conventions signées avant l'année n-1 et ayant pris fin en année n-1"
     stop_date = date(2011, 12, 31)
 
@@ -1630,7 +1630,7 @@ class f7fy(Variable):
 class f7gy(Variable):
     cerfa_field = u"7GY"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés dont handicapés: conventions signées avant l'année n-1 et ayant pris fin en année n-1"
     start_date = date(2006, 1, 1)
     stop_date = date(2011, 12, 31)
@@ -1640,7 +1640,7 @@ class f7gy(Variable):
 class f7hy(Variable):
     cerfa_field = u"7HY"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés: conventions signées en n-1 et n'ayant pas pris fin en n-1"
     start_date = date(2009, 1, 1)
     stop_date = date(2011, 12, 31)
@@ -1650,7 +1650,7 @@ class f7hy(Variable):
 class f7ky(Variable):
     cerfa_field = u"7KY"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés dont handicapés: conventions signées en n-1 et ayant pris fin en n-1"
     start_date = date(2009, 1, 1)
     stop_date = date(2011, 12, 31)
@@ -1660,7 +1660,7 @@ class f7ky(Variable):
 class f7iy(Variable):
     cerfa_field = u"7IY"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Report du solde de réduction d'impôt non encore imputé sur les investissements réalisés"
     start_date = date(2013, 1, 1)
 
@@ -1669,7 +1669,7 @@ class f7iy(Variable):
 class f7ly(Variable):
     cerfa_field = u"7LY"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés: conventions ayant pas pris fin l'année de perception des revenus déclarés"
     start_date = date(2010, 1, 1)
 
@@ -1678,7 +1678,7 @@ class f7ly(Variable):
 class f7my(Variable):
     cerfa_field = u"7MY"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés dont handicapés: conventions ayant pas pris fin l'année de perception des revenus déclarés"
     start_date = date(2010, 1, 1)
 
@@ -1688,7 +1688,7 @@ class f7my(Variable):
 class f7ra(Variable):
     cerfa_field = u"7RA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Travaux de restauration immobilière dans une zone de protection du patrimoine architectural, urbain et paysager"
     start_date = date(2009, 1, 1)
 
@@ -1697,7 +1697,7 @@ class f7ra(Variable):
 class f7rb(Variable):
     cerfa_field = u"7RB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2009, 1, 1)
 
@@ -1706,7 +1706,7 @@ class f7rb(Variable):
 class f7rc(Variable):
     cerfa_field = u"7RC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2011, 1, 1)
 
@@ -1715,7 +1715,7 @@ class f7rc(Variable):
 class f7rd(Variable):
     cerfa_field = u"7RD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2011, 1, 1)
 
@@ -1724,7 +1724,7 @@ class f7rd(Variable):
 class f7re(Variable):
     cerfa_field = u"7RE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2012, 1, 1)
 
@@ -1733,7 +1733,7 @@ class f7re(Variable):
 class f7rf(Variable):
     cerfa_field = u"7RF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2012, 1, 1)
 
@@ -1742,7 +1742,7 @@ class f7rf(Variable):
 class f7sx(Variable):
     cerfa_field = u"7SX"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2013, 1, 1)
 
@@ -1751,7 +1751,7 @@ class f7sx(Variable):
 class f7sy(Variable):
     cerfa_field = u"7SY"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     start_date = date(2013, 1, 1)
 
@@ -1760,7 +1760,7 @@ class f7sy(Variable):
 class f7gw(Variable):
     cerfa_field = u"7GW"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements achevés en n-2 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna : report de 1/5 de la réduction d'impôt"
     start_date = date(2013, 1, 1)
 
@@ -1769,7 +1769,7 @@ class f7gw(Variable):
 class f7gx(Variable):
     cerfa_field = u"7GX"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements achevés en n-2 avec promesse d'achat en n-3 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna : report de 1/5 de la réduction d'impôt"
     start_date = date(2013, 1, 1)
 
@@ -1779,7 +1779,7 @@ class f7gx(Variable):
 class f7xa(Variable):
     cerfa_field = u"7XA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: travaux engagés avant 2011 dans un village résidentiel de tourisme"
     start_date = date(2011, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1789,7 +1789,7 @@ class f7xa(Variable):
 class f7xb(Variable):
     cerfa_field = u"7XB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: travaux engagés avant 2011 dans une résidence de tourisme classée ou meublée"
     start_date = date(2011, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1799,7 +1799,7 @@ class f7xb(Variable):
 class f7xc(Variable):
     cerfa_field = u"7XC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: prix d'acquisition ou de revient d'un logement neuf acquis ou achevé en n-1"
     stop_date = date(2012, 12, 31)
 
@@ -1808,7 +1808,7 @@ class f7xc(Variable):
 class f7xd(Variable):
     cerfa_field = u"7XD"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: logement neuf, demande d'étalement du solde de la réduction d'impôt sur 6 ans"
     start_date = date(2009, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1818,7 +1818,7 @@ class f7xd(Variable):
 class f7xe(Variable):
     cerfa_field = u"7XE"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, demande d'étalement du solde de la réduction d'impôt sur 6 ans"
     start_date = date(2009, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1828,7 +1828,7 @@ class f7xe(Variable):
 class f7xf(Variable):
     cerfa_field = u"7XF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique, logement neuf: report des dépenses d'investissement des années antérieures"
 
 
@@ -1836,7 +1836,7 @@ class f7xf(Variable):
 class f7xh(Variable):
     cerfa_field = u"7XH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: travaux de reconstruction, agrandissement, réparation dans une résidence de tourisme classée ou un meublé de tourisme"
     stop_date = date(2012, 12, 31)
 
@@ -1845,7 +1845,7 @@ class f7xh(Variable):
 class f7xi(Variable):
     cerfa_field = u"7XI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique, logement neuf: report des dépenses d'investissement des années antérieures"
     start_date = date(2010, 1, 1)
 
@@ -1854,7 +1854,7 @@ class f7xi(Variable):
 class f7xj(Variable):
     cerfa_field = u"7XJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, report des dépenses d'investissement des années antérieures"
     start_date = date(2010, 1, 1)
 
@@ -1863,7 +1863,7 @@ class f7xj(Variable):
 class f7xk(Variable):
     cerfa_field = u"7XK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     start_date = date(2010, 1, 1)
 
@@ -1872,7 +1872,7 @@ class f7xk(Variable):
 class f7xl(Variable):
     cerfa_field = u"7XL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, prix de revient d'un logement réhabilité en n-1 et achevé depuis moins de 15 ans"
     stop_date = date(2012, 12, 31)
 
@@ -1881,7 +1881,7 @@ class f7xl(Variable):
 class f7xm(Variable):
     cerfa_field = u"7XM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, report de dépenses des travaux de réhabilitation achevés les années antérieures"
 
 
@@ -1890,7 +1890,7 @@ class f7xm(Variable):
 class f7xn(Variable):
     cerfa_field = u"7XN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique, logement neuf: report des dépenses d'investissement des années antérieures"
     start_date = date(2012, 1, 1)
 
@@ -1899,7 +1899,7 @@ class f7xn(Variable):
 class f7xo(Variable):
     cerfa_field = u"7XO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     start_date = date(2008, 1, 1)
 
@@ -1908,7 +1908,7 @@ class f7xo(Variable):
 class f7xp(Variable):
     cerfa_field = u"7XP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     start_date = date(2011, 1, 1)
 
@@ -1917,7 +1917,7 @@ class f7xp(Variable):
 class f7xq(Variable):
     cerfa_field = u"7XQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     start_date = date(2011, 1, 1)
 
@@ -1926,7 +1926,7 @@ class f7xq(Variable):
 class f7xr(Variable):
     cerfa_field = u"7XR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     start_date = date(2011, 1, 1)
 
@@ -1935,7 +1935,7 @@ class f7xr(Variable):
 class f7xv(Variable):
     cerfa_field = u"7XV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: Report des dépenses d'investissement des années antérieures"
     start_date = date(2012, 1, 1)
 
@@ -1944,7 +1944,7 @@ class f7xv(Variable):
 class f7xx(Variable):
     cerfa_field = u"7XX"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: travaux engagés après 2012 dans un village résidentiel de tourisme"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -1954,7 +1954,7 @@ class f7xx(Variable):
 class f7xz(Variable):
     cerfa_field = u"7XZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: travaux engagés après 2012 dans une résidence de tourisme classée ou un meublé tourisme"
     start_date = date(2012, 1, 1)
 
@@ -1963,7 +1963,7 @@ class f7xz(Variable):
 class f7uy(Variable):
     cerfa_field = u"7UY"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: Report des dépenses d'investissement des années antérieures"
     start_date = date(2013, 1, 1)
 
@@ -1972,7 +1972,7 @@ class f7uy(Variable):
 class f7uz(Variable):
     cerfa_field = u"7UZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs dans le secteur de touristique: Report des dépenses d'investissement des années antérieures"
     start_date = date(2013, 1, 1)
 
@@ -1982,7 +1982,7 @@ class f7uz(Variable):
 class f7cf(Variable):
     cerfa_field = u"7CF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscriptions au capital des PME non cotées, petites entreprises en phase de démarrage, ou d'expansion"
 
 
@@ -1990,7 +1990,7 @@ class f7cf(Variable):
 class f7cl(Variable):
     cerfa_field = u"7CL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -4"
 
 
@@ -1998,7 +1998,7 @@ class f7cl(Variable):
 class f7cm(Variable):
     cerfa_field = u"7CM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -3"
 
 
@@ -2006,7 +2006,7 @@ class f7cm(Variable):
 class f7cn(Variable):
     cerfa_field = u"7CN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -2"
 
 
@@ -2014,7 +2014,7 @@ class f7cn(Variable):
 class f7cc(Variable):
     cerfa_field = u"7CC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1"
     start_date = date(2013, 1, 1)
 
@@ -2023,7 +2023,7 @@ class f7cc(Variable):
 class f7cq(Variable):
     cerfa_field = u"7CQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1pour les start-up"
     start_date = date(2011, 1, 1)
 
@@ -2032,7 +2032,7 @@ class f7cq(Variable):
 class f7cu(Variable):
     cerfa_field = u"7CU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscriptions au capital des PME non cotées, montant versé au titre de souscriptions antérieures"
 
 
@@ -2042,7 +2042,7 @@ class f7cu(Variable):
 class f7gs(Variable):
     cerfa_field = u"7GS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Reports concernant les investissements achevés ou acquis au cours des années antérieures: Investissements réalisés en n-3 en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2013, 1, 1)
 
@@ -2052,14 +2052,14 @@ class f7gs(Variable):
 class f7ua(Variable):
     cerfa_field = u"7UA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2007, 12, 31)
 
 
 class f7ub(Variable):
     cerfa_field = u"7UB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2007, 12, 31)
 
 
@@ -2071,7 +2071,7 @@ class f7ub(Variable):
 class f7uc(Variable):
     cerfa_field = u"7UC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Cotisations pour la défense des forêts contre l'incendie "
 
 
@@ -2079,156 +2079,156 @@ class f7uc(Variable):
 class f7ui(Variable):
     cerfa_field = u"7UI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2008, 12, 31)
 
 
 class f7uj(Variable):
     cerfa_field = u"7UJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2007, 12, 31)
 
 
 class f7qb(Variable):
     cerfa_field = u"7QB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2011, 12, 31)
 
 
 class f7qc(Variable):
     cerfa_field = u"7QC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2011, 12, 31)
 
 
 class f7qd(Variable):
     cerfa_field = u"7QD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2011, 12, 31)
 
 
 class f7qk(Variable):
     cerfa_field = u"7QK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2009, 12, 31)
 
 
 class f7qn(Variable):
     cerfa_field = u"7QN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2010, 12, 31)
 
 
 class f7kg(Variable):
     cerfa_field = u"7KG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2010, 12, 31)
 
 
 class f7ql(Variable):
     cerfa_field = u"7QL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2011, 12, 31)
 
 
 class f7qt(Variable):
     cerfa_field = u"7QT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2011, 12, 31)
 
 
 class f7qm(Variable):
     cerfa_field = u"7QM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2011, 12, 31)
 
 
 class f7qu(Variable):
     cerfa_field = u"7QU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7ki(Variable):
     cerfa_field = u"7KI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7qj(Variable):
     cerfa_field = u"7QJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7qw(Variable):
     cerfa_field = u"7QW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7qx(Variable):
     cerfa_field = u"7QX"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7qf(Variable):
     cerfa_field = u"7QF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7qg(Variable):
     cerfa_field = u"7QG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7qh(Variable):
     cerfa_field = u"7QH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7qi(Variable):
     cerfa_field = u"7QI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7qq(Variable):
     cerfa_field = u"7QQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7qr(Variable):
     cerfa_field = u"7QR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7qs(Variable):
     cerfa_field = u"7QS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7mm(Variable):
     cerfa_field = u"7MM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     start_date = date(2010, 1, 1)
     stop_date = date(2012, 12, 31)
 
@@ -2236,34 +2236,34 @@ class f7mm(Variable):
 class f7lg(Variable):
     cerfa_field = u"7LG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     start_date = date(2010, 1, 1)
 
 
 class f7ma(Variable):
     cerfa_field = u"7MA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     start_date = date(2010, 1, 1)
 
 
 class f7ks(Variable):
     cerfa_field = u"7KS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class f7kh(Variable):
     cerfa_field = u"7KH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 
 class f7oa(Variable):
     cerfa_field = u"7OA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% avant 2009"
     start_date = date(2011, 1, 1)
 
@@ -2272,7 +2272,7 @@ class f7oa(Variable):
 class f7ob(Variable):
     cerfa_field = u"7OB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2009"
     start_date = date(2011, 1, 1)
 
@@ -2281,7 +2281,7 @@ class f7ob(Variable):
 class f7oc(Variable):
     cerfa_field = u"7OC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     start_date = date(2011, 1, 1)
 
@@ -2290,7 +2290,7 @@ class f7oc(Variable):
 class f7oh(Variable):
     cerfa_field = u"7OH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% avant 2009"
     start_date = date(2011, 1, 1)
 
@@ -2299,7 +2299,7 @@ class f7oh(Variable):
 class f7oi(Variable):
     cerfa_field = u"7OI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2009"
     start_date = date(2011, 1, 1)
 
@@ -2308,7 +2308,7 @@ class f7oi(Variable):
 class f7oj(Variable):
     cerfa_field = u"7OJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     start_date = date(2011, 1, 1)
 
@@ -2317,7 +2317,7 @@ class f7oj(Variable):
 class f7ok(Variable):
     cerfa_field = u"7OK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Autres investissements"
     start_date = date(2011, 1, 1)
 
@@ -2326,7 +2326,7 @@ class f7ok(Variable):
 class f7ol(Variable):
     cerfa_field = u"7OL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
     start_date = date(2012, 1, 1)
 
@@ -2335,7 +2335,7 @@ class f7ol(Variable):
 class f7om(Variable):
     cerfa_field = u"7OM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
     start_date = date(2012, 1, 1)
 
@@ -2344,7 +2344,7 @@ class f7om(Variable):
 class f7on(Variable):
     cerfa_field = u"7ON"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     start_date = date(2012, 1, 1)
 
@@ -2353,7 +2353,7 @@ class f7on(Variable):
 class f7oo(Variable):
     cerfa_field = u"7OO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
     start_date = date(2012, 1, 1)
 
@@ -2362,7 +2362,7 @@ class f7oo(Variable):
 class f7op(Variable):
     cerfa_field = u"7OP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
     start_date = date(2012, 1, 1)
 
@@ -2371,7 +2371,7 @@ class f7op(Variable):
 class f7oq(Variable):
     cerfa_field = u"7OQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     start_date = date(2012, 1, 1)
 
@@ -2380,7 +2380,7 @@ class f7oq(Variable):
 class f7or(Variable):
     cerfa_field = u"7OR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     start_date = date(2012, 1, 1)
 
@@ -2389,7 +2389,7 @@ class f7or(Variable):
 class f7os(Variable):
     cerfa_field = u"7OS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
     start_date = date(2012, 1, 1)
 
@@ -2398,7 +2398,7 @@ class f7os(Variable):
 class f7ot(Variable):
     cerfa_field = u"7OT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
     start_date = date(2012, 1, 1)
 
@@ -2407,7 +2407,7 @@ class f7ot(Variable):
 class f7ou(Variable):
     cerfa_field = u"7OU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     start_date = date(2012, 1, 1)
 
@@ -2416,7 +2416,7 @@ class f7ou(Variable):
 class f7ov(Variable):
     cerfa_field = u"7OV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     start_date = date(2012, 1, 1)
 
@@ -2425,7 +2425,7 @@ class f7ov(Variable):
 class f7ow(Variable):
     cerfa_field = u"7OW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, "
     start_date = date(2012, 1, 1)
 
@@ -2434,7 +2434,7 @@ class f7ow(Variable):
 class fhod(Variable):
     cerfa_field = u"HOD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés avant le 1.1.2011"
     start_date = date(2013, 1, 1)
 
@@ -2443,7 +2443,7 @@ class fhod(Variable):
 class fhoe(Variable):
     cerfa_field = u"HOE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     start_date = date(2013, 1, 1)
 
@@ -2452,7 +2452,7 @@ class fhoe(Variable):
 class fhof(Variable):
     cerfa_field = u"HOF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     start_date = date(2013, 1, 1)
 
@@ -2462,7 +2462,7 @@ class fhof(Variable):
 class fhog(Variable):
     cerfa_field = u"HOG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     start_date = date(2013, 1, 1)
 
@@ -2472,7 +2472,7 @@ class fhog(Variable):
 class fhox(Variable):
     cerfa_field = u"HOX"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2011"
     start_date = date(2013, 1, 1)
 
@@ -2482,7 +2482,7 @@ class fhox(Variable):
 class fhoy(Variable):
     cerfa_field = u"HOY"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2012"
     start_date = date(2013, 1, 1)
 
@@ -2492,7 +2492,7 @@ class fhoy(Variable):
 class fhoz(Variable):
     cerfa_field = u"HOZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Autres investissements"
     start_date = date(2013, 1, 1)
 
@@ -2503,7 +2503,7 @@ class fhoz(Variable):
 class fhra(Variable):
     cerfa_field = u"HRA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Investissements ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     start_date = date(2013, 1, 1)
 
@@ -2512,7 +2512,7 @@ class fhra(Variable):
 class fhrb(Variable):
     cerfa_field = u"HRB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Investissements ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     start_date = date(2013, 1, 1)
 
@@ -2521,7 +2521,7 @@ class fhrb(Variable):
 class fhrc(Variable):
     cerfa_field = u"HRC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Investissements ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2012"
     start_date = date(2013, 1, 1)
 
@@ -2530,7 +2530,7 @@ class fhrc(Variable):
 class fhrd(Variable):
     cerfa_field = u"HRD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Autres investissements"
     start_date = date(2013, 1, 1)
 
@@ -2541,7 +2541,7 @@ class fhrd(Variable):
 class f7gq(Variable):
     cerfa_field = u"7GQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscription de parts de fonds communs de placement dans l'innovation"
 
 
@@ -2549,7 +2549,7 @@ class f7gq(Variable):
 class f7fq(Variable):
     cerfa_field = u"7FQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscription de parts de fonds d'investissement de proximité"
 
 
@@ -2557,7 +2557,7 @@ class f7fq(Variable):
 class f7fm(Variable):
     cerfa_field = u"7FM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscription de parts de fonds d'investissement de proximité investis en Corse"
     start_date = date(2007, 1, 1)
 
@@ -2566,7 +2566,7 @@ class f7fm(Variable):
 class f7fl(Variable):
     cerfa_field = u"7FL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscription de parts de fonds d'investissement de proximité investis outre-mer par des personnes domiciliées outre-mer"
     start_date = date(2011, 1, 1)
 
@@ -2576,7 +2576,7 @@ class f7fl(Variable):
 class f7gn(Variable):
     cerfa_field = u"7GN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscriptions au capital de SOFICA 36 %"
     start_date = date(2006, 1, 1)
 
@@ -2585,7 +2585,7 @@ class f7gn(Variable):
 class f7fn(Variable):
     cerfa_field = u"7FN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Souscriptions au capital de SOFICA 30 %"
     start_date = date(2006, 1, 1)
 
@@ -2595,7 +2595,7 @@ class f7fn(Variable):
 class f7fh(Variable):
     cerfa_field = u"7FH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Intérêts d'emprunt pour reprise de société"
 
 
@@ -2604,7 +2604,7 @@ class f7fh(Variable):
 class f7ff(Variable):
     cerfa_field = u"7FF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Frais de comptabilité et d'adhésion à un CGA (centre de gestion agréée) ou à une AA (association agréée)"
 
 
@@ -2612,7 +2612,7 @@ class f7ff(Variable):
 class f7fg(Variable):
     cerfa_field = u"7FG"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Frais de comptabilité et d'adhésion à un CGA ou à une AA: nombre d'exploitations"
 
 
@@ -2621,7 +2621,7 @@ class f7fg(Variable):
 class f7nz(Variable):
     cerfa_field = u"7NZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Travaux de conservation et de restauration d’objets classés monuments historiques"
     start_date = date(2008, 1, 1)
 
@@ -2631,7 +2631,7 @@ class f7nz(Variable):
 class f7ka(Variable):
     cerfa_field = u"7KA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de protection du patrimoine naturel"
     start_date = date(2010, 1, 1)
 
@@ -2640,7 +2640,7 @@ class f7ka(Variable):
 class f7kb(Variable):
     cerfa_field = u"7KB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
     start_date = date(2011, 1, 1)
 
@@ -2649,7 +2649,7 @@ class f7kb(Variable):
 class f7kc(Variable):
     cerfa_field = u"7KC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
     start_date = date(2012, 1, 1)
 
@@ -2658,7 +2658,7 @@ class f7kc(Variable):
 class f7kd(Variable):
     cerfa_field = u"7KD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
     start_date = date(2013, 1, 1)
 
@@ -2667,7 +2667,7 @@ class f7kd(Variable):
 class f7uh(Variable):
     cerfa_field = u"7UH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dons et cotisations versés aux partis politiques"
     start_date = date(2007, 1, 1)
 
@@ -2677,7 +2677,7 @@ class f7uh(Variable):
 class f7un(Variable):
     cerfa_field = u"7UN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements forestiers: acquisition"
 
 
@@ -2685,7 +2685,7 @@ class f7un(Variable):
 class f7ul(Variable):
     cerfa_field = u"7UL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements forestiers"
     start_date = date(2011, 1, 1)
 
@@ -2694,7 +2694,7 @@ class f7ul(Variable):
 class f7uu(Variable):
     cerfa_field = u"7UU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements forestiers"
     start_date = date(2010, 1, 1)
 
@@ -2703,7 +2703,7 @@ class f7uu(Variable):
 class f7uv(Variable):
     cerfa_field = u"7UV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements forestiers"
     start_date = date(2011, 1, 1)
 
@@ -2712,7 +2712,7 @@ class f7uv(Variable):
 class f7uw(Variable):
     cerfa_field = u"7UW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements forestiers"
     start_date = date(2012, 1, 1)
 
@@ -2721,7 +2721,7 @@ class f7uw(Variable):
 class f7th(Variable):
     cerfa_field = u"7TH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements forestiers"
     start_date = date(2013, 1, 1)
 
@@ -2730,7 +2730,7 @@ class f7th(Variable):
 class f7ux(Variable):
     cerfa_field = u"7UX"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements forestiers"
     start_date = date(2013, 1, 1)
 
@@ -2739,7 +2739,7 @@ class f7ux(Variable):
 class f7tg(Variable):
     cerfa_field = u"7TG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements forestiers"
     start_date = date(2012, 1, 1)
 
@@ -2748,7 +2748,7 @@ class f7tg(Variable):
 class f7tf(Variable):
     cerfa_field = u"7TF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements forestiers"
     start_date = date(2011, 1, 1)
     stop_date = date(2013, 12, 31)
@@ -2758,7 +2758,7 @@ class f7tf(Variable):
 class f7ut(Variable):
     cerfa_field = u"7UT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements forestiers"
     start_date = date(2009, 1, 1)
 
@@ -2768,7 +2768,7 @@ class f7ut(Variable):
 class f7um(Variable):
     cerfa_field = u"7UM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Intérêts pour paiement différé accordé aux agriculteurs"
 
 
@@ -2777,7 +2777,7 @@ class f7um(Variable):
 class f7hj(Variable):
     cerfa_field = u"7HJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 en métropole"
     start_date = date(2009, 1, 1)
 
@@ -2786,7 +2786,7 @@ class f7hj(Variable):
 class f7hk(Variable):
     cerfa_field = u"7HK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 dans les DOM-COM"
     start_date = date(2009, 1, 1)
 
@@ -2795,7 +2795,7 @@ class f7hk(Variable):
 class f7hn(Variable):
     cerfa_field = u"7HN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 en métropole avec promesse d'achat avant le 1er janvier 2010"
     start_date = date(2010, 1, 1)
 
@@ -2804,7 +2804,7 @@ class f7hn(Variable):
 class f7ho(Variable):
     cerfa_field = u"7HO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 dans les DOM-COM avec promesse d'achat avant le 1er janvier 2010"
     start_date = date(2010, 1, 1)
 
@@ -2813,7 +2813,7 @@ class f7ho(Variable):
 class f7hl(Variable):
     cerfa_field = u"7HL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2009 (métropole et DOM ne respectant pas les plafonds)"
     start_date = date(2010, 1, 1)
 
@@ -2822,7 +2822,7 @@ class f7hl(Variable):
 class f7hm(Variable):
     cerfa_field = u"7HM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2009 dans les DOM et respectant les plafonds"
     start_date = date(2010, 1, 1)
 
@@ -2831,7 +2831,7 @@ class f7hm(Variable):
 class f7hr(Variable):
     cerfa_field = u"7HR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés et achevés en 2009, en métropole en 2009; dans les DOM du 1.1.2009 au 26.5.2009 ; dans les DOM du 27.5.2009 au 30.12.2009 lorsqu'ils ne respectent pas les plafonds spécifiques"
     start_date = date(2010, 1, 1)
 
@@ -2840,7 +2840,7 @@ class f7hr(Variable):
 class f7hs(Variable):
     cerfa_field = u"7HS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés et achevés en 2009 dans les DOM COM du 27.5.2009 au 31.12.2009 respectant les plafonds spécifiques"
     start_date = date(2010, 1, 1)
 
@@ -2849,7 +2849,7 @@ class f7hs(Variable):
 class f7la(Variable):
     cerfa_field = u"7LA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2009"
     start_date = date(2010, 1, 1)
 
@@ -2858,7 +2858,7 @@ class f7la(Variable):
 class f7lb(Variable):
     cerfa_field = u"7LB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2010"
     start_date = date(2011, 1, 1)
 
@@ -2867,7 +2867,7 @@ class f7lb(Variable):
 class f7lc(Variable):
     cerfa_field = u"7LC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report de l'année 2010"
     start_date = date(2011, 1, 1)
 
@@ -2876,7 +2876,7 @@ class f7lc(Variable):
 class f7ld(Variable):
     cerfa_field = u"7LD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report de l'année 2011"
     start_date = date(2012, 1, 1)
 
@@ -2885,7 +2885,7 @@ class f7ld(Variable):
 class f7le(Variable):
     cerfa_field = u"7LE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2011"
     start_date = date(2012, 1, 1)
 
@@ -2894,7 +2894,7 @@ class f7le(Variable):
 class f7lf(Variable):
     cerfa_field = u"7LF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2011 : report du solde de réduction d'impôt de l'année 2011"
     start_date = date(2012, 1, 1)
 
@@ -2903,7 +2903,7 @@ class f7lf(Variable):
 class f7ls(Variable):
     cerfa_field = u"7LS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010"
     start_date = date(2013, 1, 1)
 
@@ -2912,7 +2912,7 @@ class f7ls(Variable):
 class f7lm(Variable):
     cerfa_field = u"7LM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010"
     start_date = date(2013, 1, 1)
 
@@ -2921,7 +2921,7 @@ class f7lm(Variable):
 class f7lz(Variable):
     cerfa_field = u"7LZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Report du solde de réduction d'impôt de l'année 2012"
     start_date = date(2013, 1, 1)
 
@@ -2930,7 +2930,7 @@ class f7lz(Variable):
 class f7mg(Variable):
     cerfa_field = u"7MG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2012 : report du solde de réduction d'impôt de l'année 2012"
     start_date = date(2013, 1, 1)
 
@@ -2939,7 +2939,7 @@ class f7mg(Variable):
 class f7na(Variable):
     cerfa_field = u"7NA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, métropole, BBC"
     start_date = date(2011, 1, 1)
 
@@ -2948,7 +2948,7 @@ class f7na(Variable):
 class f7nb(Variable):
     cerfa_field = u"7NB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, "
     start_date = date(2011, 1, 1)
 
@@ -2957,7 +2957,7 @@ class f7nb(Variable):
 class f7nc(Variable):
     cerfa_field = u"7NC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, métropole, BBC"
     start_date = date(2011, 1, 1)
 
@@ -2966,7 +2966,7 @@ class f7nc(Variable):
 class f7nd(Variable):
     cerfa_field = u"7ND"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, métropole, BBC"
     start_date = date(2011, 1, 1)
 
@@ -2975,7 +2975,7 @@ class f7nd(Variable):
 class f7ne(Variable):
     cerfa_field = u"7NE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, métropole, BBC"
     start_date = date(2011, 1, 1)
 
@@ -2984,7 +2984,7 @@ class f7ne(Variable):
 class f7nf(Variable):
     cerfa_field = u"7NF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, "
     start_date = date(2011, 1, 1)
 
@@ -2993,7 +2993,7 @@ class f7nf(Variable):
 class f7ng(Variable):
     cerfa_field = u"7NG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, "
     start_date = date(2011, 1, 1)
 
@@ -3002,7 +3002,7 @@ class f7ng(Variable):
 class f7nh(Variable):
     cerfa_field = u"7NH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, Investissement réalisé du 1.1.2011 au 31.1.2011, métropole, non-BBC"
     start_date = date(2011, 1, 1)
 
@@ -3011,7 +3011,7 @@ class f7nh(Variable):
 class f7ni(Variable):
     cerfa_field = u"7NI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, métropole, non-BBC"
     start_date = date(2011, 1, 1)
 
@@ -3020,7 +3020,7 @@ class f7ni(Variable):
 class f7nj(Variable):
     cerfa_field = u"7NJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, métropole, non-BBC"
     start_date = date(2011, 1, 1)
 
@@ -3029,7 +3029,7 @@ class f7nj(Variable):
 class f7nk(Variable):
     cerfa_field = u"7NK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2011, 1, 1)
 
@@ -3038,7 +3038,7 @@ class f7nk(Variable):
 class f7nl(Variable):
     cerfa_field = u"7NL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2011, 1, 1)
 
@@ -3047,7 +3047,7 @@ class f7nl(Variable):
 class f7nm(Variable):
     cerfa_field = u"7NM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, Investissement réalisé du 1.1.2011 au 31.1.2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2011, 1, 1)
 
@@ -3056,7 +3056,7 @@ class f7nm(Variable):
 class f7nn(Variable):
     cerfa_field = u"7NN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2011, 1, 1)
 
@@ -3065,7 +3065,7 @@ class f7nn(Variable):
 class f7no(Variable):
     cerfa_field = u"7NO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2011, 1, 1)
 
@@ -3074,7 +3074,7 @@ class f7no(Variable):
 class f7np(Variable):
     cerfa_field = u"7NP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2011, 1, 1)
 
@@ -3083,7 +3083,7 @@ class f7np(Variable):
 class f7nq(Variable):
     cerfa_field = u"7NQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2011, 1, 1)
 
@@ -3092,7 +3092,7 @@ class f7nq(Variable):
 class f7nr(Variable):
     cerfa_field = u"7NR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, Investissement réalisé du 1.1.2011 au 31.1.2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2011, 1, 1)
 
@@ -3101,7 +3101,7 @@ class f7nr(Variable):
 class f7ns(Variable):
     cerfa_field = u"7NS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2011, 1, 1)
 
@@ -3110,7 +3110,7 @@ class f7ns(Variable):
 class f7nt(Variable):
     cerfa_field = u"7NT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2011, 1, 1)
 
@@ -3119,7 +3119,7 @@ class f7nt(Variable):
 class f7hv(Variable):
     cerfa_field = u"7HV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 en métropole"
     start_date = date(2011, 1, 1)
 
@@ -3128,7 +3128,7 @@ class f7hv(Variable):
 class f7hw(Variable):
     cerfa_field = u"7HW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 dans les DOM COM"
     start_date = date(2011, 1, 1)
 
@@ -3137,7 +3137,7 @@ class f7hw(Variable):
 class f7hx(Variable):
     cerfa_field = u"7HX"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 en métropole avec promesse d'achat avant le 1.1.2010"
     start_date = date(2011, 1, 1)
 
@@ -3146,7 +3146,7 @@ class f7hx(Variable):
 class f7hz(Variable):
     cerfa_field = u"7HZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 dans les DOM COM avec promesse d'achat avant le 1.1.2010"
     start_date = date(2011, 1, 1)
 
@@ -3155,7 +3155,7 @@ class f7hz(Variable):
 class f7ht(Variable):
     cerfa_field = u"7HT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2009, Investissements réalisés en 2009 et achevés en 2010, en métropole en 2009; dans les DOM du 1.1.2009 au 26.5.2009 ; dans les DOM du 27.5.2009 au 30.12.2009 lorsqu'ils ne respectent pas les plafonds spécifiques"
     start_date = date(2011, 1, 1)
 
@@ -3164,7 +3164,7 @@ class f7ht(Variable):
 class f7hu(Variable):
     cerfa_field = u"7HU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2009, Investissements réalisés en 2009 et achevés en 2010, dans les DOM COM du 27.5.2009 au 31.12.2009 respectant les plafonds spécifiques"
     start_date = date(2011, 1, 1)
 
@@ -3173,7 +3173,7 @@ class f7hu(Variable):
 class f7ha(Variable):
     cerfa_field = u"7HA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés et réalisés en 2011"
     start_date = date(2012, 1, 1)
 
@@ -3182,7 +3182,7 @@ class f7ha(Variable):
 class f7hb(Variable):
     cerfa_field = u"7HB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés et réalisés en 2011, avec promesse d'achat en 2010"
     start_date = date(2012, 1, 1)
 
@@ -3191,7 +3191,7 @@ class f7hb(Variable):
 class f7hg(Variable):
     cerfa_field = u"7HG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2011 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna"
     start_date = date(2012, 1, 1)
 
@@ -3200,7 +3200,7 @@ class f7hg(Variable):
 class f7hh(Variable):
     cerfa_field = u"7HH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2011 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna avec promesse d'achat en 2010"
     start_date = date(2012, 1, 1)
 
@@ -3209,7 +3209,7 @@ class f7hh(Variable):
 class f7hd(Variable):
     cerfa_field = u"7HD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés en 2011, réalisés en 2010, en métropole et dans les DOM-COM"
     start_date = date(2012, 1, 1)
 
@@ -3218,7 +3218,7 @@ class f7hd(Variable):
 class f7he(Variable):
     cerfa_field = u"7HE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés en 2011, en métropole et dans les DOM-COM avec promesse d'achat avant le 1.1.2010"
     start_date = date(2012, 1, 1)
 
@@ -3227,7 +3227,7 @@ class f7he(Variable):
 class f7hf(Variable):
     cerfa_field = u"7HF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés en 2011, Investissements réalisés en 2009 en métropole et dans les DOM-COM"
     start_date = date(2012, 1, 1)
 
@@ -3236,7 +3236,7 @@ class f7hf(Variable):
 class f7ja(Variable):
     cerfa_field = u"7JA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2012, métropole, BBC"
     start_date = date(2012, 1, 1)
 
@@ -3245,7 +3245,7 @@ class f7ja(Variable):
 class f7jb(Variable):
     cerfa_field = u"7JB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, métropole, BBC"
     start_date = date(2012, 1, 1)
 
@@ -3254,7 +3254,7 @@ class f7jb(Variable):
 class f7jd(Variable):
     cerfa_field = u"7JD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, métropole, BBC"
     start_date = date(2012, 1, 1)
 
@@ -3263,7 +3263,7 @@ class f7jd(Variable):
 class f7je(Variable):
     cerfa_field = u"7JE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, métropole, BBC "
     start_date = date(2012, 1, 1)
 
@@ -3272,7 +3272,7 @@ class f7je(Variable):
 class f7jf(Variable):
     cerfa_field = u"7JF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2012, métropole, non-BBC"
     start_date = date(2012, 1, 1)
 
@@ -3281,7 +3281,7 @@ class f7jf(Variable):
 class f7jg(Variable):
     cerfa_field = u"7JG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, métropole, non-BBC"
     start_date = date(2012, 1, 1)
 
@@ -3290,7 +3290,7 @@ class f7jg(Variable):
 class f7jh(Variable):
     cerfa_field = u"7JH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, métropole, non-BBC"
     start_date = date(2012, 1, 1)
 
@@ -3299,7 +3299,7 @@ class f7jh(Variable):
 class f7jj(Variable):
     cerfa_field = u"7JJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, métropole, non-BBC"
     start_date = date(2012, 1, 1)
 
@@ -3308,7 +3308,7 @@ class f7jj(Variable):
 class f7jk(Variable):
     cerfa_field = u"7JK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2012, 1, 1)
 
@@ -3317,7 +3317,7 @@ class f7jk(Variable):
 class f7jl(Variable):
     cerfa_field = u"7JL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2012, 1, 1)
 
@@ -3326,7 +3326,7 @@ class f7jl(Variable):
 class f7jm(Variable):
     cerfa_field = u"7JM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2012, 1, 1)
 
@@ -3335,7 +3335,7 @@ class f7jm(Variable):
 class f7jn(Variable):
     cerfa_field = u"7JN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2012, 1, 1)
 
@@ -3344,7 +3344,7 @@ class f7jn(Variable):
 class f7jo(Variable):
     cerfa_field = u"7JO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2012, 1, 1)
 
@@ -3353,7 +3353,7 @@ class f7jo(Variable):
 class f7jp(Variable):
     cerfa_field = u"7JP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2012, 1, 1)
 
@@ -3362,7 +3362,7 @@ class f7jp(Variable):
 class f7jq(Variable):
     cerfa_field = u"7JQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2012, 1, 1)
 
@@ -3371,7 +3371,7 @@ class f7jq(Variable):
 class f7jr(Variable):
     cerfa_field = u"7JR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     start_date = date(2012, 1, 1)
 
@@ -3380,7 +3380,7 @@ class f7jr(Variable):
 class f7gj(Variable):
     cerfa_field = u"7GJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés et réalisés en 2012, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2013, 1, 1)
 
@@ -3389,7 +3389,7 @@ class f7gj(Variable):
 class f7gk(Variable):
     cerfa_field = u"7GK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés et réalisés en 2012, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon, avec promesse d'achat en 2011"
     start_date = date(2013, 1, 1)
 
@@ -3398,7 +3398,7 @@ class f7gk(Variable):
 class f7gl(Variable):
     cerfa_field = u"7GL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2012 et réalisés en 2011, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2013, 1, 1)
 
@@ -3407,7 +3407,7 @@ class f7gl(Variable):
 class f7gp(Variable):
     cerfa_field = u"7GP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2012 et réalisés en 2011, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon, avec promesse d'achat en 2010s"
     start_date = date(2013, 1, 1)
 
@@ -3416,7 +3416,7 @@ class f7gp(Variable):
 class f7fa(Variable):
     cerfa_field = u"7FA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013, métropole, BBC"
     start_date = date(2013, 1, 1)
 
@@ -3425,7 +3425,7 @@ class f7fa(Variable):
 class f7fb(Variable):
     cerfa_field = u"7FB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013, métropole, non-BBC"
     start_date = date(2013, 1, 1)
 
@@ -3434,7 +3434,7 @@ class f7fb(Variable):
 class f7fc(Variable):
     cerfa_field = u"7FC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013, DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     start_date = date(2013, 1, 1)
 
@@ -3443,7 +3443,7 @@ class f7fc(Variable):
 class f7fd(Variable):
     cerfa_field = u"7FD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna"
     start_date = date(2013, 1, 1)
 
@@ -3453,7 +3453,7 @@ class f7fd(Variable):
 class f7ij(Variable):
     cerfa_field = u"7IJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissement destinés à la location meublée non professionnelle: Investissements réalisés en 2011 et achevés en 2012, engagement de réalisation de l'investissement en 2011"
     start_date = date(2009, 1, 1)
 
@@ -3462,7 +3462,7 @@ class f7ij(Variable):
 class f7il(Variable):
     cerfa_field = u"7IL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissement destinés à la location meublée non professionnelle: Investissements réalisés en 2011 et achevés en 2012, promesse d'achat en 2010"
     start_date = date(2010, 1, 1)
 
@@ -3471,7 +3471,7 @@ class f7il(Variable):
 class f7im(Variable):
     cerfa_field = u"7IM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissement destinés à la location meublée non professionnelle: Investissements réalisés en 2010 et achevés en 2012 avec promesse d'achat en 2009"
     start_date = date(2010, 1, 1)
 
@@ -3480,7 +3480,7 @@ class f7im(Variable):
 class f7ik(Variable):
     cerfa_field = u"7IK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Reports de 1/9 de l'investissement réalisé et achevé en 2009"
     start_date = date(2010, 1, 1)
 
@@ -3489,7 +3489,7 @@ class f7ik(Variable):
 class f7in(Variable):
     cerfa_field = u"7IN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, investissement réalisé du 1.1.2011 au 31.3.2011"
     start_date = date(2011, 1, 1)
 
@@ -3498,7 +3498,7 @@ class f7in(Variable):
 class f7iv(Variable):
     cerfa_field = u"7IV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, investissement réalisé du 1.4.2011 au 31.12.2011"
     start_date = date(2011, 1, 1)
 
@@ -3507,7 +3507,7 @@ class f7iv(Variable):
 class f7iw(Variable):
     cerfa_field = u"7IW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2010 et achevés en 2012"
     start_date = date(2011, 1, 1)
 
@@ -3516,7 +3516,7 @@ class f7iw(Variable):
 class f7io(Variable):
     cerfa_field = u"7IO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : "
     start_date = date(2011, 1, 1)
 
@@ -3525,7 +3525,7 @@ class f7io(Variable):
 class f7ip(Variable):
     cerfa_field = u"7IP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : "
     start_date = date(2011, 1, 1)
 
@@ -3534,7 +3534,7 @@ class f7ip(Variable):
 class f7ir(Variable):
     cerfa_field = u"7IR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : "
     start_date = date(2011, 1, 1)
 
@@ -3543,7 +3543,7 @@ class f7ir(Variable):
 class f7iq(Variable):
     cerfa_field = u"7IQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : "
     start_date = date(2011, 1, 1)
 
@@ -3552,7 +3552,7 @@ class f7iq(Variable):
 class f7iu(Variable):
     cerfa_field = u"7IU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : "
     start_date = date(2011, 1, 1)
 
@@ -3561,7 +3561,7 @@ class f7iu(Variable):
 class f7it(Variable):
     cerfa_field = u"7IT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : "
     start_date = date(2011, 1, 1)
 
@@ -3570,7 +3570,7 @@ class f7it(Variable):
 class f7is(Variable):
     cerfa_field = u"7IS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé: année  n-4"
     start_date = date(2010, 1, 1)
 
@@ -3579,7 +3579,7 @@ class f7is(Variable):
 class f7ia(Variable):
     cerfa_field = u"7IA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011"
     start_date = date(2012, 1, 1)
 
@@ -3588,7 +3588,7 @@ class f7ia(Variable):
 class f7ib(Variable):
     cerfa_field = u"7IB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 avec promesse d'achat en 2010 ou réalisés en 2010"
     start_date = date(2012, 1, 1)
 
@@ -3597,7 +3597,7 @@ class f7ib(Variable):
 class f7ic(Variable):
     cerfa_field = u"7IC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2010 et achevés en 2011 avec promesse d'achat en 2009 ou réalisés en 2009"
     start_date = date(2012, 1, 1)
 
@@ -3606,7 +3606,7 @@ class f7ic(Variable):
 class f7id(Variable):
     cerfa_field = u"7ID"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, Engagement de réalisation de l'investissement en 2012"
     start_date = date(2012, 1, 1)
 
@@ -3615,7 +3615,7 @@ class f7id(Variable):
 class f7ie(Variable):
     cerfa_field = u"7IE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, Promesse d'achat en 2011"
     start_date = date(2012, 1, 1)
 
@@ -3624,7 +3624,7 @@ class f7ie(Variable):
 class f7if(Variable):
     cerfa_field = u"7IF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, investissement réalisé du 1.1.2012 au 31.3.2012, investissement réalisé du 1.1.2012 au 31.3.2012"
     start_date = date(2012, 1, 1)
 
@@ -3633,7 +3633,7 @@ class f7if(Variable):
 class f7ig(Variable):
     cerfa_field = u"7IG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, Investissements destinés à la location meublée non professionnelle : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, investissement réalisé du 1.4.2012 au 31.12.2012"
     start_date = date(2012, 1, 1)
 
@@ -3642,7 +3642,7 @@ class f7ig(Variable):
 class f7ix(Variable):
     cerfa_field = u"7IX"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2009; réalisés en 2009 et achevés en 2010; réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report du solde de réduction d'impôt de l'année 2011"
     start_date = date(2012, 1, 1)
 
@@ -3651,7 +3651,7 @@ class f7ix(Variable):
 class f7ih(Variable):
     cerfa_field = u"7IH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report du solde de réduction d'impôt de l'année 2011"
     start_date = date(2012, 1, 1)
 
@@ -3660,7 +3660,7 @@ class f7ih(Variable):
 class f7iz(Variable):
     cerfa_field = u"7IZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 : report du solde de réduction d'impôt de l'année 2011"
     start_date = date(2012, 1, 1)
 
@@ -3669,7 +3669,7 @@ class f7iz(Variable):
 class f7jt(Variable):
     cerfa_field = u"7JT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2013, Engagement de réalisation de l'investissement en 2013"
     start_date = date(2013, 1, 1)
 
@@ -3678,7 +3678,7 @@ class f7jt(Variable):
 class f7ju(Variable):
     cerfa_field = u"7JU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2013, Engagement de réalisation de l'investissement en 2012"
     start_date = date(2013, 1, 1)
 
@@ -3687,7 +3687,7 @@ class f7ju(Variable):
 class f7jv(Variable):
     cerfa_field = u"7JV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2012"
     start_date = date(2013, 1, 1)
 
@@ -3696,7 +3696,7 @@ class f7jv(Variable):
 class f7jw(Variable):
     cerfa_field = u"7JW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011"
     start_date = date(2013, 1, 1)
 
@@ -3705,7 +3705,7 @@ class f7jw(Variable):
 class f7jx(Variable):
     cerfa_field = u"7JX"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2011 avec promesse d'achat en 2010 ou réalisés en 2010"
     start_date = date(2013, 1, 1)
 
@@ -3714,7 +3714,7 @@ class f7jx(Variable):
 class f7jy(Variable):
     cerfa_field = u"7JY"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2010 avec promesse d'achat en 2009 ou réalisés en 2009"
     start_date = date(2013, 1, 1)
 
@@ -3723,7 +3723,7 @@ class f7jy(Variable):
 class f7jc(Variable):
     cerfa_field = u"7JC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report du solde de réduction d'impôt de l'année 2012"
     start_date = date(2013, 1, 1)
 
@@ -3732,7 +3732,7 @@ class f7jc(Variable):
 class f7ji(Variable):
     cerfa_field = u"7JI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 ; réalisés en 2011 et achevés en 2011 ou 2012 ; réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2012, Report du solde de réduction d'impôt de l'année 2012"
     start_date = date(2013, 1, 1)
 
@@ -3741,7 +3741,7 @@ class f7ji(Variable):
 class f7js(Variable):
     cerfa_field = u"7JS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 ; réalisés en 2011 et achevés en 2011 ou 2012 ; réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2012, Report du solde de réduction d’impôt de l’année 2012"
     start_date = date(2013, 1, 1)
 
@@ -3757,7 +3757,7 @@ class f7js(Variable):
 class f7gt(Variable):
     cerfa_field = u"7GT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements achevés en 2012 avec promesse d'achat en 2010"
     start_date = date(2013, 1, 1)
 
@@ -3766,7 +3766,7 @@ class f7gt(Variable):
 class f7gu(Variable):
     cerfa_field = u"7GU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements achevés en 2012 avec promesse d'achat en 2009"
     start_date = date(2013, 1, 1)
 
@@ -3775,7 +3775,7 @@ class f7gu(Variable):
 class f7gv(Variable):
     cerfa_field = u"7GV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés et achevés en 2012 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
     start_date = date(2013, 1, 1)
 
@@ -3784,7 +3784,7 @@ class f7gv(Variable):
 class f7xg(Variable):
     cerfa_field = u"7XG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissement locatif dans le secteur touristique, travaux réalisés dans un village résidentiel de tourisme"
     stop_date = date(2012, 12, 1)
 
@@ -3795,7 +3795,7 @@ class f7xg(Variable):
 class f7uo(Variable):
     cerfa_field = u"7UO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Acquisition de biens culturels"
 
 
@@ -3804,7 +3804,7 @@ class f7uo(Variable):
 class f7us(Variable):
     cerfa_field = u"7US"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Réduction d'impôt mécénat d'entreprise"
 
 
@@ -3814,7 +3814,7 @@ class f7us(Variable):
 class f7sb(Variable):
     cerfa_field = u"7SB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location: crédit à 25 %"
     start_date = date(2009, 1, 1)
     stop_date = date(2011, 12, 31)
@@ -3824,7 +3824,7 @@ class f7sb(Variable):
 class f7sc(Variable):
     cerfa_field = u"7SC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédits d’impôt pour dépenses en faveur de la qualité environnementale"
     start_date = date(2009, 1, 1)
     stop_date = date(2009, 12, 1)
@@ -3837,7 +3837,7 @@ class f7sc(Variable):
 class f7sd(Variable):
     cerfa_field = u"7SD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale, économie d'énergie: chaudières à condensation"
     start_date = date(2009, 1, 1)
 
@@ -3846,7 +3846,7 @@ class f7sd(Variable):
 class f7se(Variable):
     cerfa_field = u"7SE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale, économie d'énergie: chaudières à micro-cogénération gaz"
     start_date = date(2009, 1, 1)
 
@@ -3855,7 +3855,7 @@ class f7se(Variable):
 class f7sh(Variable):
     cerfa_field = u"7SH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale, isolation thermique: matériaux d'isolation des toitures (acquisition et pose)"
     start_date = date(2010, 1, 1)
 
@@ -3867,7 +3867,7 @@ class f7sh(Variable):
 class f7up(Variable):
     cerfa_field = u"7UP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt pour investissements forestiers: travaux"
     start_date = date(2009, 1, 1)
 
@@ -3876,7 +3876,7 @@ class f7up(Variable):
 class f7uq(Variable):
     cerfa_field = u"7UQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt pour investissements forestiers: contrat de gestion"
     start_date = date(2009, 1, 1)
 
@@ -3886,7 +3886,7 @@ class f7uq(Variable):
 class f1ar(Variable):
     cerfa_field = u"1AR"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt aide à la mobilité : le déclarant déménage à plus de 200 km pour son emploi"
     stop_date = date(2080, 12, 31)
 
@@ -3895,7 +3895,7 @@ class f1ar(Variable):
 class f1br(Variable):
     cerfa_field = u"1BR"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt aide à la mobilité : le conjoint déménage à plus de 200 km pour son emploi"
     stop_date = date(2008, 12, 31)
 
@@ -3904,7 +3904,7 @@ class f1br(Variable):
 class f1cr(Variable):
     cerfa_field = u"1CR"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt aide à la mobilité : la 1ère personne à charge déménage à plus de 200 km pour son emploi"
     stop_date = date(2008, 12, 31)
 
@@ -3913,7 +3913,7 @@ class f1cr(Variable):
 class f1dr(Variable):
     cerfa_field = u"1DR"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt aide à la mobilité : la 2è personne à charge déménage à plus de 200 km pour son emploi"
     stop_date = date(2008, 12, 31)
 
@@ -3922,7 +3922,7 @@ class f1dr(Variable):
 class f1er(Variable):
     cerfa_field = u"1ER"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt aide à la mobilité : la 3è personne à charge déménage à plus de 200 km pour son emploi"
     stop_date = date(2006, 12, 31)
 
@@ -3932,7 +3932,7 @@ class f1er(Variable):
 class f4tq(Variable):
     cerfa_field = u"4TQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d’impôt représentatif de la taxe additionnelle au droit de bail"
 
   # vérif libéllé, en 2013=Montant des loyers courus du 01/01/1998 au 30/09/1998 provenant des immeubles
@@ -3944,7 +3944,7 @@ class f4tq(Variable):
 class f7sf(Variable):
     cerfa_field = u"7SF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit de travaux en faveur d'aides aux personnes pour des logements en location (avant 2012 ) / Appareils de régulation du chauffage, matériaux de calorifugeage (après 2011)"
     start_date = date(2012, 1, 1)
 
@@ -3953,7 +3953,7 @@ class f7sf(Variable):
 class f7si(Variable):
     cerfa_field = u"7SI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Matériaux d’isolation des planchers bas sur sous-sol, sur vide sanitaire ou sur passage couvert (acquisition et pose)"
     start_date = date(2012, 1, 1)
 
@@ -3962,7 +3962,7 @@ class f7si(Variable):
 class f7te(Variable):
     cerfa_field = u"7TE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses d'investissement forestier"
     start_date = date(2010, 1, 1)
 
@@ -3971,7 +3971,7 @@ class f7te(Variable):
 class f7tu(Variable):
     cerfa_field = u"7TU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de travaux dans l'habitation principale"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -3981,7 +3981,7 @@ class f7tu(Variable):
 class f7tt(Variable):
     cerfa_field = u"7TT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de travaux dans l'habitation principale"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -3991,7 +3991,7 @@ class f7tt(Variable):
 class f7tv(Variable):
     cerfa_field = u"7TV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de travaux dans l'habitation principale"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -4001,7 +4001,7 @@ class f7tv(Variable):
 class f7tx(Variable):
     cerfa_field = u"7TX"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de travaux dans l'habitation principale"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -4011,7 +4011,7 @@ class f7tx(Variable):
 class f7ty(Variable):
     cerfa_field = u"7TY"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de travaux dans l'habitation principale"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -4021,7 +4021,7 @@ class f7ty(Variable):
 class f7tw(Variable):
     cerfa_field = u"7TW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Dépenses de travaux dans l'habitation principale"
     start_date = date(2012, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -4033,7 +4033,7 @@ class f7tw(Variable):
 class f7gh(Variable):
     cerfa_field = u"7GH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs intermédiaires en métropole"
     start_date = date(2013, 1, 1)
 
@@ -4042,7 +4042,7 @@ class f7gh(Variable):
 class f7gi(Variable):
     cerfa_field = u"7GI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Investissements locatifs intermédiaires outre-mer"
     start_date = date(2013, 1, 1)
 
@@ -4054,7 +4054,7 @@ class f7gi(Variable):
 class f8tc(Variable):
     cerfa_field = u"8TC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt autres entreprises (recherche non encore remboursé (années antérieures))"
     stop_date = date(2008, 12, 31)
 
@@ -4063,7 +4063,7 @@ class f8tc(Variable):
 class f8tb(Variable):
     cerfa_field = u"8TB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt recherche (entreprises bénéficiant de la restitution immédiate)"
 
 
@@ -4071,7 +4071,7 @@ class f8tb(Variable):
 class f8te(Variable):
     cerfa_field = u"8TE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: adhésion à un groupement de prévention agréé"
 
 
@@ -4079,7 +4079,7 @@ class f8te(Variable):
 class f8tf(Variable):
     cerfa_field = u"8TF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Reprises de réductions ou de crédits d'impôt"
 
 
@@ -4087,7 +4087,7 @@ class f8tf(Variable):
 class f8tg(Variable):
     cerfa_field = u"8TG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédits d'impôt en faveur des entreprises: Investissement en Corse"
 
 
@@ -4095,7 +4095,7 @@ class f8tg(Variable):
 class f8tl(Variable):
     cerfa_field = u"8TL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt compétitivité emploi (CICE), entreprises bénéficiant de la restitution immédiate"
 
 
@@ -4103,7 +4103,7 @@ class f8tl(Variable):
 class f8to(Variable):
     cerfa_field = u"8TO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: investissement en Corse, report non imputé les années antérieures"
 
 
@@ -4111,7 +4111,7 @@ class f8to(Variable):
 class f8tp(Variable):
     cerfa_field = u"8TP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: investissement en Corse, reprise de crédit d'impôt"
 
 
@@ -4119,7 +4119,7 @@ class f8tp(Variable):
 class f8ts(Variable):
     cerfa_field = u"8TS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: investissement en Corse, crédit d'impôt"
     start_date = date(2012, 1, 1)
 
@@ -4128,7 +4128,7 @@ class f8ts(Variable):
 class f8uz(Variable):
     cerfa_field = u"8UZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Famille"
 
 
@@ -4136,7 +4136,7 @@ class f8uz(Variable):
 class f8uw(Variable):
     cerfa_field = u"8UW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt compétitivité emploi (CICE), autres entreprises"
     start_date = date(2013, 1, 1)
 
@@ -4145,7 +4145,7 @@ class f8uw(Variable):
 class f8tz(Variable):
     cerfa_field = u"8TZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Apprentissage"
 
 
@@ -4153,7 +4153,7 @@ class f8tz(Variable):
 class f8wa(Variable):
     cerfa_field = u"8WA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Agriculture biologique"
 
 
@@ -4161,7 +4161,7 @@ class f8wa(Variable):
 class f8wb(Variable):
     cerfa_field = u"8WB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Prospection commerciale"
 
 
@@ -4169,7 +4169,7 @@ class f8wb(Variable):
 class f8wc__2008(Variable):
     cerfa_field = u"8WC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Nouvelles technologies"
     stop_date = date(2008, 12, 31)
 
@@ -4178,7 +4178,7 @@ class f8wc__2008(Variable):
 class f8wc(Variable):
     cerfa_field = u"8WC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Prêts sans intérêt"
     start_date = date(2012, 1, 1)
 
@@ -4187,7 +4187,7 @@ class f8wc(Variable):
 class f8wd(Variable):
     cerfa_field = u"8WD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Formation des chefs d'entreprise"
     start_date = date(2006, 1, 1)
 
@@ -4196,7 +4196,7 @@ class f8wd(Variable):
 class f8we(Variable):
     cerfa_field = u"8WE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Intéressement"
     start_date = date(2008, 1, 1)
 
@@ -4205,7 +4205,7 @@ class f8we(Variable):
 class f8wr(Variable):
     cerfa_field = u"8WR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Métiers d'art"
     start_date = date(2006, 1, 1)
 
@@ -4214,7 +4214,7 @@ class f8wr(Variable):
 class f8ws(Variable):
     cerfa_field = u"8WS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Emploi de salariés réservistes"
     start_date = date(2006, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -4224,7 +4224,7 @@ class f8ws(Variable):
 class f8wt(Variable):
     cerfa_field = u"8WT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Remplacement pour congé des agriculteurs"
     start_date = date(2006, 1, 1)
 
@@ -4233,7 +4233,7 @@ class f8wt(Variable):
 class f8wu(Variable):
     cerfa_field = u"8WU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Maître restaurateur"
     start_date = date(2006, 1, 1)
 
@@ -4242,7 +4242,7 @@ class f8wu(Variable):
 class f8wv(Variable):
     cerfa_field = u"8WV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Débitants de tabac"
     start_date = date(2007, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -4252,7 +4252,7 @@ class f8wv(Variable):
 class f8wx(Variable):
     cerfa_field = u"8WX"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt en faveur des entreprises: Formation des salariés à l'économie d'entreprise"
     start_date = date(2007, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -4264,7 +4264,7 @@ class elig_creimp_exc_2008(Variable):
         default = 1,
         val_type = "monetary",
         )
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Éligibilité au crédit d'impôt exceptionnel sur les revenus 2008"
     start_date = date(2008, 1, 1)
     stop_date = date(2008, 12, 31)
@@ -4273,7 +4273,7 @@ class elig_creimp_exc_2008(Variable):
 
 class elig_creimp_jeunes(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Éligible au crédit d'impôt jeunes"
     start_date = date(2005, 1, 1)
     stop_date = date(2008, 1, 1)

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -588,7 +588,7 @@ class rvcm_plus_abat(Variable):
         return period, rev_cat_rvcm + rfr_rvcm
 
 
-class maj_cga_individu(Variable):
+class maj_cga(Variable):
     column = FloatCol
     entity_class = Individus
     label = u"Majoration pour non adhésion à un centre de gestion agréé (pour chaque individu du foyer)"
@@ -646,8 +646,8 @@ class bouclier_rev(Variable):
         cd_penali = simulation.calculate('cd_penali', period)
         cd_eparet = simulation.calculate('cd_eparet', period)
 
-        maj_cga_individu = simulation.calculate('maj_cga_individu', period)
-        maj_cga = simulation.foyer_fiscal.sum(maj_cga_individu)
+        maj_cga = simulation.calculate('maj_cga', period)
+        maj_cga = simulation.foyer_fiscal.sum(maj_cga)
 
         # TODO: réintégrer les déficits antérieur
         # TODO: intégrer les revenus soumis au prélèvement libératoire

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -11,13 +11,13 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 ## Immeubles bâtis
 class b1ab(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Valeur de la résidence principale avant abattement"
 
 
 class b1ac(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Valeur des autres immeubles avant abattement"
 
 
@@ -25,25 +25,25 @@ class b1ac(Variable):
 ## non bâtis
 class b1bc(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Immeubles non bâtis : bois, fôrets et parts de groupements forestiers"
 
 
 class b1be(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Immeubles non bâtis : biens ruraux loués à long termes"
 
 
 class b1bh(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Immeubles non bâtis : parts de groupements fonciers agricoles et de groupements agricoles fonciers"
 
 
 class b1bk(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Immeubles non bâtis : autres biens"
 
 
@@ -51,44 +51,44 @@ class b1bk(Variable):
 ## droits sociaux- valeurs mobilières-liquidités- autres meubles
 class b1cl(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Parts et actions détenues par les salariés et mandataires sociaux"
 
 
 class b1cb(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Parts et actions de sociétés avec engagement de conservation de 6 ans minimum"
 
 
 class b1cd(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Droits sociaux de sociétés dans lesquelles vous exercez une fonction ou une activité"
 
 
 class b1ce(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Autres valeurs mobilières"
 
 
 class b1cf(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Liquidités"
 
 
 class b1cg(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Autres biens meubles"
 
 
 
 class b1co(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Autres biens meubles : contrats d'assurance-vie"
 
 
@@ -102,7 +102,7 @@ class b1co(Variable):
 ## passifs et autres réductions
 class b2gh(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Total du passif et autres déductions"
 
 
@@ -110,43 +110,43 @@ class b2gh(Variable):
 ## réductions
 class b2mt(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Réductions pour investissements directs dans une société"
 
 
 class b2ne(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Réductions pour investissements directs dans une société"
 
 
 class b2mv(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Réductions pour investissements par sociétés interposées, holdings"
 
 
 class b2nf(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Réductions pour investissements par sociétés interposées, holdings"
 
 
 class b2mx(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Réductions pour investissements par le biais de FIP"
 
 
 class b2na(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Réductions pour investissements par le biais de FCPI ou FCPR"
 
 
 class b2nc(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Réductions pour dons à certains organismes d'intérêt général"
 
 
@@ -154,7 +154,7 @@ class b2nc(Variable):
 ##  montant impôt acquitté hors de France
 class b4rs(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Montant de l'impôt acquitté hors de France"
 
 
@@ -163,29 +163,29 @@ class b4rs(Variable):
 
 class rev_or(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class rev_exo(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 
 class tax_fonc(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Taxe foncière"
 
 
 class restit_imp(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
 
 
 class etr(Variable):
     column = IntCol
-    entity = Individus
+    entity = Individu
 
 
 
@@ -196,7 +196,7 @@ class etr(Variable):
 
 class isf_imm_bati(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"isf_imm_bati"
 
     def function(self, simulation, period):
@@ -213,7 +213,7 @@ class isf_imm_bati(Variable):
 
 class isf_imm_non_bati(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"isf_imm_non_bati"
 
     def function(self, simulation, period):
@@ -243,7 +243,7 @@ class isf_imm_non_bati(Variable):
 
 class isf_actions_sal(Variable):  # # non présent en 2005##
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"isf_actions_sal"
     start_date = date(2006, 1, 1)
 
@@ -260,7 +260,7 @@ class isf_actions_sal(Variable):  # # non présent en 2005##
 
 class isf_droits_sociaux(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"isf_droits_sociaux"
 
     def function(self, simulation, period):
@@ -279,7 +279,7 @@ class isf_droits_sociaux(Variable):
 
 class ass_isf(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"ass_isf"
 
     def function(self, simulation, period):
@@ -303,7 +303,7 @@ class ass_isf(Variable):
 
 class isf_iai(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"isf_iai"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2010, 12, 31))
@@ -324,7 +324,7 @@ class isf_iai(DatedVariable):
 
 class isf_avant_reduction(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"isf_avant_reduction"
 
     def function(self, simulation, period):
@@ -337,7 +337,7 @@ class isf_avant_reduction(Variable):
 
 class isf_reduc_pac(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"isf_reduc_pac"
 
     def function(self, simulation, period):
@@ -354,7 +354,7 @@ class isf_reduc_pac(Variable):
 
 class isf_inv_pme(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"isf_inv_pme"
     start_date = date(2008, 1, 1)
 
@@ -381,7 +381,7 @@ class isf_inv_pme(Variable):
 
 class isf_org_int_gen(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"isf_org_int_gen"
 
     def function(self, simulation, period):
@@ -394,7 +394,7 @@ class isf_org_int_gen(Variable):
 
 class isf_avant_plaf(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"isf_avant_plaf"
 
     def function(self, simulation, period):
@@ -414,7 +414,7 @@ class isf_avant_plaf(Variable):
 # # calcul du plafonnement ##
 class tot_impot(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"tot_impot"
 
     def function(self, simulation, period):
@@ -443,7 +443,7 @@ class tot_impot(Variable):
 
 class revetproduits(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus et produits perçus (avant abattement)"
 
     def function(self, simulation, period):
@@ -485,7 +485,7 @@ class revetproduits(Variable):
 
 class decote_isf(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Décote de l'ISF"
     start_date = date(2013, 1, 1)
 
@@ -501,7 +501,7 @@ class decote_isf(Variable):
 
 class isf_apres_plaf(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Impôt sur la fortune après plafonnement"
     # Plafonnement supprimé pour l'année 2012
 
@@ -552,7 +552,7 @@ class isf_apres_plaf(DatedVariable):
 
 class isf_tot(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"isf_tot"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_isf&espId=1&impot=ISF&sfid=50"
 
@@ -574,7 +574,7 @@ class isf_tot(Variable):
 # TODO: à reintégrer dans irpp
 class rvcm_plus_abat(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"rvcm_plus_abat"
 
     def function(self, simulation, period):
@@ -590,7 +590,7 @@ class rvcm_plus_abat(Variable):
 
 class maj_cga(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Majoration pour non adhésion à un centre de gestion agréé (pour chaque individu du foyer)"
 
     # TODO: à reintégrer dans irpp (et vérifier au passage que frag_impo est dans la majo_cga
@@ -627,7 +627,7 @@ class maj_cga(Variable):
 
 class bouclier_rev(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"bouclier_rev"
     start_date = date(2006, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -688,7 +688,7 @@ class bouclier_rev(Variable):
 
 class bouclier_imp_gen(Variable):  # # ajouter CSG- CRDS
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"bouclier_imp_gen"
     start_date = date(2006, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -736,7 +736,7 @@ class bouclier_imp_gen(Variable):  # # ajouter CSG- CRDS
 
 class restitutions(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"restitutions"
     start_date = date(2006, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -754,7 +754,7 @@ class restitutions(Variable):
 
 class bouclier_sumimp(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"bouclier_sumimp"
     start_date = date(2006, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -772,7 +772,7 @@ class bouclier_sumimp(Variable):
 
 class bouclier_fiscal(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"bouclier_fiscal"
     start_date = date(2006, 1, 1)
     stop_date = date(2010, 12, 31)

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -625,13 +625,6 @@ class maj_cga_individu(Variable):
         return period, max_(0, P.cga_taux2 * (ntimp + frag_impo))
 
 
-class maj_cga(PersonToEntityColumn):
-    entity_class = FoyersFiscaux
-    label = u"Majoration pour non adhésion à un centre de gestion agréé"
-    operation = 'add'
-    variable = maj_cga_individu
-
-
 class bouclier_rev(Variable):
     column = FloatCol(default = 0)
     entity_class = FoyersFiscaux
@@ -645,7 +638,6 @@ class bouclier_rev(Variable):
         '''
         period = period.this_year
         rbg = simulation.calculate('rbg', period)
-        maj_cga = simulation.calculate('maj_cga', period)
         csg_deduc = simulation.calculate('csg_deduc', period)
         rvcm_plus_abat = simulation.calculate('rvcm_plus_abat', period)
         rev_cap_lib = simulation.calculate('rev_cap_lib', period)
@@ -654,6 +646,8 @@ class bouclier_rev(Variable):
         cd_penali = simulation.calculate('cd_penali', period)
         cd_eparet = simulation.calculate('cd_eparet', period)
 
+        maj_cga_individu = simulation.calculate('maj_cga_individu', period)
+        maj_cga = simulation.foyer_fiscal.sum(maj_cga_individu)
 
         # TODO: réintégrer les déficits antérieur
         # TODO: intégrer les revenus soumis au prélèvement libératoire
@@ -705,8 +699,6 @@ class bouclier_imp_gen(Variable):  # # ajouter CSG- CRDS
         taxe_habitation_holder = simulation.compute('taxe_habitation', period)
         tax_fonc = simulation.calculate('tax_fonc', period)
         isf_tot = simulation.calculate('isf_tot', period)
-        cotsoc_lib_declarant1_holder = simulation.compute('cotsoc_lib_declarant1', period)
-        cotsoc_bar_declarant1_holder = simulation.compute('cotsoc_bar_declarant1', period)
         csg_deductible_salaire_holder = simulation.compute('csg_deductible_salaire', period)
         csg_imposable_salaire_holder = simulation.compute('csg_imposable_salaire', period)
         crds_salaire_holder = simulation.compute('crds_salaire', period)
@@ -716,8 +708,8 @@ class bouclier_imp_gen(Variable):  # # ajouter CSG- CRDS
         csg_imposable_retraite_holder = simulation.compute('csg_imposable_retraite', period)
         imp_lib = simulation.calculate('imp_lib', period)
 
-        cotsoc_bar = self.sum_by_entity(cotsoc_bar_declarant1_holder)
-        cotsoc_lib = self.sum_by_entity(cotsoc_lib_declarant1_holder)
+        cotsoc_bar = simulation.calculate('cotsoc_bar', period)
+        cotsoc_lib = simulation.calculate('cotsoc_lib', period)
         crds_salaire = self.sum_by_entity(crds_salaire_holder)
         csg_deductible_chomage = self.sum_by_entity(csg_deductible_chomage_holder)
         csg_imposable_chomage = self.sum_by_entity(csg_imposable_chomage_holder)

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -11,13 +11,13 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 ## Immeubles bâtis
 class b1ab(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Valeur de la résidence principale avant abattement"
 
 
 class b1ac(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Valeur des autres immeubles avant abattement"
 
 
@@ -25,25 +25,25 @@ class b1ac(Variable):
 ## non bâtis
 class b1bc(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Immeubles non bâtis : bois, fôrets et parts de groupements forestiers"
 
 
 class b1be(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Immeubles non bâtis : biens ruraux loués à long termes"
 
 
 class b1bh(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Immeubles non bâtis : parts de groupements fonciers agricoles et de groupements agricoles fonciers"
 
 
 class b1bk(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Immeubles non bâtis : autres biens"
 
 
@@ -51,44 +51,44 @@ class b1bk(Variable):
 ## droits sociaux- valeurs mobilières-liquidités- autres meubles
 class b1cl(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Parts et actions détenues par les salariés et mandataires sociaux"
 
 
 class b1cb(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Parts et actions de sociétés avec engagement de conservation de 6 ans minimum"
 
 
 class b1cd(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Droits sociaux de sociétés dans lesquelles vous exercez une fonction ou une activité"
 
 
 class b1ce(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Autres valeurs mobilières"
 
 
 class b1cf(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Liquidités"
 
 
 class b1cg(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Autres biens meubles"
 
 
 
 class b1co(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Autres biens meubles : contrats d'assurance-vie"
 
 
@@ -102,7 +102,7 @@ class b1co(Variable):
 ## passifs et autres réductions
 class b2gh(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Total du passif et autres déductions"
 
 
@@ -110,43 +110,43 @@ class b2gh(Variable):
 ## réductions
 class b2mt(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Réductions pour investissements directs dans une société"
 
 
 class b2ne(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Réductions pour investissements directs dans une société"
 
 
 class b2mv(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Réductions pour investissements par sociétés interposées, holdings"
 
 
 class b2nf(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Réductions pour investissements par sociétés interposées, holdings"
 
 
 class b2mx(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Réductions pour investissements par le biais de FIP"
 
 
 class b2na(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Réductions pour investissements par le biais de FCPI ou FCPR"
 
 
 class b2nc(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Réductions pour dons à certains organismes d'intérêt général"
 
 
@@ -154,7 +154,7 @@ class b2nc(Variable):
 ##  montant impôt acquitté hors de France
 class b4rs(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Montant de l'impôt acquitté hors de France"
 
 
@@ -163,29 +163,29 @@ class b4rs(Variable):
 
 class rev_or(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class rev_exo(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 
 class tax_fonc(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Taxe foncière"
 
 
 class restit_imp(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
 
 
 class etr(Variable):
     column = IntCol
-    entity_class = Individus
+    entity = Individus
 
 
 
@@ -196,7 +196,7 @@ class etr(Variable):
 
 class isf_imm_bati(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"isf_imm_bati"
 
     def function(self, simulation, period):
@@ -213,7 +213,7 @@ class isf_imm_bati(Variable):
 
 class isf_imm_non_bati(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"isf_imm_non_bati"
 
     def function(self, simulation, period):
@@ -243,7 +243,7 @@ class isf_imm_non_bati(Variable):
 
 class isf_actions_sal(Variable):  # # non présent en 2005##
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"isf_actions_sal"
     start_date = date(2006, 1, 1)
 
@@ -260,7 +260,7 @@ class isf_actions_sal(Variable):  # # non présent en 2005##
 
 class isf_droits_sociaux(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"isf_droits_sociaux"
 
     def function(self, simulation, period):
@@ -279,7 +279,7 @@ class isf_droits_sociaux(Variable):
 
 class ass_isf(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"ass_isf"
 
     def function(self, simulation, period):
@@ -303,7 +303,7 @@ class ass_isf(Variable):
 
 class isf_iai(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"isf_iai"
 
     @dated_function(start = date(2002, 1, 1), stop = date(2010, 12, 31))
@@ -324,7 +324,7 @@ class isf_iai(DatedVariable):
 
 class isf_avant_reduction(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"isf_avant_reduction"
 
     def function(self, simulation, period):
@@ -337,7 +337,7 @@ class isf_avant_reduction(Variable):
 
 class isf_reduc_pac(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"isf_reduc_pac"
 
     def function(self, simulation, period):
@@ -354,7 +354,7 @@ class isf_reduc_pac(Variable):
 
 class isf_inv_pme(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"isf_inv_pme"
     start_date = date(2008, 1, 1)
 
@@ -381,7 +381,7 @@ class isf_inv_pme(Variable):
 
 class isf_org_int_gen(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"isf_org_int_gen"
 
     def function(self, simulation, period):
@@ -394,7 +394,7 @@ class isf_org_int_gen(Variable):
 
 class isf_avant_plaf(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"isf_avant_plaf"
 
     def function(self, simulation, period):
@@ -414,7 +414,7 @@ class isf_avant_plaf(Variable):
 # # calcul du plafonnement ##
 class tot_impot(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"tot_impot"
 
     def function(self, simulation, period):
@@ -443,7 +443,7 @@ class tot_impot(Variable):
 
 class revetproduits(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus et produits perçus (avant abattement)"
 
     def function(self, simulation, period):
@@ -485,7 +485,7 @@ class revetproduits(Variable):
 
 class decote_isf(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Décote de l'ISF"
     start_date = date(2013, 1, 1)
 
@@ -501,7 +501,7 @@ class decote_isf(Variable):
 
 class isf_apres_plaf(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Impôt sur la fortune après plafonnement"
     # Plafonnement supprimé pour l'année 2012
 
@@ -552,7 +552,7 @@ class isf_apres_plaf(DatedVariable):
 
 class isf_tot(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"isf_tot"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_isf&espId=1&impot=ISF&sfid=50"
 
@@ -574,7 +574,7 @@ class isf_tot(Variable):
 # TODO: à reintégrer dans irpp
 class rvcm_plus_abat(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"rvcm_plus_abat"
 
     def function(self, simulation, period):
@@ -590,7 +590,7 @@ class rvcm_plus_abat(Variable):
 
 class maj_cga(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Majoration pour non adhésion à un centre de gestion agréé (pour chaque individu du foyer)"
 
     # TODO: à reintégrer dans irpp (et vérifier au passage que frag_impo est dans la majo_cga
@@ -627,7 +627,7 @@ class maj_cga(Variable):
 
 class bouclier_rev(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"bouclier_rev"
     start_date = date(2006, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -688,7 +688,7 @@ class bouclier_rev(Variable):
 
 class bouclier_imp_gen(Variable):  # # ajouter CSG- CRDS
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"bouclier_imp_gen"
     start_date = date(2006, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -736,7 +736,7 @@ class bouclier_imp_gen(Variable):  # # ajouter CSG- CRDS
 
 class restitutions(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"restitutions"
     start_date = date(2006, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -754,7 +754,7 @@ class restitutions(Variable):
 
 class bouclier_sumimp(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"bouclier_sumimp"
     start_date = date(2006, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -772,7 +772,7 @@ class bouclier_sumimp(Variable):
 
 class bouclier_fiscal(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"bouclier_fiscal"
     start_date = date(2006, 1, 1)
     stop_date = date(2010, 12, 31)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -185,23 +185,23 @@ class salaire_imposable(Variable):
     label = u"Salaires imposables"
     set_input = set_input_divide_by_period
 
-    def function(self, simulation, period):
-        period = period.start.period(u'month').offset('first-of')
-        salaire_de_base = simulation.calculate('salaire_de_base', period)
-        primes_salaires = simulation.calculate('primes_salaires', period)
-        primes_fonction_publique = simulation.calculate('primes_fonction_publique', period)
-        indemnite_residence = simulation.calculate('indemnite_residence', period)
-        supp_familial_traitement = simulation.calculate('supp_familial_traitement', period)
-        csg_deductible_salaire = simulation.calculate('csg_deductible_salaire', period)
-        cotisations_salariales = simulation.calculate('cotisations_salariales', period)
-        remuneration_principale = simulation.calculate('remuneration_principale', period)
-        hsup = simulation.calculate('hsup', period)
-        indemnite_fin_contrat = simulation.calculate('indemnite_fin_contrat', period)
-        complementaire_sante_salarie = simulation.calculate('complementaire_sante_salarie', period)
+    def function(individu, period):
+        period = period.this_month
+        salaire_de_base = individu('salaire_de_base', period)
+        primes_salaires = individu('primes_salaires', period)
+        primes_fonction_publique = individu('primes_fonction_publique', period)
+        indemnite_residence = individu('indemnite_residence', period)
+        supp_familial_traitement = individu('supp_familial_traitement', period)
+        csg_deductible_salaire = individu('csg_deductible_salaire', period)
+        cotisations_salariales = individu('cotisations_salariales', period)
+        remuneration_principale = individu('remuneration_principale', period)
+        hsup = individu('hsup', period)
+        indemnite_fin_contrat = individu('indemnite_fin_contrat', period)
+        complementaire_sante_salarie = individu('complementaire_sante_salarie', period)
 
         # Revenu du foyer fiscal projeté sur le demandeur
-        rev_microsocial = simulation.calculate_divide('rev_microsocial', period)
-        rev_microsocial_declarant1 = simulation.foyer_fiscal.project_on_first_person(rev_microsocial)
+        rev_microsocial = individu.foyer_fiscal('rev_microsocial', period, options = [DIVIDE])
+        rev_microsocial_declarant1 = rev_microsocial * individu.has_role(FoyersFiscaux.DECLARANT_PRINCIPAL)
 
         return period, (
             salaire_de_base + primes_salaires + remuneration_principale +

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class assiette_csg_abattue(Variable):
     column = FloatCol
     label = u"Assiette CSG - CRDS"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -44,7 +44,7 @@ class assiette_csg_abattue(Variable):
 class assiette_csg_non_abattue(Variable):
     column = FloatCol
     label = u"Assiette CSG - CRDS"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -64,7 +64,7 @@ class csg_deductible_salaire(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"CSG déductible sur les salaires"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -86,7 +86,7 @@ class csg_imposable_salaire(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"CSG imposables sur les salaires"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -109,7 +109,7 @@ class crds_salaire(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"CRDS sur les salaires"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -131,7 +131,7 @@ class crds_salaire(Variable):
 
 class forfait_social(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Forfait social"
     start_date = date(2009, 1, 1)
 
@@ -181,7 +181,7 @@ class salaire_imposable(Variable):
             },  # (f1aj, f1bj, f1cj, f1dj, f1ej)
         val_type = "monetary",
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Salaires imposables"
     set_input = set_input_divide_by_period
 
@@ -213,7 +213,7 @@ class salaire_imposable(Variable):
 class salaire_net(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Salaires nets d'après définition INSEE"
     set_input = set_input_divide_by_period
 
@@ -236,7 +236,7 @@ class salaire_net(Variable):
 
 class tehr(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Taxe exceptionnelle de solidarité sur les très hautes rémunérations"
     url = u"http://vosdroits.service-public.fr/professionnels-entreprises/F32096.xhtml"
     calculate_output = calculate_output_divide
@@ -258,7 +258,7 @@ class tehr(Variable):
 class rev_microsocial(Variable):
     """Revenu net des cotisations sociales sous régime microsocial (auto-entrepreneur)"""
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenu net des cotisations sociales pour le régime microsocial"
     start_date = date(2009, 1, 1)
     url = u"http://www.apce.com/pid6137/regime-micro-social.html"

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class assiette_csg_abattue(Variable):
     column = FloatCol
     label = u"Assiette CSG - CRDS"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -44,7 +44,7 @@ class assiette_csg_abattue(Variable):
 class assiette_csg_non_abattue(Variable):
     column = FloatCol
     label = u"Assiette CSG - CRDS"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -64,7 +64,7 @@ class csg_deductible_salaire(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"CSG déductible sur les salaires"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -86,7 +86,7 @@ class csg_imposable_salaire(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"CSG imposables sur les salaires"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -109,7 +109,7 @@ class crds_salaire(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"CRDS sur les salaires"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -131,7 +131,7 @@ class crds_salaire(Variable):
 
 class forfait_social(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Forfait social"
     start_date = date(2009, 1, 1)
 
@@ -181,7 +181,7 @@ class salaire_imposable(Variable):
             },  # (f1aj, f1bj, f1cj, f1dj, f1ej)
         val_type = "monetary",
         )
-    entity = Individus
+    entity = Individu
     label = u"Salaires imposables"
     set_input = set_input_divide_by_period
 
@@ -201,7 +201,7 @@ class salaire_imposable(Variable):
 
         # Revenu du foyer fiscal projeté sur le demandeur
         rev_microsocial = individu.foyer_fiscal('rev_microsocial', period, options = [DIVIDE])
-        rev_microsocial_declarant1 = rev_microsocial * individu.has_role(FoyersFiscaux.DECLARANT_PRINCIPAL)
+        rev_microsocial_declarant1 = rev_microsocial * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         return period, (
             salaire_de_base + primes_salaires + remuneration_principale +
@@ -213,7 +213,7 @@ class salaire_imposable(Variable):
 class salaire_net(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Salaires nets d'après définition INSEE"
     set_input = set_input_divide_by_period
 
@@ -236,7 +236,7 @@ class salaire_net(Variable):
 
 class tehr(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Taxe exceptionnelle de solidarité sur les très hautes rémunérations"
     url = u"http://vosdroits.service-public.fr/professionnels-entreprises/F32096.xhtml"
     calculate_output = calculate_output_divide
@@ -258,7 +258,7 @@ class tehr(Variable):
 class rev_microsocial(Variable):
     """Revenu net des cotisations sociales sous régime microsocial (auto-entrepreneur)"""
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenu net des cotisations sociales pour le régime microsocial"
     start_date = date(2009, 1, 1)
     url = u"http://www.apce.com/pid6137/regime-micro-social.html"

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -196,9 +196,12 @@ class salaire_imposable(Variable):
         cotisations_salariales = simulation.calculate('cotisations_salariales', period)
         remuneration_principale = simulation.calculate('remuneration_principale', period)
         hsup = simulation.calculate('hsup', period)
-        rev_microsocial_declarant1 = simulation.calculate_divide('rev_microsocial_declarant1', period)
         indemnite_fin_contrat = simulation.calculate('indemnite_fin_contrat', period)
         complementaire_sante_salarie = simulation.calculate('complementaire_sante_salarie', period)
+
+        # Revenu du foyer fiscal projeté sur le demandeur
+        rev_microsocial = simulation.calculate_divide('rev_microsocial', period)
+        rev_microsocial_declarant1 = simulation.foyer_fiscal.project_on_first_person(rev_microsocial)
 
         return period, (
             salaire_de_base + primes_salaires + remuneration_principale +
@@ -271,10 +274,3 @@ class rev_microsocial(Variable):
         total = assiette_service + assiette_vente + assiette_proflib
         prelsoc_ms = assiette_service * P.servi + assiette_vente * P.vente + assiette_proflib * P.rsi
         return period, total - prelsoc_ms
-
-
-class rev_microsocial_declarant1(EntityToPersonColumn):
-    entity_class = Individus
-    label = u"Revenu net des cotisations sociales sous régime microsocial (auto-entrepreneur) (pour le premier déclarant du foyer fiscal)"  # noqa
-    role = VOUS
-    variable = rev_microsocial

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -44,7 +44,7 @@ def _mhsup(hsup):
 class csg_cap_bar(Variable):
     """Calcule la CSG sur les revenus du capital soumis au barème."""
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"CSG sur les revenus du capital soumis au barème"
     url = u"http://fr.wikipedia.org/wiki/Contribution_sociale_généralisée"
 
@@ -59,7 +59,7 @@ class csg_cap_bar(Variable):
 class crds_cap_bar(Variable):
     """Calcule la CRDS sur les revenus du capital soumis au barème."""
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"CRDS sur les revenus du capital soumis au barème"
     url = "http://fr.wikipedia.org/wiki/Contribution_pour_le_remboursement_de_la_dette_sociale"
 
@@ -74,7 +74,7 @@ class crds_cap_bar(Variable):
 class prelsoc_cap_bar(DatedVariable):
     """Calcule le prélèvement social sur les revenus du capital soumis au barème"""
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prélèvements sociaux sur les revenus du capital soumis au barème"
     url = u"http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&paf_gm=content&typePage=cpr02&sfid=501&espId=1&impot=CS"  # noqa
 
@@ -111,7 +111,7 @@ class prelsoc_cap_bar(DatedVariable):
 
 class csg_pv_mo(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"CSG sur les plus-values de cession de valeurs mobilières"
     url = "http://vosdroits.service-public.fr/particuliers/F21618.xhtml"
 
@@ -128,7 +128,7 @@ class csg_pv_mo(Variable):
 
 class crds_pv_mo(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"CRDS sur les plus-values de cession de valeurs mobilières"
     url = "http://fr.wikipedia.org/wiki/Contribution_pour_le_remboursement_de_la_dette_sociale"
 
@@ -145,7 +145,7 @@ class crds_pv_mo(Variable):
 
 class prelsoc_pv_mo(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prélèvements sociaux sur les plus-values de cession de valeurs mobilières"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&paf_dm=popup&paf_gm=content&typePage=cpr02&sfid=501&espId=1&impot=CS"  # noqa
 
@@ -196,7 +196,7 @@ class prelsoc_pv_mo(DatedVariable):
 
 class csg_pv_immo(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"CSG sur les plus-values immobilières"
     url = "http://fr.wikipedia.org/wiki/Contribution_sociale_g%C3%A9n%C3%A9ralis%C3%A9e"
 
@@ -213,7 +213,7 @@ class csg_pv_immo(Variable):
 
 class crds_pv_immo(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"CRDS sur les plus-values immobilières"
     url = "http://fr.wikipedia.org/wiki/Contribution_pour_le_remboursement_de_la_dette_sociale"
 
@@ -230,7 +230,7 @@ class crds_pv_immo(Variable):
 
 class prelsoc_pv_immo(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prélèvements sociaux sur les plus-values immobilières"
     url = "http://www.pap.fr/argent/impots/les-plus-values-immobilieres/a1314/l-imposition-de-la-plus-value-immobiliere"
 
@@ -281,7 +281,7 @@ class prelsoc_pv_immo(DatedVariable):
 
 class csg_fon(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"CSG sur les revenus fonciers"
     url = "http://fr.wikipedia.org/wiki/Contribution_sociale_g%C3%A9n%C3%A9ralis%C3%A9e"
 
@@ -299,7 +299,7 @@ class csg_fon(Variable):
 
 class crds_fon(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"CRDS sur les revenus fonciers"
     url = "http://vosdroits.service-public.fr/particuliers/F2329.xhtml"
 
@@ -317,7 +317,7 @@ class crds_fon(Variable):
 
 class prelsoc_fon(DatedVariable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prélèvements sociaux sur les revenus fonciers"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&paf_dm=popup&paf_gm=content&typePage=cpr02&sfid=501&espId=1&impot=CS"  # noqa
 
@@ -372,7 +372,7 @@ class prelsoc_fon(DatedVariable):
 class csg_cap_lib(Variable):
     """Calcule la CSG sur les revenus du capital soumis au prélèvement libératoire."""
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"CSG sur les revenus du capital soumis au prélèvement libératoire"
     url = u"http://fr.wikipedia.org/wiki/Contribution_sociale_généralisée"
 
@@ -386,7 +386,7 @@ class csg_cap_lib(Variable):
 class crds_cap_lib(Variable):
     """Calcule la CRDS sur les revenus du capital soumis au prélèvement libératoire."""
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"CRDS sur les revenus du capital soumis au prélèvement libératoire"
     url = u"http://fr.wikipedia.org/wiki/Contribution_pour_le_remboursement_de_la_dette_sociale"
 
@@ -401,7 +401,7 @@ class crds_cap_lib(Variable):
 class prelsoc_cap_lib(Variable):
     """Calcule le prélèvement social sur les revenus du capital soumis au prélèvement libératoire."""
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Prélèvements sociaux sur les revenus du capital soumis au prélèvement libératoire"
     url = u"http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&paf_dm=popup&paf_gm=content&typePage=cpr02&sfid=501&espId=1&impot=CS"  # noqa
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -44,7 +44,7 @@ def _mhsup(hsup):
 class csg_cap_bar(Variable):
     """Calcule la CSG sur les revenus du capital soumis au barème."""
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"CSG sur les revenus du capital soumis au barème"
     url = u"http://fr.wikipedia.org/wiki/Contribution_sociale_généralisée"
 
@@ -59,7 +59,7 @@ class csg_cap_bar(Variable):
 class crds_cap_bar(Variable):
     """Calcule la CRDS sur les revenus du capital soumis au barème."""
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"CRDS sur les revenus du capital soumis au barème"
     url = "http://fr.wikipedia.org/wiki/Contribution_pour_le_remboursement_de_la_dette_sociale"
 
@@ -74,7 +74,7 @@ class crds_cap_bar(Variable):
 class prelsoc_cap_bar(DatedVariable):
     """Calcule le prélèvement social sur les revenus du capital soumis au barème"""
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prélèvements sociaux sur les revenus du capital soumis au barème"
     url = u"http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&paf_gm=content&typePage=cpr02&sfid=501&espId=1&impot=CS"  # noqa
 
@@ -111,7 +111,7 @@ class prelsoc_cap_bar(DatedVariable):
 
 class csg_pv_mo(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"CSG sur les plus-values de cession de valeurs mobilières"
     url = "http://vosdroits.service-public.fr/particuliers/F21618.xhtml"
 
@@ -128,7 +128,7 @@ class csg_pv_mo(Variable):
 
 class crds_pv_mo(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"CRDS sur les plus-values de cession de valeurs mobilières"
     url = "http://fr.wikipedia.org/wiki/Contribution_pour_le_remboursement_de_la_dette_sociale"
 
@@ -145,7 +145,7 @@ class crds_pv_mo(Variable):
 
 class prelsoc_pv_mo(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prélèvements sociaux sur les plus-values de cession de valeurs mobilières"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&paf_dm=popup&paf_gm=content&typePage=cpr02&sfid=501&espId=1&impot=CS"  # noqa
 
@@ -196,7 +196,7 @@ class prelsoc_pv_mo(DatedVariable):
 
 class csg_pv_immo(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"CSG sur les plus-values immobilières"
     url = "http://fr.wikipedia.org/wiki/Contribution_sociale_g%C3%A9n%C3%A9ralis%C3%A9e"
 
@@ -213,7 +213,7 @@ class csg_pv_immo(Variable):
 
 class crds_pv_immo(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"CRDS sur les plus-values immobilières"
     url = "http://fr.wikipedia.org/wiki/Contribution_pour_le_remboursement_de_la_dette_sociale"
 
@@ -230,7 +230,7 @@ class crds_pv_immo(Variable):
 
 class prelsoc_pv_immo(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prélèvements sociaux sur les plus-values immobilières"
     url = "http://www.pap.fr/argent/impots/les-plus-values-immobilieres/a1314/l-imposition-de-la-plus-value-immobiliere"
 
@@ -281,7 +281,7 @@ class prelsoc_pv_immo(DatedVariable):
 
 class csg_fon(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"CSG sur les revenus fonciers"
     url = "http://fr.wikipedia.org/wiki/Contribution_sociale_g%C3%A9n%C3%A9ralis%C3%A9e"
 
@@ -299,7 +299,7 @@ class csg_fon(Variable):
 
 class crds_fon(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"CRDS sur les revenus fonciers"
     url = "http://vosdroits.service-public.fr/particuliers/F2329.xhtml"
 
@@ -317,7 +317,7 @@ class crds_fon(Variable):
 
 class prelsoc_fon(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prélèvements sociaux sur les revenus fonciers"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&paf_dm=popup&paf_gm=content&typePage=cpr02&sfid=501&espId=1&impot=CS"  # noqa
 
@@ -372,7 +372,7 @@ class prelsoc_fon(DatedVariable):
 class csg_cap_lib(Variable):
     """Calcule la CSG sur les revenus du capital soumis au prélèvement libératoire."""
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"CSG sur les revenus du capital soumis au prélèvement libératoire"
     url = u"http://fr.wikipedia.org/wiki/Contribution_sociale_généralisée"
 
@@ -386,7 +386,7 @@ class csg_cap_lib(Variable):
 class crds_cap_lib(Variable):
     """Calcule la CRDS sur les revenus du capital soumis au prélèvement libératoire."""
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"CRDS sur les revenus du capital soumis au prélèvement libératoire"
     url = u"http://fr.wikipedia.org/wiki/Contribution_pour_le_remboursement_de_la_dette_sociale"
 
@@ -401,7 +401,7 @@ class crds_cap_lib(Variable):
 class prelsoc_cap_lib(Variable):
     """Calcule le prélèvement social sur les revenus du capital soumis au prélèvement libératoire."""
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Prélèvements sociaux sur les revenus du capital soumis au prélèvement libératoire"
     url = u"http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&paf_dm=popup&paf_gm=content&typePage=cpr02&sfid=501&espId=1&impot=CS"  # noqa
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -56,13 +56,6 @@ class csg_cap_bar(Variable):
         return period, -rev_cap_bar * _P.csg.capital.glob
 
 
-class csg_cap_bar_declarant1(EntityToPersonColumn):
-    entity_class = Individus
-    label = u"CSG sur les revenus du capital soumis au barème (pour le premier déclarant du foyer fiscal)"
-    role = VOUS
-    variable = csg_cap_bar
-
-
 class crds_cap_bar(Variable):
     """Calcule la CRDS sur les revenus du capital soumis au barème."""
     column = FloatCol
@@ -76,13 +69,6 @@ class crds_cap_bar(Variable):
         _P = simulation.legislation_at(period.start)
 
         return period, -rev_cap_bar * _P.crds.capital
-
-
-class crds_cap_bar_declarant1(EntityToPersonColumn):
-    entity_class = Individus
-    label = u"CRDS sur les revenus du capital soumis au barème (pour le premier déclarant du foyer fiscal)"
-    role = VOUS
-    variable = crds_cap_bar
 
 
 class prelsoc_cap_bar(DatedVariable):
@@ -118,13 +104,6 @@ class prelsoc_cap_bar(DatedVariable):
 
         total = P.base_pat + P.add_pat + P.rsa
         return period, -rev_cap_bar * total
-
-
-class prelsoc_cap_bar_declarant1(EntityToPersonColumn):
-    entity_class = Individus
-    label = u"Prélèvements sociaux sur les revenus du capital soumis au barème (pour le premier déclarant du foyer fiscal)"  # noqa
-    role = VOUS
-    variable = prelsoc_cap_bar
 
 
 # plus-values de valeurs mobilières
@@ -404,14 +383,6 @@ class csg_cap_lib(Variable):
 
         return period, -rev_cap_lib * _P.csg.capital.glob
 
-
-class csg_cap_lib_declarant1(EntityToPersonColumn):
-    entity_class = Individus
-    label = u"CSG sur les revenus du capital soumis au prélèvement libératoire (pour le premier déclarant du foyer fiscal)"  # noqa
-    role = VOUS
-    variable = csg_cap_lib
-
-
 class crds_cap_lib(Variable):
     """Calcule la CRDS sur les revenus du capital soumis au prélèvement libératoire."""
     column = FloatCol
@@ -425,13 +396,6 @@ class crds_cap_lib(Variable):
         _P = simulation.legislation_at(period.start)
 
         return period, -rev_cap_lib * _P.crds.capital
-
-
-class crds_cap_lib_declarant1(EntityToPersonColumn):
-    entity_class = Individus
-    label = u"CRDS sur les revenus du capital soumis au prélèvement libératoire (pour le premier déclarant du foyer fiscal)"  # noqa
-    role = VOUS
-    variable = crds_cap_lib
 
 
 class prelsoc_cap_lib(Variable):
@@ -454,14 +418,6 @@ class prelsoc_cap_lib(Variable):
         else:
             total = prelsoc.base_pat + prelsoc.add_pat + prelsoc.rsa
         return period, -rev_cap_lib * total
-
-
-class prelsoc_cap_lib_declarant1(EntityToPersonColumn):
-    entity_class = Individus
-    label = u"Prélèvements sociaux sur les revenus du capital soumis au prélèvement libératoire (pour le premier déclarant du foyer fiscal)"  # noqa
-    role = VOUS
-    variable = prelsoc_cap_lib
-
 
 # TODO: non_imposabilité pour les revenus au barème
 #        verse = (-csgcap_bar - crdscap_bar - prelsoccap_bar) > bareme.csg.capital.nonimp

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
@@ -23,7 +23,7 @@ class taux_csg_remplacement(Variable):
             u"Taux plein",
             ]),
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Taux retenu sur la CSG des revenus de remplacment"
 
 
@@ -37,7 +37,7 @@ class taux_csg_remplacement(Variable):
 class csg_deductible_chomage(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"CSG déductible sur les allocations chômage"
     url = u"http://vosdroits.service-public.fr/particuliers/F2329.xhtml"
 
@@ -67,7 +67,7 @@ class csg_deductible_chomage(Variable):
 class csg_imposable_chomage(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"CSG imposable sur les allocations chômage"
     url = u"http://vosdroits.service-public.fr/particuliers/F2329.xhtml"
 
@@ -90,7 +90,7 @@ class csg_imposable_chomage(Variable):
 class crds_chomage(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"CRDS sur les allocations chômage"
     url = u"http://www.insee.fr/fr/methodes/default.asp?page=definitions/contrib-remb-dette-sociale.htm"
 
@@ -132,7 +132,7 @@ class chomage_imposable(Variable):
                    QUIFOY['pac2']: u"1DP",
                    QUIFOY['pac3']: u"1EP",
                    })  # (f1ap, f1bp, f1cp, f1dp, f1ep)
-    entity_class = Individus
+    entity = Individus
     label = u"Allocations chômage imposables"
     set_input = set_input_divide_by_period
     url = u"http://www.insee.fr/fr/methodes/default.asp?page=definitions/chomage.htm"
@@ -148,7 +148,7 @@ class chomage_imposable(Variable):
 class chomage_net(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Allocations chômage nettes"
     set_input = set_input_divide_by_period
     url = u"http://vosdroits.service-public.fr/particuliers/N549.xhtml"
@@ -169,7 +169,7 @@ class chomage_net(Variable):
 class csg_deductible_retraite(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"CSG déductible sur les pensions de retraite"
     url = u"https://www.lassuranceretraite.fr/cs/Satellite/PUBPrincipale/Retraites/Paiement-Votre-Retraite/Prelevements-Sociaux?packedargs=null"  # noqa
 
@@ -192,7 +192,7 @@ class csg_deductible_retraite(Variable):
 class csg_imposable_retraite(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"CSG imposable sur les pensions de retraite"
     url = u"https://www.lassuranceretraite.fr/cs/Satellite/PUBPrincipale/Retraites/Paiement-Votre-Retraite/Prelevements-Sociaux?packedargs=null"  # noqa
 
@@ -212,7 +212,7 @@ class csg_imposable_retraite(Variable):
 class crds_retraite(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"CRDS sur les pensions de retraite"
     url = u"http://www.pensions.bercy.gouv.fr/vous-%C3%AAtes-retrait%C3%A9-ou-pensionn%C3%A9/le-calcul-de-ma-pension/les-pr%C3%A9l%C3%A8vements-effectu%C3%A9s-sur-ma-pension"  # noqa
 
@@ -232,7 +232,7 @@ class crds_retraite(Variable):
 
 class casa(DatedVariable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Contribution additionnelle de solidarité et d'autonomie"
     url = u"http://www.service-public.fr/actualites/002691.html"
 
@@ -262,7 +262,7 @@ class retraite_imposable(Variable):
                            QUIFOY['pac2']: u"1DS",
                            QUIFOY['pac3']: u"1ES",
                             })  # (f1as, f1bs, f1cs, f1ds, f1es)
-    entity_class = Individus
+    entity = Individus
     label = u"Retraites au sens strict imposables (rentes à titre onéreux exclues)"
     set_input = set_input_divide_by_period
     url = u"http://vosdroits.service-public.fr/particuliers/F415.xhtml"
@@ -278,7 +278,7 @@ class retraite_imposable(Variable):
 class retraite_nette(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Pensions de retraite nettes"
     set_input = set_input_divide_by_period
     url = u"http://vosdroits.service-public.fr/particuliers/N20166.xhtml"
@@ -296,7 +296,7 @@ class retraite_nette(Variable):
 
 class crds_pfam(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"CRDS sur les prestations familiales)"
     url = "http://www.cleiss.fr/docs/regimes/regime_francea1.html"
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
@@ -23,7 +23,7 @@ class taux_csg_remplacement(Variable):
             u"Taux plein",
             ]),
         )
-    entity = Individus
+    entity = Individu
     label = u"Taux retenu sur la CSG des revenus de remplacment"
 
 
@@ -37,7 +37,7 @@ class taux_csg_remplacement(Variable):
 class csg_deductible_chomage(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"CSG déductible sur les allocations chômage"
     url = u"http://vosdroits.service-public.fr/particuliers/F2329.xhtml"
 
@@ -67,7 +67,7 @@ class csg_deductible_chomage(Variable):
 class csg_imposable_chomage(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"CSG imposable sur les allocations chômage"
     url = u"http://vosdroits.service-public.fr/particuliers/F2329.xhtml"
 
@@ -90,7 +90,7 @@ class csg_imposable_chomage(Variable):
 class crds_chomage(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"CRDS sur les allocations chômage"
     url = u"http://www.insee.fr/fr/methodes/default.asp?page=definitions/contrib-remb-dette-sociale.htm"
 
@@ -132,7 +132,7 @@ class chomage_imposable(Variable):
                    QUIFOY['pac2']: u"1DP",
                    QUIFOY['pac3']: u"1EP",
                    })  # (f1ap, f1bp, f1cp, f1dp, f1ep)
-    entity = Individus
+    entity = Individu
     label = u"Allocations chômage imposables"
     set_input = set_input_divide_by_period
     url = u"http://www.insee.fr/fr/methodes/default.asp?page=definitions/chomage.htm"
@@ -148,7 +148,7 @@ class chomage_imposable(Variable):
 class chomage_net(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Allocations chômage nettes"
     set_input = set_input_divide_by_period
     url = u"http://vosdroits.service-public.fr/particuliers/N549.xhtml"
@@ -169,7 +169,7 @@ class chomage_net(Variable):
 class csg_deductible_retraite(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"CSG déductible sur les pensions de retraite"
     url = u"https://www.lassuranceretraite.fr/cs/Satellite/PUBPrincipale/Retraites/Paiement-Votre-Retraite/Prelevements-Sociaux?packedargs=null"  # noqa
 
@@ -192,7 +192,7 @@ class csg_deductible_retraite(Variable):
 class csg_imposable_retraite(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"CSG imposable sur les pensions de retraite"
     url = u"https://www.lassuranceretraite.fr/cs/Satellite/PUBPrincipale/Retraites/Paiement-Votre-Retraite/Prelevements-Sociaux?packedargs=null"  # noqa
 
@@ -212,7 +212,7 @@ class csg_imposable_retraite(Variable):
 class crds_retraite(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"CRDS sur les pensions de retraite"
     url = u"http://www.pensions.bercy.gouv.fr/vous-%C3%AAtes-retrait%C3%A9-ou-pensionn%C3%A9/le-calcul-de-ma-pension/les-pr%C3%A9l%C3%A8vements-effectu%C3%A9s-sur-ma-pension"  # noqa
 
@@ -232,7 +232,7 @@ class crds_retraite(Variable):
 
 class casa(DatedVariable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Contribution additionnelle de solidarité et d'autonomie"
     url = u"http://www.service-public.fr/actualites/002691.html"
 
@@ -262,7 +262,7 @@ class retraite_imposable(Variable):
                            QUIFOY['pac2']: u"1DS",
                            QUIFOY['pac3']: u"1ES",
                             })  # (f1as, f1bs, f1cs, f1ds, f1es)
-    entity = Individus
+    entity = Individu
     label = u"Retraites au sens strict imposables (rentes à titre onéreux exclues)"
     set_input = set_input_divide_by_period
     url = u"http://vosdroits.service-public.fr/particuliers/F415.xhtml"
@@ -278,7 +278,7 @@ class retraite_imposable(Variable):
 class retraite_nette(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Pensions de retraite nettes"
     set_input = set_input_divide_by_period
     url = u"http://vosdroits.service-public.fr/particuliers/N20166.xhtml"
@@ -296,7 +296,7 @@ class retraite_nette(Variable):
 
 class crds_pfam(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"CRDS sur les prestations familiales)"
     url = "http://www.cleiss.fr/docs/regimes/regime_francea1.html"
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py
@@ -10,7 +10,7 @@ from openfisca_france.france_taxbenefitsystem import COUNTRY_DIR
 
 class taux_versement_transport(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u""
 
     def function(self, simulation, period):
@@ -37,7 +37,7 @@ class taux_versement_transport(Variable):
 
 class versement_transport(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Versement transport"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py
@@ -10,7 +10,7 @@ from openfisca_france.france_taxbenefitsystem import COUNTRY_DIR
 
 class taux_versement_transport(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u""
 
     def function(self, simulation, period):
@@ -37,7 +37,7 @@ class taux_versement_transport(Variable):
 
 class versement_transport(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Versement transport"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 class assiette_allegement(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Assiette des allègements de cotisations sociales employeur"
 
     def function(self, simulation, period):
@@ -37,7 +37,7 @@ class assiette_allegement(Variable):
 
 class coefficient_proratisation(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Coefficient de proratisation du salaire notamment pour le calcul du SMIC"
 
     def function(self, simulation, period):
@@ -127,7 +127,7 @@ class coefficient_proratisation(Variable):
 
 class credit_impot_competitivite_emploi(DatedVariable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Crédit d'imôt pour la compétitivité et l'emploi"
 
     @dated_function(date(2013, 1, 1))
@@ -148,7 +148,7 @@ class credit_impot_competitivite_emploi(DatedVariable):
 
 class aide_premier_salarie(DatedVariable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Aide à l'embauche d'un premier salarié"
 
     @dated_function(start=date(2015, 6, 9))
@@ -211,7 +211,7 @@ class aide_premier_salarie(DatedVariable):
 
 class aide_embauche_pme(DatedVariable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Aide à l'embauche d'un salarié pour les PME"
     url = u"http://travail-emploi.gouv.fr/grands-dossiers/embauchepme"
 
@@ -284,7 +284,7 @@ class aide_embauche_pme(DatedVariable):
 
 class smic_proratise(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"SMIC proratisé (mensuel)"
 
     def function(self, simulation, period):
@@ -298,7 +298,7 @@ class smic_proratise(Variable):
 
 class allegement_fillon(DatedVariable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Allègement de charges employeur sur les bas et moyens salaires (dit allègement Fillon)"
 
     # Attention : cet allègement a des règles de cumul spécifiques
@@ -356,8 +356,8 @@ def compute_allegement_fillon(simulation, period):
 
 class allegement_cotisation_allocations_familiales(DatedVariable):
     column = FloatCol
-    entity_class = Individus
     label = u"Allègement de la cotisation d'allocations familiales sur les bas et moyens salaires"
+    entity = Individus
     url = u"https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-dallocations-famil/la-reduction-du-taux-de-la-cotis.html"
 
     @dated_function(date(2015, 1, 1))

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 class assiette_allegement(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Assiette des allègements de cotisations sociales employeur"
 
     def function(self, simulation, period):
@@ -37,7 +37,7 @@ class assiette_allegement(Variable):
 
 class coefficient_proratisation(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Coefficient de proratisation du salaire notamment pour le calcul du SMIC"
 
     def function(self, simulation, period):
@@ -127,7 +127,7 @@ class coefficient_proratisation(Variable):
 
 class credit_impot_competitivite_emploi(DatedVariable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Crédit d'imôt pour la compétitivité et l'emploi"
 
     @dated_function(date(2013, 1, 1))
@@ -148,7 +148,7 @@ class credit_impot_competitivite_emploi(DatedVariable):
 
 class aide_premier_salarie(DatedVariable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Aide à l'embauche d'un premier salarié"
 
     @dated_function(start=date(2015, 6, 9))
@@ -211,7 +211,7 @@ class aide_premier_salarie(DatedVariable):
 
 class aide_embauche_pme(DatedVariable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Aide à l'embauche d'un salarié pour les PME"
     url = u"http://travail-emploi.gouv.fr/grands-dossiers/embauchepme"
 
@@ -284,7 +284,7 @@ class aide_embauche_pme(DatedVariable):
 
 class smic_proratise(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"SMIC proratisé (mensuel)"
 
     def function(self, simulation, period):
@@ -298,7 +298,7 @@ class smic_proratise(Variable):
 
 class allegement_fillon(DatedVariable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Allègement de charges employeur sur les bas et moyens salaires (dit allègement Fillon)"
 
     # Attention : cet allègement a des règles de cumul spécifiques
@@ -357,7 +357,7 @@ def compute_allegement_fillon(simulation, period):
 class allegement_cotisation_allocations_familiales(DatedVariable):
     column = FloatCol
     label = u"Allègement de la cotisation d'allocations familiales sur les bas et moyens salaires"
-    entity = Individus
+    entity = Individu
     url = u"https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-dallocations-famil/la-reduction-du-taux-de-la-cotis.html"
 
     @dated_function(date(2015, 1, 1))

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/apprentissage.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/apprentissage.py
@@ -10,7 +10,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class apprenti(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"L'individu est apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 
@@ -29,7 +29,7 @@ class apprenti(Variable):
 
 class remuneration_apprenti(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Rémunération de l'apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 
@@ -92,7 +92,7 @@ class remuneration_apprenti(Variable):
 
 class exoneration_cotisations_employeur_apprenti(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Exonération de cotisations employeur pour l'emploi d'un apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
     # Artisans et employeurs de moins de 11 salariés
@@ -139,7 +139,7 @@ class exoneration_cotisations_employeur_apprenti(Variable):
 
 class exoneration_cotisations_salariales_apprenti(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Exonération de cotisations salariales pour l'emploi d'un apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 
@@ -154,7 +154,7 @@ class exoneration_cotisations_salariales_apprenti(Variable):
 
 class prime_apprentissage(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Prime d'apprentissage pour les entreprise employant un apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
     # L'employeur peut également recevoir de la région dans laquelle est situé l'établissement du lieu de travail,
@@ -181,7 +181,7 @@ class prime_apprentissage(Variable):
 
 # # class credit_impot_emploi_apprenti(Variable):
 #     column = FloatCol
-#     entity_class = Individus
+#     entity = Individus
 #     label = u" Crédit d'impôt pour l'emploi d'apprentis"
 #     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 #
@@ -205,7 +205,7 @@ class prime_apprentissage(Variable):
 
 # # class credit_impot_emploi_apprenti(Variable):
 #     column = FloatCol
-#     entity_class = Individus
+#     entity = Individus
 #     label = u"Déduction de la créance "bonus alternant"
 # Les entreprises de plus de 250 salariés, tous établissements confondus, redevables de la taxe d'apprentissage,
 # qui emploient plus de 4 % de jeunes en apprentissage (5 % pour la taxe payable en 2016 au titre de 2015), dans la

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/apprentissage.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/apprentissage.py
@@ -10,7 +10,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class apprenti(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"L'individu est apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 
@@ -29,7 +29,7 @@ class apprenti(Variable):
 
 class remuneration_apprenti(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Rémunération de l'apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 
@@ -92,7 +92,7 @@ class remuneration_apprenti(Variable):
 
 class exoneration_cotisations_employeur_apprenti(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Exonération de cotisations employeur pour l'emploi d'un apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
     # Artisans et employeurs de moins de 11 salariés
@@ -139,7 +139,7 @@ class exoneration_cotisations_employeur_apprenti(Variable):
 
 class exoneration_cotisations_salariales_apprenti(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Exonération de cotisations salariales pour l'emploi d'un apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 
@@ -154,7 +154,7 @@ class exoneration_cotisations_salariales_apprenti(Variable):
 
 class prime_apprentissage(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Prime d'apprentissage pour les entreprise employant un apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
     # L'employeur peut également recevoir de la région dans laquelle est situé l'établissement du lieu de travail,
@@ -181,7 +181,7 @@ class prime_apprentissage(Variable):
 
 # # class credit_impot_emploi_apprenti(Variable):
 #     column = FloatCol
-#     entity = Individus
+#     entity = Individu
 #     label = u" Crédit d'impôt pour l'emploi d'apprentis"
 #     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 #
@@ -205,7 +205,7 @@ class prime_apprentissage(Variable):
 
 # # class credit_impot_emploi_apprenti(Variable):
 #     column = FloatCol
-#     entity = Individus
+#     entity = Individu
 #     label = u"Déduction de la créance "bonus alternant"
 # Les entreprises de plus de 250 salariés, tous établissements confondus, redevables de la taxe d'apprentissage,
 # qui emploient plus de 4 % de jeunes en apprentissage (5 % pour la taxe payable en 2016 au titre de 2015), dans la

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/contrat_professionnalisation.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/contrat_professionnalisation.py
@@ -11,7 +11,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class professionnalisation(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"L'individu est en contrat de professionnalisation"
     url = "http://www.apce.com/pid879/contrat-de-professionnalisation.html?espace=1&tp=1"
 
@@ -32,7 +32,7 @@ class professionnalisation(Variable):
 
 class remuneration_professionnalisation(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Rémunération de l'apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 
@@ -97,7 +97,7 @@ class remuneration_professionnalisation(Variable):
 
 class exoneration_cotisations_employeur_professionnalisation(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Exonération de cotisations patronales pour l'emploi d'un apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/contrat_professionnalisation.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/contrat_professionnalisation.py
@@ -11,7 +11,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class professionnalisation(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"L'individu est en contrat de professionnalisation"
     url = "http://www.apce.com/pid879/contrat-de-professionnalisation.html?espace=1&tp=1"
 
@@ -32,7 +32,7 @@ class professionnalisation(Variable):
 
 class remuneration_professionnalisation(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Rémunération de l'apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 
@@ -97,7 +97,7 @@ class remuneration_professionnalisation(Variable):
 
 class exoneration_cotisations_employeur_professionnalisation(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Exonération de cotisations patronales pour l'emploi d'un apprenti"
     url = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -10,13 +10,13 @@ from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotis
 
 class jei_date_demande(Variable):
     column = DateCol(default = date(2099, 12, 31))
-    entity_class = Individus
+    entity = Individus
     label = u"Date de demande (et d'octroi) du statut de jeune entreprise innovante (JEI)"
 
 
 class exoneration_cotisations_employeur_geographiques(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Exonérations de cotisations employeur dépendant d'une zone géographique"
     url = "https://www.apce.com/pid815/aides-au-recrutement.html?espace=1&tp=1"
 
@@ -36,7 +36,7 @@ class exoneration_cotisations_employeur_geographiques(Variable):
 
 class exoneration_cotisations_employeur_jei(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Exonrérations de cotisations employeur pour une jeune entreprise innovante"
     url = "http://www.apce.com/pid1653/jeune-entreprise-innovante.html?pid=1653&pagination=2"
 
@@ -84,7 +84,7 @@ class exoneration_cotisations_employeur_jei(Variable):
 
 class exoneration_cotisations_employeur_zfu(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Exonrérations de cotisations employeur pour l'embauche en zone franche urbaine (ZFU)"
     url = "http://www.apce.com/pid553/exoneration-dans-les-zfu.html?espace=1&tp=1&pagination=2"
 
@@ -235,7 +235,7 @@ class exoneration_cotisations_employeur_zfu(Variable):
 
 class exoneration_cotisations_employeur_zrd(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Exonrérations de cotisations employeur pour l'embauche en zone de restructuration de la Défense (ZRD)"
     url = "http://www.apce.com/pid11668/exoneration-dans-les-zrd.html?espace=1&tp=1"
 
@@ -273,7 +273,7 @@ class exoneration_cotisations_employeur_zrd(Variable):
 
 class exoneration_cotisations_employeur_zrr(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Exonrérations de cotisations employeur pour l'embauche en zone de revitalisation rurale (ZRR)"
     url = "http://www.apce.com/pid538/embauches-en-zru-et-zrr.html?espace=1&tp=1"
 
@@ -329,7 +329,7 @@ class exoneration_cotisations_employeur_zrr(Variable):
 # Aides à la création
 class exoneration_is_creation_zrr(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Exonrérations fiscales pour création d'une entreprise en zone de revitalisation rurale (ZRR)"
     url = 'http://www.apce.com/pid11690/exonerations-d-impots-zrr.html?espace=1&tp=1'
 
@@ -376,7 +376,7 @@ class exoneration_is_creation_zrr(Variable):
 
 # # class bassin_emploi_redynamiser(Variable):
 #     column = BoolCol
-#     entity_class = Individus
+#     entity = Individus
 #     label = u"L'entreprise est située danns un bassin d'emploi à redynamiser(BER)"
 #     # La liste des bassins d'emploi à redynamiser a été fixée par le décret n°2007-228 du 20 février 2007.
 #     # Actuellement, deux régions sont concernées : Champagne-Ardenne (zone d'emploi de la Vallée de la Meuse)
@@ -388,7 +388,7 @@ class exoneration_is_creation_zrr(Variable):
 
 class jeune_entreprise_innovante(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"L'entreprise est une jeune entreprise innovante"
 
     def function(self, simulation, period):
@@ -449,7 +449,7 @@ class jeune_entreprise_innovante(Variable):
 
 class bassin_emploi_redynamiser(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"L'entreprise est située danns un bassin d'emploi à redynamiser (BER)"
     # La liste des bassins d'emploi à redynamiser a été fixée par le décret n°2007-228 du 20 février 2007.
     # Actuellement, deux régions sont concernées : Champagne-Ardenne (zone d'emploi de la Vallée de la Meuse)
@@ -463,7 +463,7 @@ class bassin_emploi_redynamiser(Variable):
 
 class zone_restructuration_defense(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"L'entreprise est située dans une zone de restructuration de la Défense (ZRD)"
 
     def function(self, simulation, period):
@@ -473,7 +473,7 @@ class zone_restructuration_defense(Variable):
 
 class zone_franche_urbaine(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"L'entreprise est située danns une zone franche urbaine (ZFU)"
 
     def function(self, simulation, period):
@@ -483,7 +483,7 @@ class zone_franche_urbaine(Variable):
 
 class zone_revitalisation_rurale(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"L'entreprise est située dans une zone de revitalisation rurale (ZRR)"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -10,13 +10,13 @@ from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotis
 
 class jei_date_demande(Variable):
     column = DateCol(default = date(2099, 12, 31))
-    entity = Individus
+    entity = Individu
     label = u"Date de demande (et d'octroi) du statut de jeune entreprise innovante (JEI)"
 
 
 class exoneration_cotisations_employeur_geographiques(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Exonérations de cotisations employeur dépendant d'une zone géographique"
     url = "https://www.apce.com/pid815/aides-au-recrutement.html?espace=1&tp=1"
 
@@ -36,7 +36,7 @@ class exoneration_cotisations_employeur_geographiques(Variable):
 
 class exoneration_cotisations_employeur_jei(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Exonrérations de cotisations employeur pour une jeune entreprise innovante"
     url = "http://www.apce.com/pid1653/jeune-entreprise-innovante.html?pid=1653&pagination=2"
 
@@ -84,7 +84,7 @@ class exoneration_cotisations_employeur_jei(Variable):
 
 class exoneration_cotisations_employeur_zfu(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Exonrérations de cotisations employeur pour l'embauche en zone franche urbaine (ZFU)"
     url = "http://www.apce.com/pid553/exoneration-dans-les-zfu.html?espace=1&tp=1&pagination=2"
 
@@ -235,7 +235,7 @@ class exoneration_cotisations_employeur_zfu(Variable):
 
 class exoneration_cotisations_employeur_zrd(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Exonrérations de cotisations employeur pour l'embauche en zone de restructuration de la Défense (ZRD)"
     url = "http://www.apce.com/pid11668/exoneration-dans-les-zrd.html?espace=1&tp=1"
 
@@ -273,7 +273,7 @@ class exoneration_cotisations_employeur_zrd(Variable):
 
 class exoneration_cotisations_employeur_zrr(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Exonrérations de cotisations employeur pour l'embauche en zone de revitalisation rurale (ZRR)"
     url = "http://www.apce.com/pid538/embauches-en-zru-et-zrr.html?espace=1&tp=1"
 
@@ -329,7 +329,7 @@ class exoneration_cotisations_employeur_zrr(Variable):
 # Aides à la création
 class exoneration_is_creation_zrr(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Exonrérations fiscales pour création d'une entreprise en zone de revitalisation rurale (ZRR)"
     url = 'http://www.apce.com/pid11690/exonerations-d-impots-zrr.html?espace=1&tp=1'
 
@@ -376,7 +376,7 @@ class exoneration_is_creation_zrr(Variable):
 
 # # class bassin_emploi_redynamiser(Variable):
 #     column = BoolCol
-#     entity = Individus
+#     entity = Individu
 #     label = u"L'entreprise est située danns un bassin d'emploi à redynamiser(BER)"
 #     # La liste des bassins d'emploi à redynamiser a été fixée par le décret n°2007-228 du 20 février 2007.
 #     # Actuellement, deux régions sont concernées : Champagne-Ardenne (zone d'emploi de la Vallée de la Meuse)
@@ -388,7 +388,7 @@ class exoneration_is_creation_zrr(Variable):
 
 class jeune_entreprise_innovante(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"L'entreprise est une jeune entreprise innovante"
 
     def function(self, simulation, period):
@@ -449,7 +449,7 @@ class jeune_entreprise_innovante(Variable):
 
 class bassin_emploi_redynamiser(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"L'entreprise est située danns un bassin d'emploi à redynamiser (BER)"
     # La liste des bassins d'emploi à redynamiser a été fixée par le décret n°2007-228 du 20 février 2007.
     # Actuellement, deux régions sont concernées : Champagne-Ardenne (zone d'emploi de la Vallée de la Meuse)
@@ -463,7 +463,7 @@ class bassin_emploi_redynamiser(Variable):
 
 class zone_restructuration_defense(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"L'entreprise est située dans une zone de restructuration de la Défense (ZRD)"
 
     def function(self, simulation, period):
@@ -473,7 +473,7 @@ class zone_restructuration_defense(Variable):
 
 class zone_franche_urbaine(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"L'entreprise est située danns une zone franche urbaine (ZFU)"
 
     def function(self, simulation, period):
@@ -483,7 +483,7 @@ class zone_franche_urbaine(Variable):
 
 class zone_revitalisation_rurale(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"L'entreprise est située dans une zone de revitalisation rurale (ZRR)"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/stage.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/stage.py
@@ -12,19 +12,19 @@ from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotis
 
 class stage_duree_heures(Variable):
     column = IntCol()
-    entity = Individus
+    entity = Individu
     label = u"Nombre d'heures effectuées en stage"
 
 
 class stage_gratification_taux(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Taux de gratification (en plafond de la Sécurité sociale)"
 
 
 class stage_gratification(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Gratification de stage"
     start_date = date(2014, 11, 1)  # TODO: remove when updating legislation backwards
 
@@ -43,7 +43,7 @@ class stage_gratification(Variable):
 
 class stage_gratification_reintegration(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Part de la gratification de stage réintégrée à l'assiette des cotisations et contributions sociales"
     start_date = date(2014, 11, 1)  # TODO: remove when updating legislation backwards
 
@@ -61,7 +61,7 @@ class stage_gratification_reintegration(Variable):
 
 class stagiaire(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"L'individu est stagiaire"
 
     def function(self, simulation, period):
@@ -72,7 +72,7 @@ class stagiaire(Variable):
 
 class exoneration_cotisations_employeur_stagiaire(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Exonrérations de cotisations employeur pour un stagaire"
     url = "http://www.apce.com/pid2798/stages.html?espace=3"
 
@@ -104,7 +104,7 @@ class exoneration_cotisations_employeur_stagiaire(Variable):
 
 class exoneration_cotisations_salarie_stagiaire(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Exonrérations de cotisations salarié pour un stagiaire"
     url = "http://www.apce.com/pid2798/stages.html?espace=3"
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/stage.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/stage.py
@@ -12,19 +12,19 @@ from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotis
 
 class stage_duree_heures(Variable):
     column = IntCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Nombre d'heures effectuées en stage"
 
 
 class stage_gratification_taux(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Taux de gratification (en plafond de la Sécurité sociale)"
 
 
 class stage_gratification(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Gratification de stage"
     start_date = date(2014, 11, 1)  # TODO: remove when updating legislation backwards
 
@@ -43,7 +43,7 @@ class stage_gratification(Variable):
 
 class stage_gratification_reintegration(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Part de la gratification de stage réintégrée à l'assiette des cotisations et contributions sociales"
     start_date = date(2014, 11, 1)  # TODO: remove when updating legislation backwards
 
@@ -61,7 +61,7 @@ class stage_gratification_reintegration(Variable):
 
 class stagiaire(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"L'individu est stagiaire"
 
     def function(self, simulation, period):
@@ -72,7 +72,7 @@ class stagiaire(Variable):
 
 class exoneration_cotisations_employeur_stagiaire(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Exonrérations de cotisations employeur pour un stagaire"
     url = "http://www.apce.com/pid2798/stages.html?espace=3"
 
@@ -104,7 +104,7 @@ class exoneration_cotisations_employeur_stagiaire(Variable):
 
 class exoneration_cotisations_salarie_stagiaire(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Exonrérations de cotisations salarié pour un stagiaire"
     url = "http://www.apce.com/pid2798/stages.html?espace=3"
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
@@ -12,7 +12,7 @@ from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotis
 
 class allocations_temporaires_invalidite(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Allocations temporaires d'invalidité (ATI, fonction publique et collectivités locales)"
     # patronale, non-contributive
 
@@ -44,7 +44,7 @@ class allocations_temporaires_invalidite(Variable):
 
 class assiette_cotisations_sociales_public(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Assiette des cotisations sociales des agents titulaires de la fonction publique"
     # TODO: gestion des heures supplémentaires
 
@@ -69,7 +69,7 @@ class assiette_cotisations_sociales_public(Variable):
 
 class contribution_exceptionnelle_solidarite(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation exceptionnelle au fonds de solidarité (salarié)"
 
     def function(self, simulation, period):
@@ -119,7 +119,7 @@ class contribution_exceptionnelle_solidarite(Variable):
 
 class fonds_emploi_hospitalier(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Fonds pour l'emploi hospitalier (employeur)"
 
     def function(self, simulation, period):
@@ -141,7 +141,7 @@ class fonds_emploi_hospitalier(Variable):
 
 class ircantec_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Ircantec salarié"
 
     def function(self, simulation, period):
@@ -163,7 +163,7 @@ class ircantec_salarie(Variable):
 
 class ircantec_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Ircantec employeur"
 
     def function(self, simulation, period):
@@ -185,7 +185,7 @@ class ircantec_employeur(Variable):
 
 class pension_civile_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Pension civile salarié"
     url = u"http://www.ac-besancon.fr/spip.php?article2662",
 
@@ -208,7 +208,7 @@ class pension_civile_salarie(Variable):
 
 class pension_civile_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation patronale pension civile"
     url = u"http://www.ac-besancon.fr/spip.php?article2662"
 
@@ -233,7 +233,7 @@ class pension_civile_employeur(Variable):
 
 class rafp_salarie(DatedVariable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Part salariale de la retraite additionelle de la fonction publique"
     # Part salariale de la retraite additionelle de la fonction publique
     # TODO: ajouter la gipa qui n'est pas affectée par le plafond d'assiette
@@ -262,7 +262,7 @@ class rafp_salarie(DatedVariable):
 
 class rafp_employeur(DatedVariable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Part patronale de la retraite additionnelle de la fonction publique"
 
     # TODO: ajouter la gipa qui n'est pas affectée par le plafond d'assiette

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
@@ -12,7 +12,7 @@ from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotis
 
 class allocations_temporaires_invalidite(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Allocations temporaires d'invalidité (ATI, fonction publique et collectivités locales)"
     # patronale, non-contributive
 
@@ -44,7 +44,7 @@ class allocations_temporaires_invalidite(Variable):
 
 class assiette_cotisations_sociales_public(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Assiette des cotisations sociales des agents titulaires de la fonction publique"
     # TODO: gestion des heures supplémentaires
 
@@ -69,7 +69,7 @@ class assiette_cotisations_sociales_public(Variable):
 
 class contribution_exceptionnelle_solidarite(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation exceptionnelle au fonds de solidarité (salarié)"
 
     def function(self, simulation, period):
@@ -119,7 +119,7 @@ class contribution_exceptionnelle_solidarite(Variable):
 
 class fonds_emploi_hospitalier(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Fonds pour l'emploi hospitalier (employeur)"
 
     def function(self, simulation, period):
@@ -141,7 +141,7 @@ class fonds_emploi_hospitalier(Variable):
 
 class ircantec_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Ircantec salarié"
 
     def function(self, simulation, period):
@@ -163,7 +163,7 @@ class ircantec_salarie(Variable):
 
 class ircantec_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Ircantec employeur"
 
     def function(self, simulation, period):
@@ -185,7 +185,7 @@ class ircantec_employeur(Variable):
 
 class pension_civile_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Pension civile salarié"
     url = u"http://www.ac-besancon.fr/spip.php?article2662",
 
@@ -208,7 +208,7 @@ class pension_civile_salarie(Variable):
 
 class pension_civile_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation patronale pension civile"
     url = u"http://www.ac-besancon.fr/spip.php?article2662"
 
@@ -233,7 +233,7 @@ class pension_civile_employeur(Variable):
 
 class rafp_salarie(DatedVariable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Part salariale de la retraite additionelle de la fonction publique"
     # Part salariale de la retraite additionelle de la fonction publique
     # TODO: ajouter la gipa qui n'est pas affectée par le plafond d'assiette
@@ -262,7 +262,7 @@ class rafp_salarie(DatedVariable):
 
 class rafp_employeur(DatedVariable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Part patronale de la retraite additionnelle de la fonction publique"
 
     # TODO: ajouter la gipa qui n'est pas affectée par le plafond d'assiette

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 class assiette_cotisations_sociales(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Assiette des cotisations sociales des salaries"
 
     def function(self, simulation, period):
@@ -40,7 +40,7 @@ class assiette_cotisations_sociales(Variable):
 
 class assiette_cotisations_sociales_prive(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Assiette des cotisations sociales des salaries du prive"
 
     def function(self, simulation, period):
@@ -73,7 +73,7 @@ class assiette_cotisations_sociales_prive(Variable):
 
 class indemnite_fin_contrat(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indemnité de fin de contrat"
     url = u"https://www.service-public.fr/particuliers/vosdroits/F40"
 
@@ -109,7 +109,7 @@ class indemnite_fin_contrat(Variable):
 
 class reintegration_titre_restaurant_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Prise en charge de l'employeur des dépenses de cantine et des titres restaurants non exonérés de charges sociales"  # noqa
 
     def function(self, simulation, period):
@@ -139,7 +139,7 @@ class reintegration_titre_restaurant_employeur(Variable):
 
 class accident_du_travail(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisations employeur accident du travail et maladie professionelle"
 
     def function(self, simulation, period):
@@ -154,7 +154,7 @@ class accident_du_travail(Variable):
 
 class agff_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation retraite AGFF tranche A (salarié)"
     # AGFF: Association pour la gestion du fonds de financement (sous-entendu des départs entre 60 et 65 ans)
 
@@ -172,7 +172,7 @@ class agff_salarie(Variable):
 
 class agff_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation retraite AGFF tranche A (employeur)"
     # TODO: améliorer pour gérer mensuel/annuel
 
@@ -205,7 +205,7 @@ class agff_employeur(Variable):
 
 class agirc_gmp_assiette(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Assiette de la cotisation AGIRC pour la garantie minimale de points (GMP,  salarié)"
     # TODO: gestion annuel/mensuel
 
@@ -222,7 +222,7 @@ class agirc_gmp_assiette(Variable):
 
 class agirc_gmp_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation AGIRC pour la garantie minimale de points (GMP,  salarié)"
     # TODO: gestion annuel/mensuel
 
@@ -249,7 +249,7 @@ class agirc_gmp_salarie(Variable):
 
 class agirc_gmp_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation AGIRC pour la garantie minimale de points (GMP, employeur)"
     # TODO: gestion annuel/mensuel
 
@@ -277,7 +277,7 @@ class agirc_gmp_employeur(Variable):
 
 class agirc_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation AGIRC tranche B (salarié)"
 
     def function(self, simulation, period):
@@ -295,7 +295,7 @@ class agirc_salarie(Variable):
 
 class agirc_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation AGIRC tranche B (employeur)"
 
     def function(self, simulation, period):
@@ -311,7 +311,7 @@ class agirc_employeur(Variable):
 
 class ags(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Contribution à l'association pour la gestion du régime de garantie des créances des salariés (AGS, employeur)"  # noqa analysis:ignore
 
     def function(self, simulation, period):
@@ -326,7 +326,7 @@ class ags(Variable):
 
 class apec_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisations agence pour l'emploi des cadres (APEC,  salarié)"
 
     def function(self, simulation, period):
@@ -343,7 +343,7 @@ class apec_salarie(Variable):
 
 class apec_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisations Agenece pour l'emploi des cadres (APEC, employeur)"
 
     def function(self, simulation, period):
@@ -359,7 +359,7 @@ class apec_employeur(Variable):
 
 class arrco_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation ARRCO tranche 1 (salarié)"
     # TODO: check gestion mensuel/annuel
 
@@ -389,7 +389,7 @@ class arrco_salarie(Variable):
 
 class arrco_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation ARRCO tranche 1 (employeur)"
     # TODO: check gestion mensuel/annuel
 
@@ -418,7 +418,7 @@ class arrco_employeur(Variable):
 
 class chomage_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation chômage tranche A (salarié)"
 
     def function(self, simulation, period):
@@ -435,7 +435,7 @@ class chomage_salarie(Variable):
 
 class chomage_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation chômage tranche A (employeur)"
 
     def function(self, simulation, period):
@@ -451,7 +451,7 @@ class chomage_employeur(Variable):
 
 class contribution_solidarite_autonomie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Contribution solidarité autonomie (employeur)"
 
     def function(self, simulation, period):
@@ -467,7 +467,7 @@ class contribution_solidarite_autonomie(Variable):
 
 class cotisation_exceptionnelle_temporaire_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation_exceptionnelle_temporaire (salarie)"
 
     def function(self, simulation, period):
@@ -483,7 +483,7 @@ class cotisation_exceptionnelle_temporaire_salarie(Variable):
 
 class cotisation_exceptionnelle_temporaire_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation exceptionnelle temporaire (employeur)"
 
     def function(self, simulation, period):
@@ -499,7 +499,7 @@ class cotisation_exceptionnelle_temporaire_employeur(Variable):
 
 class famille(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation famille (employeur)"
 
     def function(self, simulation, period):
@@ -515,7 +515,7 @@ class famille(Variable):
 
 class mmid_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation maladie (salarié)"
 
     def function(self, simulation, period):
@@ -532,7 +532,7 @@ class mmid_salarie(Variable):
 
 class mmid_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation maladie (employeur)"
 
     def function(self, simulation, period):
@@ -550,7 +550,7 @@ class mmid_employeur(Variable):
 # TODO: this formula is used only to check fiche_de_paie from memento
 class mmida_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation maladie (employeur)"
 
     def function(self, simulation, period):
@@ -569,7 +569,7 @@ class mmida_employeur(Variable):
 class mhsup(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Heures supplémentaires comptées négativement"
 
     def function(self, simulation, period):
@@ -581,7 +581,7 @@ class mhsup(Variable):
 
 class plafond_securite_sociale(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Plafond de la securite sociale"
     # TODO gérer les plafonds mensuel, trimestriel, annuel
 
@@ -628,7 +628,7 @@ class plafond_securite_sociale(Variable):
 
 class prevoyance_obligatoire_cadre(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation de prévoyance pour les cadres et assimilés"
     # TODO: gérer le mode de recouvrement et l'aspect mensuel/annuel
 
@@ -650,7 +650,7 @@ class prevoyance_obligatoire_cadre(Variable):
 
 class complementaire_sante_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Couverture complémentaire santé collective d'entreprise - part employeur"
 
     def function(self, simulation, period):
@@ -665,7 +665,7 @@ class complementaire_sante_employeur(Variable):
 
 class complementaire_sante_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Couverture complémentaire santé collective d'entreprise - part salarié"
 
     def function(self, simulation, period):
@@ -691,7 +691,7 @@ class taille_entreprise(Variable):
             ),
         default = 0,
         )
-    entity = Individus
+    entity = Individu
     label = u"Catégorie de taille d'entreprise"
     url = u"http://www.insee.fr/fr/themes/document.asp?ref_id=ip1321"
 
@@ -710,7 +710,7 @@ class taille_entreprise(Variable):
 
 class taux_accident_travail(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Approximation du taux accident à partir de l'exposition au risque donnée"
     start_date = date(2012, 1, 1)
 
@@ -725,7 +725,7 @@ class taux_accident_travail(Variable):
 
 class vieillesse_deplafonnee_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation vieillesse déplafonnée (salarié)"
 
     def function(self, simulation, period):
@@ -742,7 +742,7 @@ class vieillesse_deplafonnee_salarie(Variable):
 
 class vieillesse_plafonnee_salarie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation vieillesse plafonnée (salarié)"
 
     def function(self, simulation, period):
@@ -758,7 +758,7 @@ class vieillesse_plafonnee_salarie(Variable):
 
 class vieillesse_deplafonnee_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation vieillesse déplafonnée"
 
     def function(self, simulation, period):
@@ -774,7 +774,7 @@ class vieillesse_deplafonnee_employeur(Variable):
 
 class vieillesse_plafonnee_employeur(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation vieillesse plafonnée (employeur)"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 class assiette_cotisations_sociales(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Assiette des cotisations sociales des salaries"
 
     def function(self, simulation, period):
@@ -40,7 +40,7 @@ class assiette_cotisations_sociales(Variable):
 
 class assiette_cotisations_sociales_prive(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Assiette des cotisations sociales des salaries du prive"
 
     def function(self, simulation, period):
@@ -73,7 +73,7 @@ class assiette_cotisations_sociales_prive(Variable):
 
 class indemnite_fin_contrat(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnité de fin de contrat"
     url = u"https://www.service-public.fr/particuliers/vosdroits/F40"
 
@@ -109,7 +109,7 @@ class indemnite_fin_contrat(Variable):
 
 class reintegration_titre_restaurant_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Prise en charge de l'employeur des dépenses de cantine et des titres restaurants non exonérés de charges sociales"  # noqa
 
     def function(self, simulation, period):
@@ -139,7 +139,7 @@ class reintegration_titre_restaurant_employeur(Variable):
 
 class accident_du_travail(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisations employeur accident du travail et maladie professionelle"
 
     def function(self, simulation, period):
@@ -154,7 +154,7 @@ class accident_du_travail(Variable):
 
 class agff_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation retraite AGFF tranche A (salarié)"
     # AGFF: Association pour la gestion du fonds de financement (sous-entendu des départs entre 60 et 65 ans)
 
@@ -172,7 +172,7 @@ class agff_salarie(Variable):
 
 class agff_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation retraite AGFF tranche A (employeur)"
     # TODO: améliorer pour gérer mensuel/annuel
 
@@ -205,7 +205,7 @@ class agff_employeur(Variable):
 
 class agirc_gmp_assiette(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Assiette de la cotisation AGIRC pour la garantie minimale de points (GMP,  salarié)"
     # TODO: gestion annuel/mensuel
 
@@ -222,7 +222,7 @@ class agirc_gmp_assiette(Variable):
 
 class agirc_gmp_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation AGIRC pour la garantie minimale de points (GMP,  salarié)"
     # TODO: gestion annuel/mensuel
 
@@ -249,7 +249,7 @@ class agirc_gmp_salarie(Variable):
 
 class agirc_gmp_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation AGIRC pour la garantie minimale de points (GMP, employeur)"
     # TODO: gestion annuel/mensuel
 
@@ -277,7 +277,7 @@ class agirc_gmp_employeur(Variable):
 
 class agirc_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation AGIRC tranche B (salarié)"
 
     def function(self, simulation, period):
@@ -295,7 +295,7 @@ class agirc_salarie(Variable):
 
 class agirc_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation AGIRC tranche B (employeur)"
 
     def function(self, simulation, period):
@@ -311,7 +311,7 @@ class agirc_employeur(Variable):
 
 class ags(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Contribution à l'association pour la gestion du régime de garantie des créances des salariés (AGS, employeur)"  # noqa analysis:ignore
 
     def function(self, simulation, period):
@@ -326,7 +326,7 @@ class ags(Variable):
 
 class apec_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisations agence pour l'emploi des cadres (APEC,  salarié)"
 
     def function(self, simulation, period):
@@ -343,7 +343,7 @@ class apec_salarie(Variable):
 
 class apec_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisations Agenece pour l'emploi des cadres (APEC, employeur)"
 
     def function(self, simulation, period):
@@ -359,7 +359,7 @@ class apec_employeur(Variable):
 
 class arrco_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation ARRCO tranche 1 (salarié)"
     # TODO: check gestion mensuel/annuel
 
@@ -389,7 +389,7 @@ class arrco_salarie(Variable):
 
 class arrco_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation ARRCO tranche 1 (employeur)"
     # TODO: check gestion mensuel/annuel
 
@@ -418,7 +418,7 @@ class arrco_employeur(Variable):
 
 class chomage_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation chômage tranche A (salarié)"
 
     def function(self, simulation, period):
@@ -435,7 +435,7 @@ class chomage_salarie(Variable):
 
 class chomage_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation chômage tranche A (employeur)"
 
     def function(self, simulation, period):
@@ -451,7 +451,7 @@ class chomage_employeur(Variable):
 
 class contribution_solidarite_autonomie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Contribution solidarité autonomie (employeur)"
 
     def function(self, simulation, period):
@@ -467,7 +467,7 @@ class contribution_solidarite_autonomie(Variable):
 
 class cotisation_exceptionnelle_temporaire_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation_exceptionnelle_temporaire (salarie)"
 
     def function(self, simulation, period):
@@ -483,7 +483,7 @@ class cotisation_exceptionnelle_temporaire_salarie(Variable):
 
 class cotisation_exceptionnelle_temporaire_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation exceptionnelle temporaire (employeur)"
 
     def function(self, simulation, period):
@@ -499,7 +499,7 @@ class cotisation_exceptionnelle_temporaire_employeur(Variable):
 
 class famille(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation famille (employeur)"
 
     def function(self, simulation, period):
@@ -515,7 +515,7 @@ class famille(Variable):
 
 class mmid_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation maladie (salarié)"
 
     def function(self, simulation, period):
@@ -532,7 +532,7 @@ class mmid_salarie(Variable):
 
 class mmid_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation maladie (employeur)"
 
     def function(self, simulation, period):
@@ -550,7 +550,7 @@ class mmid_employeur(Variable):
 # TODO: this formula is used only to check fiche_de_paie from memento
 class mmida_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation maladie (employeur)"
 
     def function(self, simulation, period):
@@ -569,7 +569,7 @@ class mmida_employeur(Variable):
 class mhsup(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Heures supplémentaires comptées négativement"
 
     def function(self, simulation, period):
@@ -581,7 +581,7 @@ class mhsup(Variable):
 
 class plafond_securite_sociale(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Plafond de la securite sociale"
     # TODO gérer les plafonds mensuel, trimestriel, annuel
 
@@ -628,7 +628,7 @@ class plafond_securite_sociale(Variable):
 
 class prevoyance_obligatoire_cadre(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation de prévoyance pour les cadres et assimilés"
     # TODO: gérer le mode de recouvrement et l'aspect mensuel/annuel
 
@@ -650,7 +650,7 @@ class prevoyance_obligatoire_cadre(Variable):
 
 class complementaire_sante_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Couverture complémentaire santé collective d'entreprise - part employeur"
 
     def function(self, simulation, period):
@@ -665,7 +665,7 @@ class complementaire_sante_employeur(Variable):
 
 class complementaire_sante_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Couverture complémentaire santé collective d'entreprise - part salarié"
 
     def function(self, simulation, period):
@@ -691,7 +691,7 @@ class taille_entreprise(Variable):
             ),
         default = 0,
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Catégorie de taille d'entreprise"
     url = u"http://www.insee.fr/fr/themes/document.asp?ref_id=ip1321"
 
@@ -710,7 +710,7 @@ class taille_entreprise(Variable):
 
 class taux_accident_travail(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Approximation du taux accident à partir de l'exposition au risque donnée"
     start_date = date(2012, 1, 1)
 
@@ -725,7 +725,7 @@ class taux_accident_travail(Variable):
 
 class vieillesse_deplafonnee_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation vieillesse déplafonnée (salarié)"
 
     def function(self, simulation, period):
@@ -742,7 +742,7 @@ class vieillesse_deplafonnee_salarie(Variable):
 
 class vieillesse_plafonnee_salarie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation vieillesse plafonnée (salarié)"
 
     def function(self, simulation, period):
@@ -758,7 +758,7 @@ class vieillesse_plafonnee_salarie(Variable):
 
 class vieillesse_deplafonnee_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation vieillesse déplafonnée"
 
     def function(self, simulation, period):
@@ -774,7 +774,7 @@ class vieillesse_deplafonnee_employeur(Variable):
 
 class vieillesse_plafonnee_employeur(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation vieillesse plafonnée (employeur)"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_totaux.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_totaux.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 class cotisations_employeur(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisations sociales employeur"
     set_input = set_input_divide_by_period
 
@@ -36,7 +36,7 @@ class cotisations_employeur(Variable):
 class cotisations_employeur_contributives(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisations sociales employeur contributives"
     set_input = set_input_divide_by_period
 
@@ -82,7 +82,7 @@ class cotisations_employeur_contributives(Variable):
 class cotisations_employeur_non_contributives(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisations sociales employeur non-contributives"
     set_input = set_input_divide_by_period
 
@@ -111,7 +111,7 @@ class cotisations_employeur_non_contributives(Variable):
 class cotisations_salariales_contributives(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisations sociales salariales contributives"
     set_input = set_input_divide_by_period
 
@@ -154,7 +154,7 @@ class cotisations_salariales_contributives(Variable):
 class cotisations_salariales_non_contributives(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisations sociales salariales non-contributives"
     set_input = set_input_divide_by_period
 
@@ -177,7 +177,7 @@ class cotisations_salariales_non_contributives(Variable):
 class cotisations_salariales(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisations sociales salariales"
     set_input = set_input_divide_by_period
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_totaux.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_totaux.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 class cotisations_employeur(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisations sociales employeur"
     set_input = set_input_divide_by_period
 
@@ -36,7 +36,7 @@ class cotisations_employeur(Variable):
 class cotisations_employeur_contributives(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisations sociales employeur contributives"
     set_input = set_input_divide_by_period
 
@@ -82,7 +82,7 @@ class cotisations_employeur_contributives(Variable):
 class cotisations_employeur_non_contributives(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisations sociales employeur non-contributives"
     set_input = set_input_divide_by_period
 
@@ -111,7 +111,7 @@ class cotisations_employeur_non_contributives(Variable):
 class cotisations_salariales_contributives(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisations sociales salariales contributives"
     set_input = set_input_divide_by_period
 
@@ -154,7 +154,7 @@ class cotisations_salariales_contributives(Variable):
 class cotisations_salariales_non_contributives(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisations sociales salariales non-contributives"
     set_input = set_input_divide_by_period
 
@@ -177,7 +177,7 @@ class cotisations_salariales_non_contributives(Variable):
 class cotisations_salariales(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisations sociales salariales"
     set_input = set_input_divide_by_period
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -29,7 +29,7 @@ from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotis
 
 class conge_individuel_formation_cdd(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Contribution au financement des congé individuel de formation (CIF) des salariées en CDD"
 
     # TODO: date de début
@@ -44,7 +44,7 @@ class conge_individuel_formation_cdd(Variable):
 
 class redevable_taxe_apprentissage(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Entreprise redevable de la taxe d'apprentissage"
 
     def function(self, simulation, period):
@@ -57,7 +57,7 @@ class redevable_taxe_apprentissage(Variable):
 
 class contribution_developpement_apprentissage(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Contribution additionnelle au développement de l'apprentissage"
 
     def function(self, simulation, period):
@@ -75,7 +75,7 @@ class contribution_developpement_apprentissage(Variable):
 
 class contribution_supplementaire_apprentissage(DatedVariable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Contribution supplémentaire à l'apprentissage"
 
     @dated_function(date(2010, 1, 1))
@@ -104,7 +104,7 @@ class contribution_supplementaire_apprentissage(DatedVariable):
 class cotisations_employeur_main_d_oeuvre(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation sociales employeur main d'oeuvre"
 
     def function(self, simulation, period):
@@ -142,7 +142,7 @@ class cotisations_employeur_main_d_oeuvre(Variable):
 
 class fnal(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation fonds national action logement (FNAL)"
 
     def function(self, simulation, period):
@@ -153,7 +153,7 @@ class fnal(Variable):
 
 class fnal_tranche_a(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Cotisation fonds national action logement (FNAL tout employeur)"
 
     def function(self, simulation, period):
@@ -170,7 +170,7 @@ class fnal_tranche_a(Variable):
 
 class fnal_tranche_a_plus_20(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Fonds national action logement (FNAL, employeur avec plus de 20 salariés)"
 
     def function(self, simulation, period):
@@ -187,7 +187,7 @@ class fnal_tranche_a_plus_20(Variable):
 
 class financement_organisations_syndicales(DatedVariable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Contribution patronale au financement des organisations syndicales"
 
     @dated_function(date(2015, 1, 1))
@@ -205,7 +205,7 @@ class financement_organisations_syndicales(DatedVariable):
 
 class formation_professionnelle(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Formation professionnelle"
     url = u"https://www.service-public.fr/professionnels-entreprises/vosdroits/F22570"
 
@@ -236,7 +236,7 @@ class formation_professionnelle(Variable):
 
 class participation_effort_construction(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Participation à l'effort de construction"
 
     def function(self, simulation, period):
@@ -263,7 +263,7 @@ class participation_effort_construction(Variable):
 
 class taxe_apprentissage(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Taxe d'apprentissage (employeur, entreprise redevable de la taxe d'apprentissage uniquement)"
     url = u"https://www.service-public.fr/professionnels-entreprises/vosdroits/F22574"
 
@@ -283,7 +283,7 @@ class taxe_apprentissage(Variable):
 
 class taxe_salaires(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Taxe sur les salaires"
 # Voir
 # http://www.impots.gouv.fr/portal/deploiement/p1/fichedescriptiveformulaire_8920/fichedescriptiveformulaire_8920.pdf

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -29,7 +29,7 @@ from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotis
 
 class conge_individuel_formation_cdd(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Contribution au financement des congé individuel de formation (CIF) des salariées en CDD"
 
     # TODO: date de début
@@ -44,7 +44,7 @@ class conge_individuel_formation_cdd(Variable):
 
 class redevable_taxe_apprentissage(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Entreprise redevable de la taxe d'apprentissage"
 
     def function(self, simulation, period):
@@ -57,7 +57,7 @@ class redevable_taxe_apprentissage(Variable):
 
 class contribution_developpement_apprentissage(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Contribution additionnelle au développement de l'apprentissage"
 
     def function(self, simulation, period):
@@ -75,7 +75,7 @@ class contribution_developpement_apprentissage(Variable):
 
 class contribution_supplementaire_apprentissage(DatedVariable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Contribution supplémentaire à l'apprentissage"
 
     @dated_function(date(2010, 1, 1))
@@ -104,7 +104,7 @@ class contribution_supplementaire_apprentissage(DatedVariable):
 class cotisations_employeur_main_d_oeuvre(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation sociales employeur main d'oeuvre"
 
     def function(self, simulation, period):
@@ -142,7 +142,7 @@ class cotisations_employeur_main_d_oeuvre(Variable):
 
 class fnal(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation fonds national action logement (FNAL)"
 
     def function(self, simulation, period):
@@ -153,7 +153,7 @@ class fnal(Variable):
 
 class fnal_tranche_a(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Cotisation fonds national action logement (FNAL tout employeur)"
 
     def function(self, simulation, period):
@@ -170,7 +170,7 @@ class fnal_tranche_a(Variable):
 
 class fnal_tranche_a_plus_20(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Fonds national action logement (FNAL, employeur avec plus de 20 salariés)"
 
     def function(self, simulation, period):
@@ -187,7 +187,7 @@ class fnal_tranche_a_plus_20(Variable):
 
 class financement_organisations_syndicales(DatedVariable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Contribution patronale au financement des organisations syndicales"
 
     @dated_function(date(2015, 1, 1))
@@ -205,7 +205,7 @@ class financement_organisations_syndicales(DatedVariable):
 
 class formation_professionnelle(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Formation professionnelle"
     url = u"https://www.service-public.fr/professionnels-entreprises/vosdroits/F22570"
 
@@ -236,7 +236,7 @@ class formation_professionnelle(Variable):
 
 class participation_effort_construction(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Participation à l'effort de construction"
 
     def function(self, simulation, period):
@@ -263,7 +263,7 @@ class participation_effort_construction(Variable):
 
 class taxe_apprentissage(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Taxe d'apprentissage (employeur, entreprise redevable de la taxe d'apprentissage uniquement)"
     url = u"https://www.service-public.fr/professionnels-entreprises/vosdroits/F22574"
 
@@ -283,7 +283,7 @@ class taxe_apprentissage(Variable):
 
 class taxe_salaires(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Taxe sur les salaires"
 # Voir
 # http://www.impots.gouv.fr/portal/deploiement/p1/fichedescriptiveformulaire_8920/fichedescriptiveformulaire_8920.pdf

--- a/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
+++ b/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
@@ -9,7 +9,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class exonere_taxe_habitation(Variable):
     column = BoolCol(default = True)
-    entity_class = Menages
+    entity = Menages
     label = u"Exonération de la taxe d'habitation"
     url = "http://vosdroits.service-public.fr/particuliers/F42.xhtml"
 
@@ -59,7 +59,7 @@ class exonere_taxe_habitation(Variable):
 
 class taxe_habitation(Variable):
     column = FloatCol(default = 0)
-    entity_class = Menages
+    entity = Menages
     label = u"Taxe d'habitation"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?espId=1&pageId=part_taxe_habitation&impot=TH&sfid=50"
 

--- a/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
+++ b/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
@@ -9,7 +9,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class exonere_taxe_habitation(Variable):
     column = BoolCol(default = True)
-    entity = Menages
+    entity = Menage
     label = u"Exonération de la taxe d'habitation"
     url = "http://vosdroits.service-public.fr/particuliers/F42.xhtml"
 
@@ -59,7 +59,7 @@ class exonere_taxe_habitation(Variable):
 
 class taxe_habitation(Variable):
     column = FloatCol(default = 0)
-    entity = Menages
+    entity = Menage
     label = u"Taxe d'habitation"
     url = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?espId=1&pageId=part_taxe_habitation&impot=TH&sfid=50"
 

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -667,7 +667,7 @@ class zone_apl_famille(Variable):
     label = u"Zone apl de la famille"
 
     def function(famille, period):
-        zone_apl_menage = famille.members.menage.calculate('zone_apl', period)
+        zone_apl_menage = famille.members.menage['zone_apl'](period)
         return period, famille.transpose(zone_apl_menage, origin_entity = Menages)
 
 def preload_zone_apl():

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -24,7 +24,7 @@ zone_apl_by_depcom = None
 
 class al_nb_personnes_a_charge(Variable):
     column = IntCol
-    entity = Familles
+    entity = Famille
     label = u"Nombre de personne à charge au sens des allocations logement"
 
     def function(famille, period, legislation):
@@ -83,7 +83,7 @@ class al_nb_personnes_a_charge(Variable):
 
 class al_couple(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u'Situation de couple pour le calcul des AL'
 
     def function(self, simulation, period):
@@ -95,7 +95,7 @@ class al_couple(Variable):
 
 class aide_logement_base_ressources_eval_forfaitaire(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Base ressources en évaluation forfaitaire des aides au logement (R351-7 du CCH)"
 
     def function(self, simulation, period):
@@ -129,7 +129,7 @@ class aide_logement_base_ressources_eval_forfaitaire(Variable):
 
 class aide_logement_abattement_chomage_indemnise(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Montant de l'abattement pour personnes au chômage indemnisé (R351-13 du CCH)"
 
     def function(self, simulation, period):
@@ -147,7 +147,7 @@ class aide_logement_abattement_chomage_indemnise(Variable):
 
 class aide_logement_abattement_depart_retraite(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Montant de l'abattement sur les salaires en cas de départ en retraite"
 
     def function(self, simulation, period):
@@ -164,7 +164,7 @@ class aide_logement_abattement_depart_retraite(Variable):
 
 class aide_logement_neutralisation_rsa(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Abattement sur les revenus n-2 pour les bénéficiaires du RSA"
 
     def function(self, simulation, period):
@@ -185,7 +185,7 @@ class aide_logement_neutralisation_rsa(Variable):
 
 class aide_logement_base_ressources_defaut(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Base ressource par défaut des allocations logement"
 
     def function(self, simulation, period):
@@ -221,7 +221,7 @@ class aide_logement_base_ressources_defaut(Variable):
 
 class aide_logement_base_ressources(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Base ressources des allocations logement"
 
     def function(self, simulation, period):
@@ -273,7 +273,7 @@ class aide_logement_base_ressources(Variable):
 
 class aide_logement_loyer_retenu(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Loyer retenu (hors charge) dans le calcul des aides au logement"
 
     def function(famille, period, legislation):
@@ -316,7 +316,7 @@ class aide_logement_loyer_retenu(Variable):
 
 class aide_logement_charges(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Charges retenues dans le calcul des aides au logement"
 
     def function(famille, period, legislation):
@@ -331,7 +331,7 @@ class aide_logement_charges(Variable):
 
 class aide_logement_R0(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Revenu de référence, basé sur la situation familiale, pris en compte dans le calcul des AL."
 
     def function(famille, period, legislation):
@@ -361,7 +361,7 @@ class aide_logement_R0(Variable):
 
 class aide_logement_taux_famille(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Taux représentant la situation familiale, décroissant avec le nombre de personnes à charge"
 
     def function(famille, period, legislation):
@@ -396,7 +396,7 @@ class aide_logement_taux_famille(Variable):
 
 class aide_logement_taux_loyer(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Taux obscur basé sur une comparaison du loyer retenu à un loyer de référence."
 
     def function(self, simulation, period):
@@ -427,7 +427,7 @@ class aide_logement_taux_loyer(Variable):
 
 class aide_logement_participation_personelle(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Participation personelle de la famille au loyer"
 
     def function(self, simulation, period):
@@ -452,7 +452,7 @@ class aide_logement_participation_personelle(Variable):
 
 class aide_logement_montant_brut(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Formule des aides aux logements en secteur locatif en montant brut avant CRDS"
 
     def function(famille, period, legislation):
@@ -479,7 +479,7 @@ class aide_logement_montant_brut(Variable):
 
 class aide_logement_montant(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Montant des aides au logement net de CRDS"
 
     def function(self, simulation, period):
@@ -493,7 +493,7 @@ class aide_logement_montant(Variable):
 class alf(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Allocation logement familiale"
     url = u"http://vosdroits.service-public.fr/particuliers/F13132.xhtml"
 
@@ -509,7 +509,7 @@ class alf(Variable):
 
 class als_non_etudiant(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Allocation logement sociale (non étudiante)"
 
     def function(famille, period):
@@ -520,7 +520,7 @@ class als_non_etudiant(Variable):
         proprietaire_proche_famille = famille('proprietaire_proche_famille', period)
 
         etudiant = famille.members('etudiant', period)
-        no_parent_etudiant = not_(famille.any(etudiant, role = Familles.PARENT))
+        no_parent_etudiant = not_(famille.any(etudiant, role = Famille.PARENT))
 
         return period, (
             (al_nb_pac == 0) * (statut_occupation_logement != 3) * not_(proprietaire_proche_famille) *
@@ -530,7 +530,7 @@ class als_non_etudiant(Variable):
 class als_etudiant(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Allocation logement sociale (étudiante)"
     url = u"https://www.caf.fr/actualites/2012/etudiants-tout-savoir-sur-les-aides-au-logement"
 
@@ -542,7 +542,7 @@ class als_etudiant(Variable):
         proprietaire_proche_famille = famille('proprietaire_proche_famille', period)
 
         etudiant = famille.members('etudiant', period)
-        parent_etudiant = famille.any(etudiant, role = Familles.PARENT)
+        parent_etudiant = famille.any(etudiant, role = Famille.PARENT)
 
         return period, (
             (al_nb_pac == 0) * (statut_occupation_logement != 3) * not_(proprietaire_proche_famille) *
@@ -552,7 +552,7 @@ class als_etudiant(Variable):
 class als(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Allocation logement sociale"
     url = u"http://vosdroits.service-public.fr/particuliers/F1280.xhtml"
 
@@ -567,7 +567,7 @@ class als(Variable):
 class apl(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u" Aide personnalisée au logement"
     # (réservée aux logements conventionné, surtout des HLM, et financé par le fonds national de l'habitation)"
     url = u"http://vosdroits.service-public.fr/particuliers/F12006.xhtml",
@@ -588,7 +588,7 @@ class aide_logement_non_calculable(Variable):
         ]),
         default = 0
     )
-    entity = Familles
+    entity = Famille
     label = u"Aide au logement non calculable"
 
     def function(famille, period):
@@ -600,7 +600,7 @@ class aide_logement_non_calculable(Variable):
 
 class aide_logement(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Aide au logement (tout type)"
 
     def function(self, simulation, period):
@@ -614,7 +614,7 @@ class aide_logement(Variable):
 class crds_logement(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"CRDS des allocations logement"
     url = u"http://vosdroits.service-public.fr/particuliers/F17585.xhtml"
 
@@ -634,7 +634,7 @@ class zone_apl(Variable):
             ]),
         default = 2
         )
-    entity = Menages
+    entity = Menage
     label = u"Zone APL"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -27,7 +27,7 @@ class al_nb_personnes_a_charge(Variable):
     entity_class = Familles
     label = u"Nombre de personne à charge au sens des allocations logement"
 
-    def function(self, simulation, period):
+    def function(famille, period, legislation):
         '''
         site de la CAF en 2011:
 
@@ -49,24 +49,23 @@ class al_nb_personnes_a_charge(Variable):
         '''
 
         period = period.this_month
-        age_holder = simulation.compute('age', period)
-        age_max_enfant = simulation.legislation_at(period.start).fam.cf.age2
-        residence_dom = simulation.calculate('residence_dom', period)
+        age_max_enfant = legislation(period).fam.cf.age2
+        residence_dom = famille.demandeur.menage('residence_dom', period)
 
         def al_nb_enfants():
-            age_min_enfant = simulation.legislation_at(period.start).fam.af.age1
-            return nb_enf(simulation, period, age_min_enfant, age_max_enfant - 1)  # La limite sur l'age max est stricte.
+            age_min_enfant = legislation(period).fam.af.age1
+            return nb_enf(famille, period, age_min_enfant, age_max_enfant - 1)  # La limite sur l'age max est stricte.
 
         def al_nb_adultes_handicapes():
 
             # Variables à valeur pour un individu
-            base_ressources_i = simulation.compute('prestations_familiales_base_ressources_individu', period).array
-            inapte_travail = simulation.compute('inapte_travail', period).array
-            taux_incapacite = simulation.compute('taux_incapacite', period).array
-            age = age_holder.array
+            base_ressources_i = famille.members('prestations_familiales_base_ressources_individu', period)
+            inapte_travail = famille.members('inapte_travail', period)
+            taux_incapacite = famille.members('taux_incapacite', period)
+            age = famille.members('age', period)
 
             # Parametres
-            plafond_ressource = simulation.legislation_at(period.n_2.stop).minim.aspa.plaf_seul * 1.25
+            plafond_ressource = legislation(period.n_2.stop).minim.aspa.plaf_seul * 1.25
             taux_incapacite_minimum = 0.8
 
             adulte_handicape = (
@@ -75,7 +74,7 @@ class al_nb_personnes_a_charge(Variable):
                 (base_ressources_i <= plafond_ressource)
             )
 
-            return self.sum_by_entity(adulte_handicape)
+            return famille.sum(adulte_handicape)
 
         nb_pac = al_nb_enfants() + al_nb_adultes_handicapes()
         nb_pac = where(residence_dom, min_(nb_pac, 6), nb_pac)  # Dans les DOMs, le barème est fixe à partir de 6 enfants.
@@ -205,7 +204,7 @@ class aide_logement_base_ressources_defaut(Variable):
             max_(0, base_ressources_holder.array - abattement_ressources_enfant), roles = ENFS)
 
         # Revenus du foyer fiscal
-        rev_coll = simulation.famille.first_person.foyer_fiscal('rev_coll', period.n_2)
+        rev_coll = simulation.famille.demandeur.foyer_fiscal('rev_coll', period.n_2)
 
         ressources = (
             base_ressources_parents + br_enfants + rev_coll -
@@ -277,18 +276,18 @@ class aide_logement_loyer_retenu(Variable):
     entity_class = Familles
     label = u"Loyer retenu (hors charge) dans le calcul des aides au logement"
 
-    def function(self, simulation, period):
+    def function(famille, period, legislation):
         period = period.this_month
-        al = simulation.legislation_at(period.start).al
-        al_nb_pac = simulation.calculate('al_nb_personnes_a_charge', period)
-        couple = simulation.calculate('al_couple', period)
-        statut_occupation_logement = simulation.calculate('statut_occupation_logement_famille', period)
-        loyer = simulation.calculate('loyer_famille', period)
-        coloc_holder = simulation.compute('coloc', period)
-        coloc = self.any_by_roles(coloc_holder)
-        logement_chambre_holder = simulation.compute('logement_chambre', period)
-        chambre = self.any_by_roles(logement_chambre_holder)
-        zone_apl = simulation.calculate('zone_apl_famille', period)
+        al = legislation(period).al
+        al_nb_pac = famille('al_nb_personnes_a_charge', period)
+        couple = famille('al_couple', period)
+
+        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
+        loyer = famille.demandeur.menage('loyer', period)
+        coloc = famille.demandeur.menage('coloc', period)
+        chambre = famille.demandeur.menage('logement_chambre', period)
+        zone_apl = famille.demandeur.menage('zone_apl', period)
+
 
         def loyer_reel():  # L1
             coeff_meuble = where(statut_occupation_logement == 5, 2 / 3, 1)  # Coeff de 2/3 pour les meublés
@@ -320,12 +319,11 @@ class aide_logement_charges(Variable):
     entity_class = Familles
     label = u"Charges retenues dans le calcul des aides au logement"
 
-    def function(self, simulation, period):
-        P = simulation.legislation_at(period.start).al.forfait_charges
-        al_nb_pac = simulation.calculate('al_nb_personnes_a_charge', period)
-        couple = simulation.calculate('al_couple', period)
-        coloc_holder = simulation.compute('coloc', period)
-        coloc = self.any_by_roles(coloc_holder)
+    def function(famille, period, legislation):
+        P = legislation(period).al.forfait_charges
+        al_nb_pac = famille('al_nb_personnes_a_charge', period)
+        couple = famille('al_couple', period)
+        coloc = famille.demandeur.menage('coloc', period)
         montant_coloc = where(couple, 1, 0.5) * P.fc1 + al_nb_pac * P.fc2
         montant_cas_general = P.fc1 + al_nb_pac * P.fc2
 
@@ -336,13 +334,13 @@ class aide_logement_R0(Variable):
     entity_class = Familles
     label = u"Revenu de référence, basé sur la situation familiale, pris en compte dans le calcul des AL."
 
-    def function(self, simulation, period):
+    def function(famille, period, legislation):
         period = period.this_month
-        al = simulation.legislation_at(period.start).al
-        pfam_n_2 = simulation.legislation_at(period.start.offset(-2, 'year')).fam
-        couple = simulation.calculate('al_couple', period)
-        al_nb_pac = simulation.calculate('al_nb_personnes_a_charge', period)
-        residence_dom = simulation.calculate('residence_dom')
+        al = legislation(period).al
+        pfam_n_2 = legislation(period.start.offset(-2, 'year')).fam
+        couple = famille('al_couple', period)
+        al_nb_pac = famille('al_nb_personnes_a_charge', period)
+        residence_dom = famille.demandeur.menage('residence_dom')
 
         R1 = al.rmi * (
             al.R1.taux1 * not_(couple) * (al_nb_pac == 0) +
@@ -366,12 +364,12 @@ class aide_logement_taux_famille(Variable):
     entity_class = Familles
     label = u"Taux représentant la situation familiale, décroissant avec le nombre de personnes à charge"
 
-    def function(self, simulation, period):
+    def function(famille, period, legislation):
         period = period.this_month
-        al = simulation.legislation_at(period.start).al
-        couple = simulation.calculate('al_couple', period)
-        al_nb_pac = simulation.calculate('al_nb_personnes_a_charge', period)
-        residence_dom = simulation.calculate('residence_dom')
+        al = legislation(period).al
+        couple = famille('al_couple', period)
+        al_nb_pac = famille('al_nb_personnes_a_charge', period)
+        residence_dom = famille.demandeur.menage('residence_dom')
 
         TF_metropole = (
             al.TF.taux1 * (not_(couple)) * (al_nb_pac == 0) +
@@ -457,18 +455,18 @@ class aide_logement_montant_brut(Variable):
     entity_class = Familles
     label = u"Formule des aides aux logements en secteur locatif en montant brut avant CRDS"
 
-    def function(self, simulation, period):
+    def function(famille, period, legislation):
         period = period.this_month
 
-        al = simulation.legislation_at(period.start).al
+        al = legislation(period).al
 
-        statut_occupation_logement = simulation.calculate('statut_occupation_logement_famille', period)
+        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
         locataire = ((3 <= statut_occupation_logement) * (5 >= statut_occupation_logement)) + (statut_occupation_logement == 7)
         accedant = (statut_occupation_logement == 1)
 
-        loyer_retenu = simulation.calculate('aide_logement_loyer_retenu', period)
-        charges_retenues = simulation.calculate('aide_logement_charges', period)
-        participation_personelle = simulation.calculate('aide_logement_participation_personelle', period)
+        loyer_retenu = famille('aide_logement_loyer_retenu', period)
+        charges_retenues = famille('aide_logement_charges', period)
+        participation_personelle = famille('aide_logement_participation_personelle', period)
 
         montant_locataire = max_(0, loyer_retenu + charges_retenues - participation_personelle)
         montant_accedants = 0  # TODO: APL pour les accédants à la propriété
@@ -499,12 +497,12 @@ class alf(Variable):
     label = u"Allocation logement familiale"
     url = u"http://vosdroits.service-public.fr/particuliers/F13132.xhtml"
 
-    def function(self, simulation, period):
+    def function(famille, period):
         period = period.this_month
-        aide_logement_montant = simulation.calculate('aide_logement_montant', period)
-        al_nb_pac = simulation.calculate('al_nb_personnes_a_charge', period)
-        statut_occupation_logement = simulation.calculate('statut_occupation_logement_famille', period)
-        proprietaire_proche_famille = simulation.calculate('proprietaire_proche_famille', period)
+        aide_logement_montant = famille('aide_logement_montant', period)
+        al_nb_pac = famille('al_nb_personnes_a_charge', period)
+        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
+        proprietaire_proche_famille = famille('proprietaire_proche_famille', period)
 
         result = (al_nb_pac >= 1) * (statut_occupation_logement != 3) * not_(proprietaire_proche_famille) * aide_logement_montant
         return period, result
@@ -514,18 +512,19 @@ class als_non_etudiant(Variable):
     entity_class = Familles
     label = u"Allocation logement sociale (non étudiante)"
 
-    def function(self, simulation, period):
+    def function(famille, period):
         period = period.this_month
-        aide_logement_montant = simulation.calculate('aide_logement_montant', period)
-        al_nb_pac = simulation.calculate('al_nb_personnes_a_charge', period)
-        etudiant_holder = simulation.compute('etudiant', period)
-        statut_occupation_logement = simulation.calculate('statut_occupation_logement_famille', period)
-        proprietaire_proche_famille = simulation.calculate('proprietaire_proche_famille', period)
+        aide_logement_montant = famille('aide_logement_montant', period)
+        al_nb_pac = famille('al_nb_personnes_a_charge', period)
+        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
+        proprietaire_proche_famille = famille('proprietaire_proche_famille', period)
 
-        etudiant = self.split_by_roles(etudiant_holder, roles = [CHEF, PART])
+        etudiant = famille.members('etudiant', period)
+        no_parent_etudiant = not_(famille.any(etudiant, role = Familles.PARENT))
+
         return period, (
             (al_nb_pac == 0) * (statut_occupation_logement != 3) * not_(proprietaire_proche_famille) *
-            not_(etudiant[CHEF] | etudiant[PART]) * aide_logement_montant
+            no_parent_etudiant * aide_logement_montant
         )
 
 class als_etudiant(Variable):
@@ -535,18 +534,19 @@ class als_etudiant(Variable):
     label = u"Allocation logement sociale (étudiante)"
     url = u"https://www.caf.fr/actualites/2012/etudiants-tout-savoir-sur-les-aides-au-logement"
 
-    def function(self, simulation, period):
+    def function(famille, period):
         period = period.this_month
-        aide_logement_montant = simulation.calculate('aide_logement_montant', period)
-        al_nb_pac = simulation.calculate('al_nb_personnes_a_charge', period)
-        etudiant_holder = simulation.compute('etudiant', period)
-        statut_occupation_logement = simulation.calculate('statut_occupation_logement_famille', period)
-        proprietaire_proche_famille = simulation.calculate('proprietaire_proche_famille', period)
+        aide_logement_montant = famille('aide_logement_montant', period)
+        al_nb_pac = famille('al_nb_personnes_a_charge', period)
+        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
+        proprietaire_proche_famille = famille('proprietaire_proche_famille', period)
 
-        etudiant = self.split_by_roles(etudiant_holder, roles = [CHEF, PART])
+        etudiant = famille.members('etudiant', period)
+        parent_etudiant = famille.any(etudiant, role = Familles.PARENT)
+
         return period, (
             (al_nb_pac == 0) * (statut_occupation_logement != 3) * not_(proprietaire_proche_famille) *
-            (etudiant[CHEF] | etudiant[PART]) * aide_logement_montant
+            parent_etudiant * aide_logement_montant
         )
 
 class als(Variable):
@@ -572,10 +572,10 @@ class apl(Variable):
     # (réservée aux logements conventionné, surtout des HLM, et financé par le fonds national de l'habitation)"
     url = u"http://vosdroits.service-public.fr/particuliers/F12006.xhtml",
 
-    def function(self, simulation, period):
+    def function(famille, period):
         period = period.this_month
-        aide_logement_montant = simulation.calculate('aide_logement_montant', period)
-        statut_occupation_logement = simulation.calculate('statut_occupation_logement_famille', period)
+        aide_logement_montant = famille('aide_logement_montant', period)
+        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
 
         return period, aide_logement_montant * (statut_occupation_logement == 3)
 
@@ -591,9 +591,9 @@ class aide_logement_non_calculable(Variable):
     entity_class = Familles
     label = u"Aide au logement non calculable"
 
-    def function(self, simulation, period):
+    def function(famille, period):
         period = period.this_month
-        statut_occupation_logement = simulation.calculate('statut_occupation_logement_famille', period)
+        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
 
         return period, (statut_occupation_logement == 1) * 1 + (statut_occupation_logement == 7) * 2
 
@@ -624,16 +624,14 @@ class crds_logement(Variable):
         crds = simulation.legislation_at(period.start).fam.af.crds
         return period, -aide_logement_montant_brut * crds
 
-ZONE_APL_ENUM = Enum([
+class zone_apl(Variable):
+    column = EnumCol(
+        enum = Enum([
             u"Non renseigné",
             u"Zone 1",
             u"Zone 2",
             u"Zone 3",
-            ])
-
-class zone_apl(Variable):
-    column = EnumCol(
-        enum = ZONE_APL_ENUM,
+            ]),
         default = 2
         )
     entity_class = Menages
@@ -657,16 +655,6 @@ class zone_apl(Variable):
             dtype = int16,
             )
 
-class zone_apl_famille(Variable):
-    entity_class = Familles
-    column = EnumCol(
-        enum = ZONE_APL_ENUM,
-        default = 2
-        )
-    label = u"Zone apl de la famille"
-
-    def function(famille, period):
-        return period, famille.first_person.menage('zone_apl', period)
 
 def preload_zone_apl():
     global zone_apl_by_depcom

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -24,7 +24,7 @@ zone_apl_by_depcom = None
 
 class al_nb_personnes_a_charge(Variable):
     column = IntCol
-    entity_class = Familles
+    entity = Familles
     label = u"Nombre de personne à charge au sens des allocations logement"
 
     def function(famille, period, legislation):
@@ -83,7 +83,7 @@ class al_nb_personnes_a_charge(Variable):
 
 class al_couple(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u'Situation de couple pour le calcul des AL'
 
     def function(self, simulation, period):
@@ -95,7 +95,7 @@ class al_couple(Variable):
 
 class aide_logement_base_ressources_eval_forfaitaire(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Base ressources en évaluation forfaitaire des aides au logement (R351-7 du CCH)"
 
     def function(self, simulation, period):
@@ -129,7 +129,7 @@ class aide_logement_base_ressources_eval_forfaitaire(Variable):
 
 class aide_logement_abattement_chomage_indemnise(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Montant de l'abattement pour personnes au chômage indemnisé (R351-13 du CCH)"
 
     def function(self, simulation, period):
@@ -147,7 +147,7 @@ class aide_logement_abattement_chomage_indemnise(Variable):
 
 class aide_logement_abattement_depart_retraite(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Montant de l'abattement sur les salaires en cas de départ en retraite"
 
     def function(self, simulation, period):
@@ -164,7 +164,7 @@ class aide_logement_abattement_depart_retraite(Variable):
 
 class aide_logement_neutralisation_rsa(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Abattement sur les revenus n-2 pour les bénéficiaires du RSA"
 
     def function(self, simulation, period):
@@ -185,7 +185,7 @@ class aide_logement_neutralisation_rsa(Variable):
 
 class aide_logement_base_ressources_defaut(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Base ressource par défaut des allocations logement"
 
     def function(self, simulation, period):
@@ -221,7 +221,7 @@ class aide_logement_base_ressources_defaut(Variable):
 
 class aide_logement_base_ressources(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Base ressources des allocations logement"
 
     def function(self, simulation, period):
@@ -273,7 +273,7 @@ class aide_logement_base_ressources(Variable):
 
 class aide_logement_loyer_retenu(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Loyer retenu (hors charge) dans le calcul des aides au logement"
 
     def function(famille, period, legislation):
@@ -316,7 +316,7 @@ class aide_logement_loyer_retenu(Variable):
 
 class aide_logement_charges(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Charges retenues dans le calcul des aides au logement"
 
     def function(famille, period, legislation):
@@ -331,7 +331,7 @@ class aide_logement_charges(Variable):
 
 class aide_logement_R0(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Revenu de référence, basé sur la situation familiale, pris en compte dans le calcul des AL."
 
     def function(famille, period, legislation):
@@ -361,7 +361,7 @@ class aide_logement_R0(Variable):
 
 class aide_logement_taux_famille(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Taux représentant la situation familiale, décroissant avec le nombre de personnes à charge"
 
     def function(famille, period, legislation):
@@ -396,7 +396,7 @@ class aide_logement_taux_famille(Variable):
 
 class aide_logement_taux_loyer(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Taux obscur basé sur une comparaison du loyer retenu à un loyer de référence."
 
     def function(self, simulation, period):
@@ -427,7 +427,7 @@ class aide_logement_taux_loyer(Variable):
 
 class aide_logement_participation_personelle(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Participation personelle de la famille au loyer"
 
     def function(self, simulation, period):
@@ -452,7 +452,7 @@ class aide_logement_participation_personelle(Variable):
 
 class aide_logement_montant_brut(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Formule des aides aux logements en secteur locatif en montant brut avant CRDS"
 
     def function(famille, period, legislation):
@@ -479,7 +479,7 @@ class aide_logement_montant_brut(Variable):
 
 class aide_logement_montant(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Montant des aides au logement net de CRDS"
 
     def function(self, simulation, period):
@@ -493,7 +493,7 @@ class aide_logement_montant(Variable):
 class alf(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation logement familiale"
     url = u"http://vosdroits.service-public.fr/particuliers/F13132.xhtml"
 
@@ -509,7 +509,7 @@ class alf(Variable):
 
 class als_non_etudiant(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation logement sociale (non étudiante)"
 
     def function(famille, period):
@@ -530,7 +530,7 @@ class als_non_etudiant(Variable):
 class als_etudiant(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation logement sociale (étudiante)"
     url = u"https://www.caf.fr/actualites/2012/etudiants-tout-savoir-sur-les-aides-au-logement"
 
@@ -552,7 +552,7 @@ class als_etudiant(Variable):
 class als(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation logement sociale"
     url = u"http://vosdroits.service-public.fr/particuliers/F1280.xhtml"
 
@@ -567,7 +567,7 @@ class als(Variable):
 class apl(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u" Aide personnalisée au logement"
     # (réservée aux logements conventionné, surtout des HLM, et financé par le fonds national de l'habitation)"
     url = u"http://vosdroits.service-public.fr/particuliers/F12006.xhtml",
@@ -588,7 +588,7 @@ class aide_logement_non_calculable(Variable):
         ]),
         default = 0
     )
-    entity_class = Familles
+    entity = Familles
     label = u"Aide au logement non calculable"
 
     def function(famille, period):
@@ -600,7 +600,7 @@ class aide_logement_non_calculable(Variable):
 
 class aide_logement(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Aide au logement (tout type)"
 
     def function(self, simulation, period):
@@ -614,7 +614,7 @@ class aide_logement(Variable):
 class crds_logement(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"CRDS des allocations logement"
     url = u"http://vosdroits.service-public.fr/particuliers/F17585.xhtml"
 
@@ -634,7 +634,7 @@ class zone_apl(Variable):
             ]),
         default = 2
         )
-    entity_class = Menages
+    entity = Menages
     label = u"Zone APL"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -205,11 +205,10 @@ class aide_logement_base_ressources_defaut(Variable):
             max_(0, base_ressources_holder.array - abattement_ressources_enfant), roles = ENFS)
 
         # Revenus du foyer fiscal
-        rev_coll = simulation.calculate('rev_coll', period.n_2)
-        rev_coll_famille = simulation.famille.transpose(rev_coll, origin_entity = FoyersFiscaux)
+        rev_coll = simulation.famille.first_person.foyer_fiscal('rev_coll', period.n_2)
 
         ressources = (
-            base_ressources_parents + br_enfants + rev_coll_famille -
+            base_ressources_parents + br_enfants + rev_coll -
             (abattement_chomage_indemnise + abattement_depart_retraite + neutralisation_rsa)
         )
 
@@ -667,8 +666,7 @@ class zone_apl_famille(Variable):
     label = u"Zone apl de la famille"
 
     def function(famille, period):
-        zone_apl_menage = famille.members.menage('zone_apl', period)
-        return period, famille.transpose(zone_apl_menage, origin_entity = Menages)
+        return period, famille.first_person.menage('zone_apl', period)
 
 def preload_zone_apl():
     global zone_apl_by_depcom

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -667,7 +667,7 @@ class zone_apl_famille(Variable):
     label = u"Zone apl de la famille"
 
     def function(famille, period):
-        zone_apl_menage = famille.members.menage['zone_apl'](period)
+        zone_apl_menage = famille.members.menage('zone_apl', period)
         return period, famille.transpose(zone_apl_menage, origin_entity = Menages)
 
 def preload_zone_apl():

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -15,7 +15,7 @@ SCOLARITE_LYCEE = 2
 class bourse_college(Variable):
     column = FloatCol
     label = u"Montant mensuel de la bourse de collège"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -54,7 +54,7 @@ class bourse_college(Variable):
 class bourse_lycee_points_de_charge(Variable):
     column = FloatCol
     label = u"Nombre de points de charge pour la bourse de lycée"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -79,7 +79,7 @@ class bourse_lycee_points_de_charge(Variable):
 class bourse_lycee_nombre_parts(Variable):
     column = FloatCol
     label = u"Nombre de parts pour le calcul du montant de la bourse de lycée"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -107,7 +107,7 @@ class bourse_lycee_nombre_parts(Variable):
 class bourse_lycee(Variable):
     column = FloatCol
     label = u"Montant mensuel de la bourse de lycée"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -137,10 +137,10 @@ class scolarite(Variable):
             ),
         default = 0
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Scolarité de l'enfant : collège, lycée..."
 
 class boursier(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Élève ou étudiant boursier"

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -15,7 +15,7 @@ SCOLARITE_LYCEE = 2
 class bourse_college(Variable):
     column = FloatCol
     label = u"Montant mensuel de la bourse de collège"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -54,7 +54,7 @@ class bourse_college(Variable):
 class bourse_lycee_points_de_charge(Variable):
     column = FloatCol
     label = u"Nombre de points de charge pour la bourse de lycée"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -79,7 +79,7 @@ class bourse_lycee_points_de_charge(Variable):
 class bourse_lycee_nombre_parts(Variable):
     column = FloatCol
     label = u"Nombre de parts pour le calcul du montant de la bourse de lycée"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -107,7 +107,7 @@ class bourse_lycee_nombre_parts(Variable):
 class bourse_lycee(Variable):
     column = FloatCol
     label = u"Montant mensuel de la bourse de lycée"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -137,10 +137,10 @@ class scolarite(Variable):
             ),
         default = 0
         )
-    entity = Individus
+    entity = Individu
     label = u"Scolarité de l'enfant : collège, lycée..."
 
 class boursier(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Élève ou étudiant boursier"

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -9,7 +9,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 class aah_base_ressources(Variable):
     column = FloatCol
     label = u"Base ressources de l'allocation adulte handicapé"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -52,7 +52,7 @@ class aah_base_ressources(Variable):
 class aah_base_ressources_eval_trimestrielle(Variable):
     column = FloatCol
     label = u"Base de ressources de l'ASS pour un individu, évaluation trimestrielle"
-    entity = Individus
+    entity = Individu
 
     '''
         N'entrent pas en compte dans les ressources :
@@ -116,7 +116,7 @@ class aah_base_ressources_eval_trimestrielle(Variable):
 class aah_base_ressources_eval_annuelle(Variable):
     column = FloatCol
     label = u"Base de ressources de l'ASS pour un individu, évaluation annuelle"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -126,7 +126,7 @@ class aah_base_ressources_eval_annuelle(Variable):
 class aah_eligible(Variable):
     column = BoolCol
     label = u"Eligibilité à l'Allocation adulte handicapé"
-    entity = Individus
+    entity = Individu
 
     '''
         Allocation adulte handicapé
@@ -183,7 +183,7 @@ class aah_non_calculable(Variable):
         ]),
         default = 0
     )
-    entity = Individus
+    entity = Individu
     label = u"AAH non calculable"
 
     def function(individu, period):
@@ -199,7 +199,7 @@ class aah_base(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"Montant de l'Allocation adulte handicapé (hors complément) pour un individu, mensualisée"
-    entity = Individus
+    entity = Individu
 
     def function(individu, period, legislation):
         period = period.this_month
@@ -222,8 +222,8 @@ class aah_base(Variable):
 class aah(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    label = u"Allocation adulte handicapé (Individus) mensualisée"
-    entity = Individus
+    label = u"Allocation adulte handicapé (Individu) mensualisée"
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -239,7 +239,7 @@ class caah(DatedVariable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"Complément d'allocation adulte handicapé (mensualisé)"
-    entity = Individus
+    entity = Individu
     '''
         Complément d'allocation adulte handicapé : complément de ressources ou majoration vie autonome.
 
@@ -340,11 +340,11 @@ class caah(DatedVariable):
         return period, ancien_caah
 
 class mva(Variable):
-    entity = Individus
+    entity = Individu
     column = FloatCol
     label = u"Majoration pour la vie autonome"
 
 class pch(Variable):
-    entity = Individus
+    entity = Individu
     column = FloatCol
     label = u"Prestation de compensation du handicap"

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -9,7 +9,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 class aah_base_ressources(Variable):
     column = FloatCol
     label = u"Base ressources de l'allocation adulte handicapé"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -52,7 +52,7 @@ class aah_base_ressources(Variable):
 class aah_base_ressources_eval_trimestrielle(Variable):
     column = FloatCol
     label = u"Base de ressources de l'ASS pour un individu, évaluation trimestrielle"
-    entity_class = Individus
+    entity = Individus
 
     '''
         N'entrent pas en compte dans les ressources :
@@ -116,7 +116,7 @@ class aah_base_ressources_eval_trimestrielle(Variable):
 class aah_base_ressources_eval_annuelle(Variable):
     column = FloatCol
     label = u"Base de ressources de l'ASS pour un individu, évaluation annuelle"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -126,7 +126,7 @@ class aah_base_ressources_eval_annuelle(Variable):
 class aah_eligible(Variable):
     column = BoolCol
     label = u"Eligibilité à l'Allocation adulte handicapé"
-    entity_class = Individus
+    entity = Individus
 
     '''
         Allocation adulte handicapé
@@ -183,7 +183,7 @@ class aah_non_calculable(Variable):
         ]),
         default = 0
     )
-    entity_class = Individus
+    entity = Individus
     label = u"AAH non calculable"
 
     def function(individu, period):
@@ -199,7 +199,7 @@ class aah_base(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"Montant de l'Allocation adulte handicapé (hors complément) pour un individu, mensualisée"
-    entity_class = Individus
+    entity = Individus
 
     def function(individu, period, legislation):
         period = period.this_month
@@ -223,7 +223,7 @@ class aah(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"Allocation adulte handicapé (Individus) mensualisée"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -239,7 +239,7 @@ class caah(DatedVariable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"Complément d'allocation adulte handicapé (mensualisé)"
-    entity_class = Individus
+    entity = Individus
     '''
         Complément d'allocation adulte handicapé : complément de ressources ou majoration vie autonome.
 
@@ -340,11 +340,11 @@ class caah(DatedVariable):
         return period, ancien_caah
 
 class mva(Variable):
-    entity_class = Individus
+    entity = Individus
     column = FloatCol
     label = u"Majoration pour la vie autonome"
 
 class pch(Variable):
-    entity_class = Individus
+    entity = Individus
     column = FloatCol
     label = u"Prestation de compensation du handicap"

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -217,7 +217,7 @@ class aah_base(Variable):
 
         # Le montant est à valeur pour une famille, il faut le caster pour l'individu
         # Pour le moment, on ne neutralise pas l'aah en cas de non calculabilité pour pouvoir tester
-        return period, aah_eligible * self.cast_from_entity_to_roles(montant_aah(), entity = 'famille') # * not_(aah_non_calculable)
+        return period, aah_eligible * simulation.famille.project(montant_aah())# * not_(aah_non_calculable)
 
 
 class aah(Variable):

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -48,7 +48,7 @@ class aefa(DatedVariable):
         maj = 0  # TODO
         condition = (dummy_ass + dummy_aer + dummy_api + dummy_rmi > 0)
         if hasattr(af, "age3"):
-            nbPAC = nb_enf(simulation, period, af.age1, af.age3)
+            nbPAC = nb_enf(simulation.famille, period, af.age1, af.age3)
         else:
             nbPAC = af_nbenf
         # TODO check nombre de PAC pour une famille
@@ -81,7 +81,7 @@ class aefa(DatedVariable):
         maj = 0  # TODO
         condition = (dummy_ass + dummy_aer + dummy_api + dummy_rmi > 0)
         if hasattr(af, "age3"):
-            nbPAC = nb_enf(simulation, period, af.age1, af.age3)
+            nbPAC = nb_enf(simulation.famille, period, af.age1, af.age3)
         else:
             nbPAC = af_nbenf
         # TODO check nombre de PAC pour une famille
@@ -115,7 +115,7 @@ class aefa(DatedVariable):
         maj = 0  # TODO
         condition = (dummy_ass + dummy_aer + dummy_api + dummy_rmi > 0)
         if hasattr(af, "age3"):
-            nbPAC = nb_enf(simulation, period, af.age1, af.age3)
+            nbPAC = nb_enf(simulation.famille, period, af.age1, af.age3)
         else:
             nbPAC = af_nbenf
         # TODO check nombre de PAC pour une famille

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -24,7 +24,7 @@ class aefa(DatedVariable):
     pour la Création ou la Reprise d'Entreprise (ACCRE-ASS) ou encore allocation chômage.
     '''
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Aide exceptionelle de fin d'année (prime de Noël)"
     url = u"http://www.pole-emploi.fr/candidat/aide-exceptionnelle-de-fin-d-annee-dite-prime-de-noel--@/suarticle.jspz?id=70996"  # noqa
 

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -31,8 +31,6 @@ class aefa(DatedVariable):
     @dated_function(start = date(2009, 1, 1), stop = date(2015, 12, 31))
     def function_2009__(self, simulation, period):
         period = period.this_year
-        age_holder = simulation.compute('age', period)
-        autonomie_financiere_holder = simulation.compute('autonomie_financiere', period, accept_other_period = True)
         af_nbenf = simulation.calculate('af_nbenf', period)
         nb_parents = simulation.calculate('nb_parents', period)
         ass = simulation.calculate_add('ass', period)
@@ -42,9 +40,7 @@ class aefa(DatedVariable):
         P = simulation.legislation_at(period.start).minim.aefa
         af = simulation.legislation_at(period.start).fam.af
 
-        age = self.split_by_roles(age_holder, roles = ENFS)
         aer = self.sum_by_entity(aer_holder)
-        autonomie_financiere = self.split_by_roles(autonomie_financiere_holder, roles = ENFS)
         dummy_ass = ass > 0
         dummy_aer = aer > 0
         dummy_api = api > 0
@@ -52,7 +48,7 @@ class aefa(DatedVariable):
         maj = 0  # TODO
         condition = (dummy_ass + dummy_aer + dummy_api + dummy_rmi > 0)
         if hasattr(af, "age3"):
-            nbPAC = nb_enf(age, autonomie_financiere, af.age1, af.age3)
+            nbPAC = nb_enf(simulation, period, af.age1, af.age3)
         else:
             nbPAC = af_nbenf
         # TODO check nombre de PAC pour une famille
@@ -68,8 +64,6 @@ class aefa(DatedVariable):
     @dated_function(start = date(2008, 1, 1), stop = date(2008, 12, 31))
     def function_2008(self, simulation, period):
         period = period.this_year
-        age_holder = simulation.compute('age', period)
-        autonomie_financiere_holder = simulation.compute('autonomie_financiere', period, accept_other_period = True)
         af_nbenf = simulation.calculate('af_nbenf', period)
         nb_parents = simulation.calculate('nb_parents', period)
         ass = simulation.calculate_add('ass', period)
@@ -79,9 +73,7 @@ class aefa(DatedVariable):
         P = simulation.legislation_at(period.start).minim.aefa
         af = simulation.legislation_at(period.start).fam.af
 
-        age = self.split_by_roles(age_holder, roles = ENFS)
         aer = self.sum_by_entity(aer_holder)
-        autonomie_financiere = self.split_by_roles(autonomie_financiere_holder, roles = ENFS)
         dummy_ass = ass > 0
         dummy_aer = aer > 0
         dummy_api = api > 0
@@ -89,7 +81,7 @@ class aefa(DatedVariable):
         maj = 0  # TODO
         condition = (dummy_ass + dummy_aer + dummy_api + dummy_rmi > 0)
         if hasattr(af, "age3"):
-            nbPAC = nb_enf(age, autonomie_financiere, af.age1, af.age3)
+            nbPAC = nb_enf(simulation, period, af.age1, af.age3)
         else:
             nbPAC = af_nbenf
         # TODO check nombre de PAC pour une famille
@@ -106,8 +98,6 @@ class aefa(DatedVariable):
     @dated_function(start = date(2002, 1, 1), stop = date(2007, 12, 31))
     def function__2008_(self, simulation, period):
         period = period.this_year
-        age_holder = simulation.compute('age', period)
-        autonomie_financiere_holder = simulation.compute('autonomie_financiere', period, accept_other_period = True)
         af_nbenf = simulation.calculate('af_nbenf', period)
         nb_parents = simulation.calculate('nb_parents', period)
         ass = simulation.calculate_add('ass', period)
@@ -117,9 +107,7 @@ class aefa(DatedVariable):
         P = simulation.legislation_at(period.start).minim.aefa
         af = simulation.legislation_at(period.start).fam.af
 
-        age = self.split_by_roles(age_holder, roles = ENFS)
         aer = self.sum_by_entity(aer_holder)
-        autonomie_financiere = self.split_by_roles(autonomie_financiere_holder, roles = ENFS)
         dummy_ass = ass > 0
         dummy_aer = aer > 0
         dummy_api = api > 0
@@ -127,7 +115,7 @@ class aefa(DatedVariable):
         maj = 0  # TODO
         condition = (dummy_ass + dummy_aer + dummy_api + dummy_rmi > 0)
         if hasattr(af, "age3"):
-            nbPAC = nb_enf(age, autonomie_financiere, af.age1, af.age3)
+            nbPAC = nb_enf(simulation, period, af.age1, af.age3)
         else:
             nbPAC = af_nbenf
         # TODO check nombre de PAC pour une famille

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -24,7 +24,7 @@ class aefa(DatedVariable):
     pour la Création ou la Reprise d'Entreprise (ACCRE-ASS) ou encore allocation chômage.
     '''
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Aide exceptionelle de fin d'année (prime de Noël)"
     url = u"http://www.pole-emploi.fr/candidat/aide-exceptionnelle-de-fin-d-annee-dite-prime-de-noel--@/suarticle.jspz?id=70996"  # noqa
 

--- a/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
+++ b/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
@@ -175,10 +175,10 @@ class rsa_activite_individu(DatedVariable):
         '''
         period = period   # TODO: rentre dans le calcul de la PPE check period !!!
 
-        rsa_activite_famille = individu.famille.calculate('rsa_activite', period)
+        rsa_activite_famille = individu.famille['rsa_activite'](period)
         rsa_activite_projete = individu.famille.project(rsa_activite_famille)
-        marie = individu.calculate('statut_marital', period) == 1
-        en_couple = individu.famille.calculate('en_couple', period)
+        marie = individu['statut_marital'](period) == 1
+        en_couple = individu.famille['en_couple'](period)
 
         # On partage le rsa_activite entre les parents. Si la personne est mariée et qu'aucun conjoint n'a été déclaré, on divise par 2.
         partage_rsa = or_(marie, individu.famille.project(en_couple))

--- a/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
+++ b/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
@@ -175,12 +175,11 @@ class rsa_activite_individu(DatedVariable):
         '''
         period = period   # TODO: rentre dans le calcul de la PPE check period !!!
 
-        rsa_activite_famille = individu.famille('rsa_activite', period)
-        rsa_activite_projete = individu.famille.project(rsa_activite_famille)
+        rsa_activite = individu.famille('rsa_activite', period)
         marie = individu('statut_marital', period) == 1
         en_couple = individu.famille('en_couple', period)
 
         # On partage le rsa_activite entre les parents. Si la personne est mariée et qu'aucun conjoint n'a été déclaré, on divise par 2.
-        partage_rsa = or_(marie, individu.famille.project(en_couple))
+        partage_rsa = or_(marie, en_couple)
 
-        return period, where(partage_rsa, rsa_activite_projete / 2, rsa_activite_projete)
+        return period, where(partage_rsa, rsa_activite / 2, rsa_activite)

--- a/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
+++ b/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
@@ -10,7 +10,7 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 
 class api(DatedVariable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation de parent isolé"
     url = u"http://fr.wikipedia.org/wiki/Allocation_de_parent_isol%C3%A9",
 
@@ -97,7 +97,7 @@ class api(DatedVariable):
 
 class psa(DatedVariable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Prime de solidarité active"
     url = u"http://www.service-public.fr/actualites/001077.html"
 
@@ -131,7 +131,7 @@ class psa(DatedVariable):
 
 class rmi(DatedVariable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Revenu Minimum d'Insertion"
 
     @dated_function(start = date(1988, 12, 1), stop = date(2009, 5, 31))
@@ -149,7 +149,7 @@ class rmi(DatedVariable):
 class rsa_activite(DatedVariable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Revenu de solidarité active - activité"
     start_date = date(2009, 6, 1)
 
@@ -164,7 +164,7 @@ class rsa_activite(DatedVariable):
 
 class rsa_activite_individu(DatedVariable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenu de solidarité active - activité au niveau de l'individu"
     start_date = date(2009, 6, 1)
 

--- a/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
+++ b/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
@@ -10,7 +10,7 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 
 class api(DatedVariable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Allocation de parent isolé"
     url = u"http://fr.wikipedia.org/wiki/Allocation_de_parent_isol%C3%A9",
 
@@ -97,7 +97,7 @@ class api(DatedVariable):
 
 class psa(DatedVariable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Prime de solidarité active"
     url = u"http://www.service-public.fr/actualites/001077.html"
 
@@ -131,7 +131,7 @@ class psa(DatedVariable):
 
 class rmi(DatedVariable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Revenu Minimum d'Insertion"
 
     @dated_function(start = date(1988, 12, 1), stop = date(2009, 5, 31))
@@ -149,7 +149,7 @@ class rmi(DatedVariable):
 class rsa_activite(DatedVariable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Revenu de solidarité active - activité"
     start_date = date(2009, 6, 1)
 
@@ -164,7 +164,7 @@ class rsa_activite(DatedVariable):
 
 class rsa_activite_individu(DatedVariable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenu de solidarité active - activité au niveau de l'individu"
     start_date = date(2009, 6, 1)
 

--- a/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
+++ b/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
@@ -175,10 +175,10 @@ class rsa_activite_individu(DatedVariable):
         '''
         period = period   # TODO: rentre dans le calcul de la PPE check period !!!
 
-        rsa_activite_famille = individu.famille['rsa_activite'](period)
+        rsa_activite_famille = individu.famille('rsa_activite', period)
         rsa_activite_projete = individu.famille.project(rsa_activite_famille)
-        marie = individu['statut_marital'](period) == 1
-        en_couple = individu.famille['en_couple'](period)
+        marie = individu('statut_marital', period) == 1
+        en_couple = individu.famille('en_couple', period)
 
         # On partage le rsa_activite entre les parents. Si la personne est mariée et qu'aucun conjoint n'a été déclaré, on divise par 2.
         partage_rsa = or_(marie, individu.famille.project(en_couple))

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -9,19 +9,19 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class inapte_travail(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Reconnu inapte au travail"
 
 class taux_incapacite(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Taux d'incapacité"
 
 
 class asi_aspa_base_ressources_individu(Variable):
     column = FloatCol
     label = u"Base ressources individuelle du minimum vieillesse/ASPA"
-    entity_class = Individus
+    entity = Individus
 
     def function(individu, period, legislation):
         period = period.this_month
@@ -112,7 +112,7 @@ class asi_aspa_base_ressources_individu(Variable):
 class asi_aspa_base_ressources(Variable):
     column = FloatCol
     label = u"Base ressource du minimum vieillesse et assimilés (ASPA)"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -126,7 +126,7 @@ class asi_aspa_base_ressources(Variable):
 class aspa_eligibilite(Variable):
     column = BoolCol
     label = u"Indicatrice individuelle d'éligibilité à l'allocation de solidarité aux personnes agées"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -147,7 +147,7 @@ class aspa_eligibilite(Variable):
 class asi_eligibilite(Variable):
     column = BoolCol
     label = u"Indicatrice individuelle d'éligibilité à l'allocation supplémentaire d'invalidité"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -171,7 +171,7 @@ class asi_eligibilite(Variable):
 class asi_aspa_condition_nationalite(Variable):
     column = BoolCol
     label = u"Condition de nationnalité et de titre de séjour pour bénéficier de l'ASPA ou l'ASI"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         ressortissant_eee = simulation.calculate('ressortissant_eee', period)
@@ -184,7 +184,7 @@ class asi_aspa_condition_nationalite(Variable):
 class asi_aspa_nb_alloc(Variable):
     column = IntCol
     label = u"Nombre d'allocataires ASI/ASPA"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -203,7 +203,7 @@ class asi(Variable):
     label = u"Allocation supplémentaire d'invalidité"
     start_date = date(2007, 1, 1)
     url = u"http://vosdroits.service-public.fr/particuliers/F16940.xhtml"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -263,7 +263,7 @@ class asi(Variable):
 class aspa_couple(DatedVariable):
     column = BoolCol
     label = u"Couple au sens de l'ASPA"
-    entity_class = Familles
+    entity = Familles
 
     @dated_function(date(2002, 1, 1), date(2006, 12, 31))
     def function_2002_2006(self, simulation, period):
@@ -283,7 +283,7 @@ class aspa_couple(DatedVariable):
 class aspa(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation de solidarité aux personnes agées"
     url = "http://vosdroits.service-public.fr/particuliers/F16871.xhtml"
 

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -9,19 +9,19 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class inapte_travail(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Reconnu inapte au travail"
 
 class taux_incapacite(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Taux d'incapacité"
 
 
 class asi_aspa_base_ressources_individu(Variable):
     column = FloatCol
     label = u"Base ressources individuelle du minimum vieillesse/ASPA"
-    entity = Individus
+    entity = Individu
 
     def function(individu, period, legislation):
         period = period.this_month
@@ -56,7 +56,7 @@ class asi_aspa_base_ressources_individu(Variable):
         rev_cap_lib_foyer_fiscal = max_(0, individu.foyer_fiscal('rev_cap_lib', three_previous_months, options = [ADD, DIVIDE]))
         retraite_titre_onereux_foyer_fiscal = individu.foyer_fiscal('retraite_titre_onereux', three_previous_months, options = [ADD, DIVIDE])
         revenus_foyer_fiscal = rev_cap_bar_foyer_fiscal + rev_cap_lib_foyer_fiscal + retraite_titre_onereux_foyer_fiscal
-        revenus_foyer_fiscal_individu = revenus_foyer_fiscal * individu.has_role(FoyersFiscaux.DECLARANT_PRINCIPAL)
+        revenus_foyer_fiscal_individu = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         def revenus_tns():
             revenus_auto_entrepreneur = individu('tns_auto_entrepreneur_benefice', three_previous_months, options = [ADD])
@@ -112,7 +112,7 @@ class asi_aspa_base_ressources_individu(Variable):
 class asi_aspa_base_ressources(Variable):
     column = FloatCol
     label = u"Base ressource du minimum vieillesse et assimilés (ASPA)"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -126,7 +126,7 @@ class asi_aspa_base_ressources(Variable):
 class aspa_eligibilite(Variable):
     column = BoolCol
     label = u"Indicatrice individuelle d'éligibilité à l'allocation de solidarité aux personnes agées"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -147,7 +147,7 @@ class aspa_eligibilite(Variable):
 class asi_eligibilite(Variable):
     column = BoolCol
     label = u"Indicatrice individuelle d'éligibilité à l'allocation supplémentaire d'invalidité"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -171,7 +171,7 @@ class asi_eligibilite(Variable):
 class asi_aspa_condition_nationalite(Variable):
     column = BoolCol
     label = u"Condition de nationnalité et de titre de séjour pour bénéficier de l'ASPA ou l'ASI"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         ressortissant_eee = simulation.calculate('ressortissant_eee', period)
@@ -184,7 +184,7 @@ class asi_aspa_condition_nationalite(Variable):
 class asi_aspa_nb_alloc(Variable):
     column = IntCol
     label = u"Nombre d'allocataires ASI/ASPA"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -203,7 +203,7 @@ class asi(Variable):
     label = u"Allocation supplémentaire d'invalidité"
     start_date = date(2007, 1, 1)
     url = u"http://vosdroits.service-public.fr/particuliers/F16940.xhtml"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -263,7 +263,7 @@ class asi(Variable):
 class aspa_couple(DatedVariable):
     column = BoolCol
     label = u"Couple au sens de l'ASPA"
-    entity = Familles
+    entity = Famille
 
     @dated_function(date(2002, 1, 1), date(2006, 12, 31))
     def function_2002_2006(self, simulation, period):
@@ -283,7 +283,7 @@ class aspa_couple(DatedVariable):
 class aspa(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Allocation de solidarité aux personnes agées"
     url = "http://vosdroits.service-public.fr/particuliers/F16871.xhtml"
 

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -10,7 +10,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class ass_precondition_remplie(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Éligible à l'ASS"
 
 
@@ -19,7 +19,7 @@ class ass_precondition_remplie(Variable):
 class ass(Variable):
     column = FloatCol
     label = u"Montant de l'ASS pour une famille"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -48,7 +48,7 @@ class ass(Variable):
 class ass_base_ressources(Variable):
     column = FloatCol
     label = u"Base de ressources de l'ASS"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -64,7 +64,7 @@ class ass_base_ressources(Variable):
 class ass_base_ressources_individu(Variable):
     column = FloatCol
     label = u"Base de ressources individuelle de l'ASS"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -108,7 +108,7 @@ class ass_base_ressources_individu(Variable):
 class ass_base_ressources_conjoint(Variable):
     column = FloatCol
     label = u"Base de ressources individuelle pour le conjoint du demandeur de l'ASS"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -176,7 +176,7 @@ class ass_base_ressources_conjoint(Variable):
 class ass_eligibilite_individu(Variable):
     column = BoolCol
     label = u"Éligibilité individuelle à l'ASS"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -10,7 +10,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class ass_precondition_remplie(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Éligible à l'ASS"
 
 
@@ -19,7 +19,7 @@ class ass_precondition_remplie(Variable):
 class ass(Variable):
     column = FloatCol
     label = u"Montant de l'ASS pour une famille"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -48,7 +48,7 @@ class ass(Variable):
 class ass_base_ressources(Variable):
     column = FloatCol
     label = u"Base de ressources de l'ASS"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -64,7 +64,7 @@ class ass_base_ressources(Variable):
 class ass_base_ressources_individu(Variable):
     column = FloatCol
     label = u"Base de ressources individuelle de l'ASS"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -108,7 +108,7 @@ class ass_base_ressources_individu(Variable):
 class ass_base_ressources_conjoint(Variable):
     column = FloatCol
     label = u"Base de ressources individuelle pour le conjoint du demandeur de l'ASS"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -176,7 +176,7 @@ class ass_base_ressources_conjoint(Variable):
 class ass_eligibilite_individu(Variable):
     column = BoolCol
     label = u"Éligibilité individuelle à l'ASS"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -11,7 +11,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class cmu_acs_eligibilite(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Pré-éligibilité à la CMU, avant prise en compte des ressources"
 
     def function(self, simulation, period):
@@ -37,7 +37,7 @@ class cmu_acs_eligibilite(Variable):
 
 class acs_montant(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Montant de l'ACS en cas d'éligibilité"
     start_date = date(2009, 8, 1)
 
@@ -57,7 +57,7 @@ class acs_montant(Variable):
 
 class cmu_forfait_logement_base(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Forfait logement applicable en cas de propriété ou d'occupation à titre gratuit"
 
     def function(self, simulation, period):
@@ -71,7 +71,7 @@ class cmu_forfait_logement_base(Variable):
 
 class cmu_forfait_logement_al(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Forfait logement applicable en cas d'aide au logement"
 
     def function(self, simulation, period):
@@ -86,7 +86,7 @@ class cmu_forfait_logement_al(Variable):
 
 class cmu_nbp_foyer(Variable):
     column = PeriodSizeIndependentIntCol
-    entity = Familles
+    entity = Famille
     label = u"Nombre de personnes dans le foyer CMU"
 
     def function(self, simulation, period):
@@ -99,7 +99,7 @@ class cmu_nbp_foyer(Variable):
 
 class cmu_eligible_majoration_dom(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
 
     def function(famille, period):
         period = period.this_month
@@ -114,7 +114,7 @@ class cmu_eligible_majoration_dom(Variable):
 
 class cmu_c_plafond(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Plafond annuel de ressources pour l'éligibilité à la CMU-C"
 
     def function(self, simulation, period):
@@ -165,7 +165,7 @@ class cmu_c_plafond(Variable):
 
 class acs_plafond(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Plafond annuel de ressources pour l'éligibilité à l'ACS"
 
     def function(self, simulation, period):
@@ -179,7 +179,7 @@ class acs_plafond(Variable):
 class cmu_base_ressources_individu(Variable):
     column = FloatCol
     label = u"Base de ressources de l'individu prise en compte pour l'éligibilité à la CMU-C / ACS"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -255,7 +255,7 @@ class cmu_base_ressources_individu(Variable):
 class cmu_base_ressources(Variable):
     column = FloatCol
     label = u"Base de ressources prise en compte pour l'éligibilité à la CMU-C / ACS"
-    entity = Familles
+    entity = Famille
 
     def function(famille, period, legislation):
         period = period.this_month
@@ -288,18 +288,18 @@ class cmu_base_ressources(Variable):
             cmu_forfait_logement_al)
 
         ressources_individuelles = famille.members('cmu_base_ressources_individu', period)
-        ressources_parents = famille.sum(ressources_individuelles, role = Familles.PARENT)
+        ressources_parents = famille.sum(ressources_individuelles, role = Famille.PARENT)
 
         age = famille.members('age', period)
         condition_enfant_a_charge = (age >= 0) * (age <= P.age_limite_pac)
-        ressources_enfants = famille.sum(ressources_individuelles * condition_enfant_a_charge, role = Familles.ENFANT)
+        ressources_enfants = famille.sum(ressources_individuelles * condition_enfant_a_charge, role = Famille.ENFANT)
 
         return period, forfait_logement + ressources_famille + ressources_parents + ressources_enfants
 
 
 class cmu_nb_pac(Variable):
     column = PeriodSizeIndependentIntCol
-    entity = Familles
+    entity = Famille
     label = u"Nombre de personnes à charge au titre de la CMU"
 
     def function(self, simulation, period):
@@ -314,7 +314,7 @@ class cmu_nb_pac(Variable):
 class cmu_c(Variable):
     column = BoolCol
     label = u"Éligibilité à la CMU-C"
-    entity = Familles
+    entity = Famille
 
     def function(famille, period):
         # Note : Cette variable est calculée pour un an, mais si elle est demandée pour une période plus petite, elle
@@ -348,7 +348,7 @@ class cmu_c(Variable):
 class acs(Variable):
     column = FloatCol
     label = u"Montant (mensuel) de l'ACS"
-    entity = Familles
+    entity = Famille
 
     def function(famille, period):
         period = period.this_month

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -101,12 +101,13 @@ class cmu_eligible_majoration_dom(Variable):
     column = BoolCol
     entity_class = Familles
 
-    def function(self, simulation, period):
+    def function(famille, period):
         period = period.this_month
-        residence_guadeloupe = simulation.calculate('residence_guadeloupe', period)
-        residence_martinique = simulation.calculate('residence_martinique', period)
-        residence_guyane = simulation.calculate('residence_guyane', period)
-        residence_reunion = simulation.calculate('residence_reunion', period)
+        menage = famille.demandeur.menage
+        residence_guadeloupe = menage('residence_guadeloupe', period)
+        residence_martinique = menage('residence_martinique', period)
+        residence_guyane = menage('residence_guyane', period)
+        residence_reunion = menage('residence_reunion', period)
 
         return period, residence_guadeloupe | residence_martinique | residence_guyane | residence_reunion
 
@@ -256,7 +257,7 @@ class cmu_base_ressources(Variable):
     label = u"Base de ressources prise en compte pour l'éligibilité à la CMU-C / ACS"
     entity_class = Familles
 
-    def function(self, simulation, period):
+    def function(famille, period, legislation):
         period = period.this_month
         previous_year = period.start.period('year').offset(-1)
 
@@ -271,32 +272,29 @@ class cmu_base_ressources(Variable):
             'paje_prepare',
         ]
 
-        ressources = sum(
-            [simulation.calculate_add(ressource, previous_year) for ressource in ressources_a_inclure]
+        ressources_famille = sum(
+            [famille(ressource, previous_year, options = [ADD]) for ressource in ressources_a_inclure]
             )
 
 
-        statut_occupation_logement = simulation.calculate('statut_occupation_logement_famille', period)
-        cmu_forfait_logement_base = simulation.calculate('cmu_forfait_logement_base', period)
-        cmu_forfait_logement_al = simulation.calculate('cmu_forfait_logement_al', period)
-        age_holder = simulation.compute('age', period)
-        cmu_base_ressources_i_holder = simulation.compute('cmu_base_ressources_individu', period)
-        P = simulation.legislation_at(period.start).cmu
+        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
+        cmu_forfait_logement_base = famille('cmu_forfait_logement_base', period)
+        cmu_forfait_logement_al = famille('cmu_forfait_logement_al', period)
 
-        cmu_br_i_par = self.split_by_roles(cmu_base_ressources_i_holder, roles = [CHEF, PART])
-        cmu_br_i_pac = self.split_by_roles(cmu_base_ressources_i_holder, roles = ENFS)
+        P = legislation(period).cmu
 
-        age_pac = self.split_by_roles(age_holder, roles = ENFS)
 
         forfait_logement = (((statut_occupation_logement == 2) + (statut_occupation_logement == 6)) * cmu_forfait_logement_base +
             cmu_forfait_logement_al)
 
-        res = cmu_br_i_par[CHEF] + cmu_br_i_par[PART] + forfait_logement + ressources
+        ressources_individuelles = famille.members('cmu_base_ressources_individu', period)
+        ressources_parents = famille.sum(ressources_individuelles, role = Familles.PARENT)
 
-        for key, age in age_pac.iteritems():
-            res += (0 <= age) * (age <= P.age_limite_pac) * cmu_br_i_pac[key]
+        age = famille.members('age', period)
+        condition_enfant_a_charge = (age >= 0) * (age <= P.age_limite_pac)
+        ressources_enfants = famille.sum(ressources_individuelles * condition_enfant_a_charge, role = Familles.ENFANT)
 
-        return period, res
+        return period, forfait_logement + ressources_famille + ressources_parents + ressources_enfants
 
 
 class cmu_nb_pac(Variable):
@@ -314,14 +312,11 @@ class cmu_nb_pac(Variable):
 
 
 class cmu_c(Variable):
-    '''
-    Détermine si le foyer a droit à la CMU complémentaire
-    '''
     column = BoolCol
     label = u"Éligibilité à la CMU-C"
     entity_class = Familles
 
-    def function(self, simulation, period):
+    def function(famille, period):
         # Note : Cette variable est calculée pour un an, mais si elle est demandée pour une période plus petite, elle
         # répond pour la période demandée.
         this_month = period.this_month
@@ -331,17 +326,17 @@ class cmu_c(Variable):
         else:
             period = this_month
 
-        cmu_c_plafond = simulation.calculate('cmu_c_plafond', this_month)
-        cmu_base_ressources = simulation.calculate('cmu_base_ressources', this_month)
-        residence_mayotte = simulation.calculate('residence_mayotte', this_month)
-        cmu_acs_eligibilite = simulation.calculate('cmu_acs_eligibilite', period)
+        cmu_c_plafond = famille('cmu_c_plafond', this_month)
+        cmu_base_ressources = famille('cmu_base_ressources', this_month)
+        residence_mayotte = famille.demandeur.menage('residence_mayotte', this_month)
+        cmu_acs_eligibilite = famille('cmu_acs_eligibilite', period)
 
-        rsa_socle = simulation.calculate('rsa_socle', this_month)
-        rsa_socle_majore = simulation.calculate('rsa_socle_majore', this_month)
-        rsa_forfait_logement = simulation.calculate('rsa_forfait_logement', this_month)
-        rsa_base_ressources = simulation.calculate('rsa_base_ressources', this_month)
+        rsa_socle = famille('rsa_socle', this_month)
+        rsa_socle_majore = famille('rsa_socle_majore', this_month)
+        rsa_forfait_logement = famille('rsa_forfait_logement', this_month)
+        rsa_base_ressources = famille('rsa_base_ressources', this_month)
         socle = max_(rsa_socle, rsa_socle_majore)
-        rsa = simulation.calculate('rsa', this_month)
+        rsa = famille('rsa', this_month)
 
         eligibilite_basique = cmu_base_ressources <= cmu_c_plafond
         eligibilite_rsa = (rsa > 0) * (rsa_base_ressources < socle - rsa_forfait_logement)
@@ -355,15 +350,15 @@ class acs(Variable):
     label = u"Montant (mensuel) de l'ACS"
     entity_class = Familles
 
-    def function(self, simulation, period):
+    def function(famille, period):
         period = period.this_month
 
-        cmu_c = simulation.calculate('cmu_c', period)
-        cmu_base_ressources = simulation.calculate('cmu_base_ressources', period)
-        acs_plafond = simulation.calculate('acs_plafond', period)
-        acs_montant = simulation.calculate('acs_montant', period)
-        residence_mayotte = simulation.calculate('residence_mayotte', period)
-        cmu_acs_eligibilite = simulation.calculate('cmu_acs_eligibilite', period)
+        cmu_c = famille('cmu_c', period)
+        cmu_base_ressources = famille('cmu_base_ressources', period)
+        acs_plafond = famille('acs_plafond', period)
+        acs_montant = famille('acs_montant', period)
+        residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
+        cmu_acs_eligibilite = famille('cmu_acs_eligibilite', period)
 
         return period, (
             cmu_acs_eligibilite *

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -11,7 +11,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class cmu_acs_eligibilite(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Pré-éligibilité à la CMU, avant prise en compte des ressources"
 
     def function(self, simulation, period):
@@ -37,7 +37,7 @@ class cmu_acs_eligibilite(Variable):
 
 class acs_montant(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Montant de l'ACS en cas d'éligibilité"
     start_date = date(2009, 8, 1)
 
@@ -57,7 +57,7 @@ class acs_montant(Variable):
 
 class cmu_forfait_logement_base(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Forfait logement applicable en cas de propriété ou d'occupation à titre gratuit"
 
     def function(self, simulation, period):
@@ -71,7 +71,7 @@ class cmu_forfait_logement_base(Variable):
 
 class cmu_forfait_logement_al(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Forfait logement applicable en cas d'aide au logement"
 
     def function(self, simulation, period):
@@ -86,7 +86,7 @@ class cmu_forfait_logement_al(Variable):
 
 class cmu_nbp_foyer(Variable):
     column = PeriodSizeIndependentIntCol
-    entity_class = Familles
+    entity = Familles
     label = u"Nombre de personnes dans le foyer CMU"
 
     def function(self, simulation, period):
@@ -99,7 +99,7 @@ class cmu_nbp_foyer(Variable):
 
 class cmu_eligible_majoration_dom(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
 
     def function(famille, period):
         period = period.this_month
@@ -114,7 +114,7 @@ class cmu_eligible_majoration_dom(Variable):
 
 class cmu_c_plafond(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Plafond annuel de ressources pour l'éligibilité à la CMU-C"
 
     def function(self, simulation, period):
@@ -165,7 +165,7 @@ class cmu_c_plafond(Variable):
 
 class acs_plafond(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Plafond annuel de ressources pour l'éligibilité à l'ACS"
 
     def function(self, simulation, period):
@@ -179,7 +179,7 @@ class acs_plafond(Variable):
 class cmu_base_ressources_individu(Variable):
     column = FloatCol
     label = u"Base de ressources de l'individu prise en compte pour l'éligibilité à la CMU-C / ACS"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -255,7 +255,7 @@ class cmu_base_ressources_individu(Variable):
 class cmu_base_ressources(Variable):
     column = FloatCol
     label = u"Base de ressources prise en compte pour l'éligibilité à la CMU-C / ACS"
-    entity_class = Familles
+    entity = Familles
 
     def function(famille, period, legislation):
         period = period.this_month
@@ -299,7 +299,7 @@ class cmu_base_ressources(Variable):
 
 class cmu_nb_pac(Variable):
     column = PeriodSizeIndependentIntCol
-    entity_class = Familles
+    entity = Familles
     label = u"Nombre de personnes à charge au titre de la CMU"
 
     def function(self, simulation, period):
@@ -314,7 +314,7 @@ class cmu_nb_pac(Variable):
 class cmu_c(Variable):
     column = BoolCol
     label = u"Éligibilité à la CMU-C"
-    entity_class = Familles
+    entity = Familles
 
     def function(famille, period):
         # Note : Cette variable est calculée pour un an, mais si elle est demandée pour une période plus petite, elle
@@ -348,7 +348,7 @@ class cmu_c(Variable):
 class acs(Variable):
     column = FloatCol
     label = u"Montant (mensuel) de l'ACS"
-    entity_class = Familles
+    entity = Familles
 
     def function(famille, period):
         period = period.this_month

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -8,7 +8,7 @@ from numpy import maximum as max_, round as round_, minimum as min_, logical_not
 
 class ppa_eligibilite(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Eligibilité à la PPA pour un mois"
 
     def function(self, simulation, period, reference_period):
@@ -23,7 +23,7 @@ class ppa_eligibilite(Variable):
 
 class ppa_eligibilite_etudiants(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Eligibilité à la PPA (condition sur tout le trimestre)"
 
     def function(self, simulation, period):
@@ -48,7 +48,7 @@ class ppa_eligibilite_etudiants(Variable):
 
 class ppa_montant_forfaitaire_familial_non_majore(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Montant forfaitaire familial (sans majoration)"
 
     def function(self, simulation, period, reference_period):
@@ -71,7 +71,7 @@ class ppa_montant_forfaitaire_familial_non_majore(Variable):
 
 class ppa_montant_forfaitaire_familial_majore(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Montant forfaitaire familial (avec majoration)"
 
     def function(self, simulation, period, reference_period):
@@ -83,7 +83,7 @@ class ppa_montant_forfaitaire_familial_majore(Variable):
 
 class ppa_revenu_activite(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Revenu d'activité pris en compte pour la PPA"
 
     def function(self, simulation, period, reference_period):
@@ -95,8 +95,8 @@ class ppa_revenu_activite(Variable):
 
 class ppa_revenu_activite_individu(Variable):
     column = FloatCol
-    entity = Individus
-    label = u"Revenu d'activité pris en compte pour la PPA (Individus) pour un mois"
+    entity = Individu
+    label = u"Revenu d'activité pris en compte pour la PPA (Individu) pour un mois"
 
     def function(self, simulation, period, reference_period):
         period = period.this_month
@@ -135,7 +135,7 @@ class ppa_revenu_activite_individu(Variable):
 
 class ppa_ressources_hors_activite(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Revenu hors activité pris en compte pour la PPA"
 
     def function(self, simulation, period, reference_period):
@@ -154,8 +154,8 @@ class ppa_ressources_hors_activite(Variable):
 
 class ppa_ressources_hors_activite_individu(Variable):
     column = FloatCol
-    entity = Individus
-    label = u"Revenu hors activité pris en compte pour la PPA (Individus) pour un mois"
+    entity = Individu
+    label = u"Revenu hors activité pris en compte pour la PPA (Individu) pour un mois"
 
     def function(self, simulation, period, reference_period):
         period = period.this_month
@@ -186,7 +186,7 @@ class ppa_ressources_hors_activite_individu(Variable):
 
 class ppa_base_ressources_prestations_familiales(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Prestations familiales prises en compte dans le calcul de la PPA"
 
     def function(self, simulation, period, reference_period):
@@ -218,7 +218,7 @@ class ppa_base_ressources_prestations_familiales(Variable):
 
 class ppa_base_ressources(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Bases ressource prise en compte pour la PPA"
 
     def function(self, simulation, period, reference_period):
@@ -229,7 +229,7 @@ class ppa_base_ressources(Variable):
 
 class ppa_bonification(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Bonification de la PPA pour un individu"
 
     def function(self, simulation, period, reference_period):
@@ -250,7 +250,7 @@ class ppa_bonification(Variable):
 
 class ppa_fictive(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Prime pour l'activité fictive pour un mois"
 
     def function(self, simulation, period, reference_period):
@@ -287,7 +287,7 @@ class ppa_fictive(Variable):
 
 class ppa(DatedVariable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Prime Pour l'Activité"
 
     @dated_function(start = date(2016, 1, 1))

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -8,7 +8,7 @@ from numpy import maximum as max_, round as round_, minimum as min_, logical_not
 
 class ppa_eligibilite(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Eligibilité à la PPA pour un mois"
 
     def function(self, simulation, period, reference_period):
@@ -23,7 +23,7 @@ class ppa_eligibilite(Variable):
 
 class ppa_eligibilite_etudiants(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Eligibilité à la PPA (condition sur tout le trimestre)"
 
     def function(self, simulation, period):
@@ -48,7 +48,7 @@ class ppa_eligibilite_etudiants(Variable):
 
 class ppa_montant_forfaitaire_familial_non_majore(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Montant forfaitaire familial (sans majoration)"
 
     def function(self, simulation, period, reference_period):
@@ -71,7 +71,7 @@ class ppa_montant_forfaitaire_familial_non_majore(Variable):
 
 class ppa_montant_forfaitaire_familial_majore(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Montant forfaitaire familial (avec majoration)"
 
     def function(self, simulation, period, reference_period):
@@ -83,7 +83,7 @@ class ppa_montant_forfaitaire_familial_majore(Variable):
 
 class ppa_revenu_activite(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Revenu d'activité pris en compte pour la PPA"
 
     def function(self, simulation, period, reference_period):
@@ -95,7 +95,7 @@ class ppa_revenu_activite(Variable):
 
 class ppa_revenu_activite_individu(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenu d'activité pris en compte pour la PPA (Individus) pour un mois"
 
     def function(self, simulation, period, reference_period):
@@ -135,7 +135,7 @@ class ppa_revenu_activite_individu(Variable):
 
 class ppa_ressources_hors_activite(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Revenu hors activité pris en compte pour la PPA"
 
     def function(self, simulation, period, reference_period):
@@ -154,7 +154,7 @@ class ppa_ressources_hors_activite(Variable):
 
 class ppa_ressources_hors_activite_individu(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenu hors activité pris en compte pour la PPA (Individus) pour un mois"
 
     def function(self, simulation, period, reference_period):
@@ -186,7 +186,7 @@ class ppa_ressources_hors_activite_individu(Variable):
 
 class ppa_base_ressources_prestations_familiales(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Prestations familiales prises en compte dans le calcul de la PPA"
 
     def function(self, simulation, period, reference_period):
@@ -218,7 +218,7 @@ class ppa_base_ressources_prestations_familiales(Variable):
 
 class ppa_base_ressources(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Bases ressource prise en compte pour la PPA"
 
     def function(self, simulation, period, reference_period):
@@ -229,7 +229,7 @@ class ppa_base_ressources(Variable):
 
 class ppa_bonification(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Bonification de la PPA pour un individu"
 
     def function(self, simulation, period, reference_period):
@@ -250,7 +250,7 @@ class ppa_bonification(Variable):
 
 class ppa_fictive(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Prime pour l'activité fictive pour un mois"
 
     def function(self, simulation, period, reference_period):
@@ -287,7 +287,7 @@ class ppa_fictive(Variable):
 
 class ppa(DatedVariable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Prime Pour l'Activité"
 
     @dated_function(start = date(2016, 1, 1))

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -12,7 +12,7 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 class rsa_base_ressources(DatedVariable):
     column = FloatCol
     label = u"Base ressources du Rmi ou du Rsa"
-    entity_class = Familles
+    entity = Familles
 
     @dated_function(stop = date(2009, 5, 31))
     def function_rmi(self, simulation, period):
@@ -43,7 +43,7 @@ class rsa_base_ressources(DatedVariable):
 class rsa_has_ressources_substitution(Variable):
     column = FloatCol
     label = u"Présence de ressources de substitution au mois M, qui désactivent la neutralisation des revenus professionnels interrompus au moins M."
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -56,7 +56,7 @@ class rsa_has_ressources_substitution(Variable):
 class rsa_base_ressources_individu(Variable):
     column = FloatCol
     label = u"Base ressource individuelle du RSA/RMI (hors revenus d'actvité)"
-    entity_class = Individus
+    entity = Individus
 
     def function(individu, period, legislation):
         period = period.this_month
@@ -118,7 +118,7 @@ class rsa_base_ressources_individu(Variable):
 class rsa_base_ressources_minima_sociaux(Variable):
     column = FloatCol
     label = u"Minima sociaux inclus dans la base ressource RSA/RMI"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -136,7 +136,7 @@ class rsa_base_ressources_minima_sociaux(Variable):
 
 class rsa_base_ressources_prestations_familiales(DatedVariable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Prestations familiales inclues dans la base ressource RSA/RMI"
 
     @dated_function(date(2002, 1, 1), date(2003, 12, 31))
@@ -202,7 +202,7 @@ class rsa_base_ressources_prestations_familiales(DatedVariable):
 
 class crds_mini(DatedVariable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"CRDS versée sur les minimas sociaux"
 
     @dated_function(start = date(2009, 6, 1))
@@ -218,7 +218,7 @@ class crds_mini(DatedVariable):
 
 class div_ms(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Dividende entrant en compte dans le calcul des minimas"
 
     def function(self, simulation, period):
@@ -242,7 +242,7 @@ class div_ms(Variable):
 
 class enceinte_fam(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period
@@ -258,7 +258,7 @@ class enceinte_fam(Variable):
 
 class rsa_enfant_a_charge(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Enfant pris en compte dans le calcul du RSA"
 
     def function(individu, period, legislation):
@@ -298,7 +298,7 @@ class rsa_enfant_a_charge(Variable):
 
 class rsa_nb_enfants(Variable):
     column = IntCol
-    entity_class = Familles
+    entity = Familles
     label = u"Nombre d'enfants pris en compte pour le calcul du RSA"
 
     def function(self, simulation, period):
@@ -307,13 +307,13 @@ class rsa_nb_enfants(Variable):
 
 class participation_frais(Variable):
     column = BoolCol
-    entity_class = Menages
+    entity = Menages
     label = u"Partipation aux frais de logement pour un hebergé à titre gratuit"
 
 class rsa_revenu_activite(Variable):
     column = FloatCol
     label = u"Revenus d'activité du RSA"
-    entity_class = Familles
+    entity = Familles
     start_date = date(2009, 6, 1)
 
     def function(self, simulation, period):
@@ -329,7 +329,7 @@ class rsa_revenu_activite(Variable):
 class rsa_indemnites_journalieres_activite(Variable):
     column = FloatCol
     label = u"Indemnités journalières prises en compte comme revenu d'activité"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -366,7 +366,7 @@ class rsa_indemnites_journalieres_activite(Variable):
 class rsa_indemnites_journalieres_hors_activite(Variable):
     column = FloatCol
     label = u"Indemnités journalières prises en compte comme revenu de remplacement"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -375,7 +375,7 @@ class rsa_indemnites_journalieres_hors_activite(Variable):
 class rsa_revenu_activite_individu(Variable):
     column = FloatCol
     label = u"Revenus d'activité du Rsa - Individuel"
-    entity_class = Individus
+    entity = Individus
     start_date = date(2009, 6, 1)
 
     def function(self, simulation, period):
@@ -413,7 +413,7 @@ class rsa_revenu_activite_individu(Variable):
 
 class revenus_fonciers_minima_sociaux(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus fonciers pour la base ressource du rmi/rsa"
 
     def function(self, simulation, period):
@@ -431,7 +431,7 @@ class rsa(DatedVariable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"Revenu de solidarité active"
-    entity_class = Familles
+    entity = Familles
 
     @dated_function(start = date(2009, 06, 1))
     def function(self, simulation, period):
@@ -447,7 +447,7 @@ class rsa(DatedVariable):
 class rsa_base_ressources_patrimoine_individu(DatedVariable):
     column = FloatCol
     label = u"Base de ressources des revenus du patrimoine du RSA"
-    entity_class = Individus
+    entity = Individus
     start_date = date(2009, 6, 1)
 
     @dated_function(start = date(2009, 6, 1))
@@ -472,7 +472,7 @@ class rsa_base_ressources_patrimoine_individu(DatedVariable):
 
 class rsa_condition_nationalite(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Conditions de nationnalité et de titre de séjour pour bénéficier du RSA"
 
     def function(self, simulation, period):
@@ -485,7 +485,7 @@ class rsa_condition_nationalite(Variable):
 
 class rsa_eligibilite(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Eligibilité au RSA"
 
     def function(self, simulation, period):
@@ -514,7 +514,7 @@ class rsa_eligibilite(Variable):
 
 class rsa_eligibilite_tns(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Eligibilité au RSA pour un travailleur non salarié"
 
     def function(self, simulation, period):
@@ -570,7 +570,7 @@ class rsa_eligibilite_tns(Variable):
 
 class rsa_forfait_asf(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation de soutien familial forfaitisée pour le RSA"
     start_date = date(2014, 4, 1)
 
@@ -590,7 +590,7 @@ class rsa_forfait_asf(Variable):
 
 class rsa_forfait_logement(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Forfait logement intervenant dans le calcul du Rmi ou du Rsa"
 
     def function(famille, period, legislation):
@@ -627,13 +627,13 @@ class rsa_forfait_logement(Variable):
 
 class rsa_isolement_recent(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Situation d'isolement depuis moins de 18 mois"
 
 class rsa_majore(Variable):
     column = FloatCol
     label = u"Revenu de solidarité active - majoré"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -649,7 +649,7 @@ class rsa_majore(Variable):
 
 class rsa_majore_eligibilite(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Eligibilité au RSA majoré pour parent isolé"
 
     def function(self, simulation, period):
@@ -679,7 +679,7 @@ class rsa_non_calculable(Variable):
         ]),
         default = 0
     )
-    entity_class = Familles
+    entity = Familles
     label = u"RSA non calculable"
 
     def function(self, simulation, period):
@@ -706,7 +706,7 @@ class rsa_non_calculable(Variable):
 
 class rsa_non_calculable_tns_individu(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"RSA non calculable du fait de la situation de l'individu. Dans le cas des TNS, l'utilisateur est renvoyé vers son PCG"
 
     def function(self, simulation, period):
@@ -724,7 +724,7 @@ class rsa_non_calculable_tns_individu(Variable):
 class rsa_non_majore(Variable):
     column = FloatCol
     label = u"Revenu de solidarité active - non majoré"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -740,7 +740,7 @@ class rsa_non_majore(Variable):
 
 class rsa_socle(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = "RSA socle"
 
     def function(self, simulation, period):
@@ -763,7 +763,7 @@ class rsa_socle(Variable):
 
 class rsa_socle_majore(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Majoration pour parent isolé du Revenu de solidarité active socle"
     start_date = date(2009, 6, 1)
 

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -12,7 +12,7 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 class rsa_base_ressources(DatedVariable):
     column = FloatCol
     label = u"Base ressources du Rmi ou du Rsa"
-    entity = Familles
+    entity = Famille
 
     @dated_function(stop = date(2009, 5, 31))
     def function_rmi(self, simulation, period):
@@ -43,7 +43,7 @@ class rsa_base_ressources(DatedVariable):
 class rsa_has_ressources_substitution(Variable):
     column = FloatCol
     label = u"Présence de ressources de substitution au mois M, qui désactivent la neutralisation des revenus professionnels interrompus au moins M."
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -56,7 +56,7 @@ class rsa_has_ressources_substitution(Variable):
 class rsa_base_ressources_individu(Variable):
     column = FloatCol
     label = u"Base ressource individuelle du RSA/RMI (hors revenus d'actvité)"
-    entity = Individus
+    entity = Individu
 
     def function(individu, period, legislation):
         period = period.this_month
@@ -110,7 +110,7 @@ class rsa_base_ressources_individu(Variable):
         rev_cap_lib = max_(0, individu.foyer_fiscal('rev_cap_lib', period.last_3_months, options = [ADD]))
         retraite_titre_onereux = individu.foyer_fiscal('retraite_titre_onereux', period.last_3_months, options = [ADD])
         revenus_foyer_fiscal = rev_cap_bar + rev_cap_lib + retraite_titre_onereux
-        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(FoyersFiscaux.DECLARANT_PRINCIPAL)
+        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         return period, (revenus_pro + revenus_non_pros + revenus_foyer_fiscal_projetes) / 3
 
@@ -118,7 +118,7 @@ class rsa_base_ressources_individu(Variable):
 class rsa_base_ressources_minima_sociaux(Variable):
     column = FloatCol
     label = u"Minima sociaux inclus dans la base ressource RSA/RMI"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -136,7 +136,7 @@ class rsa_base_ressources_minima_sociaux(Variable):
 
 class rsa_base_ressources_prestations_familiales(DatedVariable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Prestations familiales inclues dans la base ressource RSA/RMI"
 
     @dated_function(date(2002, 1, 1), date(2003, 12, 31))
@@ -202,7 +202,7 @@ class rsa_base_ressources_prestations_familiales(DatedVariable):
 
 class crds_mini(DatedVariable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"CRDS versée sur les minimas sociaux"
 
     @dated_function(start = date(2009, 6, 1))
@@ -218,7 +218,7 @@ class crds_mini(DatedVariable):
 
 class div_ms(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Dividende entrant en compte dans le calcul des minimas"
 
     def function(self, simulation, period):
@@ -242,7 +242,7 @@ class div_ms(Variable):
 
 class enceinte_fam(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period
@@ -258,7 +258,7 @@ class enceinte_fam(Variable):
 
 class rsa_enfant_a_charge(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Enfant pris en compte dans le calcul du RSA"
 
     def function(individu, period, legislation):
@@ -298,7 +298,7 @@ class rsa_enfant_a_charge(Variable):
 
 class rsa_nb_enfants(Variable):
     column = IntCol
-    entity = Familles
+    entity = Famille
     label = u"Nombre d'enfants pris en compte pour le calcul du RSA"
 
     def function(self, simulation, period):
@@ -307,13 +307,13 @@ class rsa_nb_enfants(Variable):
 
 class participation_frais(Variable):
     column = BoolCol
-    entity = Menages
+    entity = Menage
     label = u"Partipation aux frais de logement pour un hebergé à titre gratuit"
 
 class rsa_revenu_activite(Variable):
     column = FloatCol
     label = u"Revenus d'activité du RSA"
-    entity = Familles
+    entity = Famille
     start_date = date(2009, 6, 1)
 
     def function(self, simulation, period):
@@ -329,7 +329,7 @@ class rsa_revenu_activite(Variable):
 class rsa_indemnites_journalieres_activite(Variable):
     column = FloatCol
     label = u"Indemnités journalières prises en compte comme revenu d'activité"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -366,7 +366,7 @@ class rsa_indemnites_journalieres_activite(Variable):
 class rsa_indemnites_journalieres_hors_activite(Variable):
     column = FloatCol
     label = u"Indemnités journalières prises en compte comme revenu de remplacement"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -375,7 +375,7 @@ class rsa_indemnites_journalieres_hors_activite(Variable):
 class rsa_revenu_activite_individu(Variable):
     column = FloatCol
     label = u"Revenus d'activité du Rsa - Individuel"
-    entity = Individus
+    entity = Individu
     start_date = date(2009, 6, 1)
 
     def function(self, simulation, period):
@@ -413,7 +413,7 @@ class rsa_revenu_activite_individu(Variable):
 
 class revenus_fonciers_minima_sociaux(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenus fonciers pour la base ressource du rmi/rsa"
 
     def function(self, simulation, period):
@@ -431,7 +431,7 @@ class rsa(DatedVariable):
     calculate_output = calculate_output_add
     column = FloatCol
     label = u"Revenu de solidarité active"
-    entity = Familles
+    entity = Famille
 
     @dated_function(start = date(2009, 06, 1))
     def function(self, simulation, period):
@@ -447,7 +447,7 @@ class rsa(DatedVariable):
 class rsa_base_ressources_patrimoine_individu(DatedVariable):
     column = FloatCol
     label = u"Base de ressources des revenus du patrimoine du RSA"
-    entity = Individus
+    entity = Individu
     start_date = date(2009, 6, 1)
 
     @dated_function(start = date(2009, 6, 1))
@@ -472,7 +472,7 @@ class rsa_base_ressources_patrimoine_individu(DatedVariable):
 
 class rsa_condition_nationalite(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Conditions de nationnalité et de titre de séjour pour bénéficier du RSA"
 
     def function(self, simulation, period):
@@ -485,7 +485,7 @@ class rsa_condition_nationalite(Variable):
 
 class rsa_eligibilite(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Eligibilité au RSA"
 
     def function(self, simulation, period):
@@ -514,7 +514,7 @@ class rsa_eligibilite(Variable):
 
 class rsa_eligibilite_tns(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Eligibilité au RSA pour un travailleur non salarié"
 
     def function(self, simulation, period):
@@ -570,7 +570,7 @@ class rsa_eligibilite_tns(Variable):
 
 class rsa_forfait_asf(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Allocation de soutien familial forfaitisée pour le RSA"
     start_date = date(2014, 4, 1)
 
@@ -590,7 +590,7 @@ class rsa_forfait_asf(Variable):
 
 class rsa_forfait_logement(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Forfait logement intervenant dans le calcul du Rmi ou du Rsa"
 
     def function(famille, period, legislation):
@@ -627,13 +627,13 @@ class rsa_forfait_logement(Variable):
 
 class rsa_isolement_recent(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Situation d'isolement depuis moins de 18 mois"
 
 class rsa_majore(Variable):
     column = FloatCol
     label = u"Revenu de solidarité active - majoré"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -649,7 +649,7 @@ class rsa_majore(Variable):
 
 class rsa_majore_eligibilite(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Eligibilité au RSA majoré pour parent isolé"
 
     def function(self, simulation, period):
@@ -679,7 +679,7 @@ class rsa_non_calculable(Variable):
         ]),
         default = 0
     )
-    entity = Familles
+    entity = Famille
     label = u"RSA non calculable"
 
     def function(self, simulation, period):
@@ -706,7 +706,7 @@ class rsa_non_calculable(Variable):
 
 class rsa_non_calculable_tns_individu(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"RSA non calculable du fait de la situation de l'individu. Dans le cas des TNS, l'utilisateur est renvoyé vers son PCG"
 
     def function(self, simulation, period):
@@ -724,7 +724,7 @@ class rsa_non_calculable_tns_individu(Variable):
 class rsa_non_majore(Variable):
     column = FloatCol
     label = u"Revenu de solidarité active - non majoré"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -740,7 +740,7 @@ class rsa_non_majore(Variable):
 
 class rsa_socle(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = "RSA socle"
 
     def function(self, simulation, period):
@@ -763,7 +763,7 @@ class rsa_socle(Variable):
 
 class rsa_socle_majore(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Majoration pour parent isolé du Revenu de solidarité active socle"
     start_date = date(2009, 6, 1)
 

--- a/openfisca_france/model/prestations/prestations_familiales/aeeh.py
+++ b/openfisca_france/model/prestations/prestations_familiales/aeeh.py
@@ -8,12 +8,12 @@ from numpy import logical_not as not_
 
 class aeeh_niveau_handicap(Variable):
     column = IntCol
-    entity_class = Individus
+    entity = Individus
     label = u"Catégorie de handicap prise en compte pour l'AEEH"
 
 class aeeh(DatedVariable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation d'éducation de l'enfant handicapé"
     url = "http://vosdroits.service-public.fr/particuliers/N14808.xhtml"
 

--- a/openfisca_france/model/prestations/prestations_familiales/aeeh.py
+++ b/openfisca_france/model/prestations/prestations_familiales/aeeh.py
@@ -8,12 +8,12 @@ from numpy import logical_not as not_
 
 class aeeh_niveau_handicap(Variable):
     column = IntCol
-    entity = Individus
+    entity = Individu
     label = u"Catégorie de handicap prise en compte pour l'AEEH"
 
 class aeeh(DatedVariable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Allocation d'éducation de l'enfant handicapé"
     url = "http://vosdroits.service-public.fr/particuliers/N14808.xhtml"
 

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -11,7 +11,7 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 
 class af_nbenf(Variable):
     column = IntCol
-    entity_class = Familles
+    entity = Familles
     label = u"Nombre d'enfants dans la famille au sens des allocations familiales"
 
     def function(self, simulation, period):
@@ -24,7 +24,7 @@ class af_nbenf(Variable):
 
 class af_coeff_garde_alternee(DatedVariable):
     column = FloatCol(default = 1)
-    entity_class = Familles
+    entity = Familles
     label = u"Coefficient à appliquer aux af pour tenir compte de la garde alternée"
 
     @dated_function(start = date(2007, 5, 1))
@@ -44,7 +44,7 @@ class af_coeff_garde_alternee(DatedVariable):
 
 class af_allocation_forfaitaire_nb_enfants(Variable):
     column = IntCol
-    entity_class = Familles
+    entity = Familles
     label = u"Nombre d'enfants ouvrant droit à l'allocation forfaitaire des AF"
 
     def function(self, simulation, period):
@@ -57,7 +57,7 @@ class af_allocation_forfaitaire_nb_enfants(Variable):
 
 class af_eligibilite_base(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocations familiales - Éligibilité pour la France métropolitaine sous condition de ressources"
 
     def function(famille, period):
@@ -71,7 +71,7 @@ class af_eligibilite_base(Variable):
 
 class af_eligibilite_dom(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocations familiales - Éligibilité pour les DOM (hors Mayotte) sous condition de ressources"
 
     def function(famille, period, legislation):
@@ -86,7 +86,7 @@ class af_eligibilite_dom(Variable):
 
 class af_base(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocations familiales - allocation de base"
     # prestations familiales (brutes de crds)
 
@@ -117,7 +117,7 @@ class af_base(Variable):
 
 class af_taux_modulation(DatedVariable):
     column = FloatCol(default = 1)
-    entity_class = Familles
+    entity = Familles
     label = u"Taux de modulation à appliquer au montant des AF depuis 2015"
 
     @dated_function(start = date(2015, 7, 1))
@@ -141,7 +141,7 @@ class af_taux_modulation(DatedVariable):
 
 class af_allocation_forfaitaire_taux_modulation(DatedVariable):
     column = FloatCol(default = 1)
-    entity_class = Familles
+    entity = Familles
     label = u"Taux de modulation à appliquer à l'allocation forfaitaire des AF depuis 2015"
 
     @dated_function(start = date(2015, 7, 1))
@@ -167,7 +167,7 @@ class af_allocation_forfaitaire_taux_modulation(DatedVariable):
 
 class af_age_aine(Variable):
     column = IntCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocations familiales - Âge de l'aîné des enfants éligibles"
 
     def function(self, simulation, period):
@@ -187,7 +187,7 @@ class af_age_aine(Variable):
 
 class af_majoration_enfant(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Allocations familiales - Majoration pour âge applicable à l'enfant"
 
     def function(individu, period, legislation):
@@ -225,7 +225,7 @@ class af_majoration_enfant(Variable):
 
 class af_majoration(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocations familiales - majoration pour âge"
 
     def function(famille, period):
@@ -241,7 +241,7 @@ class af_majoration(Variable):
 
 class af_complement_degressif(DatedVariable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"AF - Complément dégressif en cas de dépassement du plafond"
 
     @dated_function(start = date(2015, 7, 1))
@@ -270,7 +270,7 @@ class af_complement_degressif(DatedVariable):
 
 class af_allocation_forfaitaire_complement_degressif(DatedVariable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"AF - Complément dégressif pour l'allocation forfaitaire en cas de dépassement du plafond"
 
     @dated_function(start = date(2015, 7, 1))
@@ -299,7 +299,7 @@ class af_allocation_forfaitaire_complement_degressif(DatedVariable):
 
 class af_allocation_forfaitaire(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocations familiales - forfait"
 
     def function(self, simulation, period):
@@ -321,7 +321,7 @@ class af_allocation_forfaitaire(Variable):
 class af(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocations familiales - total des allocations"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -182,7 +182,7 @@ class af_age_aine(Variable):
         condition_eligibilite = pfam_enfant_a_charge * (age <= pfam.af.age2)
         age_enfants_eligiles = age * condition_eligibilite
 
-        return period, simulation.famille.max(age_enfants_eligiles, role = ENFANT)
+        return period, simulation.famille.max(age_enfants_eligiles, role = Familles.enfant)
 
 
 class af_majoration_enfant(Variable):
@@ -236,7 +236,7 @@ class af_majoration(Variable):
     def function(self, simulation, period):
         period = period.this_month
         af_majoration_enfant = simulation.calculate('af_majoration_enfant', period)
-        af_majoration_enfants = simulation.famille.sum(af_majoration_enfant, role = ENFANT)
+        af_majoration_enfants = simulation.famille.sum(af_majoration_enfant, role = Familles.enfant)
 
         af_taux_modulation = simulation.calculate('af_taux_modulation', period)
         af_majoration_enfants_module = af_majoration_enfants * af_taux_modulation

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -182,7 +182,7 @@ class af_age_aine(Variable):
         condition_eligibilite = pfam_enfant_a_charge * (age <= pfam.af.age2)
         age_enfants_eligiles = age * condition_eligibilite
 
-        return period, simulation.famille.max(age_enfants_eligiles, role = Familles.enfant)
+        return period, simulation.famille.max(age_enfants_eligiles, role = Familles.ENFANT)
 
 
 class af_majoration_enfant(Variable):
@@ -236,7 +236,7 @@ class af_majoration(Variable):
     def function(self, simulation, period):
         period = period.this_month
         af_majoration_enfant = simulation.calculate('af_majoration_enfant', period)
-        af_majoration_enfants = simulation.famille.sum(af_majoration_enfant, role = Familles.enfant)
+        af_majoration_enfants = simulation.famille.sum(af_majoration_enfant, role = Familles.ENFANT)
 
         af_taux_modulation = simulation.calculate('af_taux_modulation', period)
         af_majoration_enfants_module = af_majoration_enfants * af_taux_modulation

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -11,7 +11,7 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 
 class af_nbenf(Variable):
     column = IntCol
-    entity = Familles
+    entity = Famille
     label = u"Nombre d'enfants dans la famille au sens des allocations familiales"
 
     def function(self, simulation, period):
@@ -24,7 +24,7 @@ class af_nbenf(Variable):
 
 class af_coeff_garde_alternee(DatedVariable):
     column = FloatCol(default = 1)
-    entity = Familles
+    entity = Famille
     label = u"Coefficient à appliquer aux af pour tenir compte de la garde alternée"
 
     @dated_function(start = date(2007, 5, 1))
@@ -44,7 +44,7 @@ class af_coeff_garde_alternee(DatedVariable):
 
 class af_allocation_forfaitaire_nb_enfants(Variable):
     column = IntCol
-    entity = Familles
+    entity = Famille
     label = u"Nombre d'enfants ouvrant droit à l'allocation forfaitaire des AF"
 
     def function(self, simulation, period):
@@ -57,7 +57,7 @@ class af_allocation_forfaitaire_nb_enfants(Variable):
 
 class af_eligibilite_base(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Allocations familiales - Éligibilité pour la France métropolitaine sous condition de ressources"
 
     def function(famille, period):
@@ -71,7 +71,7 @@ class af_eligibilite_base(Variable):
 
 class af_eligibilite_dom(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Allocations familiales - Éligibilité pour les DOM (hors Mayotte) sous condition de ressources"
 
     def function(famille, period, legislation):
@@ -86,7 +86,7 @@ class af_eligibilite_dom(Variable):
 
 class af_base(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Allocations familiales - allocation de base"
     # prestations familiales (brutes de crds)
 
@@ -117,7 +117,7 @@ class af_base(Variable):
 
 class af_taux_modulation(DatedVariable):
     column = FloatCol(default = 1)
-    entity = Familles
+    entity = Famille
     label = u"Taux de modulation à appliquer au montant des AF depuis 2015"
 
     @dated_function(start = date(2015, 7, 1))
@@ -141,7 +141,7 @@ class af_taux_modulation(DatedVariable):
 
 class af_allocation_forfaitaire_taux_modulation(DatedVariable):
     column = FloatCol(default = 1)
-    entity = Familles
+    entity = Famille
     label = u"Taux de modulation à appliquer à l'allocation forfaitaire des AF depuis 2015"
 
     @dated_function(start = date(2015, 7, 1))
@@ -167,7 +167,7 @@ class af_allocation_forfaitaire_taux_modulation(DatedVariable):
 
 class af_age_aine(Variable):
     column = IntCol
-    entity = Familles
+    entity = Famille
     label = u"Allocations familiales - Âge de l'aîné des enfants éligibles"
 
     def function(self, simulation, period):
@@ -182,12 +182,12 @@ class af_age_aine(Variable):
         condition_eligibilite = pfam_enfant_a_charge * (age <= pfam.af.age2)
         age_enfants_eligiles = age * condition_eligibilite
 
-        return period, simulation.famille.max(age_enfants_eligiles, role = Familles.ENFANT)
+        return period, simulation.famille.max(age_enfants_eligiles, role = Famille.ENFANT)
 
 
 class af_majoration_enfant(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Allocations familiales - Majoration pour âge applicable à l'enfant"
 
     def function(individu, period, legislation):
@@ -225,13 +225,13 @@ class af_majoration_enfant(Variable):
 
 class af_majoration(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Allocations familiales - majoration pour âge"
 
     def function(famille, period):
         period = period.this_month
         af_majoration_enfant = famille.members('af_majoration_enfant', period)
-        af_majoration_enfants_famille = famille.sum(af_majoration_enfant, role = Familles.ENFANT)
+        af_majoration_enfants_famille = famille.sum(af_majoration_enfant, role = Famille.ENFANT)
 
         af_taux_modulation = famille('af_taux_modulation', period)
         af_majoration_enfants_module = af_majoration_enfants_famille * af_taux_modulation
@@ -241,7 +241,7 @@ class af_majoration(Variable):
 
 class af_complement_degressif(DatedVariable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"AF - Complément dégressif en cas de dépassement du plafond"
 
     @dated_function(start = date(2015, 7, 1))
@@ -270,7 +270,7 @@ class af_complement_degressif(DatedVariable):
 
 class af_allocation_forfaitaire_complement_degressif(DatedVariable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"AF - Complément dégressif pour l'allocation forfaitaire en cas de dépassement du plafond"
 
     @dated_function(start = date(2015, 7, 1))
@@ -299,7 +299,7 @@ class af_allocation_forfaitaire_complement_degressif(DatedVariable):
 
 class af_allocation_forfaitaire(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Allocations familiales - forfait"
 
     def function(self, simulation, period):
@@ -321,7 +321,7 @@ class af_allocation_forfaitaire(Variable):
 class af(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Allocations familiales - total des allocations"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -10,7 +10,7 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 
 class ars(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation de rentrée scolaire"
     url = "http://vosdroits.service-public.fr/particuliers/F1878.xhtml"
 

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -10,7 +10,7 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 
 class ars(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Allocation de rentrée scolaire"
     url = "http://vosdroits.service-public.fr/particuliers/F1878.xhtml"
 

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -20,28 +20,25 @@ class ars(Variable):
         '''
         period_br = period.this_year
         period = period.start.offset('first-of', 'year').offset(9, 'month').period('month')
-        age_holder = simulation.compute('age', period)
         af_nbenf = simulation.calculate('af_nbenf', period)
-        autonomie_financiere_holder = simulation.compute('autonomie_financiere', period)
         base_ressources = simulation.calculate('prestations_familiales_base_ressources', period_br.this_month)
         P = simulation.legislation_at(period.start).fam
         # TODO: convention sur la mensualisation
         # On tient compte du fait qu'en cas de léger dépassement du plafond, une allocation dégressive
         # (appelée allocation différentielle), calculée en fonction des revenus, peut être versée.
-        age = self.split_by_roles(age_holder, roles = ENFS)
-        autonomie_financiere = self.split_by_roles(autonomie_financiere_holder, roles = ENFS)
+
 
         bmaf = P.af.bmaf
         # On doit prendre l'âge en septembre
-        enf_05 = nb_enf(age, autonomie_financiere, P.ars.agep - 1, P.ars.agep - 1)  # 5 ans et 6 ans avant le 31 décembre
+        enf_05 = nb_enf(simulation, period, P.ars.agep - 1, P.ars.agep - 1)  # 5 ans et 6 ans avant le 31 décembre
         # enf_05 = 0
         # Un enfant scolarisé qui n'a pas encore atteint l'âge de 6 ans
         # avant le 1er février 2012 peut donner droit à l'ARS à condition qu'il
         # soit inscrit à l'école primaire. Il faudra alors présenter un
         # certificat de scolarité.
-        enf_primaire = enf_05 + nb_enf(age, autonomie_financiere, P.ars.agep, P.ars.agec - 1)
-        enf_college = nb_enf(age, autonomie_financiere, P.ars.agec, P.ars.agel - 1)
-        enf_lycee = nb_enf(age, autonomie_financiere, P.ars.agel, P.ars.ages)
+        enf_primaire = enf_05 + nb_enf(simulation, period, P.ars.agep, P.ars.agec - 1)
+        enf_college = nb_enf(simulation, period, P.ars.agec, P.ars.agel - 1)
+        enf_lycee = nb_enf(simulation, period, P.ars.agel, P.ars.ages)
 
         arsnbenf = enf_primaire + enf_college + enf_lycee
 

--- a/openfisca_france/model/prestations/prestations_familiales/asf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/asf.py
@@ -11,7 +11,7 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 
 class asf_elig_enfant(Variable):
     column = BoolCol(default = False)
-    entity = Individus
+    entity = Individu
     label = u"Enfant pouvant ouvrir droit à l'ASF"
 
     def function(individu, period, legislation):
@@ -31,7 +31,7 @@ class asf_elig_enfant(Variable):
 
 class asf_elig(Variable):
     column = BoolCol(default = False)
-    entity = Familles
+    entity = Famille
     label = u"Éligibilité à l'ASF"
 
     def function(famille, period):
@@ -48,7 +48,7 @@ class asf_elig(Variable):
 class asf(Variable):
     calculate_output = calculate_output_add
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Allocation de soutien familial (ASF)"
 
     def function(famille, period, legislation):
@@ -57,6 +57,6 @@ class asf(Variable):
         pfam = legislation(period).fam
         asf_elig = famille('asf_elig', period)
         asf_par_enfant = famille.members('asf_elig_enfant', period) * pfam.af.bmaf * pfam.asf.taux1
-        montant = famille.sum(asf_par_enfant, role = Familles.ENFANT)
+        montant = famille.sum(asf_par_enfant, role = Famille.ENFANT)
 
         return period, asf_elig * montant

--- a/openfisca_france/model/prestations/prestations_familiales/asf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/asf.py
@@ -11,7 +11,7 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 
 class asf_elig_enfant(Variable):
     column = BoolCol(default = False)
-    entity_class = Individus
+    entity = Individus
     label = u"Enfant pouvant ouvrir droit à l'ASF"
 
     def function(individu, period, legislation):
@@ -31,7 +31,7 @@ class asf_elig_enfant(Variable):
 
 class asf_elig(Variable):
     column = BoolCol(default = False)
-    entity_class = Familles
+    entity = Familles
     label = u"Éligibilité à l'ASF"
 
     def function(famille, period):
@@ -48,7 +48,7 @@ class asf_elig(Variable):
 class asf(Variable):
     calculate_output = calculate_output_add
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation de soutien familial (ASF)"
 
     def function(famille, period, legislation):

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -156,10 +156,9 @@ class prestations_familiales_base_ressources(Variable):
         base_ressources_i_total = self.sum_by_entity(ressources_i)
 
         # Revenus du foyer fiscal
-        rev_coll = simulation.calculate('rev_coll', annee_fiscale_n_2)
-        rev_coll_famille = simulation.famille.transpose(rev_coll, origin_entity = FoyersFiscaux)
+        rev_coll = simulation.famille.first_person.foyer_fiscal('rev_coll', annee_fiscale_n_2)
 
-        base_ressources = base_ressources_i_total + rev_coll_famille
+        base_ressources = base_ressources_i_total + rev_coll
         return period, base_ressources
 
 

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -68,16 +68,16 @@ class biactivite(Variable):
     entity_class = Familles
     label = u"Indicatrice de biactivité"
 
-    def function(self, simulation, period):
+    def function(famille, period, legislation):
         period = period.this_month
         annee_fiscale_n_2 = period.n_2
 
-        pfam = simulation.legislation_at(annee_fiscale_n_2.start).fam
+        pfam = legislation(annee_fiscale_n_2).fam
         seuil_rev = 12 * pfam.af.bmaf
 
-        base_ressources_i = simulation.calculate('prestations_familiales_base_ressources_individu', period)
+        base_ressources_i = famille.members('prestations_familiales_base_ressources_individu', period)
 
-        return period, simulation.famille.all(base_ressources_i >= seuil_rev, role = PARENT)
+        return period, famille.all(base_ressources_i >= seuil_rev, role = famille.parent)
 
 
 class div(Variable):
@@ -182,7 +182,7 @@ def nb_enf(simulation, period, age_min, age_max):
 #        le versement à lieu en début de mois suivant
     condition = (age >= age_min) * (age <= age_max) * not_(autonomie_financiere)
 
-    return simulation.famille.sum(condition, role = ENFANT)
+    return simulation.famille.sum(condition, role = Familles.enfant)
 
 
 

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -77,7 +77,7 @@ class biactivite(Variable):
 
         base_ressources_i = famille.members('prestations_familiales_base_ressources_individu', period)
 
-        return period, famille.all(base_ressources_i >= seuil_rev, role = famille.parent)
+        return period, famille.all(base_ressources_i >= seuil_rev, role = famille.PARENT)
 
 
 class div(Variable):
@@ -182,7 +182,7 @@ def nb_enf(simulation, period, age_min, age_max):
 #        le versement à lieu en début de mois suivant
     condition = (age >= age_min) * (age <= age_max) * not_(autonomie_financiere)
 
-    return simulation.famille.sum(condition, role = Familles.enfant)
+    return simulation.famille.sum(condition, role = Familles.ENFANT)
 
 
 

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -8,7 +8,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class autonomie_financiere(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indicatrice d'autonomie financière vis-à-vis des prestations familiales"
 
     def function(self, simulation, period):
@@ -25,7 +25,7 @@ class autonomie_financiere(Variable):
 
 class prestations_familiales_enfant_a_charge(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Enfant considéré à charge au sens des prestations familiales"
 
     def function(self, simulation, period):
@@ -47,7 +47,7 @@ class prestations_familiales_enfant_a_charge(Variable):
 
 class prestations_familiales_base_ressources_individu(Variable):
     column = FloatCol(default = 0)
-    entity_class = Individus
+    entity = Individus
     label = u"Base ressource individuelle des prestations familiales"
 
     def function(self, simulation, period):
@@ -65,7 +65,7 @@ class prestations_familiales_base_ressources_individu(Variable):
 
 class biactivite(Variable):
     column = BoolCol(default = False)
-    entity_class = Familles
+    entity = Familles
     label = u"Indicatrice de biactivité"
 
     def function(famille, period, legislation):
@@ -82,7 +82,7 @@ class biactivite(Variable):
 
 class div(Variable):
     column = FloatCol(default = 0)
-    entity_class = Individus
+    entity = Individus
     label = u"Dividendes imposés"
 
     def function(self, simulation, period):
@@ -112,7 +112,7 @@ class div(Variable):
 
 class rev_coll(Variable):
     column = FloatCol(default = 0)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus perçus par le foyer fiscal à prendre en compte dans la base ressource des prestations familiales"
 
     def function(self, simulation, period):
@@ -137,7 +137,7 @@ class rev_coll(Variable):
 
 class prestations_familiales_base_ressources(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Base ressource des prestations familiales"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -57,8 +57,10 @@ class prestations_familiales_base_ressources_individu(Variable):
         traitements_salaires_pensions_rentes = simulation.calculate('traitements_salaires_pensions_rentes', annee_fiscale_n_2)
         hsup = simulation.calculate('hsup', annee_fiscale_n_2)
         rpns = simulation.calculate('rpns', annee_fiscale_n_2)
+        glo = simulation.calculate('glo', annee_fiscale_n_2)
+        div = simulation.calculate('div', annee_fiscale_n_2)
 
-        return period, traitements_salaires_pensions_rentes + hsup + rpns
+        return period, traitements_salaires_pensions_rentes + hsup + rpns + glo + div
 
 
 class biactivite(Variable):
@@ -70,13 +72,12 @@ class biactivite(Variable):
         period = period.this_month
         annee_fiscale_n_2 = period.n_2
 
-        base_ressources_i_holder = simulation.compute('prestations_familiales_base_ressources_individu', period)
-        base_ressources_i = self.split_by_roles(base_ressources_i_holder, roles = [CHEF, PART])
-
         pfam = simulation.legislation_at(annee_fiscale_n_2.start).fam
         seuil_rev = 12 * pfam.af.bmaf
 
-        return period, (base_ressources_i[CHEF] >= seuil_rev) & (base_ressources_i[PART] >= seuil_rev)
+        base_ressources_i = simulation.calculate('prestations_familiales_base_ressources_individu', period)
+
+        return period, simulation.famille.all(base_ressources_i >= seuil_rev, role = PARENT)
 
 
 class div(Variable):
@@ -111,41 +112,27 @@ class div(Variable):
 
 class rev_coll(Variable):
     column = FloatCol(default = 0)
-    entity_class = Individus
-    label = u"Revenus collectifs"
+    entity_class = FoyersFiscaux
+    label = u"Revenus perçus par le foyer fiscal à prendre en compte dans la base ressource des prestations familiales"
 
     def function(self, simulation, period):
         period = period.start.offset('first-of', 'month').period('year')
-        # Quand rev_coll est calculé sur une année glissante, retraite_titre_onereux_net_declarant1 est calculé sur l'année légale
-        # correspondante.
-        retraite_titre_onereux_net_declarant1 = simulation.calculate('retraite_titre_onereux_net_declarant1', period.offset('first-of'))
-        rev_cap_lib_holder = simulation.compute_add('rev_cap_lib', period)
-        rev_cat_rvcm_holder = simulation.compute('rev_cat_rvcm', period)
-        div = simulation.calculate('div', period)
-        abat_spe_holder = simulation.compute('abat_spe', period)
-        glo = simulation.calculate('glo', period)
-        fon_holder = simulation.compute('fon', period)
-        # Quand rev_coll est calculé sur une année glissante, pensions_alimentaires_versees_declarant1 est calculé sur l'année légale
-        # correspondante.
-        pensions_alimentaires_versees_declarant1 = simulation.calculate('pensions_alimentaires_versees_declarant1', period.offset('first-of'))
-        f7ga_holder = simulation.compute('f7ga', period)
-        f7gb_holder = simulation.compute('f7gb', period)
-        f7gc_holder = simulation.compute('f7gc', period)
-        rev_cat_pv_holder = simulation.compute('rev_cat_pv', period)
+
+        # Quand rev_coll est calculé sur une année glissante, retraite_titre_onereux_net et pensions_alimentaires_versees sont calculés sur l'année légale correspondante.
+        retraite_titre_onereux_net = simulation.calculate('retraite_titre_onereux_net', period.offset('first-of'))
+        pensions_alimentaires_versees = simulation.calculate('pensions_alimentaires_versees', period.offset('first-of'))
+        rev_cap_lib = simulation.calculate_add('rev_cap_lib', period)
+        rev_cat_rvcm = simulation.calculate('rev_cat_rvcm', period)
+        abat_spe = simulation.calculate('abat_spe', period)
+        fon = simulation.calculate('fon', period)
+        f7ga = simulation.calculate('f7ga', period)
+        f7gb = simulation.calculate('f7gb', period)
+        f7gc = simulation.calculate('f7gc', period)
+        rev_cat_pv = simulation.calculate('rev_cat_pv', period)
 
         # TODO: ajouter les revenus de l'étranger etr*0.9
-        # pensions_alimentaires_versees_declarant1 is negative since it is paid by the declaree
-        rev_cap_lib = self.cast_from_entity_to_role(rev_cap_lib_holder, role = VOUS)
-        rev_cat_rvcm = self.cast_from_entity_to_role(rev_cat_rvcm_holder, role = VOUS)
-        abat_spe = self.cast_from_entity_to_role(abat_spe_holder, role = VOUS)
-        fon = self.cast_from_entity_to_role(fon_holder, role = VOUS)
-        f7ga = self.cast_from_entity_to_role(f7ga_holder, role = VOUS)
-        f7gb = self.cast_from_entity_to_role(f7gb_holder, role = VOUS)
-        f7gc = self.cast_from_entity_to_role(f7gc_holder, role = VOUS)
-        rev_cat_pv = self.cast_from_entity_to_role(rev_cat_pv_holder, role = VOUS)
-
-        return period, (retraite_titre_onereux_net_declarant1 + rev_cap_lib + rev_cat_rvcm + div + fon + glo + pensions_alimentaires_versees_declarant1 - f7ga - f7gb
-            - f7gc - abat_spe + rev_cat_pv)
+        # pensions_alimentaires_versees is negative since it is paid by the declaree
+        return period, (retraite_titre_onereux_net + rev_cap_lib + rev_cat_rvcm + fon + pensions_alimentaires_versees - f7ga - f7gb - f7gc - abat_spe + rev_cat_pv)
 
 
 class prestations_familiales_base_ressources(Variable):
@@ -168,11 +155,11 @@ class prestations_familiales_base_ressources(Variable):
         ressources_i = (not_(enfant_i) + enfant_a_charge_i) * base_ressources_i
         base_ressources_i_total = self.sum_by_entity(ressources_i)
 
-        rev_coll_holder = simulation.compute('rev_coll', annee_fiscale_n_2)
+        # Revenus du foyer fiscal
+        rev_coll = simulation.calculate('rev_coll', annee_fiscale_n_2)
+        rev_coll_famille = simulation.famille.transpose(rev_coll, origin_entity = FoyersFiscaux)
 
-        rev_coll = self.split_by_roles(rev_coll_holder, roles = [CHEF, PART])
-
-        base_ressources = base_ressources_i_total + rev_coll[CHEF] + rev_coll[PART]
+        base_ressources = base_ressources_i_total + rev_coll_famille
         return period, base_ressources
 
 
@@ -181,18 +168,23 @@ class prestations_familiales_base_ressources(Variable):
 ############################################################################
 
 
-def nb_enf(ages, autonomie_financiere, ag1, ag2):
+def nb_enf(simulation, period, age_min, age_max):
     """
     Renvoie le nombre d'enfant au sens des allocations familiales dont l'âge est compris entre ag1 et ag2
     """
+    period = period.this_month
+    age = simulation.calculate('age', period)
+    autonomie_financiere = simulation.calculate('autonomie_financiere', period)
+
 #        Les allocations sont dues à compter du mois civil qui suit la naissance
 #        ag1==0 ou suivant les anniversaires ag1>0.
 #        Un enfant est reconnu à charge pour le versement des prestations
 #        jusqu'au mois précédant son age limite supérieur (ag2 + 1) mais
 #        le versement à lieu en début de mois suivant
-    return sum(
-        (age >= ag1) & (age <= ag2) & not_(autonomie_financiere[key]) for key, age in ages.iteritems()
-    )
+    condition = (age >= age_min) * (age <= age_max) * not_(autonomie_financiere)
+
+    return simulation.famille.sum(condition, role = ENFANT)
+
 
 
 def age_en_mois_benjamin(ages_en_mois):

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -8,7 +8,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class autonomie_financiere(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Indicatrice d'autonomie financière vis-à-vis des prestations familiales"
 
     def function(self, simulation, period):
@@ -25,7 +25,7 @@ class autonomie_financiere(Variable):
 
 class prestations_familiales_enfant_a_charge(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Enfant considéré à charge au sens des prestations familiales"
 
     def function(self, simulation, period):
@@ -47,7 +47,7 @@ class prestations_familiales_enfant_a_charge(Variable):
 
 class prestations_familiales_base_ressources_individu(Variable):
     column = FloatCol(default = 0)
-    entity = Individus
+    entity = Individu
     label = u"Base ressource individuelle des prestations familiales"
 
     def function(self, simulation, period):
@@ -65,7 +65,7 @@ class prestations_familiales_base_ressources_individu(Variable):
 
 class biactivite(Variable):
     column = BoolCol(default = False)
-    entity = Familles
+    entity = Famille
     label = u"Indicatrice de biactivité"
 
     def function(famille, period, legislation):
@@ -82,7 +82,7 @@ class biactivite(Variable):
 
 class div(Variable):
     column = FloatCol(default = 0)
-    entity = Individus
+    entity = Individu
     label = u"Dividendes imposés"
 
     def function(self, simulation, period):
@@ -112,7 +112,7 @@ class div(Variable):
 
 class rev_coll(Variable):
     column = FloatCol(default = 0)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus perçus par le foyer fiscal à prendre en compte dans la base ressource des prestations familiales"
 
     def function(self, simulation, period):
@@ -137,7 +137,7 @@ class rev_coll(Variable):
 
 class prestations_familiales_base_ressources(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Base ressource des prestations familiales"
 
     def function(self, simulation, period):
@@ -173,7 +173,7 @@ def nb_enf(famille, period, age_min, age_max):
     """
 
     # Temporary retro-compatibility layer in case first argument is simulation instead of famille
-    if not famille.__class__ == Familles:
+    if not famille.__class__ == Famille:
         simulation = famille
         famille = simulation.famille
 
@@ -188,7 +188,7 @@ def nb_enf(famille, period, age_min, age_max):
 #        le versement à lieu en début de mois suivant
     condition = (age >= age_min) * (age <= age_max) * not_(autonomie_financiere)
 
-    return famille.sum(condition, role = Familles.ENFANT)
+    return famille.sum(condition, role = Famille.ENFANT)
 
 
 

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -9,7 +9,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class cf_enfant_a_charge(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Complément familial - Enfant considéré à charge"
 
     def function(self, simulation, period):
@@ -29,7 +29,7 @@ class cf_enfant_a_charge(Variable):
 
 class cf_enfant_eligible(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Complément familial - Enfant pris en compte pour l'éligibilité"
 
     def function(self, simulation, period):
@@ -50,7 +50,7 @@ class cf_enfant_eligible(Variable):
 
 class cf_dom_enfant_eligible(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Complément familial (DOM) - Enfant pris en compte pour l'éligibilité"
 
     def function(self, simulation, period):
@@ -70,7 +70,7 @@ class cf_dom_enfant_eligible(Variable):
 
 class cf_dom_enfant_trop_jeune(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Complément familial (DOM) - Enfant trop jeune pour ouvrir le droit"
 
     def function(self, simulation, period):
@@ -88,7 +88,7 @@ class cf_dom_enfant_trop_jeune(Variable):
 
 class cf_ressources_individu(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Complément familial - Ressources de l'individu prises en compte"
 
     def function(self, simulation, period):
@@ -103,7 +103,7 @@ class cf_ressources_individu(Variable):
 
 class cf_plafond(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Plafond d'éligibilité au Complément Familial"
 
     def function(self, simulation, period):
@@ -142,7 +142,7 @@ class cf_plafond(Variable):
 
 class cf_majore_plafond(DatedVariable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Plafond d'éligibilité au Complément Familial majoré"
 
     @dated_function(date(2014, 4, 1))
@@ -155,7 +155,7 @@ class cf_majore_plafond(DatedVariable):
 
 class cf_ressources(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Ressources prises en compte pour l'éligibilité au complément familial"
 
     def function(self, simulation, period):
@@ -167,7 +167,7 @@ class cf_ressources(Variable):
 
 class cf_eligibilite_base(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Éligibilité au complément familial sous condition de ressources et avant cumul"
 
     def function(famille, period, legislation):
@@ -182,7 +182,7 @@ class cf_eligibilite_base(Variable):
 
 class cf_eligibilite_dom(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Éligibilité au complément familial pour les DOM sous condition de ressources et avant cumul"
 
 
@@ -206,7 +206,7 @@ class cf_eligibilite_dom(Variable):
 
 class cf_non_majore_avant_cumul(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Complément familial non majoré avant cumul"
 
     def function(self, simulation, period):
@@ -238,7 +238,7 @@ class cf_non_majore_avant_cumul(Variable):
 
 class cf_majore_avant_cumul(DatedVariable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Complément familial majoré avant cumul"
 
     @dated_function(date(2014, 4, 1))
@@ -264,7 +264,7 @@ class cf_majore_avant_cumul(DatedVariable):
 
 class cf_montant(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Montant du complément familial, avant prise en compte d'éventuels cumuls"
 
     def function(self, simulation, period):
@@ -279,7 +279,7 @@ class cf_montant(Variable):
 class cf(Variable):
     calculate_output = calculate_output_add
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Complément familial"
     url = "http://vosdroits.service-public.fr/particuliers/F13214.xhtml"
 

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -9,7 +9,7 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class cf_enfant_a_charge(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Complément familial - Enfant considéré à charge"
 
     def function(self, simulation, period):
@@ -29,7 +29,7 @@ class cf_enfant_a_charge(Variable):
 
 class cf_enfant_eligible(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Complément familial - Enfant pris en compte pour l'éligibilité"
 
     def function(self, simulation, period):
@@ -50,7 +50,7 @@ class cf_enfant_eligible(Variable):
 
 class cf_dom_enfant_eligible(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Complément familial (DOM) - Enfant pris en compte pour l'éligibilité"
 
     def function(self, simulation, period):
@@ -70,7 +70,7 @@ class cf_dom_enfant_eligible(Variable):
 
 class cf_dom_enfant_trop_jeune(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Complément familial (DOM) - Enfant trop jeune pour ouvrir le droit"
 
     def function(self, simulation, period):
@@ -88,7 +88,7 @@ class cf_dom_enfant_trop_jeune(Variable):
 
 class cf_ressources_individu(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Complément familial - Ressources de l'individu prises en compte"
 
     def function(self, simulation, period):
@@ -103,7 +103,7 @@ class cf_ressources_individu(Variable):
 
 class cf_plafond(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Plafond d'éligibilité au Complément Familial"
 
     def function(self, simulation, period):
@@ -142,7 +142,7 @@ class cf_plafond(Variable):
 
 class cf_majore_plafond(DatedVariable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Plafond d'éligibilité au Complément Familial majoré"
 
     @dated_function(date(2014, 4, 1))
@@ -155,7 +155,7 @@ class cf_majore_plafond(DatedVariable):
 
 class cf_ressources(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Ressources prises en compte pour l'éligibilité au complément familial"
 
     def function(self, simulation, period):
@@ -167,7 +167,7 @@ class cf_ressources(Variable):
 
 class cf_eligibilite_base(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Éligibilité au complément familial sous condition de ressources et avant cumul"
 
     def function(famille, period, legislation):
@@ -182,7 +182,7 @@ class cf_eligibilite_base(Variable):
 
 class cf_eligibilite_dom(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Éligibilité au complément familial pour les DOM sous condition de ressources et avant cumul"
 
 
@@ -206,7 +206,7 @@ class cf_eligibilite_dom(Variable):
 
 class cf_non_majore_avant_cumul(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Complément familial non majoré avant cumul"
 
     def function(self, simulation, period):
@@ -238,7 +238,7 @@ class cf_non_majore_avant_cumul(Variable):
 
 class cf_majore_avant_cumul(DatedVariable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Complément familial majoré avant cumul"
 
     @dated_function(date(2014, 4, 1))
@@ -264,7 +264,7 @@ class cf_majore_avant_cumul(DatedVariable):
 
 class cf_montant(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Montant du complément familial, avant prise en compte d'éventuels cumuls"
 
     def function(self, simulation, period):
@@ -279,7 +279,7 @@ class cf_montant(Variable):
 class cf(Variable):
     calculate_output = calculate_output_add
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Complément familial"
     url = "http://vosdroits.service-public.fr/particuliers/F13214.xhtml"
 

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -170,13 +170,13 @@ class cf_eligibilite_base(Variable):
     entity_class = Familles
     label = u"Éligibilité au complément familial sous condition de ressources et avant cumul"
 
-    def function(self, simulation, period):
+    def function(famille, period, legislation):
         period = period.this_month
 
-        residence_dom = simulation.calculate('residence_dom', period)
+        residence_dom = famille.demandeur.menage('residence_dom', period)
 
-        cf_enfant_eligible_holder = simulation.compute('cf_enfant_eligible', period)
-        cf_nbenf = self.sum_by_entity(cf_enfant_eligible_holder)
+        cf_enfant_eligible = famille.members('cf_enfant_eligible', period)
+        cf_nbenf = famille.sum(cf_enfant_eligible)
 
         return period, not_(residence_dom) * (cf_nbenf >= 3)
 
@@ -186,17 +186,17 @@ class cf_eligibilite_dom(Variable):
     label = u"Éligibilité au complément familial pour les DOM sous condition de ressources et avant cumul"
 
 
-    def function(self, simulation, period):
+    def function(famille, period, legislation):
         period = period.this_month
 
-        residence_dom = simulation.calculate('residence_dom', period)
-        residence_mayotte = simulation.calculate('residence_mayotte', period)
+        residence_dom = famille.demandeur.menage('residence_dom', period)
+        residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
 
-        cf_dom_enfant_eligible_holder = simulation.compute('cf_dom_enfant_eligible', period)
-        cf_nbenf = self.sum_by_entity(cf_dom_enfant_eligible_holder)
+        cf_dom_enfant_eligible = famille.members('cf_dom_enfant_eligible', period)
+        cf_nbenf = famille.sum(cf_dom_enfant_eligible)
 
-        cf_dom_enfant_trop_jeune_holder = simulation.compute('cf_dom_enfant_trop_jeune', period)
-        cf_nbenf_trop_jeune = self.sum_by_entity(cf_dom_enfant_trop_jeune_holder)
+        cf_dom_enfant_trop_jeune = famille.members('cf_dom_enfant_trop_jeune', period)
+        cf_nbenf_trop_jeune = famille.sum(cf_dom_enfant_trop_jeune)
 
         condition_composition_famille = (cf_nbenf >= 1) * (cf_nbenf_trop_jeune == 0)
         condition_residence = residence_dom * not_(residence_mayotte)

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -12,49 +12,49 @@ from openfisca_core.periods import Instant
 # Prestations familiales
 class inactif(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Parent inactif (PAJE-CLCA)"
 
 
 
 class partiel1(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Parent actif à moins de 50% (PAJE-CLCA)"
 
 
 
 class partiel2(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Parent actif entre 50% et 80% (PAJE-CLCA)"
 
 
 
 class opt_colca(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Opte pour le COLCA"
 
 
 
 class empl_dir(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Emploi direct (CLCMG)"
 
 
 
 class ass_mat(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Assistante maternelle (CLCMG)"
 
 
 
 class gar_dom(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
     label = u"Garde à domicile (CLCMG)"
 
 
@@ -62,7 +62,7 @@ class gar_dom(Variable):
 
 class paje(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"PAJE - Ensemble des prestations"
     start_date = date(2004, 1, 1)
     url = "http://www.caf.fr/aides-et-services/s-informer-sur-les-aides/petite-enfance/la-prestation-d-accueil-du-jeune-enfant-paje-0"  # noqa
@@ -85,7 +85,7 @@ class paje(Variable):
 class paje_base(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity = Familles
+    entity = Famille
     label = u"Allocation de base de la PAJE"
     start_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F2552.xhtml"
@@ -171,7 +171,7 @@ class paje_base(Variable):
 
 class paje_base_enfant_eligible_avant_reforme_2014(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Enfant ouvrant droit à la PAJE de base né avant le 1er avril 2014"
 
     def function(self, simulation, period):
@@ -189,7 +189,7 @@ class paje_base_enfant_eligible_avant_reforme_2014(Variable):
 
 class paje_base_enfant_eligible_apres_reforme_2014(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Enfant ouvrant droit à la PAJE de base né après le 1er avril 2014"
 
     def function(self, simulation, period):
@@ -208,7 +208,7 @@ class paje_base_enfant_eligible_apres_reforme_2014(Variable):
 class paje_naissance(Variable):
     calculate_output = calculate_output_add
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Allocation de naissance de la PAJE"
     start_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F2550.xhtml"
@@ -253,7 +253,7 @@ class paje_naissance(Variable):
 class paje_clca(Variable):
     calculate_output = calculate_output_add
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"PAJE - Complément de libre choix d'activité"
     start_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
@@ -317,14 +317,14 @@ class paje_clca(Variable):
 
 class paje_prepare(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
     set_input = set_input_divide_by_period
     label = u"Prestation Partagée d’éducation de l’Enfant (PreParE)"
 
 
 class paje_clca_taux_plein(Variable):
     column = BoolCol(default = False)
-    entity = Familles
+    entity = Famille
     label = u"Indicatrice Clca taux plein"
     start_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
@@ -339,7 +339,7 @@ class paje_clca_taux_plein(Variable):
 
 class paje_clca_taux_partiel(Variable):
     column = BoolCol(default = False)
-    entity = Familles
+    entity = Famille
     label = u"Indicatrice Clca taux partiel"
     start_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
@@ -357,7 +357,7 @@ class paje_clca_taux_partiel(Variable):
 class paje_clmg(Variable):
     calculate_output = calculate_output_add
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"PAJE - Complément de libre choix du mode de garde"
     start_date = date(2004, 1, 1)
     url = "http://www.caf.fr/aides-et-services/s-informer-sur-les-aides/petite-enfance/le-complement-de-libre-choix-du-mode-de-garde"  # noqa
@@ -467,7 +467,7 @@ class paje_clmg(Variable):
 class paje_colca(Variable):
     calculate_output = calculate_output_add
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"PAJE - Complément optionnel de libre choix d'activité"
     start_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F15110.xhtml"
@@ -582,7 +582,7 @@ class paje_colca(Variable):
 
 class ape_avant_cumul(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Allocation parentale d'éducation, avant prise en compte de la non-cumulabilité avec le CF et l'APJE"
     stop_date = date(2004, 1, 1)
     url = "http://fr.wikipedia.org/wiki/Allocation_parentale_d'%C3%A9ducation_en_France"
@@ -646,7 +646,7 @@ class ape_avant_cumul(Variable):
 
 class apje_avant_cumul(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Allocation pour le jeune enfant, avant prise en compte de la non-cumulabilité avec le CF et l'APE"
     stop_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F2552.xhtml"
@@ -690,7 +690,7 @@ class apje_avant_cumul(Variable):
 
 class ape(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Allocation parentale d'éducation"
     stop_date = date(2004, 1, 1)
     url = "http://fr.wikipedia.org/wiki/Allocation_parentale_d'%C3%A9ducation_en_France"
@@ -710,7 +710,7 @@ class ape(Variable):
 
 class apje(Variable):
     column = FloatCol(default = 0)
-    entity = Familles
+    entity = Famille
     label = u"Allocation pour le jeune enfant"
     stop_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F2552.xhtml"

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -12,49 +12,49 @@ from openfisca_core.periods import Instant
 # Prestations familiales
 class inactif(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Parent inactif (PAJE-CLCA)"
 
 
 
 class partiel1(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Parent actif à moins de 50% (PAJE-CLCA)"
 
 
 
 class partiel2(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Parent actif entre 50% et 80% (PAJE-CLCA)"
 
 
 
 class opt_colca(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Opte pour le COLCA"
 
 
 
 class empl_dir(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Emploi direct (CLCMG)"
 
 
 
 class ass_mat(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Assistante maternelle (CLCMG)"
 
 
 
 class gar_dom(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
     label = u"Garde à domicile (CLCMG)"
 
 
@@ -62,7 +62,7 @@ class gar_dom(Variable):
 
 class paje(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"PAJE - Ensemble des prestations"
     start_date = date(2004, 1, 1)
     url = "http://www.caf.fr/aides-et-services/s-informer-sur-les-aides/petite-enfance/la-prestation-d-accueil-du-jeune-enfant-paje-0"  # noqa
@@ -85,7 +85,7 @@ class paje(Variable):
 class paje_base(Variable):
     calculate_output = calculate_output_add
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation de base de la PAJE"
     start_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F2552.xhtml"
@@ -171,7 +171,7 @@ class paje_base(Variable):
 
 class paje_base_enfant_eligible_avant_reforme_2014(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Enfant ouvrant droit à la PAJE de base né avant le 1er avril 2014"
 
     def function(self, simulation, period):
@@ -189,7 +189,7 @@ class paje_base_enfant_eligible_avant_reforme_2014(Variable):
 
 class paje_base_enfant_eligible_apres_reforme_2014(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Enfant ouvrant droit à la PAJE de base né après le 1er avril 2014"
 
     def function(self, simulation, period):
@@ -208,7 +208,7 @@ class paje_base_enfant_eligible_apres_reforme_2014(Variable):
 class paje_naissance(Variable):
     calculate_output = calculate_output_add
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation de naissance de la PAJE"
     start_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F2550.xhtml"
@@ -253,7 +253,7 @@ class paje_naissance(Variable):
 class paje_clca(Variable):
     calculate_output = calculate_output_add
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"PAJE - Complément de libre choix d'activité"
     start_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
@@ -317,14 +317,14 @@ class paje_clca(Variable):
 
 class paje_prepare(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
     set_input = set_input_divide_by_period
     label = u"Prestation Partagée d’éducation de l’Enfant (PreParE)"
 
 
 class paje_clca_taux_plein(Variable):
     column = BoolCol(default = False)
-    entity_class = Familles
+    entity = Familles
     label = u"Indicatrice Clca taux plein"
     start_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
@@ -339,7 +339,7 @@ class paje_clca_taux_plein(Variable):
 
 class paje_clca_taux_partiel(Variable):
     column = BoolCol(default = False)
-    entity_class = Familles
+    entity = Familles
     label = u"Indicatrice Clca taux partiel"
     start_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
@@ -357,7 +357,7 @@ class paje_clca_taux_partiel(Variable):
 class paje_clmg(Variable):
     calculate_output = calculate_output_add
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"PAJE - Complément de libre choix du mode de garde"
     start_date = date(2004, 1, 1)
     url = "http://www.caf.fr/aides-et-services/s-informer-sur-les-aides/petite-enfance/le-complement-de-libre-choix-du-mode-de-garde"  # noqa
@@ -467,7 +467,7 @@ class paje_clmg(Variable):
 class paje_colca(Variable):
     calculate_output = calculate_output_add
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"PAJE - Complément optionnel de libre choix d'activité"
     start_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F15110.xhtml"
@@ -582,7 +582,7 @@ class paje_colca(Variable):
 
 class ape_avant_cumul(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation parentale d'éducation, avant prise en compte de la non-cumulabilité avec le CF et l'APJE"
     stop_date = date(2004, 1, 1)
     url = "http://fr.wikipedia.org/wiki/Allocation_parentale_d'%C3%A9ducation_en_France"
@@ -646,7 +646,7 @@ class ape_avant_cumul(Variable):
 
 class apje_avant_cumul(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation pour le jeune enfant, avant prise en compte de la non-cumulabilité avec le CF et l'APE"
     stop_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F2552.xhtml"
@@ -690,7 +690,7 @@ class apje_avant_cumul(Variable):
 
 class ape(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation parentale d'éducation"
     stop_date = date(2004, 1, 1)
     url = "http://fr.wikipedia.org/wiki/Allocation_parentale_d'%C3%A9ducation_en_France"
@@ -710,7 +710,7 @@ class ape(Variable):
 
 class apje(Variable):
     column = FloatCol(default = 0)
-    entity_class = Familles
+    entity = Familles
     label = u"Allocation pour le jeune enfant"
     stop_date = date(2004, 1, 1)
     url = "http://vosdroits.service-public.fr/particuliers/F2552.xhtml"

--- a/openfisca_france/model/revenus/activite/non_salarie.py
+++ b/openfisca_france/model/revenus/activite/non_salarie.py
@@ -27,7 +27,7 @@ class f5qm(Variable):
         QUIFOY['conj']: u"5RM",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Agents généraux d’assurances: indemnités de cessation d’activité"
 
   # (f5qm, f5rm )
@@ -39,7 +39,7 @@ class ppe_du_ns(Variable):
         QUIFOY['pac1']: u"5PV",
         }
     column = IntCol
-    entity_class = Individus
+    entity = Individus
     label = u"Prime pour l'emploi des non-salariés: nombre de jours travaillés dans l'année"
     stop_date = date(2006, 12, 31)
 
@@ -51,7 +51,7 @@ class ppe_tp_ns(Variable):
         QUIFOY['pac1']: u"5PW",
         }
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Prime pour l'emploi des non-salariés: indicateur de travail à temps plein sur l'année entière"
     stop_date = date(2006, 12, 31)
 
@@ -62,7 +62,7 @@ class frag_exon(Variable):
         QUIFOY['conj']: u"5IN",
         QUIFOY['pac1']: u"5JN", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus agricoles exonérés (régime du forfait)"
     start_date = date(2007, 1, 1)
 
@@ -73,7 +73,7 @@ class frag_impo(Variable):
         QUIFOY['conj']: u"5IO",
         QUIFOY['pac1']: u"5JO", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus agricoles imposables (régime du forfait)"
     start_date = date(2007, 1, 1)
 
@@ -84,7 +84,7 @@ class arag_exon(Variable):
         QUIFOY['conj']: u"5IB",
         QUIFOY['pac1']: u"5JB", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus agricoles exonérés yc plus-values (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur), activités exercées en Corse"
     start_date = date(2007, 1, 1)
 
@@ -95,7 +95,7 @@ class arag_impg(Variable):
         QUIFOY['conj']: u"5IC",
         QUIFOY['pac1']: u"5JC", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus agricoles imposables, cas général moyenne triennale (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
     start_date = date(2007, 1, 1)
 
@@ -106,7 +106,7 @@ class arag_defi(Variable):
         QUIFOY['conj']: u"5IF",
         QUIFOY['pac1']: u"5JF", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits agricoles (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
     start_date = date(2007, 1, 1)
 
@@ -117,7 +117,7 @@ class nrag_exon(Variable):
         QUIFOY['conj']: u"5IH",
         QUIFOY['pac1']: u"5JH", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus agricoles exonérés yc plus-values (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur), activités exercées en Corse"
     start_date = date(2007, 1, 1)
 
@@ -128,7 +128,7 @@ class nrag_impg(Variable):
         QUIFOY['conj']: u"5II",
         QUIFOY['pac1']: u"5JI", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus agricoles imposables, cas général moyenne triennale (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
     start_date = date(2007, 1, 1)
 
@@ -139,7 +139,7 @@ class nrag_defi(Variable):
         QUIFOY['conj']: u"5IL",
         QUIFOY['pac1']: u"5JL", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits agricoles (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
     start_date = date(2007, 1, 1)
 
@@ -150,7 +150,7 @@ class nrag_ajag(Variable):
         QUIFOY['conj']: u"5IM",
         QUIFOY['pac1']: u"5JM", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Jeunes agriculteurs, Abattement de 50% ou 100% (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
     start_date = date(2007, 1, 1)
 
@@ -162,7 +162,7 @@ class ebic_impv(Variable):
         QUIFOY['conj']: u"5UA",
         QUIFOY['pac1']: u"5VA", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux professionnels imposables: vente de marchandises et assimilées (régime auto-entrepreneur)"
     start_date = date(2009, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -174,7 +174,7 @@ class ebic_imps(Variable):
         QUIFOY['conj']: u"5UB",
         QUIFOY['pac1']: u"5VB", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux professionnels imposables: prestations de services et locations meublées (régime auto-entrepreneur)"
     start_date = date(2009, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -186,7 +186,7 @@ class ebnc_impo(Variable):
         QUIFOY['conj']: u"5UE",
         QUIFOY['pac1']: u"5VE", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus non commerciaux (régime auto-entrepreneur ayant opté pour le versement libératoire)"
     start_date = date(2009, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -198,7 +198,7 @@ class mbic_exon(Variable):
         QUIFOY['conj']: u"5LN",
         QUIFOY['pac1']: u"5MN", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux professionnels nets exonérés (régime micro entreprise)"
 
   # (f5kn, f5ln, f5mn))
@@ -208,7 +208,7 @@ class abic_exon(Variable):
         QUIFOY['conj']: u"5LB",
         QUIFOY['pac1']: u"5MB", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux nets exonérés yc plus-values avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5kb, f5lb, f5mb))
@@ -218,7 +218,7 @@ class nbic_exon(Variable):
         QUIFOY['conj']: u"5LH",
         QUIFOY['pac1']: u"5MH", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux nets exonérés yc plus-values sans CGA (régime du bénéfice réel)"
 
   # (f5kh, f5lh, f5mh))
@@ -228,7 +228,7 @@ class mbic_impv(Variable):
         QUIFOY['conj']: u"5LO",
         QUIFOY['pac1']: u"5MO", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux professionnels imposables: vente de marchandises (régime micro entreprise)"
 
   # (f5ko, f5lo, f5mo))
@@ -238,7 +238,7 @@ class mbic_imps(Variable):
         QUIFOY['conj']: u"5LP",
         QUIFOY['pac1']: u"5MP", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux professionnels imposables: prestations de services et locations meublées (régime micro entreprise)"
 
   # (f5kp, f5lp, f5mp))
@@ -248,7 +248,7 @@ class abic_impn(Variable):
         QUIFOY['conj']: u"5LC",
         QUIFOY['pac1']: u"5MC", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux imposables: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5kc, f5lc, f5mc))
@@ -258,7 +258,7 @@ class abic_imps(Variable):
         QUIFOY['conj']: u"5LD",
         QUIFOY['pac1']: u"5MD", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux imposables: régime simplifié avec CGA ou viseur (régime du bénéfice réel)"
     stop_date = date(2009, 12, 31)
 
@@ -271,7 +271,7 @@ class nbic_impn(Variable):
         QUIFOY['pac1']: u"5MI", }
 
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux professionnels imposables: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
 
   # (f5ki, f5li, f5mi))
@@ -284,7 +284,7 @@ class nbic_imps(Variable):
         QUIFOY['conj']: u"5LJ",
         QUIFOY['pac1']: u"5MJ", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux professionnels imposables: régime simplifié sans CGA (régime du bénéfice réel)"
     stop_date = date(2009, 12, 31)
 
@@ -295,7 +295,7 @@ class nbic_mvct(Variable):
         QUIFOY['conj']: u"5LJ",
         QUIFOY['pac1']: u"5MJ", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux professionnels moins-values nettes à court terme"
     start_date = date(2012, 1, 1)
 
@@ -307,7 +307,7 @@ class abic_defn(Variable):
         QUIFOY['conj']: u"5LF",
         QUIFOY['pac1']: u"5MF", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits industriels et commerciaux: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5kf, f5lf, f5mf))
@@ -317,7 +317,7 @@ class abic_defs(Variable):
         QUIFOY['conj']: u"5LG",
         QUIFOY['pac1']: u"5MG", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits industriels et commerciaux: simplifié avec CGA ou viseur (régime du bénéfice réel)"
     stop_date = date(2009, 12, 1)
 
@@ -329,7 +329,7 @@ class nbic_defn(Variable):
         QUIFOY['conj']: u"5LL",
         QUIFOY['pac1']: u"5ML", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits industriels et commerciaux: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
 
   # (f5kl, f5ll, f5ml))
@@ -339,7 +339,7 @@ class nbic_defs(Variable):
         QUIFOY['conj']: u"5LM",
         QUIFOY['pac1']: u"5MM", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Locations déjà soumises aux prélèvements sociaux sans CGA (régime du bénéfice réel)"
     stop_date = date(2009, 12, 31)
 
@@ -350,7 +350,7 @@ class nbic_apch(Variable):
         QUIFOY['conj']: u"5LS",
         QUIFOY['pac1']: u"5MS", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Artisans pêcheurs : abattement 50% avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5ks, f5ls, f5ms))
@@ -360,7 +360,7 @@ class macc_exon(Variable):
         QUIFOY['conj']: u"5ON",
         QUIFOY['pac1']: u"5PN", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux non professionnels nets exonérés (régime micro entreprise)"
 
   # (f5nn, f5on, f5pn))
@@ -370,7 +370,7 @@ class aacc_exon(Variable):
         QUIFOY['conj']: u"5OB",
         QUIFOY['pac1']: u"5PB", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux non professionnels exonérés yc plus-values avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5nb, f5ob, f5pb))
@@ -380,7 +380,7 @@ class nacc_exon(Variable):
         QUIFOY['conj']: u"5OH",
         QUIFOY['pac1']: u"5PH", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux non professionnels exonérés yc plus-values sans CGA (régime du bénéfice réel)"
 
   # (f5nh, f5oh, f5ph))
@@ -390,7 +390,7 @@ class macc_impv(Variable):
         QUIFOY['conj']: u"5OO",
         QUIFOY['pac1']: u"5PO", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux non professionnels imposables: vente de marchandises et assimilées (régime micro entreprise)"
 
   # (f5no, f5oo, f5po))
@@ -400,7 +400,7 @@ class macc_imps(Variable):
         QUIFOY['conj']: u"5OP",
         QUIFOY['pac1']: u"5PP", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux non professionnels imposables: prestations de services (régime micro entreprise)"
 
   # (f5np, f5op, f5pp))
@@ -410,7 +410,7 @@ class aacc_impn(Variable):
         QUIFOY['conj']: u"5OC",
         QUIFOY['pac1']: u"5PC", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux non professionnels imposables: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5nc, f5oc, f5pc))
@@ -420,7 +420,7 @@ class aacc_imps(Variable):
         QUIFOY['conj']: u"5OD",
         QUIFOY['pac1']: u"5PD", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Locations meublées non professionnelles (régime micro entreprise)"
     start_date = date(2011, 1, 1)
 
@@ -431,7 +431,7 @@ class aacc_defn(Variable):
         QUIFOY['conj']: u"5OF",
         QUIFOY['pac1']: u"5PF", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits industriels et commerciaux non professionnels: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5nf, f5of, f5pf))
@@ -441,7 +441,7 @@ class aacc_gits(Variable):
         QUIFOY['conj']: u"5OG",
         QUIFOY['pac1']: u"5PG", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Location de gîtes ruraux, chambres d'hôtes et meublés de tourisme (régime micro entreprise)"
     start_date = date(2011, 1, 1)
 
@@ -452,7 +452,7 @@ class nacc_impn(Variable):
         QUIFOY['conj']: u"5OI",
         QUIFOY['pac1']: u"5PI", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus industriels et commerciaux non professionnels imposables: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
 
   # (f5ni, f5oi, f5pi))
@@ -462,7 +462,7 @@ class aacc_defs(Variable):
         QUIFOY['conj']: u"5OG",
         QUIFOY['pac1']: u"5PG", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits de revenus industriels et commerciaux non professionnels avec CGA (régime simplifié du bénéfice réel)"
     stop_date = date(2009, 12, 31)
 
@@ -473,7 +473,7 @@ class nacc_meup(Variable):
         QUIFOY['conj']: u"5OJ",
         QUIFOY['pac1']: u"5PJ", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Locations meublées non professionnelles: Locations déjà soumises aux prélèvements sociaux (régime micro entreprise)"
     start_date = date(2012, 1, 1)
 
@@ -484,7 +484,7 @@ class nacc_defn(Variable):
         QUIFOY['conj']: u"5OL",
         QUIFOY['pac1']: u"5PL", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits industriels et commerciaux non professionnels: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
 
   # (f5nl, f5ol, f5pl))
@@ -494,7 +494,7 @@ class nacc_defs(Variable):
         QUIFOY['conj']: u"5OM",
         QUIFOY['pac1']: u"5PM", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Locations meublées non professionnelles: Gîtes ruraux et chambres d'hôtes déjà soumis aux prélèvements sociaux avec CGA (régime du bénéfice réel)"
     start_date = date(2012, 1, 1)
 
@@ -505,7 +505,7 @@ class mncn_impo(Variable):
         QUIFOY['conj']: u"5LU",
         QUIFOY['pac1']: u"5MU", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus non commerciaux non professionnels imposables (régime déclaratif spécial ou micro BNC)"
 
   # (f5ku, f5lu, f5mu))
@@ -515,7 +515,7 @@ class cncn_bene(Variable):
         QUIFOY['conj']: u"5NS",
         QUIFOY['pac1']: u"5OS", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus non commerciaux non professionnels imposables sans AA (régime de la déclaration controlée)"
     start_date = date(2006, 1, 1)
 
@@ -526,7 +526,7 @@ class cncn_defi(Variable):
         QUIFOY['conj']: u"5NU",
         QUIFOY['pac1']: u"5OU", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits non commerciaux non professionnels sans AA (régime de la déclaration controlée)"
     start_date = date(2006, 1, 1)
 
@@ -538,7 +538,7 @@ class mbnc_exon(Variable):
         QUIFOY['conj']: u"5IP",
         QUIFOY['pac1']: u"5JP", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus non commerciaux professionnels nets exonérés (régime déclaratif spécial ou micro BNC)"
 
   # (f5hp, f5ip, f5jp))
@@ -548,7 +548,7 @@ class abnc_exon(Variable):
         QUIFOY['conj']: u"5RB",
         QUIFOY['pac1']: u"5SB", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus non commerciaux professionnels exonérés (yc compris plus-values) (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
 
   # (f5qb, f5rb, f5sb))
@@ -558,7 +558,7 @@ class nbnc_exon(Variable):
         QUIFOY['conj']: u"5RH",
         QUIFOY['pac1']: u"5SH", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus non commerciaux professionnels exonérés (yc compris plus-values) (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
 
   # (f5qh, f5rh, f5sh))
@@ -568,7 +568,7 @@ class mbnc_impo(Variable):
         QUIFOY['conj']: u"5IQ",
         QUIFOY['pac1']: u"5JQ", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus non commerciaux professionnels imposables (régime déclaratif spécial ou micro BNC)"
 
   # (f5hq, f5iq, f5jq))
@@ -578,7 +578,7 @@ class abnc_impo(Variable):
         QUIFOY['conj']: u"5RC",
         QUIFOY['pac1']: u"5SC", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus non commerciaux professionnels imposables (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
 
   # (f5qc, f5rc, f5sc))
@@ -588,7 +588,7 @@ class abnc_defi(Variable):
         QUIFOY['conj']: u"5RE",
         QUIFOY['pac1']: u"5SE", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits non commerciaux professionnels (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
 
   # (f5qe, f5re, f5se))
@@ -598,7 +598,7 @@ class nbnc_impo(Variable):
         QUIFOY['conj']: u"5RI",
         QUIFOY['pac1']: u"5SI", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus non commerciaux professionnels imposables (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
 
   # (f5qi, f5ri, f5si))
@@ -608,7 +608,7 @@ class nbnc_defi(Variable):
         QUIFOY['conj']: u"5RK",
         QUIFOY['pac1']: u"5SK", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits non commerciaux professionnels (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
 
   # (f5qk, f5rk, f5sk))
@@ -616,7 +616,7 @@ class nbnc_defi(Variable):
 class mbic_mvct(Variable):
     cerfa_field = u"5HU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Moins-values industrielles et commerciales nettes à court terme du foyer (régime micro entreprise)"
     stop_date = date(2011, 12, 31)
 
@@ -626,7 +626,7 @@ class mbic_mvct(Variable):
 class macc_mvct(Variable):
     cerfa_field = u"5IU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Moins-values industrielles et commerciales non professionnelles nettes à court terme du foyer (régime micro entreprise)"
 
   # (f5iu))
@@ -634,7 +634,7 @@ class macc_mvct(Variable):
 class mncn_mvct(Variable):
     cerfa_field = u"JU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Moins-values non commerciales non professionnelles nettes à court terme du foyer (régime déclaratif spécial ou micro BNC)"
 
   # (f5ju))
@@ -644,7 +644,7 @@ class mbnc_mvct(Variable):
         QUIFOY['conj']: u"5LZ",
         QUIFOY['pac1']: u"5MZ", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Moins-values non commerciales professionnelles nettes à court terme (régime déclaratif spécial ou micro BNC)"
     start_date = date(2012, 1, 1)
 
@@ -656,7 +656,7 @@ class frag_pvct(Variable):
         QUIFOY['conj']: u"5IW",
         QUIFOY['pac1']: u"5JW", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values agricoles  à court terme (régime du forfait)"
     start_date = date(2007, 1, 1)
 
@@ -667,7 +667,7 @@ class mbic_pvct(Variable):
         QUIFOY['conj']: u"5LX",
         QUIFOY['pac1']: u"5MX", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values industrielles et commerciales professionnels imposables: plus-values nettes à court terme (régime micro entreprise)"
 
   # (f5kx, f5lx, f5mx))
@@ -677,7 +677,7 @@ class macc_pvct(Variable):
         QUIFOY['conj']: u"5OX",
         QUIFOY['pac1']: u"5PX", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values industrielles et commerciales non professionnelles imposables: plus-values nettes à court terme (régime micro entreprise)"
 
   # (f5nx, f5ox, f5px))
@@ -687,7 +687,7 @@ class mbnc_pvct(Variable):
         QUIFOY['conj']: u"5IV",
         QUIFOY['pac1']: u"5JV", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values non commerciales professionnelles imposables et Plus-values nettes à court terme (régime déclaratif spécial ou micro BNC)"
 
   # (f5hv, f5iv, f5jv))
@@ -697,7 +697,7 @@ class mncn_pvct(Variable):
         QUIFOY['conj']: u"5LY",
         QUIFOY['pac1']: u"5MY", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values non commerciales non professionnelles imposables et plus-values nettes à court terme (régime déclaratif spécial ou micro BNC)"
 
   # (f5ky, f5ly, f5my))
@@ -707,7 +707,7 @@ class mbic_mvlt(Variable):
         QUIFOY['conj']: u"5LR",
         QUIFOY['pac1']: u"5MR", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Moins-values industrielles et commerciales professionnels à long terme (régime micro entreprise)"
 
   # (f5kr, f5lr, f5mr))
@@ -717,7 +717,7 @@ class macc_mvlt(Variable):
         QUIFOY['conj']: u"5OR",
         QUIFOY['pac1']: u"5PR", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Moins-values industrielles et commerciales non professionnelles à long terme (régime micro entreprise)"
 
   # (f5nr, f5or, f5pr))
@@ -727,7 +727,7 @@ class mncn_mvlt(Variable):
         QUIFOY['conj']: u"5LW",
         QUIFOY['pac1']: u"5MW", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Moins-values non commerciales non professionnelles à long terme (régime déclaratif spécial ou micro BNC)"
 
   # (f5kw, f5lw, f5mw))
@@ -737,7 +737,7 @@ class mbnc_mvlt(Variable):
         QUIFOY['conj']: u"5IS",
         QUIFOY['pac1']: u"5JS", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Moins-values non commerciales professionnelles à long terme (régime déclaratif spécial ou micro BNC)"
 
   # (f5hs, f5is, f5js))
@@ -747,7 +747,7 @@ class frag_pvce(Variable):
         QUIFOY['conj']: u"5IX",
         QUIFOY['pac1']: u"5JX", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values agricoles de cession taxables à 16% (régime du forfait)"
     start_date = date(2007, 1, 1)
 
@@ -758,7 +758,7 @@ class arag_pvce(Variable):
         QUIFOY['conj']: u"5IE",
         QUIFOY['pac1']: u"5JE", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values agricoles de cession taxables à 16% (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
     start_date = date(2007, 1, 1)
 
@@ -769,7 +769,7 @@ class nrag_pvce(Variable):
         QUIFOY['conj']: u"5LK",
         QUIFOY['pac1']: u"5JK", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values agricoles de cession taxables à 16% (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
     stop_date = date(2006, 12, 31)
 
@@ -780,7 +780,7 @@ class mbic_pvce(Variable):
         QUIFOY['conj']: u"5LQ",
         QUIFOY['pac1']: u"5MQ", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values industrielles et commerciales professionnelles imposables: plus-values de cession taxables à 16% (régime micro entreprise)"
 
   # (f5kq, f5lq, f5mq))
@@ -790,7 +790,7 @@ class abic_pvce(Variable):
         QUIFOY['conj']: u"5LE",
         QUIFOY['pac1']: u"5ME", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values industrielles et commerciales de cession taxables à 16% avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5ke, f5le, f5me))
@@ -800,7 +800,7 @@ class nbic_pvce(Variable):
         QUIFOY['conj']: u"5KK",
         QUIFOY['pac1']: u"5MK", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus non commerciaux non professionnels exonérés sans AA (régime de la déclaration controlée)"
     start_date = date(2008, 1, 1)
 
@@ -811,7 +811,7 @@ class macc_pvce(Variable):
         QUIFOY['conj']: u"5OQ",
         QUIFOY['pac1']: u"5PQ", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values industrielles et commerciales non professionnelles imposables: plus-values de cession taxables à 16% (régime micro entreprise)"
 
   # (f5nq, f5oq, f5pq))
@@ -821,7 +821,7 @@ class aacc_pvce(Variable):
         QUIFOY['conj']: u"5OE",
         QUIFOY['pac1']: u"5PE", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values industrielles et commerciales non professionnelles de cession taxables à 16% avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5ne, f5oe, f5pe))
@@ -831,7 +831,7 @@ class nacc_pvce(Variable):
         QUIFOY['conj']: u"5OK",
         QUIFOY['pac1']: u"5PK", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Locations meublées non professionnelles: Revenus imposables sans CGA (régime du bénéfice réel)"
     start_date = date(2009, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -843,7 +843,7 @@ class mncn_pvce(Variable):
         QUIFOY['conj']: u"5LV",
         QUIFOY['pac1']: u"5MV", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values non commerciales non professionnelles de cession taxables à 16% (régime déclaratif spécial ou micro BNC)"
 
   # (f5kv, f5lv, f5mv))
@@ -853,7 +853,7 @@ class cncn_pvce(Variable):
         QUIFOY['conj']: u"5NT",
         QUIFOY['pac1']: u"5OT", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values non commerciales non professionnelles taxables à 16% avec AA ou viseur (régime de la déclaration controlée)"
     start_date = date(2006, 1, 1)
 
@@ -864,7 +864,7 @@ class mbnc_pvce(Variable):
         QUIFOY['conj']: u"5IR",
         QUIFOY['pac1']: u"5JR", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values non commerciales professionnelles de cession taxables à 16% (régime déclaratif spécial ou micro BNC)"
 
   # (f5hr, f5ir, f5jr))
@@ -874,7 +874,7 @@ class abnc_pvce(Variable):
         QUIFOY['conj']: u"5RD",
         QUIFOY['pac1']: u"5SD", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values non commerciaux professionnels de cession taxables à 16% (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
 
   # (f5qd, f5rd, f5sd))
@@ -884,7 +884,7 @@ class nbnc_pvce(Variable):
         QUIFOY['conj']: u"5RJ",
         QUIFOY['pac1']: u"5SJ", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits industriels et commerciaux: locations meublées sans CGA (régime du bénéfice réel)"
     start_date = date(2009, 1, 1)
 
@@ -895,7 +895,7 @@ class frag_fore(Variable):
         QUIFOY['conj']: u"5ID",
         QUIFOY['pac1']: u"5JD", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus des exploitants forestiers (régime du forfait)"
     start_date = date(2007, 1, 1)
 
@@ -906,7 +906,7 @@ class arag_sjag(Variable):
         QUIFOY['conj']: u"5IZ",
         QUIFOY['pac1']: u"5JZ", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Abattement pour les jeunes agriculteurs des revenus agricoles sans CGA (régime du bénéfice réel)"
     start_date = date(2011, 1, 1)
 
@@ -917,7 +917,7 @@ class abic_impm(Variable):
         QUIFOY['conj']: u"5IA",
         QUIFOY['pac1']: u"5JA", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Locations meublées imposables avec CGA ou viseur (régime du bénéfice réel pour les revenus industriels et commerciaux professionnels)"
     start_date = date(2009, 1, 1)
 
@@ -928,7 +928,7 @@ class nbic_impm(Variable):
         QUIFOY['conj']: u"5LA",
         QUIFOY['pac1']: u"5MA", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Locations meublées imposables sans CGA (régime du bénéfice réel)"
     start_date = date(2009, 1, 1)
 
@@ -939,7 +939,7 @@ class abic_defm(Variable):
         QUIFOY['conj']: u"5RA",
         QUIFOY['pac1']: u"5SA", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits de locations meubléesavec CGA ou viseur (régime du bénéfice réel pour les revenus industriels et commerciaux professionnels)"
     start_date = date(2009, 1, 1)
 
@@ -950,7 +950,7 @@ class alnp_imps(Variable):
         QUIFOY['conj']: u"5OA",
         QUIFOY['pac1']: u"5PA", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Locations meublées non professionnelles imposables avec CGA ou viseur (régime du bénéfice réel)"
     start_date = date(2009, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -962,7 +962,7 @@ class alnp_defs(Variable):
         QUIFOY['conj']: u"5OY",
         QUIFOY['pac1']: u"5PY", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits de locations meublées non professionnelles avec CGA ou viseur (régime du bénéfice réel)"
     start_date = date(2009, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -974,7 +974,7 @@ class nlnp_defs(Variable):
         QUIFOY['conj']: u"5OZ",
         QUIFOY['pac1']: u"5PZ", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits de locations meublées non professionnelles imposables sans CGA (régime du bénéfice réel)"
     start_date = date(2009, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -985,7 +985,7 @@ class cbnc_assc(Variable):
     cerfa_field = {QUIFOY['vous']: u"5QM",
         QUIFOY['conj']: u"5RM", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Agents généraux d'assurances : indemnités de cessation d'activité (revenus non commerciaux professionnels, régime de la déclaration contrôlée)"
     start_date = date(2006, 1, 1)
 
@@ -996,7 +996,7 @@ class abnc_proc(Variable):
         QUIFOY['conj']: u"5UF",
         QUIFOY['pac1']: u"5VF", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Honoraires de prospection commerciale exonérés avec CGA ou viseur (revenus non commerciaux professionnels, régime de la déclaration contrôlée)"
     start_date = date(2009, 1, 1)
 
@@ -1007,7 +1007,7 @@ class nbnc_proc(Variable):
         QUIFOY['conj']: u"5UI",
         QUIFOY['pac1']: u"5VI", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Honoraires de prospection commerciale exonérés sans CGA (revenus non commerciaux professionnels, régime de la déclaration contrôlée)"
     start_date = date(2009, 1, 1)
 
@@ -1018,7 +1018,7 @@ class mncn_exon(Variable):
         QUIFOY['conj']: u"5UH",
         QUIFOY['pac1']: u"5VH", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus nets exonérés non commerciaux non professionnels (régime déclaratif spécial ou micro BNC)"
     start_date = date(2009, 1, 1)
 
@@ -1029,7 +1029,7 @@ class cncn_exon(Variable):
         QUIFOY['conj']: u"5JK",
         QUIFOY['pac1']: u"5LK", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus nets exonérés non commerciaux non professionnels (régime de la déclaration contrôlée)"
     start_date = date(2008, 1, 1)
 
@@ -1040,7 +1040,7 @@ class cncn_aimp(Variable):
         QUIFOY['conj']: u"5RF",
         QUIFOY['pac1']: u"5SF", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus imposables non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
     start_date = date(2007, 1, 1)
 
@@ -1051,7 +1051,7 @@ class cncn_adef(Variable):
         QUIFOY['conj']: u"5RG",
         QUIFOY['pac1']: u"5SG", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Déficits non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
     start_date = date(2007, 1, 1)
 
@@ -1062,7 +1062,7 @@ class cncn_info(Variable):
         QUIFOY['conj']: u"5UC",
         QUIFOY['pac1']: u"5VC", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Inventeurs et auteurs de logiciels : produits taxables à 16%, revenus non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
     start_date = date(2009, 1, 1)
 
@@ -1073,7 +1073,7 @@ class cncn_jcre(Variable):
         QUIFOY['conj']: u"5SW",
         QUIFOY['pac1']: u"5SX", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Jeunes créateurs : abattement de 50%, revenus non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
     start_date = date(2006, 1, 1)
 
@@ -1084,7 +1084,7 @@ class revimpres(Variable):
         QUIFOY['conj']: u"5IY",
         QUIFOY['pac1']: u"5JY", }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus nets à imposer aux prélèvements sociaux"
 
 
@@ -1093,7 +1093,7 @@ class pveximpres(Variable):
     cerfa_field = {QUIFOY['vous']: u"5HG",
         QUIFOY['conj']: u"5IG", }
     column = IntCol
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values à long terme exonérées en cas de départ à la retraite à imposer aux prélèvements sociaux"
     start_date = date(2006, 1, 1)
 
@@ -1105,7 +1105,7 @@ class pvtaimpres(Variable):
         QUIFOY['conj']: u"5IZ",
         QUIFOY['pac1']: u"5JZ", }
     column = IntCol
-    entity_class = Individus
+    entity = Individus
     label = u"Plus-values à long terme taxables à 16% à la retraite à imposer aux prélèvements sociaux"
     stop_date = date(2009, 12, 31)
 
@@ -1114,7 +1114,7 @@ class pvtaimpres(Variable):
 class f5qf(Variable):
     cerfa_field = u"5QF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-6)"
     start_date = date(2007, 1, 1)
 
@@ -1123,7 +1123,7 @@ class f5qf(Variable):
 class f5qg(Variable):
     cerfa_field = u"5QG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-5)"
     start_date = date(2007, 1, 1)
 
@@ -1132,7 +1132,7 @@ class f5qg(Variable):
 class f5qn(Variable):
     cerfa_field = u"5QN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-4)"
     start_date = date(2007, 1, 1)
 
@@ -1141,7 +1141,7 @@ class f5qn(Variable):
 class f5qo(Variable):
     cerfa_field = u"5QO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-3)"
     start_date = date(2007, 1, 1)
 
@@ -1150,7 +1150,7 @@ class f5qo(Variable):
 class f5qp(Variable):
     cerfa_field = u"5QP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-2)"
     start_date = date(2007, 1, 1)
 
@@ -1159,7 +1159,7 @@ class f5qp(Variable):
 class f5qq(Variable):
     cerfa_field = u"5QQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-1)"
     start_date = date(2007, 1, 1)
 
@@ -1168,7 +1168,7 @@ class f5qq(Variable):
 class f5ga(Variable):
     cerfa_field = u"5GA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-10)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1178,7 +1178,7 @@ class f5ga(Variable):
 class f5gb(Variable):
     cerfa_field = u"5GB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-9)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1188,7 +1188,7 @@ class f5gb(Variable):
 class f5gc(Variable):
     cerfa_field = u"5GC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-8)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1198,7 +1198,7 @@ class f5gc(Variable):
 class f5gd(Variable):
     cerfa_field = u"5GD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-7)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1208,7 +1208,7 @@ class f5gd(Variable):
 class f5ge(Variable):
     cerfa_field = u"5GE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-6)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1218,7 +1218,7 @@ class f5ge(Variable):
 class f5gf(Variable):
     cerfa_field = u"5GF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-5)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1228,7 +1228,7 @@ class f5gf(Variable):
 class f5gg(Variable):
     cerfa_field = u"5GG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-4)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1238,7 +1238,7 @@ class f5gg(Variable):
 class f5gh(Variable):
     cerfa_field = u"5GH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-3)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1248,7 +1248,7 @@ class f5gh(Variable):
 class f5gi(Variable):
     cerfa_field = u"5GI"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-2)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1258,7 +1258,7 @@ class f5gi(Variable):
 class f5gj(Variable):
     cerfa_field = u"5GJ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-1)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1268,7 +1268,7 @@ class f5gj(Variable):
 class f5rn(Variable):
     cerfa_field = u"5RN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-6)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1278,7 +1278,7 @@ class f5rn(Variable):
 class f5ro(Variable):
     cerfa_field = u"5RO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-5)"
 
 
@@ -1286,7 +1286,7 @@ class f5ro(Variable):
 class f5rp(Variable):
     cerfa_field = u"5RP"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-4)"
 
 
@@ -1294,7 +1294,7 @@ class f5rp(Variable):
 class f5rq(Variable):
     cerfa_field = u"5RQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-3)"
 
 
@@ -1302,7 +1302,7 @@ class f5rq(Variable):
 class f5rr(Variable):
     cerfa_field = u"5RR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-2)"
 
 
@@ -1310,7 +1310,7 @@ class f5rr(Variable):
 class f5rw(Variable):
     cerfa_field = u"5RW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-1)"
 
 
@@ -1318,7 +1318,7 @@ class f5rw(Variable):
 class f5ht(Variable):
     cerfa_field = u"5HT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-6)"
     start_date = date(2007, 1, 1)
 
@@ -1327,7 +1327,7 @@ class f5ht(Variable):
 class f5it(Variable):
     cerfa_field = u"5IT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-5)"
     start_date = date(2007, 1, 1)
 
@@ -1336,7 +1336,7 @@ class f5it(Variable):
 class f5jt(Variable):
     cerfa_field = u"5JT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-4)"
     start_date = date(2007, 1, 1)
 
@@ -1345,7 +1345,7 @@ class f5jt(Variable):
 class f5kt(Variable):
     cerfa_field = u"5KT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-3)"
     start_date = date(2007, 1, 1)
 
@@ -1354,7 +1354,7 @@ class f5kt(Variable):
 class f5lt(Variable):
     cerfa_field = u"5LT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-2)"
     start_date = date(2007, 1, 1)
 
@@ -1363,7 +1363,7 @@ class f5lt(Variable):
 class f5mt(Variable):
     cerfa_field = u"5MT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-1)"
     start_date = date(2007, 1, 1)
 
@@ -1371,7 +1371,7 @@ class f5mt(Variable):
 
 class f5sq(Variable):
     column = IntCol
-    entity_class = Individus
+    entity = Individus
 
 
 
@@ -1383,14 +1383,14 @@ class f5sq(Variable):
 # Input mensuel
 class tns_auto_entrepreneur_chiffre_affaires(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     set_input = set_input_divide_by_period
     label = u"Chiffre d'affaires en tant qu'auto-entrepreneur"
 
 # Input annuel
 class tns_micro_entreprise_chiffre_affaires(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     set_input = set_input_divide_by_period
     label = u"Chiffre d'affaires en de micro-entreprise"
 
@@ -1400,46 +1400,46 @@ enum_tns_type_activite = Enum([u'achat_revente', u'bic', u'bnc'])
 # TODO remove this ugly is_permanent
 class tns_auto_entrepreneur_type_activite(Variable):
     column = EnumCol(enum = enum_tns_type_activite)
-    entity_class = Individus
+    entity = Individus
     is_permanent = True
     label = u"Type d'activité de l'auto-entrepreneur"
 
 # TODO remove this ugly is_permanent
 class tns_micro_entreprise_type_activite(Variable):
     column = EnumCol(enum = enum_tns_type_activite)
-    entity_class = Individus
+    entity = Individus
     is_permanent = True
     label = u"Type d'activité de la micro-entreprise"
 
 # Input sur le dernier exercice. Par convention, sur l'année dernière.
 class tns_autres_revenus(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     set_input = set_input_divide_by_period
     label = u"Autres revenus non salariés"
 
 class tns_autres_revenus_chiffre_affaires(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     set_input = set_input_divide_by_period
     label = u"Chiffre d'affaire pour les TNS non agricoles autres que les AE et ME"
 
 class tns_autres_revenus_type_activite(Variable):
     column = EnumCol(enum = enum_tns_type_activite)
-    entity_class = Individus
+    entity = Individus
     is_permanent = True
     label = u"Type d'activité de l'entreprise non AE ni ME"
 
 class tns_avec_employe(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     set_input = set_input_dispatch_by_period
     label = u"Le TNS a au moins un employé. Ne s'applique pas pour les agricoles ni auto-entrepreneurs ni micro entreprise"
 
 # Input annuel
 class tns_benefice_exploitant_agricole(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     set_input = set_input_dispatch_by_period
     label = u"Dernier bénéfice agricole"
 
@@ -1449,7 +1449,7 @@ class tns_benefice_exploitant_agricole(Variable):
 class travailleur_non_salarie(Variable):
     label = u"L'individu a une activité professionnelle non salariée"
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -1483,7 +1483,7 @@ def compute_benefice_auto_entrepreneur_micro_entreprise(bareme, type_activite, c
 class tns_auto_entrepreneur_benefice(DatedVariable):
     column = FloatCol
     label = u"Bénéfice en tant qu'auto-entrepreneur"
-    entity_class = Individus
+    entity = Individus
 
     @dated_function(start = date(2008, 1, 1))
     def function(self, simulation, period):
@@ -1500,7 +1500,7 @@ class tns_auto_entrepreneur_benefice(DatedVariable):
 class tns_micro_entreprise_benefice(DatedVariable):
     column = FloatCol
     label = u"Bénéfice de la micro entreprise"
-    entity_class = Individus
+    entity = Individus
 
     @dated_function(start = date(2008, 1, 1))
     def function(self, simulation, period):
@@ -1520,7 +1520,7 @@ class tns_micro_entreprise_benefice(DatedVariable):
 class tns_auto_entrepreneur_revenus_net(DatedVariable) :
     column = FloatCol
     label = u"Revenu d'un auto-entrepreneur"
-    entity_class = Individus
+    entity = Individus
 
     @dated_function(start = date(2008, 1, 1))
     def function(self, simulation, period):
@@ -1542,7 +1542,7 @@ class tns_auto_entrepreneur_revenus_net(DatedVariable) :
 class tns_micro_entreprise_revenus_net(Variable) :
     column = FloatCol
     label = u"Revenu d'un TNS dans une micro-entreprise"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month

--- a/openfisca_france/model/revenus/activite/non_salarie.py
+++ b/openfisca_france/model/revenus/activite/non_salarie.py
@@ -27,7 +27,7 @@ class f5qm(Variable):
         QUIFOY['conj']: u"5RM",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Agents généraux d’assurances: indemnités de cessation d’activité"
 
   # (f5qm, f5rm )
@@ -39,7 +39,7 @@ class ppe_du_ns(Variable):
         QUIFOY['pac1']: u"5PV",
         }
     column = IntCol
-    entity = Individus
+    entity = Individu
     label = u"Prime pour l'emploi des non-salariés: nombre de jours travaillés dans l'année"
     stop_date = date(2006, 12, 31)
 
@@ -51,7 +51,7 @@ class ppe_tp_ns(Variable):
         QUIFOY['pac1']: u"5PW",
         }
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Prime pour l'emploi des non-salariés: indicateur de travail à temps plein sur l'année entière"
     stop_date = date(2006, 12, 31)
 
@@ -62,7 +62,7 @@ class frag_exon(Variable):
         QUIFOY['conj']: u"5IN",
         QUIFOY['pac1']: u"5JN", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus agricoles exonérés (régime du forfait)"
     start_date = date(2007, 1, 1)
 
@@ -73,7 +73,7 @@ class frag_impo(Variable):
         QUIFOY['conj']: u"5IO",
         QUIFOY['pac1']: u"5JO", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus agricoles imposables (régime du forfait)"
     start_date = date(2007, 1, 1)
 
@@ -84,7 +84,7 @@ class arag_exon(Variable):
         QUIFOY['conj']: u"5IB",
         QUIFOY['pac1']: u"5JB", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus agricoles exonérés yc plus-values (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur), activités exercées en Corse"
     start_date = date(2007, 1, 1)
 
@@ -95,7 +95,7 @@ class arag_impg(Variable):
         QUIFOY['conj']: u"5IC",
         QUIFOY['pac1']: u"5JC", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus agricoles imposables, cas général moyenne triennale (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
     start_date = date(2007, 1, 1)
 
@@ -106,7 +106,7 @@ class arag_defi(Variable):
         QUIFOY['conj']: u"5IF",
         QUIFOY['pac1']: u"5JF", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits agricoles (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
     start_date = date(2007, 1, 1)
 
@@ -117,7 +117,7 @@ class nrag_exon(Variable):
         QUIFOY['conj']: u"5IH",
         QUIFOY['pac1']: u"5JH", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus agricoles exonérés yc plus-values (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur), activités exercées en Corse"
     start_date = date(2007, 1, 1)
 
@@ -128,7 +128,7 @@ class nrag_impg(Variable):
         QUIFOY['conj']: u"5II",
         QUIFOY['pac1']: u"5JI", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus agricoles imposables, cas général moyenne triennale (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
     start_date = date(2007, 1, 1)
 
@@ -139,7 +139,7 @@ class nrag_defi(Variable):
         QUIFOY['conj']: u"5IL",
         QUIFOY['pac1']: u"5JL", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits agricoles (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
     start_date = date(2007, 1, 1)
 
@@ -150,7 +150,7 @@ class nrag_ajag(Variable):
         QUIFOY['conj']: u"5IM",
         QUIFOY['pac1']: u"5JM", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Jeunes agriculteurs, Abattement de 50% ou 100% (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
     start_date = date(2007, 1, 1)
 
@@ -162,7 +162,7 @@ class ebic_impv(Variable):
         QUIFOY['conj']: u"5UA",
         QUIFOY['pac1']: u"5VA", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux professionnels imposables: vente de marchandises et assimilées (régime auto-entrepreneur)"
     start_date = date(2009, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -174,7 +174,7 @@ class ebic_imps(Variable):
         QUIFOY['conj']: u"5UB",
         QUIFOY['pac1']: u"5VB", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux professionnels imposables: prestations de services et locations meublées (régime auto-entrepreneur)"
     start_date = date(2009, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -186,7 +186,7 @@ class ebnc_impo(Variable):
         QUIFOY['conj']: u"5UE",
         QUIFOY['pac1']: u"5VE", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus non commerciaux (régime auto-entrepreneur ayant opté pour le versement libératoire)"
     start_date = date(2009, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -198,7 +198,7 @@ class mbic_exon(Variable):
         QUIFOY['conj']: u"5LN",
         QUIFOY['pac1']: u"5MN", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux professionnels nets exonérés (régime micro entreprise)"
 
   # (f5kn, f5ln, f5mn))
@@ -208,7 +208,7 @@ class abic_exon(Variable):
         QUIFOY['conj']: u"5LB",
         QUIFOY['pac1']: u"5MB", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux nets exonérés yc plus-values avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5kb, f5lb, f5mb))
@@ -218,7 +218,7 @@ class nbic_exon(Variable):
         QUIFOY['conj']: u"5LH",
         QUIFOY['pac1']: u"5MH", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux nets exonérés yc plus-values sans CGA (régime du bénéfice réel)"
 
   # (f5kh, f5lh, f5mh))
@@ -228,7 +228,7 @@ class mbic_impv(Variable):
         QUIFOY['conj']: u"5LO",
         QUIFOY['pac1']: u"5MO", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux professionnels imposables: vente de marchandises (régime micro entreprise)"
 
   # (f5ko, f5lo, f5mo))
@@ -238,7 +238,7 @@ class mbic_imps(Variable):
         QUIFOY['conj']: u"5LP",
         QUIFOY['pac1']: u"5MP", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux professionnels imposables: prestations de services et locations meublées (régime micro entreprise)"
 
   # (f5kp, f5lp, f5mp))
@@ -248,7 +248,7 @@ class abic_impn(Variable):
         QUIFOY['conj']: u"5LC",
         QUIFOY['pac1']: u"5MC", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux imposables: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5kc, f5lc, f5mc))
@@ -258,7 +258,7 @@ class abic_imps(Variable):
         QUIFOY['conj']: u"5LD",
         QUIFOY['pac1']: u"5MD", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux imposables: régime simplifié avec CGA ou viseur (régime du bénéfice réel)"
     stop_date = date(2009, 12, 31)
 
@@ -271,7 +271,7 @@ class nbic_impn(Variable):
         QUIFOY['pac1']: u"5MI", }
 
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux professionnels imposables: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
 
   # (f5ki, f5li, f5mi))
@@ -284,7 +284,7 @@ class nbic_imps(Variable):
         QUIFOY['conj']: u"5LJ",
         QUIFOY['pac1']: u"5MJ", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux professionnels imposables: régime simplifié sans CGA (régime du bénéfice réel)"
     stop_date = date(2009, 12, 31)
 
@@ -295,7 +295,7 @@ class nbic_mvct(Variable):
         QUIFOY['conj']: u"5LJ",
         QUIFOY['pac1']: u"5MJ", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux professionnels moins-values nettes à court terme"
     start_date = date(2012, 1, 1)
 
@@ -307,7 +307,7 @@ class abic_defn(Variable):
         QUIFOY['conj']: u"5LF",
         QUIFOY['pac1']: u"5MF", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits industriels et commerciaux: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5kf, f5lf, f5mf))
@@ -317,7 +317,7 @@ class abic_defs(Variable):
         QUIFOY['conj']: u"5LG",
         QUIFOY['pac1']: u"5MG", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits industriels et commerciaux: simplifié avec CGA ou viseur (régime du bénéfice réel)"
     stop_date = date(2009, 12, 1)
 
@@ -329,7 +329,7 @@ class nbic_defn(Variable):
         QUIFOY['conj']: u"5LL",
         QUIFOY['pac1']: u"5ML", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits industriels et commerciaux: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
 
   # (f5kl, f5ll, f5ml))
@@ -339,7 +339,7 @@ class nbic_defs(Variable):
         QUIFOY['conj']: u"5LM",
         QUIFOY['pac1']: u"5MM", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Locations déjà soumises aux prélèvements sociaux sans CGA (régime du bénéfice réel)"
     stop_date = date(2009, 12, 31)
 
@@ -350,7 +350,7 @@ class nbic_apch(Variable):
         QUIFOY['conj']: u"5LS",
         QUIFOY['pac1']: u"5MS", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Artisans pêcheurs : abattement 50% avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5ks, f5ls, f5ms))
@@ -360,7 +360,7 @@ class macc_exon(Variable):
         QUIFOY['conj']: u"5ON",
         QUIFOY['pac1']: u"5PN", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux non professionnels nets exonérés (régime micro entreprise)"
 
   # (f5nn, f5on, f5pn))
@@ -370,7 +370,7 @@ class aacc_exon(Variable):
         QUIFOY['conj']: u"5OB",
         QUIFOY['pac1']: u"5PB", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux non professionnels exonérés yc plus-values avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5nb, f5ob, f5pb))
@@ -380,7 +380,7 @@ class nacc_exon(Variable):
         QUIFOY['conj']: u"5OH",
         QUIFOY['pac1']: u"5PH", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux non professionnels exonérés yc plus-values sans CGA (régime du bénéfice réel)"
 
   # (f5nh, f5oh, f5ph))
@@ -390,7 +390,7 @@ class macc_impv(Variable):
         QUIFOY['conj']: u"5OO",
         QUIFOY['pac1']: u"5PO", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux non professionnels imposables: vente de marchandises et assimilées (régime micro entreprise)"
 
   # (f5no, f5oo, f5po))
@@ -400,7 +400,7 @@ class macc_imps(Variable):
         QUIFOY['conj']: u"5OP",
         QUIFOY['pac1']: u"5PP", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux non professionnels imposables: prestations de services (régime micro entreprise)"
 
   # (f5np, f5op, f5pp))
@@ -410,7 +410,7 @@ class aacc_impn(Variable):
         QUIFOY['conj']: u"5OC",
         QUIFOY['pac1']: u"5PC", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux non professionnels imposables: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5nc, f5oc, f5pc))
@@ -420,7 +420,7 @@ class aacc_imps(Variable):
         QUIFOY['conj']: u"5OD",
         QUIFOY['pac1']: u"5PD", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Locations meublées non professionnelles (régime micro entreprise)"
     start_date = date(2011, 1, 1)
 
@@ -431,7 +431,7 @@ class aacc_defn(Variable):
         QUIFOY['conj']: u"5OF",
         QUIFOY['pac1']: u"5PF", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits industriels et commerciaux non professionnels: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5nf, f5of, f5pf))
@@ -441,7 +441,7 @@ class aacc_gits(Variable):
         QUIFOY['conj']: u"5OG",
         QUIFOY['pac1']: u"5PG", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Location de gîtes ruraux, chambres d'hôtes et meublés de tourisme (régime micro entreprise)"
     start_date = date(2011, 1, 1)
 
@@ -452,7 +452,7 @@ class nacc_impn(Variable):
         QUIFOY['conj']: u"5OI",
         QUIFOY['pac1']: u"5PI", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus industriels et commerciaux non professionnels imposables: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
 
   # (f5ni, f5oi, f5pi))
@@ -462,7 +462,7 @@ class aacc_defs(Variable):
         QUIFOY['conj']: u"5OG",
         QUIFOY['pac1']: u"5PG", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits de revenus industriels et commerciaux non professionnels avec CGA (régime simplifié du bénéfice réel)"
     stop_date = date(2009, 12, 31)
 
@@ -473,7 +473,7 @@ class nacc_meup(Variable):
         QUIFOY['conj']: u"5OJ",
         QUIFOY['pac1']: u"5PJ", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Locations meublées non professionnelles: Locations déjà soumises aux prélèvements sociaux (régime micro entreprise)"
     start_date = date(2012, 1, 1)
 
@@ -484,7 +484,7 @@ class nacc_defn(Variable):
         QUIFOY['conj']: u"5OL",
         QUIFOY['pac1']: u"5PL", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits industriels et commerciaux non professionnels: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
 
   # (f5nl, f5ol, f5pl))
@@ -494,7 +494,7 @@ class nacc_defs(Variable):
         QUIFOY['conj']: u"5OM",
         QUIFOY['pac1']: u"5PM", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Locations meublées non professionnelles: Gîtes ruraux et chambres d'hôtes déjà soumis aux prélèvements sociaux avec CGA (régime du bénéfice réel)"
     start_date = date(2012, 1, 1)
 
@@ -505,7 +505,7 @@ class mncn_impo(Variable):
         QUIFOY['conj']: u"5LU",
         QUIFOY['pac1']: u"5MU", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus non commerciaux non professionnels imposables (régime déclaratif spécial ou micro BNC)"
 
   # (f5ku, f5lu, f5mu))
@@ -515,7 +515,7 @@ class cncn_bene(Variable):
         QUIFOY['conj']: u"5NS",
         QUIFOY['pac1']: u"5OS", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus non commerciaux non professionnels imposables sans AA (régime de la déclaration controlée)"
     start_date = date(2006, 1, 1)
 
@@ -526,7 +526,7 @@ class cncn_defi(Variable):
         QUIFOY['conj']: u"5NU",
         QUIFOY['pac1']: u"5OU", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits non commerciaux non professionnels sans AA (régime de la déclaration controlée)"
     start_date = date(2006, 1, 1)
 
@@ -538,7 +538,7 @@ class mbnc_exon(Variable):
         QUIFOY['conj']: u"5IP",
         QUIFOY['pac1']: u"5JP", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus non commerciaux professionnels nets exonérés (régime déclaratif spécial ou micro BNC)"
 
   # (f5hp, f5ip, f5jp))
@@ -548,7 +548,7 @@ class abnc_exon(Variable):
         QUIFOY['conj']: u"5RB",
         QUIFOY['pac1']: u"5SB", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus non commerciaux professionnels exonérés (yc compris plus-values) (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
 
   # (f5qb, f5rb, f5sb))
@@ -558,7 +558,7 @@ class nbnc_exon(Variable):
         QUIFOY['conj']: u"5RH",
         QUIFOY['pac1']: u"5SH", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus non commerciaux professionnels exonérés (yc compris plus-values) (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
 
   # (f5qh, f5rh, f5sh))
@@ -568,7 +568,7 @@ class mbnc_impo(Variable):
         QUIFOY['conj']: u"5IQ",
         QUIFOY['pac1']: u"5JQ", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus non commerciaux professionnels imposables (régime déclaratif spécial ou micro BNC)"
 
   # (f5hq, f5iq, f5jq))
@@ -578,7 +578,7 @@ class abnc_impo(Variable):
         QUIFOY['conj']: u"5RC",
         QUIFOY['pac1']: u"5SC", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus non commerciaux professionnels imposables (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
 
   # (f5qc, f5rc, f5sc))
@@ -588,7 +588,7 @@ class abnc_defi(Variable):
         QUIFOY['conj']: u"5RE",
         QUIFOY['pac1']: u"5SE", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits non commerciaux professionnels (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
 
   # (f5qe, f5re, f5se))
@@ -598,7 +598,7 @@ class nbnc_impo(Variable):
         QUIFOY['conj']: u"5RI",
         QUIFOY['pac1']: u"5SI", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus non commerciaux professionnels imposables (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
 
   # (f5qi, f5ri, f5si))
@@ -608,7 +608,7 @@ class nbnc_defi(Variable):
         QUIFOY['conj']: u"5RK",
         QUIFOY['pac1']: u"5SK", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits non commerciaux professionnels (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
 
   # (f5qk, f5rk, f5sk))
@@ -616,7 +616,7 @@ class nbnc_defi(Variable):
 class mbic_mvct(Variable):
     cerfa_field = u"5HU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Moins-values industrielles et commerciales nettes à court terme du foyer (régime micro entreprise)"
     stop_date = date(2011, 12, 31)
 
@@ -626,7 +626,7 @@ class mbic_mvct(Variable):
 class macc_mvct(Variable):
     cerfa_field = u"5IU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Moins-values industrielles et commerciales non professionnelles nettes à court terme du foyer (régime micro entreprise)"
 
   # (f5iu))
@@ -634,7 +634,7 @@ class macc_mvct(Variable):
 class mncn_mvct(Variable):
     cerfa_field = u"JU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Moins-values non commerciales non professionnelles nettes à court terme du foyer (régime déclaratif spécial ou micro BNC)"
 
   # (f5ju))
@@ -644,7 +644,7 @@ class mbnc_mvct(Variable):
         QUIFOY['conj']: u"5LZ",
         QUIFOY['pac1']: u"5MZ", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Moins-values non commerciales professionnelles nettes à court terme (régime déclaratif spécial ou micro BNC)"
     start_date = date(2012, 1, 1)
 
@@ -656,7 +656,7 @@ class frag_pvct(Variable):
         QUIFOY['conj']: u"5IW",
         QUIFOY['pac1']: u"5JW", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values agricoles  à court terme (régime du forfait)"
     start_date = date(2007, 1, 1)
 
@@ -667,7 +667,7 @@ class mbic_pvct(Variable):
         QUIFOY['conj']: u"5LX",
         QUIFOY['pac1']: u"5MX", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values industrielles et commerciales professionnels imposables: plus-values nettes à court terme (régime micro entreprise)"
 
   # (f5kx, f5lx, f5mx))
@@ -677,7 +677,7 @@ class macc_pvct(Variable):
         QUIFOY['conj']: u"5OX",
         QUIFOY['pac1']: u"5PX", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values industrielles et commerciales non professionnelles imposables: plus-values nettes à court terme (régime micro entreprise)"
 
   # (f5nx, f5ox, f5px))
@@ -687,7 +687,7 @@ class mbnc_pvct(Variable):
         QUIFOY['conj']: u"5IV",
         QUIFOY['pac1']: u"5JV", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values non commerciales professionnelles imposables et Plus-values nettes à court terme (régime déclaratif spécial ou micro BNC)"
 
   # (f5hv, f5iv, f5jv))
@@ -697,7 +697,7 @@ class mncn_pvct(Variable):
         QUIFOY['conj']: u"5LY",
         QUIFOY['pac1']: u"5MY", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values non commerciales non professionnelles imposables et plus-values nettes à court terme (régime déclaratif spécial ou micro BNC)"
 
   # (f5ky, f5ly, f5my))
@@ -707,7 +707,7 @@ class mbic_mvlt(Variable):
         QUIFOY['conj']: u"5LR",
         QUIFOY['pac1']: u"5MR", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Moins-values industrielles et commerciales professionnels à long terme (régime micro entreprise)"
 
   # (f5kr, f5lr, f5mr))
@@ -717,7 +717,7 @@ class macc_mvlt(Variable):
         QUIFOY['conj']: u"5OR",
         QUIFOY['pac1']: u"5PR", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Moins-values industrielles et commerciales non professionnelles à long terme (régime micro entreprise)"
 
   # (f5nr, f5or, f5pr))
@@ -727,7 +727,7 @@ class mncn_mvlt(Variable):
         QUIFOY['conj']: u"5LW",
         QUIFOY['pac1']: u"5MW", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Moins-values non commerciales non professionnelles à long terme (régime déclaratif spécial ou micro BNC)"
 
   # (f5kw, f5lw, f5mw))
@@ -737,7 +737,7 @@ class mbnc_mvlt(Variable):
         QUIFOY['conj']: u"5IS",
         QUIFOY['pac1']: u"5JS", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Moins-values non commerciales professionnelles à long terme (régime déclaratif spécial ou micro BNC)"
 
   # (f5hs, f5is, f5js))
@@ -747,7 +747,7 @@ class frag_pvce(Variable):
         QUIFOY['conj']: u"5IX",
         QUIFOY['pac1']: u"5JX", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values agricoles de cession taxables à 16% (régime du forfait)"
     start_date = date(2007, 1, 1)
 
@@ -758,7 +758,7 @@ class arag_pvce(Variable):
         QUIFOY['conj']: u"5IE",
         QUIFOY['pac1']: u"5JE", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values agricoles de cession taxables à 16% (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
     start_date = date(2007, 1, 1)
 
@@ -769,7 +769,7 @@ class nrag_pvce(Variable):
         QUIFOY['conj']: u"5LK",
         QUIFOY['pac1']: u"5JK", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values agricoles de cession taxables à 16% (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
     stop_date = date(2006, 12, 31)
 
@@ -780,7 +780,7 @@ class mbic_pvce(Variable):
         QUIFOY['conj']: u"5LQ",
         QUIFOY['pac1']: u"5MQ", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values industrielles et commerciales professionnelles imposables: plus-values de cession taxables à 16% (régime micro entreprise)"
 
   # (f5kq, f5lq, f5mq))
@@ -790,7 +790,7 @@ class abic_pvce(Variable):
         QUIFOY['conj']: u"5LE",
         QUIFOY['pac1']: u"5ME", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values industrielles et commerciales de cession taxables à 16% avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5ke, f5le, f5me))
@@ -800,7 +800,7 @@ class nbic_pvce(Variable):
         QUIFOY['conj']: u"5KK",
         QUIFOY['pac1']: u"5MK", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus non commerciaux non professionnels exonérés sans AA (régime de la déclaration controlée)"
     start_date = date(2008, 1, 1)
 
@@ -811,7 +811,7 @@ class macc_pvce(Variable):
         QUIFOY['conj']: u"5OQ",
         QUIFOY['pac1']: u"5PQ", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values industrielles et commerciales non professionnelles imposables: plus-values de cession taxables à 16% (régime micro entreprise)"
 
   # (f5nq, f5oq, f5pq))
@@ -821,7 +821,7 @@ class aacc_pvce(Variable):
         QUIFOY['conj']: u"5OE",
         QUIFOY['pac1']: u"5PE", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values industrielles et commerciales non professionnelles de cession taxables à 16% avec CGA ou viseur (régime du bénéfice réel)"
 
   # (f5ne, f5oe, f5pe))
@@ -831,7 +831,7 @@ class nacc_pvce(Variable):
         QUIFOY['conj']: u"5OK",
         QUIFOY['pac1']: u"5PK", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Locations meublées non professionnelles: Revenus imposables sans CGA (régime du bénéfice réel)"
     start_date = date(2009, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -843,7 +843,7 @@ class mncn_pvce(Variable):
         QUIFOY['conj']: u"5LV",
         QUIFOY['pac1']: u"5MV", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values non commerciales non professionnelles de cession taxables à 16% (régime déclaratif spécial ou micro BNC)"
 
   # (f5kv, f5lv, f5mv))
@@ -853,7 +853,7 @@ class cncn_pvce(Variable):
         QUIFOY['conj']: u"5NT",
         QUIFOY['pac1']: u"5OT", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values non commerciales non professionnelles taxables à 16% avec AA ou viseur (régime de la déclaration controlée)"
     start_date = date(2006, 1, 1)
 
@@ -864,7 +864,7 @@ class mbnc_pvce(Variable):
         QUIFOY['conj']: u"5IR",
         QUIFOY['pac1']: u"5JR", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values non commerciales professionnelles de cession taxables à 16% (régime déclaratif spécial ou micro BNC)"
 
   # (f5hr, f5ir, f5jr))
@@ -874,7 +874,7 @@ class abnc_pvce(Variable):
         QUIFOY['conj']: u"5RD",
         QUIFOY['pac1']: u"5SD", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Plus-values non commerciaux professionnels de cession taxables à 16% (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
 
   # (f5qd, f5rd, f5sd))
@@ -884,7 +884,7 @@ class nbnc_pvce(Variable):
         QUIFOY['conj']: u"5RJ",
         QUIFOY['pac1']: u"5SJ", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits industriels et commerciaux: locations meublées sans CGA (régime du bénéfice réel)"
     start_date = date(2009, 1, 1)
 
@@ -895,7 +895,7 @@ class frag_fore(Variable):
         QUIFOY['conj']: u"5ID",
         QUIFOY['pac1']: u"5JD", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus des exploitants forestiers (régime du forfait)"
     start_date = date(2007, 1, 1)
 
@@ -906,7 +906,7 @@ class arag_sjag(Variable):
         QUIFOY['conj']: u"5IZ",
         QUIFOY['pac1']: u"5JZ", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Abattement pour les jeunes agriculteurs des revenus agricoles sans CGA (régime du bénéfice réel)"
     start_date = date(2011, 1, 1)
 
@@ -917,7 +917,7 @@ class abic_impm(Variable):
         QUIFOY['conj']: u"5IA",
         QUIFOY['pac1']: u"5JA", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Locations meublées imposables avec CGA ou viseur (régime du bénéfice réel pour les revenus industriels et commerciaux professionnels)"
     start_date = date(2009, 1, 1)
 
@@ -928,7 +928,7 @@ class nbic_impm(Variable):
         QUIFOY['conj']: u"5LA",
         QUIFOY['pac1']: u"5MA", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Locations meublées imposables sans CGA (régime du bénéfice réel)"
     start_date = date(2009, 1, 1)
 
@@ -939,7 +939,7 @@ class abic_defm(Variable):
         QUIFOY['conj']: u"5RA",
         QUIFOY['pac1']: u"5SA", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits de locations meubléesavec CGA ou viseur (régime du bénéfice réel pour les revenus industriels et commerciaux professionnels)"
     start_date = date(2009, 1, 1)
 
@@ -950,7 +950,7 @@ class alnp_imps(Variable):
         QUIFOY['conj']: u"5OA",
         QUIFOY['pac1']: u"5PA", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Locations meublées non professionnelles imposables avec CGA ou viseur (régime du bénéfice réel)"
     start_date = date(2009, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -962,7 +962,7 @@ class alnp_defs(Variable):
         QUIFOY['conj']: u"5OY",
         QUIFOY['pac1']: u"5PY", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits de locations meublées non professionnelles avec CGA ou viseur (régime du bénéfice réel)"
     start_date = date(2009, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -974,7 +974,7 @@ class nlnp_defs(Variable):
         QUIFOY['conj']: u"5OZ",
         QUIFOY['pac1']: u"5PZ", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits de locations meublées non professionnelles imposables sans CGA (régime du bénéfice réel)"
     start_date = date(2009, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -985,7 +985,7 @@ class cbnc_assc(Variable):
     cerfa_field = {QUIFOY['vous']: u"5QM",
         QUIFOY['conj']: u"5RM", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Agents généraux d'assurances : indemnités de cessation d'activité (revenus non commerciaux professionnels, régime de la déclaration contrôlée)"
     start_date = date(2006, 1, 1)
 
@@ -996,7 +996,7 @@ class abnc_proc(Variable):
         QUIFOY['conj']: u"5UF",
         QUIFOY['pac1']: u"5VF", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Honoraires de prospection commerciale exonérés avec CGA ou viseur (revenus non commerciaux professionnels, régime de la déclaration contrôlée)"
     start_date = date(2009, 1, 1)
 
@@ -1007,7 +1007,7 @@ class nbnc_proc(Variable):
         QUIFOY['conj']: u"5UI",
         QUIFOY['pac1']: u"5VI", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Honoraires de prospection commerciale exonérés sans CGA (revenus non commerciaux professionnels, régime de la déclaration contrôlée)"
     start_date = date(2009, 1, 1)
 
@@ -1018,7 +1018,7 @@ class mncn_exon(Variable):
         QUIFOY['conj']: u"5UH",
         QUIFOY['pac1']: u"5VH", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus nets exonérés non commerciaux non professionnels (régime déclaratif spécial ou micro BNC)"
     start_date = date(2009, 1, 1)
 
@@ -1029,7 +1029,7 @@ class cncn_exon(Variable):
         QUIFOY['conj']: u"5JK",
         QUIFOY['pac1']: u"5LK", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus nets exonérés non commerciaux non professionnels (régime de la déclaration contrôlée)"
     start_date = date(2008, 1, 1)
 
@@ -1040,7 +1040,7 @@ class cncn_aimp(Variable):
         QUIFOY['conj']: u"5RF",
         QUIFOY['pac1']: u"5SF", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus imposables non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
     start_date = date(2007, 1, 1)
 
@@ -1051,7 +1051,7 @@ class cncn_adef(Variable):
         QUIFOY['conj']: u"5RG",
         QUIFOY['pac1']: u"5SG", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Déficits non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
     start_date = date(2007, 1, 1)
 
@@ -1062,7 +1062,7 @@ class cncn_info(Variable):
         QUIFOY['conj']: u"5UC",
         QUIFOY['pac1']: u"5VC", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Inventeurs et auteurs de logiciels : produits taxables à 16%, revenus non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
     start_date = date(2009, 1, 1)
 
@@ -1073,7 +1073,7 @@ class cncn_jcre(Variable):
         QUIFOY['conj']: u"5SW",
         QUIFOY['pac1']: u"5SX", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Jeunes créateurs : abattement de 50%, revenus non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
     start_date = date(2006, 1, 1)
 
@@ -1084,7 +1084,7 @@ class revimpres(Variable):
         QUIFOY['conj']: u"5IY",
         QUIFOY['pac1']: u"5JY", }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Revenus nets à imposer aux prélèvements sociaux"
 
 
@@ -1093,7 +1093,7 @@ class pveximpres(Variable):
     cerfa_field = {QUIFOY['vous']: u"5HG",
         QUIFOY['conj']: u"5IG", }
     column = IntCol
-    entity = Individus
+    entity = Individu
     label = u"Plus-values à long terme exonérées en cas de départ à la retraite à imposer aux prélèvements sociaux"
     start_date = date(2006, 1, 1)
 
@@ -1105,7 +1105,7 @@ class pvtaimpres(Variable):
         QUIFOY['conj']: u"5IZ",
         QUIFOY['pac1']: u"5JZ", }
     column = IntCol
-    entity = Individus
+    entity = Individu
     label = u"Plus-values à long terme taxables à 16% à la retraite à imposer aux prélèvements sociaux"
     stop_date = date(2009, 12, 31)
 
@@ -1114,7 +1114,7 @@ class pvtaimpres(Variable):
 class f5qf(Variable):
     cerfa_field = u"5QF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-6)"
     start_date = date(2007, 1, 1)
 
@@ -1123,7 +1123,7 @@ class f5qf(Variable):
 class f5qg(Variable):
     cerfa_field = u"5QG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-5)"
     start_date = date(2007, 1, 1)
 
@@ -1132,7 +1132,7 @@ class f5qg(Variable):
 class f5qn(Variable):
     cerfa_field = u"5QN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-4)"
     start_date = date(2007, 1, 1)
 
@@ -1141,7 +1141,7 @@ class f5qn(Variable):
 class f5qo(Variable):
     cerfa_field = u"5QO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-3)"
     start_date = date(2007, 1, 1)
 
@@ -1150,7 +1150,7 @@ class f5qo(Variable):
 class f5qp(Variable):
     cerfa_field = u"5QP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-2)"
     start_date = date(2007, 1, 1)
 
@@ -1159,7 +1159,7 @@ class f5qp(Variable):
 class f5qq(Variable):
     cerfa_field = u"5QQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-1)"
     start_date = date(2007, 1, 1)
 
@@ -1168,7 +1168,7 @@ class f5qq(Variable):
 class f5ga(Variable):
     cerfa_field = u"5GA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-10)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1178,7 +1178,7 @@ class f5ga(Variable):
 class f5gb(Variable):
     cerfa_field = u"5GB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-9)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1188,7 +1188,7 @@ class f5gb(Variable):
 class f5gc(Variable):
     cerfa_field = u"5GC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-8)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1198,7 +1198,7 @@ class f5gc(Variable):
 class f5gd(Variable):
     cerfa_field = u"5GD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-7)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1208,7 +1208,7 @@ class f5gd(Variable):
 class f5ge(Variable):
     cerfa_field = u"5GE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-6)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1218,7 +1218,7 @@ class f5ge(Variable):
 class f5gf(Variable):
     cerfa_field = u"5GF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-5)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1228,7 +1228,7 @@ class f5gf(Variable):
 class f5gg(Variable):
     cerfa_field = u"5GG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-4)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1238,7 +1238,7 @@ class f5gg(Variable):
 class f5gh(Variable):
     cerfa_field = u"5GH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-3)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1248,7 +1248,7 @@ class f5gh(Variable):
 class f5gi(Variable):
     cerfa_field = u"5GI"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-2)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1258,7 +1258,7 @@ class f5gi(Variable):
 class f5gj(Variable):
     cerfa_field = u"5GJ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-1)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1268,7 +1268,7 @@ class f5gj(Variable):
 class f5rn(Variable):
     cerfa_field = u"5RN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-6)"
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -1278,7 +1278,7 @@ class f5rn(Variable):
 class f5ro(Variable):
     cerfa_field = u"5RO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-5)"
 
 
@@ -1286,7 +1286,7 @@ class f5ro(Variable):
 class f5rp(Variable):
     cerfa_field = u"5RP"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-4)"
 
 
@@ -1294,7 +1294,7 @@ class f5rp(Variable):
 class f5rq(Variable):
     cerfa_field = u"5RQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-3)"
 
 
@@ -1302,7 +1302,7 @@ class f5rq(Variable):
 class f5rr(Variable):
     cerfa_field = u"5RR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-2)"
 
 
@@ -1310,7 +1310,7 @@ class f5rr(Variable):
 class f5rw(Variable):
     cerfa_field = u"5RW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-1)"
 
 
@@ -1318,7 +1318,7 @@ class f5rw(Variable):
 class f5ht(Variable):
     cerfa_field = u"5HT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-6)"
     start_date = date(2007, 1, 1)
 
@@ -1327,7 +1327,7 @@ class f5ht(Variable):
 class f5it(Variable):
     cerfa_field = u"5IT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-5)"
     start_date = date(2007, 1, 1)
 
@@ -1336,7 +1336,7 @@ class f5it(Variable):
 class f5jt(Variable):
     cerfa_field = u"5JT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-4)"
     start_date = date(2007, 1, 1)
 
@@ -1345,7 +1345,7 @@ class f5jt(Variable):
 class f5kt(Variable):
     cerfa_field = u"5KT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-3)"
     start_date = date(2007, 1, 1)
 
@@ -1354,7 +1354,7 @@ class f5kt(Variable):
 class f5lt(Variable):
     cerfa_field = u"5LT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-2)"
     start_date = date(2007, 1, 1)
 
@@ -1363,7 +1363,7 @@ class f5lt(Variable):
 class f5mt(Variable):
     cerfa_field = u"5MT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-1)"
     start_date = date(2007, 1, 1)
 
@@ -1371,7 +1371,7 @@ class f5mt(Variable):
 
 class f5sq(Variable):
     column = IntCol
-    entity = Individus
+    entity = Individu
 
 
 
@@ -1383,14 +1383,14 @@ class f5sq(Variable):
 # Input mensuel
 class tns_auto_entrepreneur_chiffre_affaires(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     set_input = set_input_divide_by_period
     label = u"Chiffre d'affaires en tant qu'auto-entrepreneur"
 
 # Input annuel
 class tns_micro_entreprise_chiffre_affaires(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     set_input = set_input_divide_by_period
     label = u"Chiffre d'affaires en de micro-entreprise"
 
@@ -1400,46 +1400,46 @@ enum_tns_type_activite = Enum([u'achat_revente', u'bic', u'bnc'])
 # TODO remove this ugly is_permanent
 class tns_auto_entrepreneur_type_activite(Variable):
     column = EnumCol(enum = enum_tns_type_activite)
-    entity = Individus
+    entity = Individu
     is_permanent = True
     label = u"Type d'activité de l'auto-entrepreneur"
 
 # TODO remove this ugly is_permanent
 class tns_micro_entreprise_type_activite(Variable):
     column = EnumCol(enum = enum_tns_type_activite)
-    entity = Individus
+    entity = Individu
     is_permanent = True
     label = u"Type d'activité de la micro-entreprise"
 
 # Input sur le dernier exercice. Par convention, sur l'année dernière.
 class tns_autres_revenus(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     set_input = set_input_divide_by_period
     label = u"Autres revenus non salariés"
 
 class tns_autres_revenus_chiffre_affaires(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     set_input = set_input_divide_by_period
     label = u"Chiffre d'affaire pour les TNS non agricoles autres que les AE et ME"
 
 class tns_autres_revenus_type_activite(Variable):
     column = EnumCol(enum = enum_tns_type_activite)
-    entity = Individus
+    entity = Individu
     is_permanent = True
     label = u"Type d'activité de l'entreprise non AE ni ME"
 
 class tns_avec_employe(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     set_input = set_input_dispatch_by_period
     label = u"Le TNS a au moins un employé. Ne s'applique pas pour les agricoles ni auto-entrepreneurs ni micro entreprise"
 
 # Input annuel
 class tns_benefice_exploitant_agricole(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     set_input = set_input_dispatch_by_period
     label = u"Dernier bénéfice agricole"
 
@@ -1449,7 +1449,7 @@ class tns_benefice_exploitant_agricole(Variable):
 class travailleur_non_salarie(Variable):
     label = u"L'individu a une activité professionnelle non salariée"
     column = BoolCol
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -1483,7 +1483,7 @@ def compute_benefice_auto_entrepreneur_micro_entreprise(bareme, type_activite, c
 class tns_auto_entrepreneur_benefice(DatedVariable):
     column = FloatCol
     label = u"Bénéfice en tant qu'auto-entrepreneur"
-    entity = Individus
+    entity = Individu
 
     @dated_function(start = date(2008, 1, 1))
     def function(self, simulation, period):
@@ -1500,7 +1500,7 @@ class tns_auto_entrepreneur_benefice(DatedVariable):
 class tns_micro_entreprise_benefice(DatedVariable):
     column = FloatCol
     label = u"Bénéfice de la micro entreprise"
-    entity = Individus
+    entity = Individu
 
     @dated_function(start = date(2008, 1, 1))
     def function(self, simulation, period):
@@ -1520,7 +1520,7 @@ class tns_micro_entreprise_benefice(DatedVariable):
 class tns_auto_entrepreneur_revenus_net(DatedVariable) :
     column = FloatCol
     label = u"Revenu d'un auto-entrepreneur"
-    entity = Individus
+    entity = Individu
 
     @dated_function(start = date(2008, 1, 1))
     def function(self, simulation, period):
@@ -1542,7 +1542,7 @@ class tns_auto_entrepreneur_revenus_net(DatedVariable) :
 class tns_micro_entreprise_revenus_net(Variable) :
     column = FloatCol
     label = u"Revenu d'un TNS dans une micro-entreprise"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -10,19 +10,19 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 
 class indemnites_stage(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnités de stage"
 
 
 class revenus_stage_formation_pro(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus de stage de formation professionnelle"
 
 
 class bourse_recherche(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Bourse de recherche"
 
 
@@ -36,7 +36,7 @@ class sal_pen_exo_etr(Variable):
         QUIFOY['pac2']: u"1DC",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Salaires et pensions exonérés de source étrangère retenus pour le calcul du taux effectif"
     start_date = date(2013, 1, 1)
 
@@ -51,7 +51,7 @@ class frais_reels(Variable):
         QUIFOY['pac3']: u"1EK",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Frais réels"
 
   # (f1ak, f1bk, f1ck, f1dk, f1ek)
@@ -65,7 +65,7 @@ class hsup(Variable):
         QUIFOY['pac2']: u"1DU",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Heures supplémentaires : revenus exonérés connus"
     start_date = date(2007, 1, 1)
     stop_date = date(2013, 12, 13)
@@ -80,7 +80,7 @@ class ppe_du_sa(Variable):
         QUIFOY['pac3']: u"1QV",
         }
     column = IntCol
-    entity_class = Individus
+    entity = Individus
     label = u"Prime pour l'emploi des salariés: nombre d'heures payées dans l'année"
 
   # (f1av, f1bv, f1cv, f1dv, f1qv)
@@ -95,7 +95,7 @@ class ppe_tp_sa(Variable):
         }
 
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Prime pour l'emploi des salariés: indicateur de travail à temps plein sur l'année entière"
 
   # (f1ax, f1bx, f1cx, f1dx, f1qx)
@@ -117,14 +117,14 @@ class nbsala(Variable):
             ])
             ,
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Nombre de salariés dans l'établissement de l'emploi actuel"
 
 
 
 class tva_ent(Variable):
     column = BoolCol(default = True)
-    entity_class = Individus
+    entity = Individus
     label = u"L'entreprise employant le salarié paye de la TVA"
 
 
@@ -142,7 +142,7 @@ class exposition_accident(Variable):
             ])
             ,
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Exposition au risque pour les accidents du travail"
 
 
@@ -158,7 +158,7 @@ class allegement_fillon_mode_recouvrement(Variable):
                 ],
             ),
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Mode de recouvrement des allègements Fillon"
 
 
@@ -172,49 +172,49 @@ class allegement_cotisation_allocations_familiales_mode_recouvrement(Variable):
                 ],
             ),
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Mode de recouvrement de l'allègement de la cotisation d'allocations familiales"
 
 
 class apprentissage_contrat_debut(Variable):
     column = DateCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Date de début du contrat d'apprentissage"
 
 
 class arrco_tranche_a_taux_employeur(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Taux ARRCO tranche A employeur) propre à l'entreprise"
 
 
 class arrco_tranche_a_taux_salarie(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Taux ARRCO tranche A salarié) propre à l'entreprise"
 
 
 class assujettie_taxe_salaires(Variable):
     column = BoolCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Entreprise assujettie à la taxe sur les salaires"
 
 
 class avantage_en_nature_valeur_reelle(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Avantages en nature (Valeur réelle)"
 
 
 class indemnites_compensatrices_conges_payes(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"indemnites_compensatrices_conges_payes"
 
 
 class indemnite_fin_contrat_due(Variable):
     column = BoolCol()
-    entity_class = Individus
+    entity = Individus
     label = u"indemnite_fin_contrat_due"
 
 
@@ -231,19 +231,19 @@ class contrat_de_travail(Variable):
                 ],
             ),
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Type contrat de travail"
 
 
 class contrat_de_travail_debut(Variable):
     column = DateCol(default = date(1870, 1, 1))
-    entity_class = Individus
+    entity = Individus
     label = u"Date d'arrivée dans l'entreprise"
 
 
 class contrat_de_travail_fin(Variable):
     column = DateCol(default = date(2099, 12, 31))
-    entity_class = Individus
+    entity = Individus
     label = u"Date de départ de l'entreprise"
 
 
@@ -254,7 +254,7 @@ class contrat_de_travail_duree(Variable):
             u"cdd",
             ]),
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Type (durée determinée ou indéterminée) du contrat de travail"
 
 
@@ -265,29 +265,29 @@ class cotisation_sociale_mode_recouvrement(Variable):
             u"Annuel",
             ]),
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Mode de recouvrement des cotisations sociales"
 
 class entreprise_est_association_non_lucrative(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"L'entreprise est une association à but non lucratif, par exemple loi de 1901"
 
 
 class depcom_entreprise(Variable):
     column = FixedStrCol(max_length = 5)
-    entity_class = Individus
+    entity = Individus
     label = u"Localisation entreprise (depcom)"
 
 
 class code_postal_entreprise(Variable):
     column = FixedStrCol(max_length = 5)
-    entity_class = Individus
+    entity = Individus
     label = u"Localisation entreprise (Code postal)"
 
 
 class effectif_entreprise(Variable):
-    entity_class = Individus
+    entity = Individus
     column = IntCol()
     base_function = requested_period_last_value
     label = u"Effectif de l'entreprise"
@@ -296,132 +296,132 @@ class effectif_entreprise(Variable):
 
 class entreprise_assujettie_cet(Variable):
     column = BoolCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Entreprise assujettie à la contribution économique territoriale"
 
 
 class entreprise_assujettie_is(Variable):
     column = BoolCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Entreprise assujettie à l'impôt sur les sociétés (IS)"
 
 
 class entreprise_assujettie_tva(Variable):
     column = BoolCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Entreprise assujettie à la TVA"
 
 
 class entreprise_benefice(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     set_input = set_input_divide_by_period
     label = u"Bénéfice de l'entreprise"
 
 
 class entreprise_bilan(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Bilan de l'entreprise"
 
 
 class entreprise_chiffre_affaire(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Chiffre d'affaire de l'entreprise"
 
 
 class entreprise_creation(Variable):
     column = DateCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Date de création de l'entreprise"
 
 
 class nombre_tickets_restaurant(Variable):
     column = IntCol()
-    entity_class = Individus
+    entity = Individus
     base_function = requested_period_last_value
     label = u"Nombre de tickets restaurant"
 
 
 class nouvelle_bonification_indiciaire(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Nouvelle bonification indicaire"
 
 
 class prevoyance_obligatoire_cadre_taux_employe(Variable):
     column = FloatCol(default = 0.015)  # 1.5% est le minimum en 2014
-    entity_class = Individus
+    entity = Individus
     base_function = requested_period_last_value
     label = u"Taux de cotisation employeur pour la prévoyance obligatoire des cadres"
 
 
 class prevoyance_obligatoire_cadre_taux_employeur(Variable):
     column = FloatCol(default = 0.015)  # 1.5% est le minimum en 2014
-    entity_class = Individus
+    entity = Individus
     base_function = requested_period_last_value
     label = u"Taux de cotisation employeur pour la prévoyance obligatoire des cadres"
 
 
 class primes_salaires(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnités, primes et avantages en argent"
 
 
 class complementaire_sante_montant(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Montant de la complémentaire santé obligatoire retenue par l'employeur"
 
 
 class complementaire_sante_taux_employeur(Variable):
     column = FloatCol(default = 0.5)
     # La part minimum légale est de 50 %
-    entity_class = Individus
+    entity = Individus
     label = u"Part de la complémentaire santé obligatoire payée par l'employeur"
 
 
 class prise_en_charge_employeur_prevoyance_complementaire(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Part salariale des cotisations de prévoyance complémentaire prise en charge par l'employeur"
 
 
 class prise_en_charge_employeur_retraite_complementaire(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Part salariale des cotisations de retraite complémentaire prise en charge par l'employeur"
 
 
 class prise_en_charge_employeur_retraite_supplementaire(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Part salariale des cotisations de retraite supplémentaire prise en charge par l'employeur"
 
 
 class ratio_alternants(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Ratio d'alternants dans l'effectif moyen"
 
 
 class remboursement_transport_base(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Base pour le calcul du remboursement des frais de transport"
 
 
 class indemnites_forfaitaires(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnités forfaitaires (transport, nourriture)"
 
 
 class salaire_de_base(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Salaire de base, en général appelé salaire brut, la 1ère ligne sur la fiche de paie"
     set_input = set_input_divide_by_period
     url = u'http://www.insee.fr/fr/methodes/default.asp?page=definitions/salaire-mensuel-base-smb.htm'
@@ -429,25 +429,25 @@ class salaire_de_base(Variable):
 
 class titre_restaurant_taux_employeur(Variable):
     column = FloatCol(default = 0.5)
-    entity_class = Individus
+    entity = Individus
     label = u"Taux de participation de l'employeur au titre restaurant"
 
 
 class titre_restaurant_valeur_unitaire(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Valeur faciale unitaire du titre restaurant"
 
 
 class titre_restaurant_volume(Variable):
     column = IntCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Volume des titres restaurant"
 
 
 class traitement_indiciaire_brut(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Traitement indiciaire brut (TIB)"
 
 
@@ -465,52 +465,52 @@ class categorie_salarie(Variable):
                 ],
             ),
         )
-    entity_class = Individus
+    entity = Individus
     label = u"Catégorie de salarié"
 
 
 class heures_duree_collective_entreprise(Variable):
     column = IntCol()  # TODO default la valeur de la durée légale ?
-    entity_class = Individus
+    entity = Individus
     label = u"Durée mensuelle collective dans l'entreprise (heures, temps plein)"
 
 
 class heures_non_remunerees_volume(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Volume des heures non rémunérées (convenance personnelle hors contrat/forfait)"
     set_input = set_input_divide_by_period
 
 
 class heures_remunerees_volume(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Volume des heures rémunérées contractuellement (heures/mois, temps partiel)"
     set_input = set_input_divide_by_period
 
 
 class forfait_heures_remunerees_volume(Variable):
     column = IntCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Volume des heures rémunérées à un forfait heures"
 
 
 class forfait_jours_remuneres_volume(Variable):
     column = IntCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Volume des heures rémunérées à forfait jours"
 
 
 class volume_jours_ijss(Variable):
     column = IntCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Volume des jours pour lesquels sont versés une idemnité journalière par la sécurité sociale"
 
 
 class avantage_en_nature(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Avantages en nature"
 
     def function(self, simulation, period):
@@ -524,7 +524,7 @@ class avantage_en_nature(Variable):
 class avantage_en_nature_valeur_forfaitaire(Variable):
     # base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Evaluation fofaitaire des avantages en nature "
 
     # TODO: coplete this function
@@ -538,7 +538,7 @@ class avantage_en_nature_valeur_forfaitaire(Variable):
 class depense_cantine_titre_restaurant_employe(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Dépense de cantine et de titre restaurant à charge de l'employe"
 
     def function(self, simulation, period):
@@ -554,7 +554,7 @@ class depense_cantine_titre_restaurant_employe(Variable):
 class depense_cantine_titre_restaurant_employeur(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Dépense de cantine et de titre restaurant à charge de l'employeur"
 
     def function(self, simulation, period):
@@ -568,7 +568,7 @@ class depense_cantine_titre_restaurant_employeur(Variable):
 
 class nombre_jours_calendaires(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Nombre de jours calendaires travaillés"
 
     def function(self, simulation, period):
@@ -592,7 +592,7 @@ class nombre_jours_calendaires(Variable):
 
 class remboursement_transport(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Remboursement partiel des frais de transport par l'employeur"
 
     def function(self, simulation, period):
@@ -606,7 +606,7 @@ class remboursement_transport(Variable):
 
 class gipa(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnité de garantie individuelle du pouvoir d'achat"
     # TODO: à coder
 
@@ -617,7 +617,7 @@ class gipa(Variable):
 
 class indemnite_residence(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnité de résidence des fonctionnaires"
 
     def function(individu, period, legislation):
@@ -641,7 +641,7 @@ class indemnite_residence(Variable):
 
 class indice_majore(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indice majoré"
 
     def function(self, simulation, period):
@@ -656,7 +656,7 @@ class indice_majore(Variable):
 
 class primes_fonction_publique(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Calcul des primes pour les fonctionnaries"
     url = u"http://vosdroits.service-public.fr/particuliers/F465.xhtml"
 
@@ -675,8 +675,8 @@ class primes_fonction_publique(Variable):
 
 class af_nbenf_fonc(Variable):
     column = IntCol
-    entity_class = Familles
     label = u"Nombre d'enfants dans la famille au sens des allocations familiales pour les fonctionnaires"
+    entity = Familles
     # Hack pour éviter une boucle infinie
 
     def function(self, simulation, period):
@@ -696,7 +696,7 @@ class af_nbenf_fonc(Variable):
 
 class supp_familial_traitement(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Supplément familial de traitement"
     # Attention : par hypothèse ne peut êre attribué qu'à la tête du ménage
     # TODO: gérer le cas encore problématique du conjoint fonctionnaire
@@ -773,7 +773,7 @@ def _traitement_brut_mensuel(indice_maj, law):
 
 class remuneration_principale(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Rémunération principale des agents titulaires de la fonction publique"
 
     def function(self, simulation, period):
@@ -790,7 +790,7 @@ class remuneration_principale(Variable):
 class salaire_net_a_payer(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Salaire net à payer (fiche de paie)"
     set_input = set_input_divide_by_period
 
@@ -819,7 +819,7 @@ class salaire_net_a_payer(Variable):
 class salaire_super_brut_hors_allegements(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Salaire super-brut (fiche de paie): rémunération + cotisations sociales employeur"
     set_input = set_input_divide_by_period
 
@@ -850,7 +850,7 @@ class salaire_super_brut_hors_allegements(Variable):
 
 class salaire_super_brut(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Coût du travail à court terme. Inclut les exonérations et allègements de charges"
     set_input = set_input_divide_by_period
 
@@ -864,7 +864,7 @@ class salaire_super_brut(Variable):
 
 class exonerations_et_allegements(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Charges, aides et crédits différées ou particulières"
 
     def function(self, simulation, period):
@@ -892,7 +892,7 @@ class exonerations_et_allegements(Variable):
 
 class cout_du_travail(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Coût du travail à long terme. Inclut les charges, aides et crédits différés"
     set_input = set_input_divide_by_period
 
@@ -906,7 +906,7 @@ class cout_du_travail(Variable):
 
 class cout_differe(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Charges, aides et crédits différées ou particulières"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -10,19 +10,19 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 
 class indemnites_stage(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indemnités de stage"
 
 
 class revenus_stage_formation_pro(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenus de stage de formation professionnelle"
 
 
 class bourse_recherche(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Bourse de recherche"
 
 
@@ -36,7 +36,7 @@ class sal_pen_exo_etr(Variable):
         QUIFOY['pac2']: u"1DC",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Salaires et pensions exonérés de source étrangère retenus pour le calcul du taux effectif"
     start_date = date(2013, 1, 1)
 
@@ -51,7 +51,7 @@ class frais_reels(Variable):
         QUIFOY['pac3']: u"1EK",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Frais réels"
 
   # (f1ak, f1bk, f1ck, f1dk, f1ek)
@@ -65,7 +65,7 @@ class hsup(Variable):
         QUIFOY['pac2']: u"1DU",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Heures supplémentaires : revenus exonérés connus"
     start_date = date(2007, 1, 1)
     stop_date = date(2013, 12, 13)
@@ -80,7 +80,7 @@ class ppe_du_sa(Variable):
         QUIFOY['pac3']: u"1QV",
         }
     column = IntCol
-    entity = Individus
+    entity = Individu
     label = u"Prime pour l'emploi des salariés: nombre d'heures payées dans l'année"
 
   # (f1av, f1bv, f1cv, f1dv, f1qv)
@@ -95,7 +95,7 @@ class ppe_tp_sa(Variable):
         }
 
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Prime pour l'emploi des salariés: indicateur de travail à temps plein sur l'année entière"
 
   # (f1ax, f1bx, f1cx, f1dx, f1qx)
@@ -117,14 +117,14 @@ class nbsala(Variable):
             ])
             ,
         )
-    entity = Individus
+    entity = Individu
     label = u"Nombre de salariés dans l'établissement de l'emploi actuel"
 
 
 
 class tva_ent(Variable):
     column = BoolCol(default = True)
-    entity = Individus
+    entity = Individu
     label = u"L'entreprise employant le salarié paye de la TVA"
 
 
@@ -142,7 +142,7 @@ class exposition_accident(Variable):
             ])
             ,
         )
-    entity = Individus
+    entity = Individu
     label = u"Exposition au risque pour les accidents du travail"
 
 
@@ -158,7 +158,7 @@ class allegement_fillon_mode_recouvrement(Variable):
                 ],
             ),
         )
-    entity = Individus
+    entity = Individu
     label = u"Mode de recouvrement des allègements Fillon"
 
 
@@ -172,49 +172,49 @@ class allegement_cotisation_allocations_familiales_mode_recouvrement(Variable):
                 ],
             ),
         )
-    entity = Individus
+    entity = Individu
     label = u"Mode de recouvrement de l'allègement de la cotisation d'allocations familiales"
 
 
 class apprentissage_contrat_debut(Variable):
     column = DateCol()
-    entity = Individus
+    entity = Individu
     label = u"Date de début du contrat d'apprentissage"
 
 
 class arrco_tranche_a_taux_employeur(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Taux ARRCO tranche A employeur) propre à l'entreprise"
 
 
 class arrco_tranche_a_taux_salarie(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Taux ARRCO tranche A salarié) propre à l'entreprise"
 
 
 class assujettie_taxe_salaires(Variable):
     column = BoolCol()
-    entity = Individus
+    entity = Individu
     label = u"Entreprise assujettie à la taxe sur les salaires"
 
 
 class avantage_en_nature_valeur_reelle(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Avantages en nature (Valeur réelle)"
 
 
 class indemnites_compensatrices_conges_payes(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"indemnites_compensatrices_conges_payes"
 
 
 class indemnite_fin_contrat_due(Variable):
     column = BoolCol()
-    entity = Individus
+    entity = Individu
     label = u"indemnite_fin_contrat_due"
 
 
@@ -231,19 +231,19 @@ class contrat_de_travail(Variable):
                 ],
             ),
         )
-    entity = Individus
+    entity = Individu
     label = u"Type contrat de travail"
 
 
 class contrat_de_travail_debut(Variable):
     column = DateCol(default = date(1870, 1, 1))
-    entity = Individus
+    entity = Individu
     label = u"Date d'arrivée dans l'entreprise"
 
 
 class contrat_de_travail_fin(Variable):
     column = DateCol(default = date(2099, 12, 31))
-    entity = Individus
+    entity = Individu
     label = u"Date de départ de l'entreprise"
 
 
@@ -254,7 +254,7 @@ class contrat_de_travail_duree(Variable):
             u"cdd",
             ]),
         )
-    entity = Individus
+    entity = Individu
     label = u"Type (durée determinée ou indéterminée) du contrat de travail"
 
 
@@ -265,29 +265,29 @@ class cotisation_sociale_mode_recouvrement(Variable):
             u"Annuel",
             ]),
         )
-    entity = Individus
+    entity = Individu
     label = u"Mode de recouvrement des cotisations sociales"
 
 class entreprise_est_association_non_lucrative(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"L'entreprise est une association à but non lucratif, par exemple loi de 1901"
 
 
 class depcom_entreprise(Variable):
     column = FixedStrCol(max_length = 5)
-    entity = Individus
+    entity = Individu
     label = u"Localisation entreprise (depcom)"
 
 
 class code_postal_entreprise(Variable):
     column = FixedStrCol(max_length = 5)
-    entity = Individus
+    entity = Individu
     label = u"Localisation entreprise (Code postal)"
 
 
 class effectif_entreprise(Variable):
-    entity = Individus
+    entity = Individu
     column = IntCol()
     base_function = requested_period_last_value
     label = u"Effectif de l'entreprise"
@@ -296,132 +296,132 @@ class effectif_entreprise(Variable):
 
 class entreprise_assujettie_cet(Variable):
     column = BoolCol()
-    entity = Individus
+    entity = Individu
     label = u"Entreprise assujettie à la contribution économique territoriale"
 
 
 class entreprise_assujettie_is(Variable):
     column = BoolCol()
-    entity = Individus
+    entity = Individu
     label = u"Entreprise assujettie à l'impôt sur les sociétés (IS)"
 
 
 class entreprise_assujettie_tva(Variable):
     column = BoolCol()
-    entity = Individus
+    entity = Individu
     label = u"Entreprise assujettie à la TVA"
 
 
 class entreprise_benefice(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     set_input = set_input_divide_by_period
     label = u"Bénéfice de l'entreprise"
 
 
 class entreprise_bilan(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Bilan de l'entreprise"
 
 
 class entreprise_chiffre_affaire(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Chiffre d'affaire de l'entreprise"
 
 
 class entreprise_creation(Variable):
     column = DateCol()
-    entity = Individus
+    entity = Individu
     label = u"Date de création de l'entreprise"
 
 
 class nombre_tickets_restaurant(Variable):
     column = IntCol()
-    entity = Individus
+    entity = Individu
     base_function = requested_period_last_value
     label = u"Nombre de tickets restaurant"
 
 
 class nouvelle_bonification_indiciaire(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Nouvelle bonification indicaire"
 
 
 class prevoyance_obligatoire_cadre_taux_employe(Variable):
     column = FloatCol(default = 0.015)  # 1.5% est le minimum en 2014
-    entity = Individus
+    entity = Individu
     base_function = requested_period_last_value
     label = u"Taux de cotisation employeur pour la prévoyance obligatoire des cadres"
 
 
 class prevoyance_obligatoire_cadre_taux_employeur(Variable):
     column = FloatCol(default = 0.015)  # 1.5% est le minimum en 2014
-    entity = Individus
+    entity = Individu
     base_function = requested_period_last_value
     label = u"Taux de cotisation employeur pour la prévoyance obligatoire des cadres"
 
 
 class primes_salaires(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Indemnités, primes et avantages en argent"
 
 
 class complementaire_sante_montant(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Montant de la complémentaire santé obligatoire retenue par l'employeur"
 
 
 class complementaire_sante_taux_employeur(Variable):
     column = FloatCol(default = 0.5)
     # La part minimum légale est de 50 %
-    entity = Individus
+    entity = Individu
     label = u"Part de la complémentaire santé obligatoire payée par l'employeur"
 
 
 class prise_en_charge_employeur_prevoyance_complementaire(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Part salariale des cotisations de prévoyance complémentaire prise en charge par l'employeur"
 
 
 class prise_en_charge_employeur_retraite_complementaire(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Part salariale des cotisations de retraite complémentaire prise en charge par l'employeur"
 
 
 class prise_en_charge_employeur_retraite_supplementaire(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Part salariale des cotisations de retraite supplémentaire prise en charge par l'employeur"
 
 
 class ratio_alternants(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Ratio d'alternants dans l'effectif moyen"
 
 
 class remboursement_transport_base(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Base pour le calcul du remboursement des frais de transport"
 
 
 class indemnites_forfaitaires(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Indemnités forfaitaires (transport, nourriture)"
 
 
 class salaire_de_base(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Salaire de base, en général appelé salaire brut, la 1ère ligne sur la fiche de paie"
     set_input = set_input_divide_by_period
     url = u'http://www.insee.fr/fr/methodes/default.asp?page=definitions/salaire-mensuel-base-smb.htm'
@@ -429,25 +429,25 @@ class salaire_de_base(Variable):
 
 class titre_restaurant_taux_employeur(Variable):
     column = FloatCol(default = 0.5)
-    entity = Individus
+    entity = Individu
     label = u"Taux de participation de l'employeur au titre restaurant"
 
 
 class titre_restaurant_valeur_unitaire(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Valeur faciale unitaire du titre restaurant"
 
 
 class titre_restaurant_volume(Variable):
     column = IntCol()
-    entity = Individus
+    entity = Individu
     label = u"Volume des titres restaurant"
 
 
 class traitement_indiciaire_brut(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Traitement indiciaire brut (TIB)"
 
 
@@ -465,52 +465,52 @@ class categorie_salarie(Variable):
                 ],
             ),
         )
-    entity = Individus
+    entity = Individu
     label = u"Catégorie de salarié"
 
 
 class heures_duree_collective_entreprise(Variable):
     column = IntCol()  # TODO default la valeur de la durée légale ?
-    entity = Individus
+    entity = Individu
     label = u"Durée mensuelle collective dans l'entreprise (heures, temps plein)"
 
 
 class heures_non_remunerees_volume(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Volume des heures non rémunérées (convenance personnelle hors contrat/forfait)"
     set_input = set_input_divide_by_period
 
 
 class heures_remunerees_volume(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Volume des heures rémunérées contractuellement (heures/mois, temps partiel)"
     set_input = set_input_divide_by_period
 
 
 class forfait_heures_remunerees_volume(Variable):
     column = IntCol()
-    entity = Individus
+    entity = Individu
     label = u"Volume des heures rémunérées à un forfait heures"
 
 
 class forfait_jours_remuneres_volume(Variable):
     column = IntCol()
-    entity = Individus
+    entity = Individu
     label = u"Volume des heures rémunérées à forfait jours"
 
 
 class volume_jours_ijss(Variable):
     column = IntCol()
-    entity = Individus
+    entity = Individu
     label = u"Volume des jours pour lesquels sont versés une idemnité journalière par la sécurité sociale"
 
 
 class avantage_en_nature(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Avantages en nature"
 
     def function(self, simulation, period):
@@ -524,7 +524,7 @@ class avantage_en_nature(Variable):
 class avantage_en_nature_valeur_forfaitaire(Variable):
     # base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Evaluation fofaitaire des avantages en nature "
 
     # TODO: coplete this function
@@ -538,7 +538,7 @@ class avantage_en_nature_valeur_forfaitaire(Variable):
 class depense_cantine_titre_restaurant_employe(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Dépense de cantine et de titre restaurant à charge de l'employe"
 
     def function(self, simulation, period):
@@ -554,7 +554,7 @@ class depense_cantine_titre_restaurant_employe(Variable):
 class depense_cantine_titre_restaurant_employeur(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Dépense de cantine et de titre restaurant à charge de l'employeur"
 
     def function(self, simulation, period):
@@ -568,7 +568,7 @@ class depense_cantine_titre_restaurant_employeur(Variable):
 
 class nombre_jours_calendaires(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Nombre de jours calendaires travaillés"
 
     def function(self, simulation, period):
@@ -592,7 +592,7 @@ class nombre_jours_calendaires(Variable):
 
 class remboursement_transport(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Remboursement partiel des frais de transport par l'employeur"
 
     def function(self, simulation, period):
@@ -606,7 +606,7 @@ class remboursement_transport(Variable):
 
 class gipa(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indemnité de garantie individuelle du pouvoir d'achat"
     # TODO: à coder
 
@@ -617,7 +617,7 @@ class gipa(Variable):
 
 class indemnite_residence(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indemnité de résidence des fonctionnaires"
 
     def function(individu, period, legislation):
@@ -641,7 +641,7 @@ class indemnite_residence(Variable):
 
 class indice_majore(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indice majoré"
 
     def function(self, simulation, period):
@@ -656,7 +656,7 @@ class indice_majore(Variable):
 
 class primes_fonction_publique(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Calcul des primes pour les fonctionnaries"
     url = u"http://vosdroits.service-public.fr/particuliers/F465.xhtml"
 
@@ -676,7 +676,7 @@ class primes_fonction_publique(Variable):
 class af_nbenf_fonc(Variable):
     column = IntCol
     label = u"Nombre d'enfants dans la famille au sens des allocations familiales pour les fonctionnaires"
-    entity = Familles
+    entity = Famille
     # Hack pour éviter une boucle infinie
 
     def function(self, simulation, period):
@@ -691,12 +691,12 @@ class af_nbenf_fonc(Variable):
         age = simulation.calculate('age', period)
         condition_enfant = (age >= law.fam.af.age1) * (age <= law.fam.af.age2) * not_(autonomie_financiere)
 
-        return period, simulation.famille.sum(condition_enfant, role = Familles.ENFANT)
+        return period, simulation.famille.sum(condition_enfant, role = Famille.ENFANT)
 
 
 class supp_familial_traitement(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Supplément familial de traitement"
     # Attention : par hypothèse ne peut êre attribué qu'à la tête du ménage
     # TODO: gérer le cas encore problématique du conjoint fonctionnaire
@@ -707,7 +707,7 @@ class supp_familial_traitement(Variable):
         traitement_indiciaire_brut = individu('traitement_indiciaire_brut', period)
         _P = legislation(period)
 
-        fonc_nbenf = individu.famille('af_nbenf_fonc', period) * individu.has_role(Familles.DEMANDEUR)
+        fonc_nbenf = individu.famille('af_nbenf_fonc', period) * individu.has_role(Famille.DEMANDEUR)
 
         P = _P.fonc.supp_fam
         part_fixe_1 = P.fixe.enf1
@@ -773,7 +773,7 @@ def _traitement_brut_mensuel(indice_maj, law):
 
 class remuneration_principale(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Rémunération principale des agents titulaires de la fonction publique"
 
     def function(self, simulation, period):
@@ -790,7 +790,7 @@ class remuneration_principale(Variable):
 class salaire_net_a_payer(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Salaire net à payer (fiche de paie)"
     set_input = set_input_divide_by_period
 
@@ -819,7 +819,7 @@ class salaire_net_a_payer(Variable):
 class salaire_super_brut_hors_allegements(Variable):
     base_function = requested_period_added_value
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Salaire super-brut (fiche de paie): rémunération + cotisations sociales employeur"
     set_input = set_input_divide_by_period
 
@@ -850,7 +850,7 @@ class salaire_super_brut_hors_allegements(Variable):
 
 class salaire_super_brut(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Coût du travail à court terme. Inclut les exonérations et allègements de charges"
     set_input = set_input_divide_by_period
 
@@ -864,7 +864,7 @@ class salaire_super_brut(Variable):
 
 class exonerations_et_allegements(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Charges, aides et crédits différées ou particulières"
 
     def function(self, simulation, period):
@@ -892,7 +892,7 @@ class exonerations_et_allegements(Variable):
 
 class cout_du_travail(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Coût du travail à long terme. Inclut les charges, aides et crédits différés"
     set_input = set_input_divide_by_period
 
@@ -906,7 +906,7 @@ class cout_du_travail(Variable):
 
 class cout_differe(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Charges, aides et crédits différées ou particulières"
 
     def function(self, simulation, period):

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -693,7 +693,7 @@ class af_nbenf_fonc(Variable):
         age = simulation.calculate('age', period)
         condition_enfant = (age >= law.fam.af.age1) * (age <= law.fam.af.age2) * not_(autonomie_financiere)
 
-        return period, simulation.famille.sum(condition_enfant, role = ENFANT)
+        return period, simulation.famille.sum(condition_enfant, role = Familles.enfant)
 
 
 class supp_familial_traitement(Variable):

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -2,7 +2,7 @@
 
 from functools import partial
 from numpy import (
-    busday_count as original_busday_count, datetime64, maximum as max_, minimum as min_, timedelta64,
+    busday_count as original_busday_count, datetime64, maximum as max_, minimum as min_, timedelta64, logical_not as not_,
     )
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
@@ -625,7 +625,8 @@ class indemnite_residence(Variable):
         traitement_indiciaire_brut = simulation.calculate('traitement_indiciaire_brut', period)
         salaire_de_base = simulation.calculate('salaire_de_base', period)
         categorie_salarie = simulation.calculate('categorie_salarie', period)
-        zone_apl_individu = simulation.calculate('zone_apl_individu', period)
+        zone_apl_menage = simulation.calculate('zone_apl', period)
+        zone_apl_individu = simulation.menage.project(zone_apl_menage)
         _P = simulation.legislation_at(period.start)
 
         zone_apl = zone_apl_individu  # TODO: ces zones ne correpondent pas aux zones APL
@@ -683,17 +684,16 @@ class af_nbenf_fonc(Variable):
     def function(self, simulation, period):
         # Note : Cette variable est "instantanée" : quelque soit la période demandée, elle retourne la valeur au premier
         # jour, sans changer la période.
-        age_holder = simulation.compute('age', period)
         salaire_de_base = simulation.calculate_add('salaire_de_base', period.start.period('month', 6).offset(-6))
         law = simulation.legislation_at(period.start)
         nbh_travaillees = 169
         smic_mensuel_brut = law.cotsoc.gen.smic_h_b * nbh_travaillees
-        autonomie_financiere_holder = (salaire_de_base / 6) >= (law.fam.af.seuil_rev_taux * smic_mensuel_brut)
-        age = self.split_by_roles(age_holder, roles = ENFS)
-        autonomie_financiere = self.split_by_roles(autonomie_financiere_holder, roles = ENFS)
-        af_nbenf = nb_enf(age, autonomie_financiere, law.fam.af.age1, law.fam.af.age2)
 
-        return period, af_nbenf
+        autonomie_financiere = (salaire_de_base / 6) >= (law.fam.af.seuil_rev_taux * smic_mensuel_brut)
+        age = simulation.calculate('age', period)
+        condition_enfant = (age >= law.fam.af.age1) * (age <= law.fam.af.age2) * not_(autonomie_financiere)
+
+        return period, simulation.famille.sum(condition_enfant, role = ENFANT)
 
 
 class supp_familial_traitement(Variable):
@@ -707,10 +707,11 @@ class supp_familial_traitement(Variable):
         period = period.start.period(u'month').offset('first-of')
         categorie_salarie = simulation.calculate('categorie_salarie', period)
         traitement_indiciaire_brut = simulation.calculate('traitement_indiciaire_brut', period)
-        af_nbenf_fonc_holder = simulation.compute('af_nbenf_fonc', period)
         _P = simulation.legislation_at(period.start)
 
-        fonc_nbenf = self.cast_from_entity_to_role(af_nbenf_fonc_holder, role = CHEF)
+        af_nbenf_fonc = simulation.calculate('af_nbenf_fonc', period)
+        fonc_nbenf = simulation.famille.project_on_first_person(af_nbenf_fonc)
+
         P = _P.fonc.supp_fam
         part_fixe_1 = P.fixe.enf1
         part_fixe_2 = P.fixe.enf2

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -693,7 +693,7 @@ class af_nbenf_fonc(Variable):
         age = simulation.calculate('age', period)
         condition_enfant = (age >= law.fam.af.age1) * (age <= law.fam.af.age2) * not_(autonomie_financiere)
 
-        return period, simulation.famille.sum(condition_enfant, role = Familles.enfant)
+        return period, simulation.famille.sum(condition_enfant, role = Familles.ENFANT)
 
 
 class supp_familial_traitement(Variable):

--- a/openfisca_france/model/revenus/autres.py
+++ b/openfisca_france/model/revenus/autres.py
@@ -11,76 +11,76 @@ class pensions_alimentaires_percues(Variable):
         QUIFOY['pac3']: u"1EO",
         }
     column = FloatCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Pensions alimentaires perçues"
 
   # (f1ao, f1bo, f1co, f1do, f1eo)
 class pensions_alimentaires_percues_decl(Variable):
     column = BoolCol(default = True)
-    entity = Individus
+    entity = Individu
     label = u"Pension déclarée"
 
 
 
 class pensions_alimentaires_versees_individu(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Pensions alimentaires versées pour un individu"
 
 
 
 class gains_exceptionnels(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Gains exceptionnels"
 
 
 
 class allocation_aide_retour_emploi(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Allocation d'aide au retour à l'emploi"
 
 
 class allocation_securisation_professionnelle(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Allocation de sécurisation professionnelle"
 
 
 class prime_forfaitaire_mensuelle_reprise_activite(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Prime forfaitaire mensuelle pour la reprise d'activité"
 
 
 class indemnites_volontariat(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indemnités de volontariat"
 
 
 class dedommagement_victime_amiante(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Dédommagement versé aux victimes de l'amiante"
 
 
 class prestation_compensatoire(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Prestation compensatoire"
 
 
 class pensions_invalidite(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Pensions d'invalidité"
 
 
 class bourse_enseignement_sup(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Bourse de l'enseignement supérieur"
 
 
@@ -91,7 +91,7 @@ class bourse_enseignement_sup(Variable):
 class f8ta(Variable):
     cerfa_field = u"8TA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Retenue à la source en France ou impôt payé à l'étranger"
 
 
@@ -100,7 +100,7 @@ class f8ta(Variable):
 class f8th(Variable):
     cerfa_field = u"8TH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Retenue à la source élus locaux"
 
 
@@ -109,7 +109,7 @@ class f8th(Variable):
 class f8td_2002_2005(Variable):
     cerfa_field = u"8TD"
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Contribution exceptionnelle sur les hauts revenus"
     start_date = date(2002, 1, 1)
     stop_date = date(2005, 12, 31)
@@ -119,7 +119,7 @@ class f8td_2002_2005(Variable):
 class f8td(Variable):
     cerfa_field = u"8TD"
     column = BoolCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus non imposables dépassent la moitié du RFR"
     start_date = date(2011, 1, 1)
     stop_date = date(2014, 12, 31)
@@ -130,7 +130,7 @@ class f8td(Variable):
 class f8ti(Variable):
     cerfa_field = u"8TK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus de l'étranger exonérés d'impôt"
 
 
@@ -138,7 +138,7 @@ class f8ti(Variable):
 class f8tk(Variable):
     cerfa_field = u"8TK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus de l'étranger imposables"
 
 
@@ -147,7 +147,7 @@ class f8tk(Variable):
 class f8uy(Variable):
     cerfa_field = u"8UY"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Auto-entrepreneur : versements libératoires d’impôt sur le revenu dont le remboursement est demandé"
     start_date = date(2009, 1, 1)
 

--- a/openfisca_france/model/revenus/autres.py
+++ b/openfisca_france/model/revenus/autres.py
@@ -11,76 +11,76 @@ class pensions_alimentaires_percues(Variable):
         QUIFOY['pac3']: u"1EO",
         }
     column = FloatCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Pensions alimentaires perçues"
 
   # (f1ao, f1bo, f1co, f1do, f1eo)
 class pensions_alimentaires_percues_decl(Variable):
     column = BoolCol(default = True)
-    entity_class = Individus
+    entity = Individus
     label = u"Pension déclarée"
 
 
 
 class pensions_alimentaires_versees_individu(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Pensions alimentaires versées pour un individu"
 
 
 
 class gains_exceptionnels(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Gains exceptionnels"
 
 
 
 class allocation_aide_retour_emploi(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Allocation d'aide au retour à l'emploi"
 
 
 class allocation_securisation_professionnelle(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Allocation de sécurisation professionnelle"
 
 
 class prime_forfaitaire_mensuelle_reprise_activite(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Prime forfaitaire mensuelle pour la reprise d'activité"
 
 
 class indemnites_volontariat(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnités de volontariat"
 
 
 class dedommagement_victime_amiante(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Dédommagement versé aux victimes de l'amiante"
 
 
 class prestation_compensatoire(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Prestation compensatoire"
 
 
 class pensions_invalidite(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Pensions d'invalidité"
 
 
 class bourse_enseignement_sup(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Bourse de l'enseignement supérieur"
 
 
@@ -91,7 +91,7 @@ class bourse_enseignement_sup(Variable):
 class f8ta(Variable):
     cerfa_field = u"8TA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Retenue à la source en France ou impôt payé à l'étranger"
 
 
@@ -100,7 +100,7 @@ class f8ta(Variable):
 class f8th(Variable):
     cerfa_field = u"8TH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Retenue à la source élus locaux"
 
 
@@ -109,7 +109,7 @@ class f8th(Variable):
 class f8td_2002_2005(Variable):
     cerfa_field = u"8TD"
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Contribution exceptionnelle sur les hauts revenus"
     start_date = date(2002, 1, 1)
     stop_date = date(2005, 12, 31)
@@ -119,7 +119,7 @@ class f8td_2002_2005(Variable):
 class f8td(Variable):
     cerfa_field = u"8TD"
     column = BoolCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus non imposables dépassent la moitié du RFR"
     start_date = date(2011, 1, 1)
     stop_date = date(2014, 12, 31)
@@ -130,7 +130,7 @@ class f8td(Variable):
 class f8ti(Variable):
     cerfa_field = u"8TK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus de l'étranger exonérés d'impôt"
 
 
@@ -138,7 +138,7 @@ class f8ti(Variable):
 class f8tk(Variable):
     cerfa_field = u"8TK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus de l'étranger imposables"
 
 
@@ -147,7 +147,7 @@ class f8tk(Variable):
 class f8uy(Variable):
     cerfa_field = u"8UY"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Auto-entrepreneur : versements libératoires d’impôt sur le revenu dont le remboursement est demandé"
     start_date = date(2009, 1, 1)
 

--- a/openfisca_france/model/revenus/capital/financier.py
+++ b/openfisca_france/model/revenus/capital/financier.py
@@ -8,7 +8,7 @@ from openfisca_france.model.base import *  # noqa
 class f2da(Variable):
     cerfa_field = u"2DA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus des actions et parts soumis au prélèvement libératoire de 21 %"
     start_date = date(2008, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -18,7 +18,7 @@ class f2da(Variable):
 class f2dh(Variable):
     cerfa_field = u"2DH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Produits d’assurance-vie et de capitalisation soumis au prélèvement libératoire de 7.5 %"
 
 
@@ -26,7 +26,7 @@ class f2dh(Variable):
 class f2ee(Variable):
     cerfa_field = u"2EE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Autres produits de placement soumis aux prélèvements libératoires"
 
 
@@ -35,7 +35,7 @@ class f2ee(Variable):
 class f2dc(Variable):
     cerfa_field = u"2DC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus des actions et parts donnant droit à abattement"
 
 
@@ -43,14 +43,14 @@ class f2dc(Variable):
 class f2fu(Variable):
     cerfa_field = u"2FU"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus imposables des titres non côtés détenus dans le PEA et distributions perçues via votre entreprise donnant droit à abattement"
 
 
 class f2ch(Variable):
     cerfa_field = u"2CH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Produits des contrats d'assurance-vie et de capitalisation d'une durée d'au moins 6 ou 8 ans donnant droit à abattement"
 
 
@@ -59,21 +59,21 @@ class f2ch(Variable):
 class f2ts(Variable):
     cerfa_field = u"2TS"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus de valeurs mobilières, produits des contrats d'assurance-vie d'une durée inférieure à 8 ans et distributions (n'ouvrant pas droit à abattement)"
 
 
 class f2go(Variable):
     cerfa_field = u"2GO"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Autres revenus distribués et revenus des structures soumises hors de France à un régime fiscal privilégié (n'ouvrant pas droit à abattement)"
 
 
 class f2tr(Variable):
     cerfa_field = u"2TR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Produits de placements à revenu fixe, intérêts et autres revenus assimilés (n'ouvrant pas droit à abattement)"
 
 
@@ -83,7 +83,7 @@ class f2tr(Variable):
 class f2cg(Variable):
     cerfa_field = u"2CG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus des lignes 2DC, 2CH, 2TS, 2TR déjà soumis au prélèvement sociaux sans CSG déductible"
 
 
@@ -91,7 +91,7 @@ class f2cg(Variable):
 class f2bh(Variable):
     cerfa_field = u"2BH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus des lignes 2DC, 2CH, 2TS, 2TR déjà soumis au prélèvement sociaux avec CSG déductible"
     start_date = date(2007, 1, 1)
 
@@ -100,7 +100,7 @@ class f2bh(Variable):
 class f2ca(Variable):
     cerfa_field = u"2CA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Frais et charges déductibles"
 
 
@@ -108,7 +108,7 @@ class f2ca(Variable):
 class f2ck(Variable):
     cerfa_field = u"2CK"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédit d'impôt égal au prélèvement forfaitaire déjà versé"
     start_date = date(2013, 1, 1)
 
@@ -117,7 +117,7 @@ class f2ck(Variable):
 class f2ab(Variable):
     cerfa_field = u"2AB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédits d'impôt sur valeurs étrangères"
 
 
@@ -125,7 +125,7 @@ class f2ab(Variable):
 class f2bg(Variable):
     cerfa_field = u"2BG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Crédits d'impôt 'directive épargne' et autres crédits d'impôt restituables"
 
 
@@ -133,7 +133,7 @@ class f2bg(Variable):
 class f2aa(Variable):
     cerfa_field = u"2AA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des années antérieures non encore déduits"
     start_date = date(2007, 1, 1)
 
@@ -142,7 +142,7 @@ class f2aa(Variable):
 class f2al(Variable):
     cerfa_field = u"2AL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des années antérieures non encore déduits"
     start_date = date(2008, 1, 1)
 
@@ -151,7 +151,7 @@ class f2al(Variable):
 class f2am(Variable):
     cerfa_field = u"2AM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des années antérieures non encore déduits"
     start_date = date(2009, 1, 1)
 
@@ -160,7 +160,7 @@ class f2am(Variable):
 class f2an(Variable):
     cerfa_field = u"2AN"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des années antérieures non encore déduits"
     start_date = date(2010, 1, 1)
 
@@ -169,7 +169,7 @@ class f2an(Variable):
 class f2aq(Variable):
     cerfa_field = u"2AQ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des années antérieures non encore déduits"
     start_date = date(2011, 1, 1)
 
@@ -178,7 +178,7 @@ class f2aq(Variable):
 class f2ar(Variable):
     cerfa_field = u"2AR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des années antérieures non encore déduits"
     start_date = date(2012, 1, 1)
 
@@ -188,7 +188,7 @@ class f2ar(Variable):
 #
 class f2as(Variable):
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits des années antérieures non encore déduits: année 2012"
     stop_date = date(2011, 12, 31)
 
@@ -197,7 +197,7 @@ class f2as(Variable):
 class f2dm(Variable):
     cerfa_field = u"2DM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Impatriés: revenus de capitaux mobiliers perçus à l'étranger, abattement de 50 %"
     start_date = date(2008, 1, 1)
 
@@ -207,7 +207,7 @@ class f2dm(Variable):
 class f2gr(Variable):
     cerfa_field = u"2GR"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus distribués dans le PEA (pour le calcul du crédit d'impôt de 50 %)"
     start_date = date(2005, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -218,17 +218,17 @@ class f2gr(Variable):
 # Utilisés par mes aides. TODO: à consolider
 class epargne_non_remuneree(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     base_function = requested_period_last_value
     label = u"Épargne non rémunérée"
 
 class interets_epargne_sur_livrets(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     base_function = requested_period_last_value
     label = u"Intérêts versés pour l'épargne sur livret"
 
 class revenus_capital(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenus du capital"

--- a/openfisca_france/model/revenus/capital/financier.py
+++ b/openfisca_france/model/revenus/capital/financier.py
@@ -8,7 +8,7 @@ from openfisca_france.model.base import *  # noqa
 class f2da(Variable):
     cerfa_field = u"2DA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus des actions et parts soumis au prélèvement libératoire de 21 %"
     start_date = date(2008, 1, 1)
     stop_date = date(2012, 12, 31)
@@ -18,7 +18,7 @@ class f2da(Variable):
 class f2dh(Variable):
     cerfa_field = u"2DH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Produits d’assurance-vie et de capitalisation soumis au prélèvement libératoire de 7.5 %"
 
 
@@ -26,7 +26,7 @@ class f2dh(Variable):
 class f2ee(Variable):
     cerfa_field = u"2EE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Autres produits de placement soumis aux prélèvements libératoires"
 
 
@@ -35,7 +35,7 @@ class f2ee(Variable):
 class f2dc(Variable):
     cerfa_field = u"2DC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus des actions et parts donnant droit à abattement"
 
 
@@ -43,14 +43,14 @@ class f2dc(Variable):
 class f2fu(Variable):
     cerfa_field = u"2FU"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus imposables des titres non côtés détenus dans le PEA et distributions perçues via votre entreprise donnant droit à abattement"
 
 
 class f2ch(Variable):
     cerfa_field = u"2CH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Produits des contrats d'assurance-vie et de capitalisation d'une durée d'au moins 6 ou 8 ans donnant droit à abattement"
 
 
@@ -59,21 +59,21 @@ class f2ch(Variable):
 class f2ts(Variable):
     cerfa_field = u"2TS"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus de valeurs mobilières, produits des contrats d'assurance-vie d'une durée inférieure à 8 ans et distributions (n'ouvrant pas droit à abattement)"
 
 
 class f2go(Variable):
     cerfa_field = u"2GO"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Autres revenus distribués et revenus des structures soumises hors de France à un régime fiscal privilégié (n'ouvrant pas droit à abattement)"
 
 
 class f2tr(Variable):
     cerfa_field = u"2TR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Produits de placements à revenu fixe, intérêts et autres revenus assimilés (n'ouvrant pas droit à abattement)"
 
 
@@ -83,7 +83,7 @@ class f2tr(Variable):
 class f2cg(Variable):
     cerfa_field = u"2CG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus des lignes 2DC, 2CH, 2TS, 2TR déjà soumis au prélèvement sociaux sans CSG déductible"
 
 
@@ -91,7 +91,7 @@ class f2cg(Variable):
 class f2bh(Variable):
     cerfa_field = u"2BH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus des lignes 2DC, 2CH, 2TS, 2TR déjà soumis au prélèvement sociaux avec CSG déductible"
     start_date = date(2007, 1, 1)
 
@@ -100,7 +100,7 @@ class f2bh(Variable):
 class f2ca(Variable):
     cerfa_field = u"2CA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Frais et charges déductibles"
 
 
@@ -108,7 +108,7 @@ class f2ca(Variable):
 class f2ck(Variable):
     cerfa_field = u"2CK"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédit d'impôt égal au prélèvement forfaitaire déjà versé"
     start_date = date(2013, 1, 1)
 
@@ -117,7 +117,7 @@ class f2ck(Variable):
 class f2ab(Variable):
     cerfa_field = u"2AB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédits d'impôt sur valeurs étrangères"
 
 
@@ -125,7 +125,7 @@ class f2ab(Variable):
 class f2bg(Variable):
     cerfa_field = u"2BG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Crédits d'impôt 'directive épargne' et autres crédits d'impôt restituables"
 
 
@@ -133,7 +133,7 @@ class f2bg(Variable):
 class f2aa(Variable):
     cerfa_field = u"2AA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des années antérieures non encore déduits"
     start_date = date(2007, 1, 1)
 
@@ -142,7 +142,7 @@ class f2aa(Variable):
 class f2al(Variable):
     cerfa_field = u"2AL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des années antérieures non encore déduits"
     start_date = date(2008, 1, 1)
 
@@ -151,7 +151,7 @@ class f2al(Variable):
 class f2am(Variable):
     cerfa_field = u"2AM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des années antérieures non encore déduits"
     start_date = date(2009, 1, 1)
 
@@ -160,7 +160,7 @@ class f2am(Variable):
 class f2an(Variable):
     cerfa_field = u"2AN"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des années antérieures non encore déduits"
     start_date = date(2010, 1, 1)
 
@@ -169,7 +169,7 @@ class f2an(Variable):
 class f2aq(Variable):
     cerfa_field = u"2AQ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des années antérieures non encore déduits"
     start_date = date(2011, 1, 1)
 
@@ -178,7 +178,7 @@ class f2aq(Variable):
 class f2ar(Variable):
     cerfa_field = u"2AR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des années antérieures non encore déduits"
     start_date = date(2012, 1, 1)
 
@@ -188,7 +188,7 @@ class f2ar(Variable):
 #
 class f2as(Variable):
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits des années antérieures non encore déduits: année 2012"
     stop_date = date(2011, 12, 31)
 
@@ -197,7 +197,7 @@ class f2as(Variable):
 class f2dm(Variable):
     cerfa_field = u"2DM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Impatriés: revenus de capitaux mobiliers perçus à l'étranger, abattement de 50 %"
     start_date = date(2008, 1, 1)
 
@@ -207,7 +207,7 @@ class f2dm(Variable):
 class f2gr(Variable):
     cerfa_field = u"2GR"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus distribués dans le PEA (pour le calcul du crédit d'impôt de 50 %)"
     start_date = date(2005, 1, 1)
     stop_date = date(2009, 12, 31)
@@ -218,17 +218,17 @@ class f2gr(Variable):
 # Utilisés par mes aides. TODO: à consolider
 class epargne_non_remuneree(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     base_function = requested_period_last_value
     label = u"Épargne non rémunérée"
 
 class interets_epargne_sur_livrets(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     base_function = requested_period_last_value
     label = u"Intérêts versés pour l'épargne sur livret"
 
 class revenus_capital(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus du capital"

--- a/openfisca_france/model/revenus/capital/foncier.py
+++ b/openfisca_france/model/revenus/capital/foncier.py
@@ -7,7 +7,7 @@ from openfisca_france.model.base import *  # noqa
 class f1aw(Variable):
     cerfa_field = u"1AW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : Moins de 50 ans"
 
 
@@ -15,21 +15,21 @@ class f1aw(Variable):
 class f1bw(Variable):
     cerfa_field = u"1BW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : De 50 à 59 ans"
 
 
 class f1cw(Variable):
     cerfa_field = u"1CW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : De 60 à 69 ans"
 
 
 class f1dw(Variable):
     cerfa_field = u"1DW"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : A partir de 70 ans"
 
 
@@ -39,7 +39,7 @@ class f1dw(Variable):
 class f4ba(Variable):
     cerfa_field = u"4BA"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Revenus fonciers imposables"
 
 
@@ -47,7 +47,7 @@ class f4ba(Variable):
 class f4bb(Variable):
     cerfa_field = u"4BB"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficit imputable sur les revenus fonciers"
 
 
@@ -55,7 +55,7 @@ class f4bb(Variable):
 class f4bc(Variable):
     cerfa_field = u"4BC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficit imputable sur le revenu global"
 
 
@@ -63,7 +63,7 @@ class f4bc(Variable):
 class f4bd(Variable):
     cerfa_field = u"4BD"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Déficits antérieurs non encore imputés"
 
 
@@ -71,7 +71,7 @@ class f4bd(Variable):
 class f4be(Variable):
     cerfa_field = u"4BE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Micro foncier: recettes brutes sans abattement"
 
 
@@ -80,14 +80,14 @@ class f4be(Variable):
 class f4bf(Variable):
     cerfa_field = u"4BF"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Primes d'assurance pour loyers impayés des locations conventionnées"
 
 
 
 class f4bl(Variable):
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2009, 12, 31)
 
   # TODO: cf 2010 2011
@@ -95,17 +95,17 @@ class f4bl(Variable):
 # Variables utilisées par mes aides TODO: consolider
 class revenus_locatifs(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Revenus locatifs"
 
 class valeur_locative_immo_non_loue(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     base_function = requested_period_last_value
     label = u"Valeur locative des biens immobiliers possédés et non loués"
 
 class valeur_locative_terrains_non_loue(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     base_function = requested_period_last_value
     label = u"Valeur locative des terrains possédés et non loués"

--- a/openfisca_france/model/revenus/capital/foncier.py
+++ b/openfisca_france/model/revenus/capital/foncier.py
@@ -7,7 +7,7 @@ from openfisca_france.model.base import *  # noqa
 class f1aw(Variable):
     cerfa_field = u"1AW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : Moins de 50 ans"
 
 
@@ -15,21 +15,21 @@ class f1aw(Variable):
 class f1bw(Variable):
     cerfa_field = u"1BW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : De 50 à 59 ans"
 
 
 class f1cw(Variable):
     cerfa_field = u"1CW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : De 60 à 69 ans"
 
 
 class f1dw(Variable):
     cerfa_field = u"1DW"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : A partir de 70 ans"
 
 
@@ -39,7 +39,7 @@ class f1dw(Variable):
 class f4ba(Variable):
     cerfa_field = u"4BA"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Revenus fonciers imposables"
 
 
@@ -47,7 +47,7 @@ class f4ba(Variable):
 class f4bb(Variable):
     cerfa_field = u"4BB"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficit imputable sur les revenus fonciers"
 
 
@@ -55,7 +55,7 @@ class f4bb(Variable):
 class f4bc(Variable):
     cerfa_field = u"4BC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficit imputable sur le revenu global"
 
 
@@ -63,7 +63,7 @@ class f4bc(Variable):
 class f4bd(Variable):
     cerfa_field = u"4BD"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Déficits antérieurs non encore imputés"
 
 
@@ -71,7 +71,7 @@ class f4bd(Variable):
 class f4be(Variable):
     cerfa_field = u"4BE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Micro foncier: recettes brutes sans abattement"
 
 
@@ -80,14 +80,14 @@ class f4be(Variable):
 class f4bf(Variable):
     cerfa_field = u"4BF"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Primes d'assurance pour loyers impayés des locations conventionnées"
 
 
 
 class f4bl(Variable):
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2009, 12, 31)
 
   # TODO: cf 2010 2011
@@ -95,17 +95,17 @@ class f4bl(Variable):
 # Variables utilisées par mes aides TODO: consolider
 class revenus_locatifs(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Revenus locatifs"
 
 class valeur_locative_immo_non_loue(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     base_function = requested_period_last_value
     label = u"Valeur locative des biens immobiliers possédés et non loués"
 
 class valeur_locative_terrains_non_loue(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     base_function = requested_period_last_value
     label = u"Valeur locative des terrains possédés et non loués"

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -15,7 +15,7 @@ class f1tv(Variable):
         QUIFOY['conj']: u"1UV",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Gains de levée d'options sur titres en cas de cession ou de conversion au porteur dans le délai d'indisponibilité: entre 1 et 2 ans"
 
   # (f1tv,f1uv))
@@ -25,7 +25,7 @@ class f1tw(Variable):
         QUIFOY['conj']: u"1UW",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Gains de levée d'options sur titres en cas de cession ou de conversion au porteur dans le délai d'indisponibilité: entre 2 et 3 ans"
 
   # (f1tw,f1uw))
@@ -35,7 +35,7 @@ class f1tx(Variable):
         QUIFOY['conj']: u"1UX",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Gains de levée d'options sur titres en cas de cession ou de conversion au porteur dans le délai d'indisponibilité: entre 3 et 4 ans"
 
   # (f1tx,f1ux))
@@ -44,7 +44,7 @@ class f1tx(Variable):
 
 class f3si(Variable):
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     start_date = date(2012, 1, 1)
 
   # TODO: parmi ces cas créer des valeurs individuelles
@@ -52,21 +52,21 @@ class f3si(Variable):
 
 class f3sa(Variable):
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2009, 12, 31)
 
   # TODO: n'existe pas en 2013 et 2012 vérifier 2011 et 2010
 
 class f3sf(Variable):
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     start_date = date(2012, 1, 1)
 
   # TODO: déjà définit plus haut, vérifier si 2009, 2010, 2011 correspondent à la même chose que 12 et 13
 
 class f3sd(Variable):
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     start_date = date(2012, 1, 1)
 
   # TODO: déjà définit plus haut, vérifier si 2009, 2010, 2011 correspondent à la même chose que 12 et 13
@@ -74,7 +74,7 @@ class f3sd(Variable):
 class f3vc(Variable):
     cerfa_field = u"3VC"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Produits et plus-values exonérés provenant de structure de capital-risque"
     start_date = date(2006, 1, 1)
 
@@ -85,7 +85,7 @@ class f3vd(Variable):
         QUIFOY['conj']: u"3SD",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 18 %"
     start_date = date(2008, 1, 1)
 
@@ -94,7 +94,7 @@ class f3vd(Variable):
 class f3ve(Variable):
     cerfa_field = u"3VE"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Plus-values réalisées par les non-résidents pour lesquelles vous demandez le remboursement de l'excédent du prélèvement de 45 %"
 
 
@@ -114,7 +114,7 @@ class f3vf(Variable):
         QUIFOY['conj']: u"3SF",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 41 %"
 
   # (f3vf, f3sf)
@@ -135,7 +135,7 @@ class f3vf(Variable):
 class f3vl(Variable):
     cerfa_field = u"3VL"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Distributions par des sociétés de capital-risque taxables à 19 %"
 
   # vérifier pour 2011 et 2010
@@ -145,7 +145,7 @@ class f3vi(Variable):
         QUIFOY['conj']: u"3SI",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 30 %"
 
   # (f3vi, f3si )
@@ -153,7 +153,7 @@ class f3vi(Variable):
 class f3vm(Variable):
     cerfa_field = u"3VM"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Clôture du PEA avant l'expiration de la 2e année: gains taxables à 22.5 %"
 
 
@@ -161,7 +161,7 @@ class f3vm(Variable):
 class f3vt(Variable):
     cerfa_field = u"3VT"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Clôture du PEA  entre la 2e et la 5e année: gains taxables à 19 %"
     start_date = date(2012, 1, 1)
 
@@ -172,7 +172,7 @@ class f3vj(Variable):
         QUIFOY['conj']: u"3VK",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Gains imposables sur option dans la catégorie des salaires"
 
   # (f3vj, f3vk )
@@ -182,7 +182,7 @@ class f3va(Variable):
         QUIFOY['conj']: u"3VB",
         }
     column = IntCol(val_type = "monetary")
-    entity = Individus
+    entity = Individu
     label = u"Abattement pour durée de détention des titres en cas de départ à la retraite d'un dirigeant appliqué sur des plus-values"
     start_date = date(2006, 1, 1)
 
@@ -193,7 +193,7 @@ class f3va(Variable):
 class f3vg(Variable):
     cerfa_field = u"3VG"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Plus-value imposable sur gains de cession de valeurs mobilières, de droits sociaux et gains assimilés"
 
 
@@ -201,14 +201,14 @@ class f3vg(Variable):
 class f3vh(Variable):
     cerfa_field = u"3VH"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Perte de l'année de perception des revenus"
 
 
 
 class f3vu(Variable):
     column = IntCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     stop_date = date(2009, 12, 31)
 
   # TODO: vérifier pour 2010 et 2011
@@ -216,7 +216,7 @@ class f3vu(Variable):
 class f3vv(Variable):
     cerfa_field = u"3VV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Plus-values réalisées par les non-résidents: montant du prélèvement de 45 % déjà versé"
     start_date = date(2013, 1, 1)
 
@@ -225,7 +225,7 @@ class f3vv(Variable):
 class f3vv_end_2010(Variable):
     cerfa_field = u"3VV"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Pertes ouvrant droit au crédit d’impôt de 19 % "
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -235,7 +235,7 @@ class f3vv_end_2010(Variable):
 class f3vz(Variable):
     cerfa_field = u"3VZ"
     column = IntCol(val_type = "monetary")
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Plus-values imposables sur cessions d’immeubles ou de biens meubles"
     start_date = date(2011, 1, 1)
 

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -15,7 +15,7 @@ class f1tv(Variable):
         QUIFOY['conj']: u"1UV",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Gains de levée d'options sur titres en cas de cession ou de conversion au porteur dans le délai d'indisponibilité: entre 1 et 2 ans"
 
   # (f1tv,f1uv))
@@ -25,7 +25,7 @@ class f1tw(Variable):
         QUIFOY['conj']: u"1UW",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Gains de levée d'options sur titres en cas de cession ou de conversion au porteur dans le délai d'indisponibilité: entre 2 et 3 ans"
 
   # (f1tw,f1uw))
@@ -35,7 +35,7 @@ class f1tx(Variable):
         QUIFOY['conj']: u"1UX",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Gains de levée d'options sur titres en cas de cession ou de conversion au porteur dans le délai d'indisponibilité: entre 3 et 4 ans"
 
   # (f1tx,f1ux))
@@ -44,7 +44,7 @@ class f1tx(Variable):
 
 class f3si(Variable):
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     start_date = date(2012, 1, 1)
 
   # TODO: parmi ces cas créer des valeurs individuelles
@@ -52,21 +52,21 @@ class f3si(Variable):
 
 class f3sa(Variable):
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2009, 12, 31)
 
   # TODO: n'existe pas en 2013 et 2012 vérifier 2011 et 2010
 
 class f3sf(Variable):
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     start_date = date(2012, 1, 1)
 
   # TODO: déjà définit plus haut, vérifier si 2009, 2010, 2011 correspondent à la même chose que 12 et 13
 
 class f3sd(Variable):
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     start_date = date(2012, 1, 1)
 
   # TODO: déjà définit plus haut, vérifier si 2009, 2010, 2011 correspondent à la même chose que 12 et 13
@@ -74,7 +74,7 @@ class f3sd(Variable):
 class f3vc(Variable):
     cerfa_field = u"3VC"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Produits et plus-values exonérés provenant de structure de capital-risque"
     start_date = date(2006, 1, 1)
 
@@ -85,7 +85,7 @@ class f3vd(Variable):
         QUIFOY['conj']: u"3SD",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 18 %"
     start_date = date(2008, 1, 1)
 
@@ -94,7 +94,7 @@ class f3vd(Variable):
 class f3ve(Variable):
     cerfa_field = u"3VE"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Plus-values réalisées par les non-résidents pour lesquelles vous demandez le remboursement de l'excédent du prélèvement de 45 %"
 
 
@@ -114,7 +114,7 @@ class f3vf(Variable):
         QUIFOY['conj']: u"3SF",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 41 %"
 
   # (f3vf, f3sf)
@@ -135,7 +135,7 @@ class f3vf(Variable):
 class f3vl(Variable):
     cerfa_field = u"3VL"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Distributions par des sociétés de capital-risque taxables à 19 %"
 
   # vérifier pour 2011 et 2010
@@ -145,7 +145,7 @@ class f3vi(Variable):
         QUIFOY['conj']: u"3SI",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 30 %"
 
   # (f3vi, f3si )
@@ -153,7 +153,7 @@ class f3vi(Variable):
 class f3vm(Variable):
     cerfa_field = u"3VM"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Clôture du PEA avant l'expiration de la 2e année: gains taxables à 22.5 %"
 
 
@@ -161,7 +161,7 @@ class f3vm(Variable):
 class f3vt(Variable):
     cerfa_field = u"3VT"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Clôture du PEA  entre la 2e et la 5e année: gains taxables à 19 %"
     start_date = date(2012, 1, 1)
 
@@ -172,7 +172,7 @@ class f3vj(Variable):
         QUIFOY['conj']: u"3VK",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Gains imposables sur option dans la catégorie des salaires"
 
   # (f3vj, f3vk )
@@ -182,7 +182,7 @@ class f3va(Variable):
         QUIFOY['conj']: u"3VB",
         }
     column = IntCol(val_type = "monetary")
-    entity_class = Individus
+    entity = Individus
     label = u"Abattement pour durée de détention des titres en cas de départ à la retraite d'un dirigeant appliqué sur des plus-values"
     start_date = date(2006, 1, 1)
 
@@ -193,7 +193,7 @@ class f3va(Variable):
 class f3vg(Variable):
     cerfa_field = u"3VG"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Plus-value imposable sur gains de cession de valeurs mobilières, de droits sociaux et gains assimilés"
 
 
@@ -201,14 +201,14 @@ class f3vg(Variable):
 class f3vh(Variable):
     cerfa_field = u"3VH"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Perte de l'année de perception des revenus"
 
 
 
 class f3vu(Variable):
     column = IntCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     stop_date = date(2009, 12, 31)
 
   # TODO: vérifier pour 2010 et 2011
@@ -216,7 +216,7 @@ class f3vu(Variable):
 class f3vv(Variable):
     cerfa_field = u"3VV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Plus-values réalisées par les non-résidents: montant du prélèvement de 45 % déjà versé"
     start_date = date(2013, 1, 1)
 
@@ -225,7 +225,7 @@ class f3vv(Variable):
 class f3vv_end_2010(Variable):
     cerfa_field = u"3VV"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Pertes ouvrant droit au crédit d’impôt de 19 % "
     start_date = date(2010, 1, 1)
     stop_date = date(2010, 12, 31)
@@ -235,7 +235,7 @@ class f3vv_end_2010(Variable):
 class f3vz(Variable):
     cerfa_field = u"3VZ"
     column = IntCol(val_type = "monetary")
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Plus-values imposables sur cessions d’immeubles ou de biens meubles"
     start_date = date(2011, 1, 1)
 

--- a/openfisca_france/model/revenus/remplacement/chomage.py
+++ b/openfisca_france/model/revenus/remplacement/chomage.py
@@ -11,7 +11,7 @@ class chomeur_longue_duree(Variable):
         QUIFOY['pac3']: u"1EI",
         }
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Demandeur d'emploi inscrit depuis plus d'un an"
 
   # Pour toutes les variables de ce type, les pac3 ne sont plus proposés après 2007
@@ -19,13 +19,13 @@ class chomeur_longue_duree(Variable):
 
 class chomage_brut(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Chômage brut"
 
 
 class indemnites_chomage_partiel(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indemnités de chômage partiel"
 
 

--- a/openfisca_france/model/revenus/remplacement/chomage.py
+++ b/openfisca_france/model/revenus/remplacement/chomage.py
@@ -11,7 +11,7 @@ class chomeur_longue_duree(Variable):
         QUIFOY['pac3']: u"1EI",
         }
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Demandeur d'emploi inscrit depuis plus d'un an"
 
   # Pour toutes les variables de ce type, les pac3 ne sont plus proposés après 2007
@@ -19,13 +19,13 @@ class chomeur_longue_duree(Variable):
 
 class chomage_brut(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Chômage brut"
 
 
 class indemnites_chomage_partiel(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnités de chômage partiel"
 
 

--- a/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
+++ b/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
@@ -7,44 +7,44 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class indemnites_journalieres_maternite(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnités journalières de maternité"
 
 
 class indemnites_journalieres_paternite(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnités journalières de paternité"
 
 
 class indemnites_journalieres_adoption(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnités journalières d'adoption"
 
 
 class indemnites_journalieres_maladie(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnités journalières de maladie"
 
 
 class indemnites_journalieres_accident_travail(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnités journalières d'accident du travail"
 
 
 class indemnites_journalieres_maladie_professionnelle(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Indemnités journalières de maladie professionnelle"
 
 
 class indemnites_journalieres(Variable):
     column = FloatCol
     label = u"Total des indemnités journalières"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         ressources = [
@@ -63,7 +63,7 @@ class indemnites_journalieres(Variable):
 class indemnites_journalieres_imposables(Variable):
     column = FloatCol
     label = u"Total des indemnités journalières imposables"
-    entity_class = Individus
+    entity = Individus
     url = "http://vosdroits.service-public.fr/particuliers/F3152.xhtml"
 
     def function(self, simulation, period):
@@ -78,6 +78,6 @@ class indemnites_journalieres_imposables(Variable):
 
 class date_arret_de_travail(Variable):
     column = DateCol(default = datetime.date.min)
-    entity_class = Individus
+    entity = Individus
     is_permanent = True
     label = u"Date depuis laquelle la personne est en arrêt de travail"

--- a/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
+++ b/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
@@ -7,44 +7,44 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class indemnites_journalieres_maternite(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indemnités journalières de maternité"
 
 
 class indemnites_journalieres_paternite(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indemnités journalières de paternité"
 
 
 class indemnites_journalieres_adoption(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indemnités journalières d'adoption"
 
 
 class indemnites_journalieres_maladie(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indemnités journalières de maladie"
 
 
 class indemnites_journalieres_accident_travail(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indemnités journalières d'accident du travail"
 
 
 class indemnites_journalieres_maladie_professionnelle(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Indemnités journalières de maladie professionnelle"
 
 
 class indemnites_journalieres(Variable):
     column = FloatCol
     label = u"Total des indemnités journalières"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         ressources = [
@@ -63,7 +63,7 @@ class indemnites_journalieres(Variable):
 class indemnites_journalieres_imposables(Variable):
     column = FloatCol
     label = u"Total des indemnités journalières imposables"
-    entity = Individus
+    entity = Individu
     url = "http://vosdroits.service-public.fr/particuliers/F3152.xhtml"
 
     def function(self, simulation, period):
@@ -78,6 +78,6 @@ class indemnites_journalieres_imposables(Variable):
 
 class date_arret_de_travail(Variable):
     column = DateCol(default = datetime.date.min)
-    entity = Individus
+    entity = Individu
     is_permanent = True
     label = u"Date depuis laquelle la personne est en arrêt de travail"

--- a/openfisca_france/model/revenus/remplacement/retraite.py
+++ b/openfisca_france/model/revenus/remplacement/retraite.py
@@ -5,20 +5,20 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class retraite_brute(Variable):
     column = FloatCol()
-    entity_class = Individus
+    entity = Individus
     label = u"Retraite brute"
 
 # L'AER est remplacée depuis le 1er juillet 2011 par l'allocation transitoire de solidarité (ATS).
 class aer(Variable):
     column = IntCol
-    entity_class = Individus
+    entity = Individus
     label = u"Allocation équivalent retraite (AER)"
 
 
 
 class retraite_combattant(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Retraite du combattant"
 
 

--- a/openfisca_france/model/revenus/remplacement/retraite.py
+++ b/openfisca_france/model/revenus/remplacement/retraite.py
@@ -5,20 +5,20 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class retraite_brute(Variable):
     column = FloatCol()
-    entity = Individus
+    entity = Individu
     label = u"Retraite brute"
 
 # L'AER est remplacée depuis le 1er juillet 2011 par l'allocation transitoire de solidarité (ATS).
 class aer(Variable):
     column = IntCol
-    entity = Individus
+    entity = Individu
     label = u"Allocation équivalent retraite (AER)"
 
 
 
 class retraite_combattant(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Retraite du combattant"
 
 

--- a/openfisca_france/reforms/aides_cd93.py
+++ b/openfisca_france/reforms/aides_cd93.py
@@ -10,13 +10,13 @@ from ..model.base import *
 
 class perte_autonomie(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
     label = u"Personne en perte d'autonomie"
 
 class resident_93(Variable):
     column = BoolCol
     label = u"Résident en Seine-Saint-Denis"
-    entity_class = Menages
+    entity = Menages
 
     def function(self, simulation, period):
         period = period.this_month
@@ -36,7 +36,7 @@ class resident_93(Variable):
 class adpa_eligibilite(Variable):
     column = BoolCol
     label = u"Eligibilité à l'ADPA"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -51,7 +51,7 @@ class adpa_eligibilite(Variable):
 class adpa_base_ressources_i(Variable):
     column = FloatCol
     label = u"Base ressources ADPA pour un individu"
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         period = period.this_month
@@ -77,7 +77,7 @@ class adpa_base_ressources_i(Variable):
 class adpa_base_ressources(Variable):
     column = FloatCol
     label = u"Base ressources ADPA pour une famille"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month
@@ -89,7 +89,7 @@ class adpa_base_ressources(Variable):
 class adpa(Variable):
     column = FloatCol
     label = u"ADPA"
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         period = period.this_month

--- a/openfisca_france/reforms/aides_cd93.py
+++ b/openfisca_france/reforms/aides_cd93.py
@@ -10,13 +10,13 @@ from ..model.base import *
 
 class perte_autonomie(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
     label = u"Personne en perte d'autonomie"
 
 class resident_93(Variable):
     column = BoolCol
     label = u"Résident en Seine-Saint-Denis"
-    entity = Menages
+    entity = Menage
 
     def function(self, simulation, period):
         period = period.this_month
@@ -36,7 +36,7 @@ class resident_93(Variable):
 class adpa_eligibilite(Variable):
     column = BoolCol
     label = u"Eligibilité à l'ADPA"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -51,7 +51,7 @@ class adpa_eligibilite(Variable):
 class adpa_base_ressources_i(Variable):
     column = FloatCol
     label = u"Base ressources ADPA pour un individu"
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         period = period.this_month
@@ -77,7 +77,7 @@ class adpa_base_ressources_i(Variable):
 class adpa_base_ressources(Variable):
     column = FloatCol
     label = u"Base ressources ADPA pour une famille"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month
@@ -89,7 +89,7 @@ class adpa_base_ressources(Variable):
 class adpa(Variable):
     column = FloatCol
     label = u"ADPA"
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         period = period.this_month

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -79,7 +79,7 @@ class allocations_familiales_imposables(Reform):
 
     class allocations_familiales_imposables(Variable):
         column = columns.FloatCol
-        entity = FoyersFiscaux
+        entity = FoyerFiscal
         label = u"Allocations familiales imposables"
 
         def function(self, simulation, period):

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -6,8 +6,7 @@ from numpy import maximum as max_
 from openfisca_core import columns
 from openfisca_core.reforms import Reform
 from openfisca_core.variables import Variable
-from .. import entities
-from ..model.base import QUIFOY
+from ..model.base import *
 
 
 def modify_legislation_json(reference_legislation_json_copy):
@@ -80,16 +79,15 @@ class allocations_familiales_imposables(Reform):
 
     class allocations_familiales_imposables(Variable):
         column = columns.FloatCol
-        entity_class = entities.FoyersFiscaux
+        entity_class = FoyersFiscaux
         label = u"Allocations familiales imposables"
 
         def function(self, simulation, period):
             period = period.this_year
-            af_holder = simulation.calculate_add('af')
             imposition = simulation.legislation_at(period.start).allocations_familiales_imposables.imposition
+            af_famille_year = simulation.calculate_add('af', period)
+            af = simulation.foyer_fiscal.transpose(af_famille_year, origin_entity = Familles)
 
-            af = self.cast_from_entity_to_role(af_holder, entity= "famille", role = QUIFOY['vous'])
-            af = self.sum_by_entity(af)
             return period, af * imposition
 
     def apply(self):

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -85,8 +85,7 @@ class allocations_familiales_imposables(Reform):
         def function(self, simulation, period):
             period = period.this_year
             imposition = simulation.legislation_at(period.start).allocations_familiales_imposables.imposition
-            af_famille_year = simulation.calculate_add('af', period)
-            af = simulation.foyer_fiscal.transpose(af_famille_year, origin_entity = Familles)
+            af = simulation.foyer_fiscal.first_person.famille('af', period, options = [ADD])
 
             return period, af * imposition
 

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -79,7 +79,7 @@ class allocations_familiales_imposables(Reform):
 
     class allocations_familiales_imposables(Variable):
         column = columns.FloatCol
-        entity_class = FoyersFiscaux
+        entity = FoyersFiscaux
         label = u"Allocations familiales imposables"
 
         def function(self, simulation, period):

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -85,7 +85,7 @@ class allocations_familiales_imposables(Reform):
         def function(self, simulation, period):
             period = period.this_year
             imposition = simulation.legislation_at(period.start).allocations_familiales_imposables.imposition
-            af = simulation.foyer_fiscal.first_person.famille('af', period, options = [ADD])
+            af = simulation.foyer_fiscal.declarant_principal.famille('af', period, options = [ADD])
 
             return period, af * imposition
 

--- a/openfisca_france/reforms/cesthra_invalidee.py
+++ b/openfisca_france/reforms/cesthra_invalidee.py
@@ -37,7 +37,7 @@ def modify_legislation_json(reference_legislation_json_copy):
 
 class cesthra(Variable):
     column = columns.FloatCol
-    entity = entities.FoyersFiscaux
+    entity = entities.FoyerFiscal
     label = u"Contribution exceptionnelle de solidarité sur les très hauts revenus d'activité"
     # PLF 2013 (rejeté) : 'taxe à 75%'
 

--- a/openfisca_france/reforms/cesthra_invalidee.py
+++ b/openfisca_france/reforms/cesthra_invalidee.py
@@ -37,7 +37,7 @@ def modify_legislation_json(reference_legislation_json_copy):
 
 class cesthra(Variable):
     column = columns.FloatCol
-    entity_class = entities.FoyersFiscaux
+    entity = entities.FoyersFiscaux
     label = u"Contribution exceptionnelle de solidarité sur les très hauts revenus d'activité"
     # PLF 2013 (rejeté) : 'taxe à 75%'
 

--- a/openfisca_france/reforms/de_net_a_brut.py
+++ b/openfisca_france/reforms/de_net_a_brut.py
@@ -33,7 +33,7 @@ def calculate_net_from(salaire_de_base, simulation, period, requested_variable_n
 
 class salaire_de_base(Variable):
     column = columns.FloatCol
-    entity_class = entities.Individus
+    entity = entities.Individus
     label = u"Salaire brut ou traitement indiciaire brut"
     url = u"http://www.trader-finance.fr/lexique-finance/definition-lettre-S/Salaire-brut.html"
 

--- a/openfisca_france/reforms/de_net_a_brut.py
+++ b/openfisca_france/reforms/de_net_a_brut.py
@@ -33,7 +33,7 @@ def calculate_net_from(salaire_de_base, simulation, period, requested_variable_n
 
 class salaire_de_base(Variable):
     column = columns.FloatCol
-    entity = entities.Individus
+    entity = entities.Individu
     label = u"Salaire brut ou traitement indiciaire brut"
     url = u"http://www.trader-finance.fr/lexique-finance/definition-lettre-S/Salaire-brut.html"
 

--- a/openfisca_france/reforms/inversion_directe_salaires.py
+++ b/openfisca_france/reforms/inversion_directe_salaires.py
@@ -17,7 +17,7 @@ TAUX_DE_PRIME = .10
 
 class salaire_imposable_pour_inversion(Variable):
     column = columns.FloatCol
-    entity = entities.Individus
+    entity = entities.Individu
     label = u'Salaire imposable utilisé pour remonter au salaire brut'
 
 

--- a/openfisca_france/reforms/inversion_directe_salaires.py
+++ b/openfisca_france/reforms/inversion_directe_salaires.py
@@ -17,7 +17,7 @@ TAUX_DE_PRIME = .10
 
 class salaire_imposable_pour_inversion(Variable):
     column = columns.FloatCol
-    entity_class = entities.Individus
+    entity = entities.Individus
     label = u'Salaire imposable utilisé pour remonter au salaire brut'
 
 

--- a/openfisca_france/reforms/inversion_revenus.py
+++ b/openfisca_france/reforms/inversion_revenus.py
@@ -32,22 +32,22 @@ def build_reform(tax_benefit_system):
 
     class salaire_imposable_pour_inversion(Reform.Variable):
         column = columns.FloatCol
-        entity = entities.Individus
+        entity = entities.Individu
         label = u'Salaire imposable utilisé pour remonter au salaire brut'
 
     class chomage_imposable_pour_inversion(Reform.Variable):
         column = columns.FloatCol
-        entity = entities.Individus
+        entity = entities.Individu
         label = u'Autres revenus imposables (chômage, préretraite), utilisé pour l’inversion'
 
     class retraite_imposable_pour_inversion(Reform.Variable):
         column = columns.FloatCol
-        entity = entities.Individus
+        entity = entities.Individu
         label = u'Pensions, retraites, rentes connues imposables, utilisé pour l’inversion'
 
     class salaire_de_base(Reform.Variable):
         column = columns.FloatCol
-        entity = entities.Individus
+        entity = entities.Individu
         label = u"Salaire brut ou traitement indiciaire brut"
         reference = tax_benefit_system.column_by_name["salaire_de_base"]
         url = u"http://www.trader-finance.fr/lexique-finance/definition-lettre-S/Salaire-brut.html"
@@ -179,7 +179,7 @@ def build_reform(tax_benefit_system):
 
     class chomage_brut(Reform.Variable):
         column = columns.FloatCol
-        entity = entities.Individus
+        entity = entities.Individu
         label = u"Allocations chômage brutes"
         url = u"http://vosdroits.service-public.fr/particuliers/N549.xhtml"
 
@@ -229,7 +229,7 @@ def build_reform(tax_benefit_system):
 
     class retraite_brute(Reform.Variable):
         column = columns.FloatCol
-        entity = entities.Individus
+        entity = entities.Individu
         label = u"Pensions de retraite brutes"
         url = u"http://vosdroits.service-public.fr/particuliers/N20166.xhtml"
 

--- a/openfisca_france/reforms/inversion_revenus.py
+++ b/openfisca_france/reforms/inversion_revenus.py
@@ -32,22 +32,22 @@ def build_reform(tax_benefit_system):
 
     class salaire_imposable_pour_inversion(Reform.Variable):
         column = columns.FloatCol
-        entity_class = entities.Individus
+        entity = entities.Individus
         label = u'Salaire imposable utilisé pour remonter au salaire brut'
 
     class chomage_imposable_pour_inversion(Reform.Variable):
         column = columns.FloatCol
-        entity_class = entities.Individus
+        entity = entities.Individus
         label = u'Autres revenus imposables (chômage, préretraite), utilisé pour l’inversion'
 
     class retraite_imposable_pour_inversion(Reform.Variable):
         column = columns.FloatCol
-        entity_class = entities.Individus
+        entity = entities.Individus
         label = u'Pensions, retraites, rentes connues imposables, utilisé pour l’inversion'
 
     class salaire_de_base(Reform.Variable):
         column = columns.FloatCol
-        entity_class = entities.Individus
+        entity = entities.Individus
         label = u"Salaire brut ou traitement indiciaire brut"
         reference = tax_benefit_system.column_by_name["salaire_de_base"]
         url = u"http://www.trader-finance.fr/lexique-finance/definition-lettre-S/Salaire-brut.html"
@@ -179,7 +179,7 @@ def build_reform(tax_benefit_system):
 
     class chomage_brut(Reform.Variable):
         column = columns.FloatCol
-        entity_class = entities.Individus
+        entity = entities.Individus
         label = u"Allocations chômage brutes"
         url = u"http://vosdroits.service-public.fr/particuliers/N549.xhtml"
 
@@ -229,7 +229,7 @@ def build_reform(tax_benefit_system):
 
     class retraite_brute(Reform.Variable):
         column = columns.FloatCol
-        entity_class = entities.Individus
+        entity = entities.Individus
         label = u"Pensions de retraite brutes"
         url = u"http://vosdroits.service-public.fr/particuliers/N20166.xhtml"
 

--- a/openfisca_france/reforms/landais_piketty_saez.py
+++ b/openfisca_france/reforms/landais_piketty_saez.py
@@ -18,7 +18,7 @@ from openfisca_france.model.base import QUIFAM, QUIFOY
 
 class assiette_csg(Variable):
     column = columns.FloatCol
-    entity_class = entities.Individus
+    entity = entities.Individus
     label = u"Assiette de la CSG"
 
     def function(self, simulation, period):
@@ -34,7 +34,7 @@ class assiette_csg(Variable):
 
 class impot_revenu_lps(Variable):
     column = columns.FloatCol
-    entity_class = entities.Individus
+    entity = entities.Individus
     label = u"Impôt individuel sur l'ensemble de l'assiette de la csg, comme proposé par Landais, Piketty et Saez"
 
     def function(self, simulation, period):
@@ -57,7 +57,7 @@ class impot_revenu_lps(Variable):
 
 class revdisp(Variable):
     column = columns.FloatCol(default = 0)
-    entity_class = entities.Menages
+    entity = entities.Menages
     label = u"Revenu disponible du ménage"
     url = u"http://fr.wikipedia.org/wiki/Revenu_disponible"
 

--- a/openfisca_france/reforms/landais_piketty_saez.py
+++ b/openfisca_france/reforms/landais_piketty_saez.py
@@ -18,7 +18,7 @@ from openfisca_france.model.base import QUIFAM, QUIFOY
 
 class assiette_csg(Variable):
     column = columns.FloatCol
-    entity = entities.Individus
+    entity = entities.Individu
     label = u"Assiette de la CSG"
 
     def function(self, simulation, period):
@@ -34,7 +34,7 @@ class assiette_csg(Variable):
 
 class impot_revenu_lps(Variable):
     column = columns.FloatCol
-    entity = entities.Individus
+    entity = entities.Individu
     label = u"Impôt individuel sur l'ensemble de l'assiette de la csg, comme proposé par Landais, Piketty et Saez"
 
     def function(self, simulation, period):
@@ -57,7 +57,7 @@ class impot_revenu_lps(Variable):
 
 class revdisp(Variable):
     column = columns.FloatCol(default = 0)
-    entity = entities.Menages
+    entity = entities.Menage
     label = u"Revenu disponible du ménage"
     url = u"http://fr.wikipedia.org/wiki/Revenu_disponible"
 

--- a/openfisca_france/reforms/plf2016_ayrault_muet.py
+++ b/openfisca_france/reforms/plf2016_ayrault_muet.py
@@ -88,11 +88,11 @@ class reduction_csg_nette(DatedVariable):
     label = u"Réduction dégressive de CSG"
 
     @dated_function(start = date(2015, 1, 1))
-    def function_2015__(self, simulation, period):
-        period = period.start.offset('first-of', 'year').period('year')
-        reduction_csg = simulation.calculate('reduction_csg', period)
-        ppe_elig_bis_individu = simulation.calculate('ppe_elig_bis_individu', period)
-        return period, reduction_csg * ppe_elig_bis_individu
+    def function_2015__(individu, period):
+        period = period.this_year
+        reduction_csg = individu('reduction_csg', period)
+        ppe_elig_bis = individu.foyer_fiscal('ppe_elig_bis', period)
+        return period, reduction_csg * ppe_elig_bis
 
 class ppe_elig_bis(Variable):
     column = BoolCol(default = False)
@@ -117,13 +117,6 @@ class ppe_elig_bis(Variable):
             + maries_ou_pacses * (ppe.eligi2 + 2 * max_(nbptr - 2, 0) * ppe.eligi3)
         return period, (rfr * ppe_coef) <= (seuil * variator)
 
-class ppe_elig_bis_individu(Variable):
-    entity_class = Individus
-    column = BoolCol
-
-    def function(self, simulation, period):
-        ppe_elig_bis = simulation.calculate('ppe_elig_bis', period)
-        return period, simulation.foyer_fiscal.project(ppe_elig_bis)
 
 class regularisation_reduction_csg(DatedVariable):
     column = FloatCol
@@ -150,7 +143,6 @@ class ayrault_muet(Reform):
             reduction_csg_foyer_fiscal,
             reduction_csg_nette,
             ppe_elig_bis,
-            ppe_elig_bis_individu,
             variator
             ]:
             self.update_variable(variable)

--- a/openfisca_france/reforms/plf2016_ayrault_muet.py
+++ b/openfisca_france/reforms/plf2016_ayrault_muet.py
@@ -46,12 +46,12 @@ def ayrault_muet_modify_legislation_json(reference_legislation_json_copy):
 
 class variator(Variable):
     column = FloatCol(default = 1)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u'Multiplicateur du seuil de régularisation'
 
 class reduction_csg(DatedVariable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Réduction dégressive de CSG"
 
     @dated_function(start = date(2015, 1, 1))
@@ -74,7 +74,7 @@ class reduction_csg(DatedVariable):
         return period, taux_allegement_csg * assiette_csg_abattue
 
 class reduction_csg_foyer_fiscal(Variable):
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Réduction dégressive de CSG des memebres du foyer fiscal"
     column = FloatCol
 
@@ -84,7 +84,7 @@ class reduction_csg_foyer_fiscal(Variable):
 
 class reduction_csg_nette(DatedVariable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
     label = u"Réduction dégressive de CSG"
 
     @dated_function(start = date(2015, 1, 1))
@@ -96,7 +96,7 @@ class reduction_csg_nette(DatedVariable):
 
 class ppe_elig_bis(Variable):
     column = BoolCol(default = False)
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"ppe_elig_bis"
 
     def function(self, simulation, period):
@@ -120,7 +120,7 @@ class ppe_elig_bis(Variable):
 
 class regularisation_reduction_csg(DatedVariable):
     column = FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Régularisation complète réduction dégressive de CSG"
 
     @dated_function(start = date(2015, 1, 1))

--- a/openfisca_france/reforms/plf2016_ayrault_muet.py
+++ b/openfisca_france/reforms/plf2016_ayrault_muet.py
@@ -46,12 +46,12 @@ def ayrault_muet_modify_legislation_json(reference_legislation_json_copy):
 
 class variator(Variable):
     column = FloatCol(default = 1)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u'Multiplicateur du seuil de régularisation'
 
 class reduction_csg(DatedVariable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Réduction dégressive de CSG"
 
     @dated_function(start = date(2015, 1, 1))
@@ -74,7 +74,7 @@ class reduction_csg(DatedVariable):
         return period, taux_allegement_csg * assiette_csg_abattue
 
 class reduction_csg_foyer_fiscal(Variable):
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Réduction dégressive de CSG des memebres du foyer fiscal"
     column = FloatCol
 
@@ -84,7 +84,7 @@ class reduction_csg_foyer_fiscal(Variable):
 
 class reduction_csg_nette(DatedVariable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
     label = u"Réduction dégressive de CSG"
 
     @dated_function(start = date(2015, 1, 1))
@@ -96,7 +96,7 @@ class reduction_csg_nette(DatedVariable):
 
 class ppe_elig_bis(Variable):
     column = BoolCol(default = False)
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"ppe_elig_bis"
 
     def function(self, simulation, period):
@@ -120,7 +120,7 @@ class ppe_elig_bis(Variable):
 
 class regularisation_reduction_csg(DatedVariable):
     column = FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Régularisation complète réduction dégressive de CSG"
 
     @dated_function(start = date(2015, 1, 1))

--- a/openfisca_france/reforms/plf2016_ayrault_muet.py
+++ b/openfisca_france/reforms/plf2016_ayrault_muet.py
@@ -73,11 +73,14 @@ class reduction_csg(DatedVariable):
         # Montant de l'allegment
         return period, taux_allegement_csg * assiette_csg_abattue
 
-class reduction_csg_foyer_fiscal(PersonToEntityColumn):
+class reduction_csg_foyer_fiscal(Variable):
     entity_class = FoyersFiscaux
     label = u"Réduction dégressive de CSG des memebres du foyer fiscal"
-    operation = 'add'
-    variable = reduction_csg
+    column = FloatCol
+
+    def function(self, simulation, period):
+        reduction_csg = simulation.calculate('reduction_csg', period)
+        return period, simulation.foyer_fiscal.sum(reduction_csg)
 
 class reduction_csg_nette(DatedVariable):
     column = FloatCol
@@ -114,9 +117,13 @@ class ppe_elig_bis(Variable):
             + maries_ou_pacses * (ppe.eligi2 + 2 * max_(nbptr - 2, 0) * ppe.eligi3)
         return period, (rfr * ppe_coef) <= (seuil * variator)
 
-class ppe_elig_bis_individu(EntityToPersonColumn):
+class ppe_elig_bis_individu(Variable):
     entity_class = Individus
-    variable = ppe_elig_bis
+    column = BoolCol
+
+    def function(self, simulation, period):
+        ppe_elig_bis = simulation.calculate('ppe_elig_bis', period)
+        return period, simulation.foyer_fiscal.project(ppe_elig_bis)
 
 class regularisation_reduction_csg(DatedVariable):
     column = FloatCol

--- a/openfisca_france/reforms/trannoy_wasmer.py
+++ b/openfisca_france/reforms/trannoy_wasmer.py
@@ -7,9 +7,8 @@ from openfisca_core import columns
 from openfisca_core.reforms import Reform
 from openfisca_core.variables import Variable
 
-from .. import entities
-from ..model.base import PREF
 from ..model.prelevements_obligatoires.impot_revenu import charges_deductibles
+from ..model.base import *
 
 def modify_legislation_json(reference_legislation_json_copy):
     reform_legislation_subtree = {
@@ -53,15 +52,14 @@ class charges_deduc(Variable):
 
 class charge_loyer(Variable):
     column = columns.FloatCol
-    entity_class = entities.FoyersFiscaux
+    entity_class = FoyersFiscaux
     label = u"Charge déductible pour paiement d'un loyer"
 
     def function(self, simulation, period):
         period = period.this_year
-        loyer_holder = simulation.calculate('loyer', period)
         nbptr = simulation.calculate('nbptr', period)
-        loyer = self.cast_from_entity_to_role(loyer_holder, entity = "menage", role = PREF)
-        loyer = self.sum_by_entity(loyer)
+        loyer_famille = simulation.calculate('loyer', period)
+        loyer = simulation.foyer_fiscal.transpose(loyer_famille, origin_entity = Familles)
         charge_loyer = simulation.legislation_at(period.start).charge_loyer
 
         plaf = charge_loyer.plaf

--- a/openfisca_france/reforms/trannoy_wasmer.py
+++ b/openfisca_france/reforms/trannoy_wasmer.py
@@ -59,7 +59,7 @@ class charge_loyer(Variable):
         period = period.this_year
         nbptr = simulation.calculate('nbptr', period)
 
-        loyer = simulation.foyer_fiscal.first_person.menage('loyer', period)
+        loyer = simulation.foyer_fiscal.declarant_principal.menage('loyer', period)
 
         charge_loyer = simulation.legislation_at(period.start).charge_loyer
 

--- a/openfisca_france/reforms/trannoy_wasmer.py
+++ b/openfisca_france/reforms/trannoy_wasmer.py
@@ -52,7 +52,7 @@ class charges_deduc(Variable):
 
 class charge_loyer(Variable):
     column = columns.FloatCol
-    entity_class = FoyersFiscaux
+    entity = FoyersFiscaux
     label = u"Charge déductible pour paiement d'un loyer"
 
     def function(self, simulation, period):

--- a/openfisca_france/reforms/trannoy_wasmer.py
+++ b/openfisca_france/reforms/trannoy_wasmer.py
@@ -52,7 +52,7 @@ class charges_deduc(Variable):
 
 class charge_loyer(Variable):
     column = columns.FloatCol
-    entity = FoyersFiscaux
+    entity = FoyerFiscal
     label = u"Charge déductible pour paiement d'un loyer"
 
     def function(self, simulation, period):

--- a/openfisca_france/reforms/trannoy_wasmer.py
+++ b/openfisca_france/reforms/trannoy_wasmer.py
@@ -58,8 +58,9 @@ class charge_loyer(Variable):
     def function(self, simulation, period):
         period = period.this_year
         nbptr = simulation.calculate('nbptr', period)
-        loyer_famille = simulation.calculate('loyer', period)
-        loyer = simulation.foyer_fiscal.transpose(loyer_famille, origin_entity = Familles)
+
+        loyer = simulation.foyer_fiscal.first_person.menage('loyer', period)
+
         charge_loyer = simulation.legislation_at(period.start).charge_loyer
 
         plaf = charge_loyer.plaf

--- a/openfisca_france/scenarios.py
+++ b/openfisca_france/scenarios.py
@@ -8,7 +8,7 @@ import re
 import uuid
 
 from openfisca_core import conv, scenarios
-from entities import Individus, Familles, FoyersFiscaux, Menages
+from entities import Individu, Famille, FoyerFiscal, Menage
 
 
 def N_(message):
@@ -115,7 +115,7 @@ class Scenario(scenarios.AbstractScenario):
                                         (
                                             (column.name, column.json_to_python)
                                             for column in column_by_name.itervalues()
-                                            if column.entity == Familles
+                                            if column.entity == Famille
                                             ),
                                         )),
                                     drop_none_values = True,
@@ -162,7 +162,7 @@ class Scenario(scenarios.AbstractScenario):
                                         (
                                             (column.name, column.json_to_python)
                                             for column in column_by_name.itervalues()
-                                            if column.entity == FoyersFiscaux
+                                            if column.entity == FoyerFiscal
                                             ),
                                         )),
                                     drop_none_values = True,
@@ -191,7 +191,7 @@ class Scenario(scenarios.AbstractScenario):
                                         (
                                             (column.name, column.json_to_python)
                                             for column in column_by_name.itervalues()
-                                            if column.entity == Individus
+                                            if column.entity == Individu
                                             ),
                                         )),
                                     drop_none_values = True,
@@ -244,7 +244,7 @@ class Scenario(scenarios.AbstractScenario):
                                         (
                                             (column.name, column.json_to_python)
                                             for column in column_by_name.itervalues()
-                                            if column.entity == Menages
+                                            if column.entity == Menage
                                             ),
                                         )),
                                     drop_none_values = True,
@@ -776,7 +776,7 @@ class Scenario(scenarios.AbstractScenario):
                     famille_json['enfants'] = enfants
                 for column_name, variable_value in famille.iteritems():
                     column = column_by_name.get(column_name)
-                    if column is not None and column.entity == Familles:
+                    if column is not None and column.entity == Famille:
                         variable_value_json = column.transform_value_to_json(variable_value)
                         if variable_value_json is not None:
                             famille_json[column_name] = variable_value_json
@@ -796,7 +796,7 @@ class Scenario(scenarios.AbstractScenario):
                     foyer_fiscal_json['personnes_a_charge'] = personnes_a_charge
                 for column_name, variable_value in foyer_fiscal.iteritems():
                     column = column_by_name.get(column_name)
-                    if column is not None and column.entity == FoyersFiscaux:
+                    if column is not None and column.entity == FoyerFiscal:
                         variable_value_json = column.transform_value_to_json(variable_value)
                         if variable_value_json is not None:
                             foyer_fiscal_json[column_name] = variable_value_json
@@ -810,7 +810,7 @@ class Scenario(scenarios.AbstractScenario):
                 individu_json['id'] = individu['id']
                 for column_name, variable_value in individu.iteritems():
                     column = column_by_name.get(column_name)
-                    if column is not None and column.entity == Individus:
+                    if column is not None and column.entity == Individu:
                         variable_value_json = column.transform_value_to_json(variable_value)
                         if variable_value_json is not None:
                             individu_json[column_name] = variable_value_json
@@ -836,7 +836,7 @@ class Scenario(scenarios.AbstractScenario):
                     menage_json['autres'] = autres
                 for column_name, variable_value in menage.iteritems():
                     column = column_by_name.get(column_name)
-                    if column is not None and column.entity == Menages:
+                    if column is not None and column.entity == Menage:
                         variable_value_json = column.transform_value_to_json(variable_value)
                         if variable_value_json is not None:
                             menage_json[column_name] = variable_value_json

--- a/openfisca_france/scenarios.py
+++ b/openfisca_france/scenarios.py
@@ -8,6 +8,7 @@ import re
 import uuid
 
 from openfisca_core import conv, scenarios
+from entities import Individus, Familles, FoyersFiscaux, Menages
 
 
 def N_(message):
@@ -19,6 +20,7 @@ year_or_month_or_day_re = re.compile(ur'(18|19|20)\d{2}(-(0[1-9]|1[0-2])(-([0-2]
 
 
 class Scenario(scenarios.AbstractScenario):
+
     def init_single_entity(self, axes = None, enfants = None, famille = None, foyer_fiscal = None, menage = None,
             parent1 = None, parent2 = None, period = None):
         if enfants is None:
@@ -113,7 +115,7 @@ class Scenario(scenarios.AbstractScenario):
                                         (
                                             (column.name, column.json_to_python)
                                             for column in column_by_name.itervalues()
-                                            if column.entity == 'fam'
+                                            if column.entity == Familles
                                             ),
                                         )),
                                     drop_none_values = True,
@@ -160,7 +162,7 @@ class Scenario(scenarios.AbstractScenario):
                                         (
                                             (column.name, column.json_to_python)
                                             for column in column_by_name.itervalues()
-                                            if column.entity == 'foy'
+                                            if column.entity == FoyersFiscaux
                                             ),
                                         )),
                                     drop_none_values = True,
@@ -189,8 +191,7 @@ class Scenario(scenarios.AbstractScenario):
                                         (
                                             (column.name, column.json_to_python)
                                             for column in column_by_name.itervalues()
-                                            if column.entity == 'ind' and column.name not in (
-                                                'idfam', 'idfoy', 'idmen', 'quifam', 'quifoy', 'quimen')
+                                            if column.entity == Individus
                                             ),
                                         )),
                                     drop_none_values = True,
@@ -243,7 +244,7 @@ class Scenario(scenarios.AbstractScenario):
                                         (
                                             (column.name, column.json_to_python)
                                             for column in column_by_name.itervalues()
-                                            if column.entity == 'men'
+                                            if column.entity == Menages
                                             ),
                                         )),
                                     drop_none_values = True,
@@ -645,12 +646,7 @@ class Scenario(scenarios.AbstractScenario):
                                             #         default = 100) >= 18,
                                             #     error = u"Un déclarant d'un foyer fiscal doit être agé d'au moins 18"
                                             #         u" ans",
-                                            #     ),
-                                            conv.test(
-                                                lambda individu_id: individu_id in parents_id,
-                                                error = u"Un déclarant ou un conjoint sur la déclaration d'impôt, doit"
-                                                        u" être un parent dans sa famille",
-                                                ),
+                                            #     )
                                             )),
                                         ),
                                     personnes_a_charge = conv.uniform_sequence(
@@ -780,7 +776,7 @@ class Scenario(scenarios.AbstractScenario):
                     famille_json['enfants'] = enfants
                 for column_name, variable_value in famille.iteritems():
                     column = column_by_name.get(column_name)
-                    if column is not None and column.entity == 'fam':
+                    if column is not None and column.entity == Familles:
                         variable_value_json = column.transform_value_to_json(variable_value)
                         if variable_value_json is not None:
                             famille_json[column_name] = variable_value_json
@@ -800,7 +796,7 @@ class Scenario(scenarios.AbstractScenario):
                     foyer_fiscal_json['personnes_a_charge'] = personnes_a_charge
                 for column_name, variable_value in foyer_fiscal.iteritems():
                     column = column_by_name.get(column_name)
-                    if column is not None and column.entity == 'foy':
+                    if column is not None and column.entity == FoyersFiscaux:
                         variable_value_json = column.transform_value_to_json(variable_value)
                         if variable_value_json is not None:
                             foyer_fiscal_json[column_name] = variable_value_json
@@ -814,7 +810,7 @@ class Scenario(scenarios.AbstractScenario):
                 individu_json['id'] = individu['id']
                 for column_name, variable_value in individu.iteritems():
                     column = column_by_name.get(column_name)
-                    if column is not None and column.entity == 'ind':
+                    if column is not None and column.entity == Individus:
                         variable_value_json = column.transform_value_to_json(variable_value)
                         if variable_value_json is not None:
                             individu_json[column_name] = variable_value_json
@@ -840,7 +836,7 @@ class Scenario(scenarios.AbstractScenario):
                     menage_json['autres'] = autres
                 for column_name, variable_value in menage.iteritems():
                     column = column_by_name.get(column_name)
-                    if column is not None and column.entity == 'men':
+                    if column is not None and column.entity == Menages:
                         variable_value_json = column.transform_value_to_json(variable_value)
                         if variable_value_json is not None:
                             menage_json[column_name] = variable_value_json

--- a/openfisca_france/tests/formulas/aah.yaml
+++ b/openfisca_france/tests/formulas/aah.yaml
@@ -1,4 +1,4 @@
-- name: "AAH niveau Individus - Eligible, célibataire, sans enfants"
+- name: "AAH niveau Individu - Eligible, célibataire, sans enfants"
   description: Montant AAH au niveau de l individu
   period: 2014-11
   absolute_error_margin: 1
@@ -11,7 +11,7 @@
   output_variables:
     aah: 9100 / 12  # (9605,40 - 500)  / 12
 
-- name: "AAH niveau Individus - Eligible, en concubinage, sans enfants, ressources supérieures au plafond"
+- name: "AAH niveau Individu - Eligible, en concubinage, sans enfants, ressources supérieures au plafond"
   description: Montant AAH au niveau de l individu
   period: 2012-03
   absolute_error_margin: 1

--- a/openfisca_france/tests/formulas/aah_famille.yaml
+++ b/openfisca_france/tests/formulas/aah_famille.yaml
@@ -1,4 +1,4 @@
-- name: "AAH niveau Familles - célibataire, sans enfants, ressources supérieures au plafond"
+- name: "AAH niveau Famille - célibataire, sans enfants, ressources supérieures au plafond"
   description: Montant AAH au niveau de la famille
   period: 2015-01
   absolute_error_margin: 100
@@ -14,7 +14,7 @@
   output_variables:
     aah_base: 0
 
-- name: "AAH niveau Familles - célibataire, sans enfants, sans ressources"
+- name: "AAH niveau Famille - célibataire, sans enfants, sans ressources"
   description: Montant AAH au niveau de la famille
   period: 2015-01
   absolute_error_margin: 100
@@ -30,7 +30,7 @@
   output_variables:
     aah_base: 800.45  # l'aah taux plein
 
-- name: "AAH niveau Familles - concubinage, sans enfants, un éligible (chef), ressources inférieures au plafond"
+- name: "AAH niveau Famille - concubinage, sans enfants, un éligible (chef), ressources inférieures au plafond"
   description: Montant AAH au niveau de la famille
   period: 2013-03
   absolute_error_margin: 100
@@ -47,7 +47,7 @@
   output_variables:
     aah_base: [3638.16 / 12, 0]  # (18638,16 - 15000) / 12
 
-- name: "AAH niveau Familles - concubinage, sans enfants, deux éligibles, ressources inférieures au plafond"
+- name: "AAH niveau Famille - concubinage, sans enfants, deux éligibles, ressources inférieures au plafond"
   description: Montant AAH au niveau de la famille
   period: 2013-03
   absolute_error_margin: 100
@@ -64,7 +64,7 @@
   output_variables:
     aah_base: [3638.16 / 12, 3638.16 / 12]  # (18638,16 - 15000) / 12   # il faut que ce soit ça, ou le double ??
 
-- name: "AAH niveau Familles - concubinage, avec enfants, un seul éligible, ressources inférieures au plafond"
+- name: "AAH niveau Famille - concubinage, avec enfants, un seul éligible, ressources inférieures au plafond"
   description: Montant AAH au niveau de la famille
   period: 2013-10
   absolute_error_margin: 100
@@ -81,7 +81,7 @@
   output_variables:
     aah_base: [0, 3638.16 / 12] # (18964,32 + 4741,08 (= 23705,4) - 20000) / 12
 
-- name: "AAH niveau Familles - concubinage, avec enfant, enfant éligible, ressources inférieures au plafond"
+- name: "AAH niveau Famille - concubinage, avec enfant, enfant éligible, ressources inférieures au plafond"
   description: Montant AAH au niveau de la famille
   period: 2014-01
   absolute_error_margin: 100

--- a/openfisca_france/tests/formulas/aides_logement.yaml
+++ b/openfisca_france/tests/formulas/aides_logement.yaml
@@ -148,10 +148,12 @@
   relative_error_margin: 0.01
   familles:
     parents: ["parent1"]
-    zone_apl_famille: 1
-    loyer_famille: 800
     aide_logement_base_ressources: 12000
-    statut_occupation_logement_famille: 4  # Locataire
+  menages:
+    personne_de_reference: "parent1"
+    statut_occupation_logement: 4  # Locataire
+    zone_apl: 1
+    loyer: 800
   individus:
     - id: "parent1"
       age: 40

--- a/openfisca_france/tests/formulas/irpp.yaml
+++ b/openfisca_france/tests/formulas/irpp.yaml
@@ -992,16 +992,22 @@
   output_variables:
     irpp: -0
     decote_gain_fiscal: 0
+
 - period: "2014"
   absolute_error_margin: 0.5
   name: "IRPP Couple, salaire_net = [30000, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfoy: [0, 0]
-    quifoy: [VOUS, CONJ]
-    salaire_imposable:
-      2014: [30000, 0]
-    statut_marital: [5,5] #pacsés
+  foyers_fiscaux:
+    declarants: [1, 2]
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+      salaire_imposable: 30000
+      statut_marital: 5 #pacsés
+
+    - id: 2
+      date_naissance: "1985-01-01"
+      salaire_imposable: 0
+      statut_marital: 5 #pacsés
   output_variables:
     decote_gain_fiscal: 803
     irpp: -264

--- a/openfisca_france/tests/formulas/ppa.yaml
+++ b/openfisca_france/tests/formulas/ppa.yaml
@@ -305,7 +305,7 @@
 - name: "PPA/RSA forfait logement 1 personne"
   period: 2016-01
   input_variables:
-    statut_occupation_logement_famille: 2 # propriétaire
+    statut_occupation_logement: 2 # propriétaire
     age: 40
   output_variables:
     rsa_forfait_logement:
@@ -315,7 +315,10 @@
   period: 2016-01
   familles:
     parents: ["parent1", "parent2"]
-    statut_occupation_logement_famille: 2 # propriétaire
+  menages:
+    personne_de_reference: parent1
+    conjoint: parent2
+    statut_occupation_logement: 2 # propriétaire
   individus:
     - id: "parent1"
       age: 40
@@ -330,7 +333,11 @@
   familles:
     parents: ["parent1", "parent2"]
     enfants: ["enfant1"]
-    statut_occupation_logement_famille: 2 # propriétaire
+  menages:
+    personne_de_reference: parent1
+    conjoint: parent2
+    enfants: ["enfant1"]
+    statut_occupation_logement: 2 # propriétaire
   individus:
     - id: "parent1"
       age: 40
@@ -347,7 +354,7 @@
   relative_error_margin: 0.05
   input_variables:
     age: 40
-    statut_occupation_logement_famille: 2 # propriétaire
+    statut_occupation_logement: 2 # propriétaire
     salaire_net:
       2016-01: 918 # > 95 smic horaire brut
       2015-12: 918

--- a/openfisca_france/tests/formulas/rsa_couple.yaml
+++ b/openfisca_france/tests/formulas/rsa_couple.yaml
@@ -1,8 +1,9 @@
 - period: "2014"
   name: "RSA couple, salaire_net = [0, 0]"
-  familles:
-    parents: [1, 2]
-    statut_occupation_logement_famille:
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
+    statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
   individus:
     - id: 1

--- a/openfisca_france/tests/formulas/rsa_couple.yaml
+++ b/openfisca_france/tests/formulas/rsa_couple.yaml
@@ -1,15 +1,14 @@
 - period: "2014"
   name: "RSA couple, salaire_net = [0, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    statut_occupation_logement:
+  familles:
+    parents: [1, 2]
+    statut_occupation_logement_famille:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+    - id: 2
+      date_naissance: "1985-01-01"
   output_variables:
     aide_logement:
       "2014-01": 0
@@ -32,292 +31,315 @@
 
 - period: "2014"
   name: "RSA couple, salaire_net = [5000, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    salaire_net:
-      2012: [5000, 0]
-      2013: [5000, 0]
-      2014: [5000, 0]
+  familles:
+    parents: [1, 2]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+      salaire_net:
+        2012: 5000
+        2013: 5000
+        2014: 5000
+    - id: 2
+      date_naissance: "1985-01-01"
   output_variables:
+    rsa_forfait_logement:
+      "2014-06": 119.83
+    rsa_base_ressources:
+      "2014-06": 5000 / 12
     rsa:
-      "2014-01": 470.80
+      # "2014-01": 470.80
+      "2014-06": 470.80
 
 - period: "2014"
   name: "RSA couple, salaire_net = [10000, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    salaire_net:
-      2012: [10000, 0]
-      2013: [10000, 0]
-      2014: [10000, 0]
+  familles:
+    parents: [1, 2]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+      salaire_net:
+        2012: 10000
+        2013: 10000
+        2014: 10000
+    - id: 2
+      date_naissance: "1985-01-01"
   output_variables:
     rsa:
       "2014-01": 312.46
 
 - period: "2014"
   name: "RSA couple, salaire_net = [12000, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    salaire_net:
-      2012: [12000, 0]
-      2013: [12000, 0]
-      2014: [12000, 0]
+  familles:
+    parents: [1, 2]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+      salaire_net:
+        2012: 12000
+        2013: 12000
+        2014: 12000
+    - id: 2
+      date_naissance: "1985-01-01"
   output_variables:
     rsa:
       "2014-01": 249.13
 
 - period: "2014"
   name: "RSA couple, salaire_net = [13000, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    salaire_net:
-      2012: [13000, 0]
-      2013: [13000, 0]
-      2014: [13000, 0]
+  familles:
+    parents: [1, 2]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+      salaire_net:
+        2012: 13000
+        2013: 13000
+        2014: 13000
+    - id: 2
+      date_naissance: "1985-01-01"
   output_variables:
     rsa:
       "2014-01": 217.46
 
 - period: "2014"
   name: "RSA couple, salaire_net = [14000, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    salaire_net:
-      2012: [14000, 0]
-      2013: [14000, 0]
-      2014: [14000, 0]
+  familles:
+    parents: [1, 2]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+      salaire_net:
+        2012: 14000
+        2013: 14000
+        2014: 14000
+    - id: 2
+      date_naissance: "1985-01-01"
   output_variables:
     rsa:
       "2014-01": 185.80
 
 - period: "2014"
   name: "RSA couple, salaire_net = [15000, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    salaire_net:
-      2012: [15000, 0]
-      2013: [15000, 0]
-      2014: [15000, 0]
+  familles:
+    parents: [1, 2]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+      salaire_net:
+        2012: 15000
+        2013: 15000
+        2014: 15000
+    - id: 2
+      date_naissance: "1985-01-01"
   output_variables:
     rsa:
       "2014-01": 154.13
 
 - period: "2014"
   name: "RSA couple, salaire_net = [16000, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    salaire_net:
-      2012: [16000, 0]
-      2013: [16000, 0]
-      2014: [16000, 0]
+  familles:
+    parents: [1, 2]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+      salaire_net:
+        2012: 16000
+        2013: 16000
+        2014: 16000
+    - id: 2
+      date_naissance: "1985-01-01"
   output_variables:
     rsa:
       "2014-01": 122.46
 
 - period: "2014"
   name: "RSA couple, salaire_net = [17000, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    salaire_net:
-      2012: [17000, 0]
-      2013: [17000, 0]
-      2014: [17000, 0]
+  familles:
+    parents: [1, 2]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+      salaire_net:
+        2012: 17000
+        2013: 17000
+        2014: 17000
+    - id: 2
+      date_naissance: "1985-01-01"
   output_variables:
     rsa:
       "2014-01": 90.80
 
 - period: "2014"
   name: "RSA couple, salaire_net = [18000, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    salaire_net:
-      2012: [18000, 0]
-      2013: [18000, 0]
-      2014: [18000, 0]
+  familles:
+    parents: [1, 2]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+      salaire_net:
+        2012: 18000
+        2013: 18000
+        2014: 18000
+    - id: 2
+      date_naissance: "1985-01-01"
   output_variables:
     rsa:
       "2014-01": 59.13
 
 - period: "2014"
   name: "RSA couple, salaire_net = [19000, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    salaire_net:
-      2012: [19000, 0]
-      2013: [19000, 0]
-      2014: [19000, 0]
+  familles:
+    parents: [1, 2]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+      salaire_net:
+        2012: 19000
+        2013: 19000
+        2014: 19000
+    - id: 2
+      date_naissance: "1985-01-01"
   output_variables:
     rsa:
       "2014-01": 27.46
 
 - period: "2014"
   name: "RSA couple, salaire_net = [20000, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    salaire_net:
-      2012: [20000, 0]
-      2013: [20000, 0]
-      2014: [20000, 0]
+  familles:
+    parents: [1, 2]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+      salaire_net:
+        2012: 20000
+        2013: 20000
+        2014: 20000
+    - id: 2
+      date_naissance: "1985-01-01"
   output_variables:
     rsa:
       "2014-01": 0
 
-# - period: "2014"
-#   name: "RSA couple, salaire_net = [9000, 11000]"
-#   input_variables:
-#     date_naissance: ["1985-01-01", "1985-01-01"]  # 29 ans
-#     idfam: [0, 0]
-#     idfoy: [0, 0]
-#     idmen: [0, 0]
-#     quifam: [CHEF, PART]
-#     quifoy: [VOUS, CONJ]
-#     quimen: [PREF, CREF]
-#     salaire_net:
-#       2012: [9000, 11000]
-#       2013: [9000, 11000]
-#       2014: [9000, 11000]
-#     statut_occupation_logement:
-#       "2014-01": 2  # Propriétaire (non accédant) du logement
-#   output_variables:
-#     rsa:
-#       "2014-01": 0
-
 - period: "2014"
   name: "RSA couple, age = [< 25, < 25], salaire_net = [400 * 12, 3000 * 12]"
-  input_variables:
-    date_naissance: ["1993-01-01", "1993-01-01"]  # 21 ans
-    idfam: [0, 0]
-    idfoy: [0, 0]
-    idmen: [0, 0]
-    quifam: [CHEF, PART]
-    quifoy: [VOUS, CONJ]
-    quimen: [PREF, CREF]
-    salaire_net:
-      2012: [400 * 12, 3000 * 12]
-      2013: [400 * 12, 3000 * 12]
-      2014: [400 * 12, 3000 * 12]
+  familles:
+    parents: [1, 2]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1993-01-01"
+      salaire_net:
+        2012: 400 * 12
+        2013: 400 * 12
+        2014: 400 * 12
+    - id: 2
+      date_naissance: "1993-01-01"
+      salaire_net:
+        2012: 3000 * 12
+        2013: 3000 * 12
+        2014: 3000 * 12
   output_variables:
     rsa:
       "2014-01": 0
 
 - period: "2014"
   name: "RSA couple avec enfant < 3 ans, salaire_net = [0, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01", "2012-01-01"]  # [29, 29, 2] ans
-    idfam: [0, 0, 0]
-    idfoy: [0, 0, 0]
-    idmen: [0, 0, 0]
-    quifam: [CHEF, PART, ENF1]
-    quifoy: [VOUS, CONJ, PAC1]
-    quimen: [PREF, CREF, ENF1]
+  familles:
+    parents: [1, 2]
+    enfants: [3]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+    - id: 2
+      date_naissance: "1985-01-01"
+    - id: 3
+      date_naissance: "2012-01-01"
   output_variables:
     rsa:
       "2014-01": 564.92
 
 - period: "2014"
   name: "RSA couple avec enfant entre 3 et 13 ans, salaire_net = [0, 0]"
-  input_variables:
-    date_naissance: ["1985-01-01", "1985-01-01", "2004-01-01"]  # [29, 29, 10] ans
-    idfam: [0, 0, 0]
-    idfoy: [0, 0, 0]
-    idmen: [0, 0, 0]
-    quifam: [CHEF, PART, ENF1]
-    quifoy: [VOUS, CONJ, PAC1]
-    quimen: [PREF, CREF, ENF1]
+  familles:
+    parents: [1, 2]
+    enfants: [3]
+  menages:
+    personne_de_reference: 1
+    conjoint: 2
     statut_occupation_logement:
       "2014-01": 2  # Propriétaire (non accédant) du logement
+  individus:
+    - id: 1
+      date_naissance: "1985-01-01"
+    - id: 2
+      date_naissance: "1985-01-01"
+    - id: 3
+      date_naissance: "2004-01-01"
   output_variables:
     rsa:
       "2014-01": 750.46

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54d8df76b93972db44593f80.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54d8df76b93972db44593f80.yaml
@@ -30,7 +30,6 @@ individus:
   date_naissance: "1980-09-12"
   chomage_imposable:
     2013: 0
-  coloc: 1
   epargne_non_remuneree:
     2012-01: 0
   etudiant: 0
@@ -298,6 +297,7 @@ foyers_fiscaux:
   personnes_a_charge:
   rfr:
 menages:
+  coloc: 1
   depcom: 67382
   enfants:
   loyer: 500

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54d8e0821fe4e8cf448e2bf3.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54d8e0821fe4e8cf448e2bf3.yaml
@@ -30,7 +30,6 @@ individus:
     date_naissance: "1980-08-12"
     chomage_imposable:
       2013: 0
-    coloc: 1
     epargne_non_remuneree:
       2012-01: 0
     etudiant: 0
@@ -326,6 +325,7 @@ foyers_fiscaux:
   personnes_a_charge:
   rfr:
 menages:
+  coloc: 1
   conjoint: 54d8e0041fe4e8cf448e2bf1
   depcom: 75111
   enfants:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54ef4cdefa384b5575517bc2.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54ef4cdefa384b5575517bc2.yaml
@@ -41,7 +41,6 @@ individus:
   interets_epargne_sur_livrets:
     2012-01: 0
   handicap: 0
-  logement_chambre: 1
   pensions_alimentaires_percues:
     2013: 0
   retraite_imposable:
@@ -301,6 +300,7 @@ foyers_fiscaux:
   personnes_a_charge:
   rfr:
 menages:
+  logement_chambre: 1
   depcom: 75111
   enfants:
   loyer: 1000

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54ef4e8999fc215675536d0f.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_54ef4e8999fc215675536d0f.yaml
@@ -41,7 +41,6 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    logement_chambre: 1
     pensions_alimentaires_percues:
       2013: 0
     retraite_imposable:
@@ -372,6 +371,7 @@ menages:
     - 54ef4df1d36576597541953f
     - 54ef4df1d36576597541953e
   loyer: 1000
+  logement_chambre: 1
   personne_de_reference: 54ef4df1d365765975419541
   statut_occupation_logement: 4
 output_variables:

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55311c5802fb377a16fbd5b5.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_55311c5802fb377a16fbd5b5.yaml
@@ -19,7 +19,6 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    logement_chambre: 1
     pensions_alimentaires_percues:
       2013: 0
     retraite_imposable:
@@ -339,6 +338,7 @@ foyers_fiscaux:
   personnes_a_charge: 55311bf2d4217171166024dc
   rfr:
 menages:
+  logement_chambre: 1
   depcom: 97419
   enfants: 55311bf2d4217171166024dc
   loyer: 500

--- a/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_553125ecda3de56a7b3c8ce2.yaml
+++ b/openfisca_france/tests/mes-aides.gouv.fr/test_mes_aides_553125ecda3de56a7b3c8ce2.yaml
@@ -19,7 +19,6 @@ individus:
     interets_epargne_sur_livrets:
       2012-01: 0
     handicap: 0
-    logement_chambre: 1
     pensions_alimentaires_percues:
       2013: 0
     retraite_imposable:
@@ -417,6 +416,7 @@ menages:
     - 553125bada3de56a7b3c8cd1
     - 553125bada3de56a7b3c8cd0
   loyer: 500
+  logement_chambre: 1
   personne_de_reference: 553125bada3de56a7b3c8cd5
   statut_occupation_logement: 4
 output_variables:

--- a/openfisca_france/tests/test_entities.py
+++ b/openfisca_france/tests/test_entities.py
@@ -77,8 +77,7 @@ def test_transpose():
     simulation = new_simulation(test_case)
     foyer_fiscal = simulation.foyer_fiscal
 
-    af = foyer_fiscal.members.famille('af')
-    af_foyer_fiscal = foyer_fiscal.transpose(af, origin_entity = Menages)
+    af_foyer_fiscal = foyer_fiscal.first_person.famille('af')
 
     assert_near(af_foyer_fiscal, [20000, 10000, 0])
 

--- a/openfisca_france/tests/test_entities.py
+++ b/openfisca_france/tests/test_entities.py
@@ -8,29 +8,29 @@ from openfisca_core.columns import FloatCol, IntCol, BoolCol
 from openfisca_core.tools import assert_near
 
 from openfisca_france.scenarios import Scenario
-from openfisca_france.entities import entities, Individus, Familles, FoyersFiscaux, Menages
+from openfisca_france.entities import entities, Individu, Famille, FoyerFiscal, Menage
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 
 class af(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
 
 class salaire(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
 
 class age(Variable):
     column = IntCol
-    entity = Individus
+    entity = Individu
 
 class autonomie_financiere(Variable):
     column = BoolCol
-    entity = Individus
+    entity = Individu
 
 class depcom(Variable):
     column = FixedStrCol(max_length = 5)
-    entity = Menages
+    entity = Menage
     is_permanent = True
     label = u"""Code INSEE "depcom" de la commune de résidence de la famille"""
 

--- a/openfisca_france/tests/test_entities.py
+++ b/openfisca_france/tests/test_entities.py
@@ -108,7 +108,6 @@ def test_value_from_person():
     foyer_fiscal = simulation.foyer_fiscal
     age = foyer_fiscal.members('age')
 
-    age_conjoint = foyer_fiscal.value_from_person(age, role = foyer_fiscal.conjoint, default = -1)
-
-    assert_near(age_conjoint, [37, -1])
+    age_conjoint = foyer_fiscal.conjoint('age')
+    assert_near(age_conjoint, [37, 0])
 

--- a/openfisca_france/tests/test_entities.py
+++ b/openfisca_france/tests/test_entities.py
@@ -89,6 +89,6 @@ def test_value_from_person():
     foyer_fiscal = simulation.foyer_fiscal
     age = foyer_fiscal.members('age')
 
-    age_conjoint = foyer_fiscal.value_from_person(age, role = CONJOINT, default = -1)
+    age_conjoint = foyer_fiscal.value_from_person(age, role = foyer_fiscal.conjoint, default = -1)
 
     assert_near(age_conjoint, [37, -1])

--- a/openfisca_france/tests/test_entities.py
+++ b/openfisca_france/tests/test_entities.py
@@ -77,7 +77,7 @@ def test_transpose():
     simulation = new_simulation(test_case)
     foyer_fiscal = simulation.foyer_fiscal
 
-    af = foyer_fiscal.members.famille.calculate('af')
+    af = foyer_fiscal.members.famille('af')
     af_foyer_fiscal = foyer_fiscal.transpose(af, origin_entity = Menages)
 
     assert_near(af_foyer_fiscal, [20000, 10000, 0])
@@ -88,7 +88,7 @@ def test_value_from_person():
     simulation = new_simulation(test_case)
 
     foyer_fiscal = simulation.foyer_fiscal
-    age = foyer_fiscal.members.calculate('age')
+    age = foyer_fiscal.members('age')
 
     age_conjoint = foyer_fiscal.value_from_person(age, role = CONJOINT, default = -1)
 

--- a/openfisca_france/tests/test_entities.py
+++ b/openfisca_france/tests/test_entities.py
@@ -14,23 +14,23 @@ from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class af(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
 
 class salaire(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
 
 class age(Variable):
     column = IntCol
-    entity_class = Individus
+    entity = Individus
 
 class autonomie_financiere(Variable):
     column = BoolCol
-    entity_class = Individus
+    entity = Individus
 
 class depcom(Variable):
     column = FixedStrCol(max_length = 5)
-    entity_class = Menages
+    entity = Menages
     is_permanent = True
     label = u"""Code INSEE "depcom" de la commune de résidence de la famille"""
 

--- a/openfisca_france/tests/test_entities.py
+++ b/openfisca_france/tests/test_entities.py
@@ -1,0 +1,95 @@
+from copy import deepcopy
+
+from openfisca_core.taxbenefitsystems import TaxBenefitSystem
+from openfisca_core.variables import Variable
+from openfisca_core.columns import FloatCol, IntCol, BoolCol
+from openfisca_core.tools import assert_near
+
+from openfisca_france.scenarios import Scenario
+from openfisca_france.entities import entities, Individus, Familles, FoyersFiscaux, Menages
+from openfisca_france.model.base import *  # noqa analysis:ignore
+
+
+class af(Variable):
+    column = FloatCol
+    entity_class = Familles
+
+class salaire(Variable):
+    column = FloatCol
+    entity_class = Individus
+
+class age(Variable):
+    column = IntCol
+    entity_class = Individus
+
+class autonomie_financiere(Variable):
+    column = BoolCol
+    entity_class = Individus
+
+# This tests are more about core than france, but we need france entities to run some of them.
+# We use a dummy TBS to run the tests faster
+class DummyTaxBenefitSystem(TaxBenefitSystem):
+    def __init__(self):
+        TaxBenefitSystem.__init__(self, entities)
+        self.Scenario = Scenario
+        self.add_variables(af, salaire, age, autonomie_financiere)
+
+tax_benefit_system = DummyTaxBenefitSystem()
+
+TEST_CASE = {
+    'individus': [{'id': 'ind0'}, {'id': 'ind1'}, {'id': 'ind2'}, {'id': 'ind3'},{'id': 'ind4'}, {'id': 'ind5'}],
+    'familles': [
+        {'enfants': ['ind2', 'ind3'], 'parents': ['ind0', 'ind1']},
+        {'enfants': ['ind5'], 'parents': ['ind4']}
+        ],
+    'foyers_fiscaux': [
+        {'declarants': ['ind0', 'ind1'], 'personnes_a_charge': ['ind2', 'ind3']},
+        {'personnes_a_charge': ['ind5'], 'declarants': ['ind4']}
+        ],
+    'menages': [
+        {'conjoint': 'ind1', 'enfants': ['ind2', 'ind3'], 'personne_de_reference': 'ind0'},
+        {'conjoint': None, 'enfants': ['ind5'], 'personne_de_reference': 'ind4'},
+        ],
+    }
+
+TEST_CASE_AGES = deepcopy(TEST_CASE)
+AGES = [40, 37, 7, 9, 54, 20]
+for (individu, age) in zip(TEST_CASE_AGES['individus'], AGES):
+        individu['age'] = age
+
+def new_simulation(test_case):
+    return tax_benefit_system.new_scenario().init_from_test_case(
+        period = 2013,
+        test_case = test_case
+    ).new_simulation()
+
+
+def test_transpose():
+    test_case = deepcopy(TEST_CASE)
+    test_case['familles'][0]['af'] = 20000
+    test_case['familles'][1]['af'] = 10000
+    test_case['foyers_fiscaux'] = [
+        TEST_CASE['foyers_fiscaux'][0],
+        {'declarants': ['ind4']},
+        {'declarants': ['ind5']}
+        ]
+
+    simulation = new_simulation(test_case)
+    foyer_fiscal = simulation.foyer_fiscal
+
+    af = foyer_fiscal.members.famille.calculate('af')
+    af_foyer_fiscal = foyer_fiscal.transpose(af, origin_entity = Menages)
+
+    assert_near(af_foyer_fiscal, [20000, 10000, 0])
+
+
+def test_value_from_person():
+    test_case = deepcopy(TEST_CASE_AGES)
+    simulation = new_simulation(test_case)
+
+    foyer_fiscal = simulation.foyer_fiscal
+    age = foyer_fiscal.members.calculate('age')
+
+    age_conjoint = foyer_fiscal.value_from_person(age, role = CONJOINT, default = -1)
+
+    assert_near(age_conjoint, [37, -1])

--- a/openfisca_france/tests/test_entities.py
+++ b/openfisca_france/tests/test_entities.py
@@ -111,3 +111,41 @@ def test_value_from_person():
     age_conjoint = foyer_fiscal.conjoint('age')
     assert_near(age_conjoint, [37, 0])
 
+def test_combination_projections():
+    test_case = deepcopy(TEST_CASE_AGES)
+    simulation = new_simulation(test_case)
+
+    individu = simulation.persons
+
+    age_parent1 = individu.famille.demandeur('age')
+
+    assert_near(age_parent1, [40, 40, 40, 40, 54, 54])
+
+def test_complex_chain_2():
+    test_case = {
+        'individus': [
+            {'id': 'ind0', 'age': 30}, {'id': 'ind1', 'age': 31}, {'id': 'ind2', 'age': 32}, {'id': 'ind3', 'age': 33}
+            ],
+        'familles': [
+            {'parents': ['ind0', 'ind1']},
+            {'parents': ['ind2']},
+            {'parents': ['ind3']},
+            ],
+        'foyers_fiscaux': [
+            {'declarants': ['ind0', 'ind1']},
+            {'declarants': ['ind2', 'ind3']},
+            ],
+        'menages': [
+            {'personne_de_reference': 'ind0'},
+            {'personne_de_reference': 'ind1', 'autres': 'ind2'},
+            {'personne_de_reference': 'ind3'},
+            ],
+        }
+
+
+    simulation = new_simulation(test_case)
+
+    assert_near(simulation.famille.demandeur.menage.personne_de_reference('age'), [30, 31, 33])
+    assert_near(simulation.famille.conjoint.menage.personne_de_reference('age'), [31, 0, 0])
+    assert_near(simulation.famille.demandeur.foyer_fiscal.declarant_principal('age'), [30, 32, 32])
+    assert_near(simulation.foyer_fiscal.conjoint.famille.demandeur('age'), [30, 33])

--- a/openfisca_france/tests/test_legacy_entities.py
+++ b/openfisca_france/tests/test_legacy_entities.py
@@ -1,0 +1,120 @@
+from copy import deepcopy
+
+from openfisca_core.tools import assert_near
+
+from openfisca_france.model.base import *  # noqa analysis:ignore
+from openfisca_france.tests.test_entities import TEST_CASE, tax_benefit_system
+
+class salaire_famille(Variable):
+    column = FloatCol
+    entity_class = Familles
+
+    def function(self, simulation, period):
+        salaire_holder = simulation.compute('salaire')
+        return period, self.sum_by_entity(salaire_holder)
+
+class salaire_enfants(Variable):
+    column = FloatCol
+    entity_class = Familles
+
+    def function(self, simulation, period):
+        salaire_holder = simulation.compute('salaire')
+        return period, self.sum_by_entity(salaire_holder, roles = ENFS)
+
+class salaire_enf1(Variable):
+    column = FloatCol
+    entity_class = Familles
+
+    def function(self, simulation, period):
+        salaire_holder = simulation.compute('salaire')
+        salaire = self.split_by_roles(salaire_holder)
+        assert_near(salaire[CHEF], [1000, 3000])
+        return period, salaire[ENFS[0]]
+
+class salaire_conj(Variable):
+    column = FloatCol
+    entity_class = Familles
+
+    def function(self, simulation, period):
+        salaire_holder = simulation.compute('salaire')
+        salaire = self.filter_role(salaire_holder, role = CONJ)
+        return period, salaire
+
+class af_chef(Variable):
+    column = FloatCol
+    entity_class = Individus
+
+    def function(self, simulation, period):
+        af_holder = simulation.compute('af')
+        return period, self.cast_from_entity_to_roles(af_holder, roles = [CHEF])
+
+class af_tous(Variable):
+    column = FloatCol
+    entity_class = Individus
+
+    def function(self, simulation, period):
+        af_holder = simulation.compute('af')
+        return period, self.cast_from_entity_to_roles(af_holder)
+
+class has_enfant_autonome(Variable):
+    column = BoolCol
+    entity_class = Familles
+
+    def function(self, simulation, period):
+        salaire = simulation.calculate('salaire')
+        condition = salaire > 450
+        return period, self.any_by_roles(condition, roles = ENFS, entity = Familles)
+
+
+tax_benefit_system.add_variables(salaire_famille, salaire_enfants, salaire_enf1, salaire_conj, af_chef, af_tous, has_enfant_autonome)
+
+TEST_CASE_1 = deepcopy(TEST_CASE)
+TEST_CASE_1['individus'][0]['salaire'] = 1000
+TEST_CASE_1['individus'][1]['salaire'] = 1500
+TEST_CASE_1['individus'][2]['salaire'] = 400
+TEST_CASE_1['individus'][4]['salaire'] = 3000
+TEST_CASE_1['individus'][5]['salaire'] = 500
+TEST_CASE_1['familles'][0]['af'] = 2000
+TEST_CASE_1['familles'][1]['af'] = 1200
+
+def new_simulation(test_case):
+    return tax_benefit_system.new_scenario().init_from_test_case(
+        period = "2013-01",
+        test_case = TEST_CASE_1
+    ).new_simulation()
+
+
+def test_sum_by_entity():
+    simulation = new_simulation(TEST_CASE_1)
+    salaire_famille = simulation.calculate('salaire_famille')
+    assert_near(salaire_famille, [2900, 3500])
+    salaire_enfants = simulation.calculate('salaire_enfants')
+    assert_near(salaire_enfants, [400, 500])
+
+def test_split_by_roles():
+    simulation = new_simulation(TEST_CASE_1)
+    salaire_enf1 = simulation.calculate('salaire_enf1')
+    assert_near(salaire_enf1, [400, 500])
+
+def test_filter_role():
+    simulation = new_simulation(TEST_CASE_1)
+    salaire_enf1 = simulation.calculate('salaire_conj')
+    assert_near(salaire_enf1, [1500, 0])
+
+def test_filter_role():
+    simulation = new_simulation(TEST_CASE_1)
+    salaire_enf1 = simulation.calculate('salaire_conj')
+    assert_near(salaire_enf1, [1500, 0])
+
+def test_cast_from_entity_to_roles():
+    simulation = new_simulation(TEST_CASE_1)
+    af_chef = simulation.calculate('af_chef')
+    af_tous = simulation.calculate('af_tous')
+    assert_near(af_chef, [2000, 0, 0, 0, 1200, 0])
+    assert_near(af_tous, [2000, 2000, 2000, 2000, 1200, 1200])
+
+def test_any_by_roles():
+    simulation = new_simulation(TEST_CASE_1)
+    has_enfant_autonome = simulation.calculate('has_enfant_autonome')
+    assert_near(has_enfant_autonome, [False, True])
+

--- a/openfisca_france/tests/test_legacy_entities.py
+++ b/openfisca_france/tests/test_legacy_entities.py
@@ -7,7 +7,7 @@ from openfisca_france.tests.test_entities import TEST_CASE, tax_benefit_system
 
 class salaire_famille(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         salaire_holder = simulation.compute('salaire')
@@ -15,7 +15,7 @@ class salaire_famille(Variable):
 
 class salaire_enfants(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         salaire_holder = simulation.compute('salaire')
@@ -23,7 +23,7 @@ class salaire_enfants(Variable):
 
 class salaire_enf1(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         salaire_holder = simulation.compute('salaire')
@@ -33,7 +33,7 @@ class salaire_enf1(Variable):
 
 class salaire_conj(Variable):
     column = FloatCol
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         salaire_holder = simulation.compute('salaire')
@@ -42,7 +42,7 @@ class salaire_conj(Variable):
 
 class af_chef(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         af_holder = simulation.compute('af')
@@ -50,7 +50,7 @@ class af_chef(Variable):
 
 class af_tous(Variable):
     column = FloatCol
-    entity_class = Individus
+    entity = Individus
 
     def function(self, simulation, period):
         af_holder = simulation.compute('af')
@@ -58,7 +58,7 @@ class af_tous(Variable):
 
 class has_enfant_autonome(Variable):
     column = BoolCol
-    entity_class = Familles
+    entity = Familles
 
     def function(self, simulation, period):
         salaire = simulation.calculate('salaire')

--- a/openfisca_france/tests/test_legacy_entities.py
+++ b/openfisca_france/tests/test_legacy_entities.py
@@ -7,7 +7,7 @@ from openfisca_france.tests.test_entities import TEST_CASE, tax_benefit_system
 
 class salaire_famille(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         salaire_holder = simulation.compute('salaire')
@@ -15,7 +15,7 @@ class salaire_famille(Variable):
 
 class salaire_enfants(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         salaire_holder = simulation.compute('salaire')
@@ -23,7 +23,7 @@ class salaire_enfants(Variable):
 
 class salaire_enf1(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         salaire_holder = simulation.compute('salaire')
@@ -33,7 +33,7 @@ class salaire_enf1(Variable):
 
 class salaire_conj(Variable):
     column = FloatCol
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         salaire_holder = simulation.compute('salaire')
@@ -42,7 +42,7 @@ class salaire_conj(Variable):
 
 class af_chef(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         af_holder = simulation.compute('af')
@@ -50,7 +50,7 @@ class af_chef(Variable):
 
 class af_tous(Variable):
     column = FloatCol
-    entity = Individus
+    entity = Individu
 
     def function(self, simulation, period):
         af_holder = simulation.compute('af')
@@ -58,12 +58,12 @@ class af_tous(Variable):
 
 class has_enfant_autonome(Variable):
     column = BoolCol
-    entity = Familles
+    entity = Famille
 
     def function(self, simulation, period):
         salaire = simulation.calculate('salaire')
         condition = salaire > 450
-        return period, self.any_by_roles(condition, roles = ENFS, entity = Familles)
+        return period, self.any_by_roles(condition, roles = ENFS, entity = Famille)
 
 
 tax_benefit_system.add_variables(salaire_famille, salaire_enfants, salaire_enf1, salaire_conj, af_chef, af_tous, has_enfant_autonome)

--- a/openfisca_france/tests/test_nb_enfants.py
+++ b/openfisca_france/tests/test_nb_enfants.py
@@ -1,0 +1,23 @@
+from copy import deepcopy
+
+from openfisca_france.tests.test_entities import TEST_CASE_AGES, new_simulation
+from openfisca_france import CountryTaxBenefitSystem as FranceTBS
+from openfisca_core.tools import assert_near
+
+tax_benefit_system = FranceTBS()
+
+def test_nb_enfants():
+    test_case = deepcopy(TEST_CASE_AGES)
+    simulation = tax_benefit_system.new_scenario().init_from_test_case(
+        period = 2013,
+        test_case = test_case
+    ).new_simulation()
+    from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf
+
+    assert_near(nb_enf(simulation, simulation.period, 3, 18), [2, 0])
+    assert_near(nb_enf(simulation, simulation.period, 19, 50), [0, 1]) # Adults don't count
+
+    test_case['individus'][5]['autonomie_financiere'] = True
+    simulation_2 = new_simulation(test_case)
+
+    assert_near(nb_enf(simulation_2, simulation_2.period, 19, 50), [0, 0])

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Babel >= 0.9.4',
         'Biryani[datetimeconv] >= 0.10.4',
         'numpy >= 1.11',
-        'OpenFisca-Core >= 3.0.0, < 4.0',
+        'OpenFisca-Core >= 4.0.0b1, < 5.0',
         'PyYAML >= 3.10',
         'requests >= 2.8',
         ],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '4.1.20',
+    version = '5.0.0b0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
This PR adapts France to [`openfisca-core#v4`](https://github.com/openfisca/openfisca-core/pull/415). `core` changes are mainly backward compatible, but migrations have been done opportunistically in `france`.

Some changes have been temporarily reverted to simplify review, but will be re-added before merging: 
- Rename `entity_class` -> `entity`.
- Use singular instead of plural for `Famille`, `FoyerFiscal`, etc.

Changelog
----------
* Adapt France to Openfisca-Core#v4
	* Declare entities in the new way

* Deprecate all conversion variables:
	* `cotsoc_lib_declarant1`
	* `crds_cap_bar_declarant1`
	* `crds_cap_lib_declarant1`
	* `csg_cap_bar_declarant1`
	* `csg_cap_lib_declarant1`
	* `loyer_famille`
	* `loyer_individu`
	* `maj_cga_individu`
	* `pensions_alimentaires_versees_declarant1`
	* `prelsoc_cap_bar_declarant1`
	* `prelsoc_cap_lib_declarant1`
	* `retraite_titre_onereux_declarant1`
	* `retraite_titre_onereux_net_declarant1`
	* `rev_microsocial_declarant1`
	* `statut_occupation_famille`
	* `statut_occupation_logement_individu`
	* `zone_apl_famille `
	* `zone_apl_individu `

* Deprecate entity structure variables:
	* `idmen`
	* `idfoy`
	* `idfam`
	* `quimen`
	* `quifoy`
	* `quifam`

* Change some variables entity:
	* `FoyersFiscaux` -> `Individus`
		* `maj_cga`
	* `Individus` -> `FoyersFiscaux
		* `rev_coll`
	* `Individus` -> `Menages`
		* `coloc`
		* `logement_chambre`
	* `Familles` -> `Individus`
		* `aah_non_calculable`
	* `Familles` -> `Menages`
		* `residence_dom`
		* `residence_guadeloupe`
		* `residence_martinique`
		* `residence_guyane`
		* `residence_reunion`
		* `residence_mayotte`

* Introduce:
    * `cotsoc_bar`
    * `cotsoc_lib`