### PR TITLE
Fix some regressions in parameters introcduced by 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.0.4
+
+* Fix some regressions in parameters introcduced by 6.0.0
+    * Re-apply RSA revalorisation from september
+    * Correct bonification rate for PPA
+
 ## 6.0.3
 
 * Migrate some formulas to new syntax

--- a/openfisca_france/parameters/prestations.xml
+++ b/openfisca_france/parameters/prestations.xml
@@ -3254,7 +3254,7 @@
           <VALUE deb="2016-01-01" fuzzy="true" valeur="95" />
         </CODE>
         <CODE code="taux_bonification_max" conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2016-01-01,openfisca_fin=2016-12-31,openfisca_valeur=0.12782,ipp_valeur=unknown)" description="Bonification maximale, en pourcentage du montant de base du RSA" format="percent" origin="ipp">
-          <VALUE deb="2016-01-01" fuzzy="true" valeur="0.122782" />
+          <VALUE deb="2016-01-01" fuzzy="true" valeur="0.12782" />
         </CODE>
       </NODE>
       <CODE code="majoration_isolement_enf_charge" format="percent" origin="ipp">

--- a/openfisca_france/parameters/prestations.xml
+++ b/openfisca_france/parameters/prestations.xml
@@ -3435,7 +3435,8 @@
         <VALUE deb="2009-01-01" fin="2009-12-31" valeur="200" />
       </CODE>
       <CODE code="rmi" description="Rsa socle" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-04-01" fuzzy="true" valeur="524.68" />
+        <VALUE deb="2016-09-01" fuzzy="true" valeur="535.17" />
+        <VALUE deb="2016-04-01" fin="2016-08-31" valeur="524.68" />
         <VALUE deb="2016-01-01" fin="2016-03-31" valeur="524.16" />
         <VALUE deb="2015-09-01" fin="2015-12-31" valeur="524.16" />
         <VALUE deb="2015-01-01" fin="2015-08-31" valeur="513.88" />
@@ -3576,7 +3577,8 @@
         </CODE>
       </NODE>
       <CODE code="montant_de_base_du_rsa" conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2001-01-01,openfisca_fin=2001-12-31,openfisca_valeur=397.6,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2005-01-01,openfisca_fin=2005-12-31,openfisca_valeur=425.4,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2002-01-01,openfisca_fin=2002-12-31,openfisca_valeur=405.62,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2003-01-01,openfisca_fin=2003-12-31,openfisca_valeur=411.7,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2009-01-01,openfisca_fin=2009-12-31,openfisca_valeur=454.63,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2007-01-01,openfisca_fin=2007-12-31,openfisca_valeur=440.86,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2006-01-01,openfisca_fin=2006-12-31,openfisca_valeur=433.06,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2008-01-01,openfisca_fin=2008-12-31,openfisca_valeur=447.91,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2004-01-01,openfisca_fin=2004-12-31,openfisca_valeur=417.88,ipp_valeur=unknown)" description="Rsa socle" format="float" origin="ipp" type="monetary">
-        <VALUE deb="2016-04-01" fuzzy="true" valeur="524.68" />
+        <VALUE deb="2016-09-01" fuzzy="true" valeur="535.17" />
+        <VALUE deb="2016-04-01" fin="2016-08-31" valeur="524.68" />
         <VALUE deb="2015-09-01" fin="2016-03-31" valeur="524.16" />
         <VALUE deb="2015-01-01" fin="2015-08-31" valeur="513.88" />
         <VALUE deb="2014-09-01" fin="2014-12-31" valeur="509.3" />

--- a/openfisca_france/tests/formulas/rsa_celibataire.yaml
+++ b/openfisca_france/tests/formulas/rsa_celibataire.yaml
@@ -274,3 +274,12 @@
       age: 8
   output_variables:
     rsa_forfait_asf: 91.38
+
+- name: "Revalorisation septembre 2016"
+  period: 2016-10
+  relative_error_margin: 0.01
+  input_variables:
+    age: 40
+  output_variables:
+    rsa: 535.17
+

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '6.0.3',
+    version = '6.0.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Re-apply RSA revalorisation from september
* Correct bonification rate for PPA

The merge of `baremes-ipp` seems to have brought some regressions in the parameters :

#### PPA bonification rate

I think it was just a typo in the parameter from IPP.

[Source:](https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=A0D42BE09B11FC3AF57EF08286453FA5.tpdila13v_3?idArticle=JORFARTI000031665104&cidTexte=JORFTEXT000031665094&dateTexte=29990101&categorieLien=id)
>« Le montant maximal de la bonification s'élève à 12,782 % du montant forfaitaire mentionné au 1° de l'article L. 842-3 applicable à un foyer composé d'une seule personne.

But this brings the question of the conflict resolving process, which is today:

* IPP parameters are always prioritised over openfisca ones.
* The conflict is added as a tag, and is supposed to be resolved later by a human being

This process is worth a discussion, and should be clearly documented.

#### RSA revalorisation

I think the `xml` files (such as `prestations.xml`) were generated from an older version of `param.xml`.
This is preoccupying, because all parameters update done from the day the `xml` files were generated to the day of the `baremes-ipp` merge are probably **not taken into account** in the current version of Openfisca. @laem this may be a problem for you too.

To solve this, we should probably re-generate the `xml` files... but without ignoring the parameters update that have been done since the merge 🤔 

----------

We should probably meet IRL with @benjello @cbenz @MattiSG @laem to discuss to build a better process, but we don't have much time at the moment.




