### PR TITLE
Automatically import some numpy functions in formulas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 16.1.1 - [#632](https://github.com/openfisca/openfisca-france/pull/632) 
+
+* Changement mineur
+* Détails :
+    - Arrête d'importer de numpy des fonctions qui sont déjà fournies par `openfisca_core.model_api`
+
 ## 16.1.0 - [#707](https://github.com/openfisca/openfisca-france/pull/707))
 
 * Évolution du système socio-fiscal
@@ -10,7 +16,7 @@
     - Met à jour le mode de calcul des bourses de collège et lycée, entré en vigueur à la rentrée 2016.
     - Introduit les variables `bourse_college_echelon` et `bourse_lycee_echelon`
 
-## 16.0.0 - [#710](https://github.com/openfisca/openfisca-france/pull/710)
+# 16.0.0 - [#710](https://github.com/openfisca/openfisca-france/pull/710)
 * Amélioration technique **non-rétrocompatible**
 * Détails :
     - Restreint les périodes acceptées par OpenFisca

--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from numpy import logical_not as not_, logical_or as or_
 from numpy.core.defchararray import startswith
 
 

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import floor, logical_not as not_
+from numpy import floor
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
@@ -4,9 +4,6 @@ from __future__ import division
 
 import logging
 
-from numpy import minimum as min_, maximum as max_
-
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import logging
 
-from numpy import logical_not as not_, maximum as max_, minimum as min_, around, logical_or as or_
+from numpy import around, logical_or as or_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -5,8 +5,7 @@ from __future__ import division
 
 import logging
 
-from numpy import (datetime64, logical_and as and_, logical_not as not_, logical_or as or_, logical_xor as xor_,
-    maximum as max_, minimum as min_, round)
+from numpy import datetime64, logical_and as and_, logical_or as or_, logical_xor as xor_, round
 
 from openfisca_core import periods
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/plus_values_immobilieres.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/plus_values_immobilieres.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from numpy import maximum as max_, minimum as min_
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import logging
 
-from numpy import minimum as min_, maximum as max_, logical_not as not_, around
+from numpy import around
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -2,8 +2,6 @@
 
 from __future__ import division
 
-from numpy import maximum as max_, minimum as min_
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 # Variables apparaissant dans la feuille de déclaration de patrimoine soumis à l'ISF

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
@@ -4,9 +4,6 @@ from __future__ import division
 
 import logging
 
-from numpy import maximum as max_
-
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.contributions_sociales.base import (
     montant_csg_crds

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -6,8 +6,7 @@ from functools import partial
 import logging
 
 from numpy import (
-    busday_count as original_busday_count, datetime64, logical_not as not_, logical_or as or_, logical_and as and_,
-    maximum as max_, minimum as min_, round as round_, timedelta64
+    busday_count as original_busday_count, datetime64, logical_or as or_, logical_and as and_, round as round_, timedelta64
     )
 
 from openfisca_core import periods

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -3,7 +3,7 @@
 from __future__ import division
 
 
-from numpy import datetime64, maximum as max_, minimum as min_, round as round_, timedelta64
+from numpy import datetime64, round as round_, timedelta64
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotisations_sociales.base import apply_bareme_for_relevant_type_sal

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/stage.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/stage.py
@@ -3,9 +3,6 @@
 from __future__ import division
 
 
-from numpy import maximum as max_
-
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotisations_sociales.base import apply_bareme_for_relevant_type_sal
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
@@ -4,8 +4,6 @@ from __future__ import division
 
 import math
 
-from numpy import minimum as min_
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotisations_sociales.base import apply_bareme_for_relevant_type_sal
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -4,9 +4,7 @@ from __future__ import division
 
 import logging
 
-
-from numpy import int16, maximum as max_, minimum as min_, logical_not as not_
-
+from numpy import int16
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotisations_sociales.base import apply_bareme, apply_bareme_for_relevant_type_sal

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 import logging
 
-from numpy import logical_or as or_, logical_and as and_, round as round_, logical_not as not_
+from numpy import logical_or as or_, logical_and as and_, round as round_
 
 import numpy as np
 

--- a/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
+++ b/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
@@ -2,8 +2,6 @@
 
 from __future__ import division
 
-from numpy import logical_not as not_, maximum as max_, minimum as min_
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -7,8 +7,7 @@ import json
 import logging
 import pkg_resources
 
-from numpy import (ceil, fromiter, int16, logical_not as not_, logical_or as or_, logical_and as and_, maximum as max_,
-    minimum as min_, round as round_, where, select, take)
+from numpy import ceil, fromiter, int16, logical_or as or_, logical_and as and_, round as round_, take
 
 import openfisca_france
 from openfisca_core.periods import Instant

--- a/openfisca_france/model/prestations/bourses_superieur.py
+++ b/openfisca_france/model/prestations/bourses_superieur.py
@@ -2,8 +2,6 @@
 
 from __future__ import division
 
-from numpy import logical_not as not_, logical_or as or_, round as round_
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 class echelon_bourse(Variable):

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import logical_not as not_, logical_or as or_, round as round_, select
+from numpy import logical_or as or_, round as round_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 
-from numpy import (maximum as max_, logical_not as not_, absolute as abs_, minimum as min_)
+from numpy import absolute as abs_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -2,8 +2,6 @@
 
 from __future__ import division
 
-from numpy import maximum as max_
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf
 

--- a/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
+++ b/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import (floor, logical_and as and_, logical_not as not_, logical_or as or_, maximum as max_, minimum as min_, select, where)
+from numpy import floor, logical_and as and_, logical_or as or_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import abs as abs_, logical_not as not_, logical_or as or_, maximum as max_, minimum as min_, where
+from numpy import abs as abs_, logical_or as or_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -2,8 +2,7 @@
 
 from __future__ import division
 
-from numpy import (absolute as abs_, logical_and as and_, logical_not as not_, logical_or as or_, maximum as max_,
-                   minimum as min_)
+from numpy import absolute as abs_, logical_and as and_, logical_or as or_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -4,8 +4,7 @@ from __future__ import division
 
 from functools import partial
 
-from numpy import (absolute as abs_, apply_along_axis, array, int32, logical_not as not_, logical_or as or_,
-                   maximum as max_, minimum as min_, select)
+from numpy import absolute as abs_, apply_along_axis, array, int32, logical_or as or_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
-from numpy import maximum as max_, round as round_, minimum as min_, logical_not as not_, where, select
+from numpy import round as round_
 
 
 class ppa_eligibilite(Variable):

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -3,7 +3,7 @@
 from __future__ import division
 
 
-from numpy import (datetime64, floor, logical_and as and_, logical_not as not_, logical_or as or_, maximum as max_, minimum as min_, select, where)
+from numpy import datetime64, floor, logical_and as and_, logical_or as or_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf

--- a/openfisca_france/model/prestations/prestations_familiales/aeeh.py
+++ b/openfisca_france/model/prestations/prestations_familiales/aeeh.py
@@ -4,8 +4,6 @@ from __future__ import division
 
 from openfisca_france.model.base import *  # noqa
 
-from numpy import logical_not as not_
-
 
 class aeeh_niveau_handicap(Variable):
     column = IntCol

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import round, maximum as max_, logical_not as not_, logical_or as or_, vectorize, where
+from numpy import round, logical_or as or_
 
 
 from openfisca_france.model.base import *  # noqa analysis:ignore

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -2,8 +2,6 @@
 
 from __future__ import division
 
-from numpy import maximum as max_
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf
 

--- a/openfisca_france/model/prestations/prestations_familiales/asf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/asf.py
@@ -2,8 +2,6 @@
 
 from __future__ import division
 
-from numpy import logical_not as not_
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import int32, logical_not as not_, logical_or as or_
+from numpy import int32, logical_or as or_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import (round, maximum as max_, minimum as min_, logical_not as not_, logical_or as or_)
+from numpy import round, logical_or as or_
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -2,7 +2,7 @@
 
 from __future__ import division
 
-from numpy import (round, floor, maximum as max_, minimum as min_, logical_not as not_, datetime64)
+from numpy import round, floor, datetime64
 
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from functools import partial
-from numpy import (
-    busday_count as original_busday_count, datetime64, logical_not as not_,
-    maximum as max_, minimum as min_, timedelta64,
-    )
+from numpy import busday_count as original_busday_count, datetime64, timedelta64
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 

--- a/openfisca_france/reforms/aides_cd93.py
+++ b/openfisca_france/reforms/aides_cd93.py
@@ -3,7 +3,7 @@
 from __future__ import division
 
 from openfisca_core.reforms import Reform
-from numpy import vectorize, maximum as max_, logical_not as not_, logical_or as or_, absolute as abs_
+from numpy import vectorize, logical_or as or_, absolute as abs_
 
 from ..model.base import *
 

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -4,7 +4,6 @@ from __future__ import division
 
 from openfisca_core import columns
 from openfisca_core.reforms import Reform
-from openfisca_core.variables import Variable
 from ..model.base import *
 
 

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -2,7 +2,6 @@
 
 from __future__ import division
 
-from numpy import maximum as max_
 from openfisca_core import columns
 from openfisca_core.reforms import Reform
 from openfisca_core.variables import Variable

--- a/openfisca_france/reforms/cesthra_invalidee.py
+++ b/openfisca_france/reforms/cesthra_invalidee.py
@@ -4,7 +4,6 @@ from __future__ import division
 
 from openfisca_core import columns
 from openfisca_core.reforms import Reform
-from openfisca_core.variables import Variable
 from openfisca_france.model.base import *
 
 from .. import entities

--- a/openfisca_france/reforms/cesthra_invalidee.py
+++ b/openfisca_france/reforms/cesthra_invalidee.py
@@ -2,7 +2,6 @@
 
 from __future__ import division
 
-from numpy import maximum as max_
 from openfisca_core import columns
 from openfisca_core.reforms import Reform
 from openfisca_core.variables import Variable

--- a/openfisca_france/reforms/landais_piketty_saez.py
+++ b/openfisca_france/reforms/landais_piketty_saez.py
@@ -9,7 +9,6 @@
 
 from __future__ import division
 
-from numpy import maximum as max_
 from openfisca_core import columns
 from openfisca_core.reforms import Reform
 from openfisca_core.variables import Variable

--- a/openfisca_france/reforms/landais_piketty_saez.py
+++ b/openfisca_france/reforms/landais_piketty_saez.py
@@ -9,15 +9,12 @@
 
 from __future__ import division
 
-from openfisca_core import columns
 from openfisca_core.reforms import Reform
-from openfisca_core.variables import Variable
-from openfisca_france import entities
-from openfisca_france.model.base import QUIFAM, QUIFOY, YEAR
+from openfisca_france.model.base import *
 
 class assiette_csg(Variable):
-    column = columns.FloatCol
-    entity = entities.Individu
+    column = FloatCol
+    entity = Individu
     label = u"Assiette de la CSG"
     definition_period = YEAR
 
@@ -32,8 +29,8 @@ class assiette_csg(Variable):
         return salaire_de_base + chomage_brut + retraite_brute + rev_cap_bar + rev_cap_lib
 
 class impot_revenu_lps(Variable):
-    column = columns.FloatCol
-    entity = entities.Individu
+    column = FloatCol
+    entity = Individu
     label = u"Impôt individuel sur l'ensemble de l'assiette de la csg, comme proposé par Landais, Piketty et Saez"
     definition_period = YEAR
 
@@ -58,8 +55,8 @@ class impot_revenu_lps(Variable):
 
 
 class revenu_disponible(Variable):
-    column = columns.FloatCol
-    entity = entities.Menage
+    column = FloatCol
+    entity = Menage
     label = u"Revenu disponible du ménage"
     url = u"http://fr.wikipedia.org/wiki/Revenu_disponible"
     definition_period = YEAR

--- a/openfisca_france/reforms/plf2015.py
+++ b/openfisca_france/reforms/plf2015.py
@@ -5,7 +5,7 @@ from datetime import date
 
 from openfisca_core import periods
 from openfisca_core.reforms import Reform, update_legislation
-from ..model.base import DatedVariable, dated_function, YEAR
+from ..model.base import *
 
 
 def modify_legislation_json(reference_legislation_json_copy):

--- a/openfisca_france/reforms/plf2016.py
+++ b/openfisca_france/reforms/plf2016.py
@@ -4,8 +4,6 @@
 from __future__ import division
 
 
-from numpy import maximum as max_, minimum as min_
-
 from openfisca_core import periods
 from openfisca_core.reforms import Reform, update_legislation
 from ..model.base import DatedVariable, dated_function, date, YEAR

--- a/openfisca_france/reforms/plf2016.py
+++ b/openfisca_france/reforms/plf2016.py
@@ -6,7 +6,7 @@ from __future__ import division
 
 from openfisca_core import periods
 from openfisca_core.reforms import Reform, update_legislation
-from ..model.base import DatedVariable, dated_function, date, YEAR
+from ..model.base import *
 
 
 # What if the reform was applied the year before it should

--- a/openfisca_france/reforms/plf2016_ayrault_muet.py
+++ b/openfisca_france/reforms/plf2016_ayrault_muet.py
@@ -2,10 +2,6 @@
 
 from __future__ import division
 
-
-from numpy import maximum as max_, minimum as min_, logical_not as not_
-
-
 from openfisca_core import periods
 from openfisca_core.reforms import Reform, update_legislation
 from ..model.base import *

--- a/openfisca_france/reforms/plfr2014.py
+++ b/openfisca_france/reforms/plfr2014.py
@@ -4,7 +4,6 @@ from __future__ import division
 
 from datetime import date
 
-from numpy import maximum as max_, minimum as min_
 from openfisca_core import columns
 from openfisca_core.reforms import Reform
 

--- a/openfisca_france/reforms/plfr2014.py
+++ b/openfisca_france/reforms/plfr2014.py
@@ -8,7 +8,7 @@ from openfisca_core import columns
 from openfisca_core.reforms import Reform
 
 from .. import entities
-from ..model.base import DatedVariable, dated_function, date, YEAR
+from ..model.base import *
 from ..model.prelevements_obligatoires.impot_revenu import reductions_impot
 
 

--- a/openfisca_france/reforms/trannoy_wasmer.py
+++ b/openfisca_france/reforms/trannoy_wasmer.py
@@ -2,7 +2,6 @@
 
 from __future__ import division
 
-from numpy import logical_not as not_, minimum as min_
 from openfisca_core import columns
 from openfisca_core.reforms import Reform
 from openfisca_core.variables import Variable

--- a/openfisca_france/reforms/trannoy_wasmer.py
+++ b/openfisca_france/reforms/trannoy_wasmer.py
@@ -2,9 +2,7 @@
 
 from __future__ import division
 
-from openfisca_core import columns
 from openfisca_core.reforms import Reform
-from openfisca_core.variables import Variable
 
 from ..model.prelevements_obligatoires.impot_revenu import charges_deductibles
 from ..model.base import *
@@ -50,7 +48,7 @@ class charges_deduc(Variable):
         return cd1 + cd2 + charge_loyer
 
 class charge_loyer(Variable):
-    column = columns.FloatCol
+    column = FloatCol
     entity = FoyerFiscal
     label = u"Charge déductible pour paiement d'un loyer"
     definition_period = YEAR

--- a/openfisca_france/tests/test_entities.py
+++ b/openfisca_france/tests/test_entities.py
@@ -3,8 +3,6 @@
 from copy import deepcopy
 
 from openfisca_core.taxbenefitsystems import TaxBenefitSystem
-from openfisca_core.variables import Variable
-from openfisca_core.columns import FloatCol, IntCol, BoolCol
 from openfisca_core.tools import assert_near
 
 from openfisca_france.scenarios import Scenario

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '16.1.0',
+    version = '16.1.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Automatically import some numpy functions in formulas, as they are [documented](https://doc.openfisca.fr/coding-the-legislation/25_vectorial_computing.html) standard openfisca helpers:

* `max_`
* `min_`
* `not_`
* `where`
* `select`