### PR TITLE
Move yaml testing to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 12.0.0
+
+* Use core `test_runner` for yaml tests
+* Return yearly amount for `acs`, `bourse_college`, `bourse_lycee` instead of artificially divide it by 12 (breaking change).
+
 ## 11.1.0
 
  * Implement "Aides au logement" degression when rent is above a threshold.

--- a/openfisca_france/entities.py
+++ b/openfisca_france/entities.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import collections
-import itertools
-
 from openfisca_core.entities import build_entity
 
 Famille = build_entity(

--- a/openfisca_france/france_taxbenefitsystem.py
+++ b/openfisca_france/france_taxbenefitsystem.py
@@ -4,7 +4,7 @@ import os, itertools, glob
 
 from openfisca_core.taxbenefitsystems import TaxBenefitSystem
 
-from . import entities
+from .entities import entities
 from . import decompositions, scenarios
 from .model import datatrees
 from .model.prelevements_obligatoires.prelevements_sociaux.cotisations_sociales import preprocessing
@@ -34,7 +34,7 @@ class FranceTaxBenefitSystem(TaxBenefitSystem):
     }
 
     def __init__(self):
-        TaxBenefitSystem.__init__(self, entities.entities)
+        TaxBenefitSystem.__init__(self, entities)
         self.Scenario = scenarios.Scenario
 
         param_files = [

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -14,7 +14,7 @@ SCOLARITE_LYCEE = 2
 
 class bourse_college(Variable):
     column = FloatCol
-    label = u"Montant mensuel de la bourse de collège"
+    label = u"Montant annuel de la bourse de collège"
     entity = Famille
 
     def function(self, simulation, period):
@@ -48,7 +48,7 @@ class bourse_college(Variable):
 
         montant = nb_enfants_college * montant_par_enfant
 
-        return period, montant / 12
+        return period, montant
 
 
 class bourse_lycee_points_de_charge(Variable):
@@ -106,7 +106,7 @@ class bourse_lycee_nombre_parts(Variable):
 
 class bourse_lycee(Variable):
     column = FloatCol
-    label = u"Montant mensuel de la bourse de lycée"
+    label = u"Montant annuel de la bourse de lycée"
     entity = Famille
 
     def function(self, simulation, period):
@@ -123,7 +123,7 @@ class bourse_lycee(Variable):
 
         montant = nombre_parts * valeur_part * nb_enfants_lycee
 
-        return period, montant / 12
+        return period, montant
 
 
 class scolarite(Variable):

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -351,7 +351,7 @@ class cmu_c(Variable):
 
 class acs(Variable):
     column = FloatCol
-    label = u"Montant (mensuel) de l'ACS"
+    label = u"Montant (annuel) de l'ACS"
     entity = Famille
 
     def function(famille, period):
@@ -368,7 +368,7 @@ class acs(Variable):
             cmu_acs_eligibilite *
             not_(residence_mayotte) * not_(cmu_c) *
             (cmu_base_ressources <= acs_plafond) *
-            acs_montant / 12)
+            acs_montant)
 
 
 ############################################################################

--- a/openfisca_france/tests/formulas/bourse.yaml
+++ b/openfisca_france/tests/formulas/bourse.yaml
@@ -21,7 +21,7 @@
       scolarite: 1 # Collège
   output_variables:
     bourse_college:
-      2015-09: 360 / 12 # Le montant testé est par mois
+      2015-09: 360
 
 - name: "Bourse collège taux 2, 2 enfants, rfr = 4000"
   period: 2015-09
@@ -46,7 +46,7 @@
       scolarite: 1 # Collège
   output_variables:
     bourse_college:
-      2015-09: 231 / 12 # Le montant testé est par mois
+      2015-09: 231
 
 - name: "Bourse collège taux 1, 2 enfants, rfr = 9800"
   period: 2015-09
@@ -71,7 +71,7 @@
       scolarite: 1 # Collège
   output_variables:
     bourse_college:
-      2015-09: 84 / 12 # Le montant testé est par mois
+      2015-09: 84
 
 - name: "Bourse collège refusée, 2 enfants, rfr = 18500"
   period: 2015-09
@@ -97,4 +97,4 @@
       scolarite: 1 # Collège
   output_variables:
     bourse_college:
-      2015-09: 0 # Le montant testé est par mois
+      2015-09: 0

--- a/openfisca_france/tests/formulas/cmu.yaml
+++ b/openfisca_france/tests/formulas/cmu.yaml
@@ -76,5 +76,5 @@
     date_naissance: '1994-01-01' # 22 ans
     cmu_c: False
   output_variables:
-    acs: 200 / 12
+    acs: 200
 

--- a/openfisca_france/tests/test_yaml.py
+++ b/openfisca_france/tests/test_yaml.py
@@ -1,338 +1,53 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""Test YAML files."""
-
-
-from __future__ import division
-
-import collections
-import copy
-import logging
 import os
+from nose.tools import nottest
 
-from openfisca_core import conv, periods, scenarios
-from openfisca_core.tools import assert_near
-import numpy as np
-import yaml
+from openfisca_core.tools.test_runner import generate_tests
 
 from openfisca_france.tests import base
 
+nottest(generate_tests)
 
-log = logging.getLogger(__name__)
-
-options_by_dir = collections.OrderedDict((
-    (
-        os.path.abspath(os.path.join(os.path.dirname(__file__), 'calculateur_impots')),
-        dict(
-            calculate_output = False,
-            default_absolute_error_margin = 0.5,
-            ignore = True,  # TODO: Remove
-            reforms = ['inversion_revenus'],
-            ),
-        ),
-    (
-        os.path.abspath(os.path.join(os.path.dirname(__file__), 'fiches_de_paie')),
-        dict(
-            calculate_output = False,
-            default_absolute_error_margin = 0.005,
-            ),
-        ),
-    (
-        os.path.abspath(os.path.join(os.path.dirname(__file__), 'formulas')),
-        dict(
-            calculate_output = False,
-            default_absolute_error_margin = 0.005,
-            ),
-        ),
-    (
-        os.path.abspath(os.path.join(os.path.dirname(__file__), 'mes-aides.gouv.fr')),
-        dict(
-            calculate_output = True,
-            default_relative_error_margin = 0.02,
-            ),
-        ),
-    (
-        os.path.abspath(os.path.join(os.path.dirname(__file__), 'ui.openfisca.fr')),
-        dict(
-            calculate_output = False,
-            default_absolute_error_margin = 0.005,
-            ),
-        ),
-    (
-        os.path.abspath(os.path.join(os.path.dirname(__file__), 'scipy')),
-        dict(
-            calculate_output = False,
-            default_absolute_error_margin = 0.005,
-            reforms = ['de_net_a_brut'],
-            requires = 'scipy',
-            ),
-        ),
-    ))
+options_by_dir = {
+    # 'calculateur_impots': {
+    #     'default_absolute_error_margin': 0.5,
+    #     'reforms' : ['inversion_revenus'],
+    #     },
+    'fiches_de_paie': {},
+    'formulas': {},
+    'mes-aides.gouv.fr': {
+        'default_relative_error_margin': 0.02
+        },
+    'ui.openfisca.fr': {},
+    'scipy': {
+        'reforms':['de_net_a_brut'],
+        'requires': 'scipy'
+        },
+}
 
 
-# YAML configuration
-
-
-class folded_unicode(unicode):
-    pass
-
-
-class literal_unicode(unicode):
-    pass
-
-
-def dict_constructor(loader, node):
-    return collections.OrderedDict(loader.construct_pairs(node))
-
-
-yaml.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, dict_constructor)
-
-yaml.add_representer(collections.OrderedDict, lambda dumper, data: dumper.represent_dict(
-    (copy.deepcopy(key), value)
-    for key, value in data.iteritems()
-    ))
-yaml.add_representer(dict, lambda dumper, data: dumper.represent_dict(
-    (copy.deepcopy(key), value)
-    for key, value in data.iteritems()
-    ))
-yaml.add_representer(folded_unicode, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str',
-    data, style='>'))
-yaml.add_representer(literal_unicode, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str',
-    data, style='|'))
-yaml.add_representer(np.ndarray, lambda dumper, data: dumper.represent_list(data.tolist()))
-yaml.add_representer(periods.Instant, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str', str(data)))
-yaml.add_representer(periods.Period, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str', str(data)))
-yaml.add_representer(tuple, lambda dumper, data: dumper.represent_list(data))
-yaml.add_representer(unicode, lambda dumper, data: dumper.represent_scalar(u'tag:yaml.org,2002:str', data))
-
-
-# Functions
-
-
-def assert_near_calculate_output(value, target_value, absolute_error_margin = 0, message = '',
-        relative_error_margin = None):
-    # Redefinition of assert_near that accepts to compare monthy values with yearly values.
-    assert absolute_error_margin is not None or relative_error_margin is not None
-    if isinstance(value, (list, tuple)):
-        value = np.array(value)
-    if isinstance(target_value, (list, tuple)):
-        target_value = np.array(target_value)
-    if isinstance(message, unicode):
-        message = message.encode('utf-8')
-    if isinstance(value, np.ndarray):
-        if absolute_error_margin is not None:
-            assert (abs(target_value - value) <= absolute_error_margin).all() \
-                or (abs(target_value - value * 12) <= absolute_error_margin).all() \
-                or (abs(target_value - value / 12) <= absolute_error_margin).all(), \
-                '{}{} differs from {} with an absolute margin {} > {}'.format(message, value, target_value,
-                    abs(target_value - value), absolute_error_margin)
-        if relative_error_margin is not None:
-            assert (abs(target_value - value) <= abs(relative_error_margin * target_value)).all() \
-                or (abs(target_value - value * 12) <= abs(relative_error_margin * target_value)).all() \
-                or (abs(target_value - value / 12) <= abs(relative_error_margin * target_value)).all(), \
-                '{}{} differs from {} with a relative margin {} > {}'.format(message, value, target_value,
-                    abs(target_value - value), abs(relative_error_margin * target_value))
-    else:
-        if absolute_error_margin is not None:
-            assert abs(target_value - value) <= absolute_error_margin \
-                or abs(target_value - value * 12) <= absolute_error_margin \
-                or abs(target_value - value / 12) <= absolute_error_margin, \
-                '{}{} differs from {} with an absolute margin {} > {}'.format(message, value, target_value,
-                    abs(target_value - value), absolute_error_margin)
-        if relative_error_margin is not None:
-            assert abs(target_value - value) <= abs(relative_error_margin * target_value) \
-                or abs(target_value - value * 12) <= abs(relative_error_margin * target_value) \
-                or abs(target_value - value / 12) <= abs(relative_error_margin * target_value), \
-                '{}{} differs from {} with a relative margin {} > {}'.format(message, value, target_value,
-                    abs(target_value - value), abs(relative_error_margin * target_value))
-
-
-def check(yaml_path, name, period_str, test, force, verbose = False):
-    scenario = test['scenario']
-    scenario.suggest()
-    simulation = scenario.new_simulation(debug = verbose)
-    output_variables = test.get(u'output_variables')
-    if output_variables is not None:
-        output_variables_name_to_ignore = test.get(u'output_variables_name_to_ignore') or set()
-        for variable_name, expected_value in output_variables.iteritems():
-            if not force and variable_name in output_variables_name_to_ignore:
-                continue
-            if isinstance(expected_value, dict):
-                for requested_period, expected_value_at_period in expected_value.iteritems():
-                    assert_near(
-                        simulation.calculate(variable_name, requested_period),
-                        expected_value_at_period,
-                        absolute_error_margin = test.get('absolute_error_margin'),
-                        message = u'{}@{}: '.format(variable_name, requested_period),
-                        relative_error_margin = test.get('relative_error_margin'),
-                        )
-            else:
-                assert_near(
-                    simulation.calculate(variable_name),
-                    expected_value,
-                    absolute_error_margin = test.get('absolute_error_margin'),
-                    message = u'{}@{}: '.format(variable_name, period_str),
-                    relative_error_margin = test.get('relative_error_margin'),
-                    )
-
-
-def check_calculate_output(yaml_path, name, period_str, test, force, verbose = False):
-    scenario = test['scenario']
-    scenario.suggest()
-    simulation = scenario.new_simulation(debug = verbose)
-    output_variables = test.get(u'output_variables')
-    if output_variables is not None:
-        output_variables_name_to_ignore = test.get(u'output_variables_name_to_ignore') or set()
-        for variable_name, expected_value in output_variables.iteritems():
-            if not force and variable_name in output_variables_name_to_ignore:
-                continue
-            if isinstance(expected_value, dict):
-                for requested_period, expected_value_at_period in expected_value.iteritems():
-                    assert_near_calculate_output(
-                        simulation.calculate_output(variable_name, requested_period),
-                        expected_value_at_period,
-                        absolute_error_margin = test.get('absolute_error_margin'),
-                        message = u'{}@{}: '.format(variable_name, requested_period),
-                        relative_error_margin = test.get('relative_error_margin'),
-                        )
-            else:
-                assert_near_calculate_output(
-                    simulation.calculate_output(variable_name),
-                    expected_value,
-                    absolute_error_margin = test.get('absolute_error_margin'),
-                    message = u'{}@{}: '.format(variable_name, period_str),
-                    relative_error_margin = test.get('relative_error_margin'),
-                    )
-
-
-def run_test(force = False, name_filter = None, options_by_path = None):
-    if isinstance(name_filter, str):
-        name_filter = name_filter.decode('utf-8')
-    if options_by_path is None:
-        options_by_path = options_by_dir
-    for path, options in options_by_path.iteritems():
-        if not force and options.get('ignore', False):
-            log.info(u'Ignoring {}'.format(path))
-            continue
-        if not os.path.exists(path):
-            log.warning(u'Skipping missing {}'.format(path))
-            continue
-        if os.path.isdir(path):
-            yaml_paths = [
-                os.path.join(path, filename)
-                for filename in sorted(os.listdir(path))
-                if filename.endswith('.yaml')
-                ]
-        else:
-            yaml_paths = [path]
+def test():
+    for directory, options in options_by_dir.iteritems():
+        path = os.path.abspath(os.path.join(os.path.dirname(__file__), directory))
 
         if options.get('requires'):
             # Check if the required package was successfully imported in tests/base.py
             if getattr(base, options.get('requires')) is None:
                 continue
 
+        if not options.get('default_relative_error_margin') and not options.get('default_absolute_error_margin'):
+            options['default_absolute_error_margin'] = 0.005
+
         reform_keys = options.get('reforms')
-        tax_benefit_system_for_path = base.get_cached_composed_reform(
+        tax_benefit_system = base.get_cached_composed_reform(
             reform_keys = reform_keys,
             tax_benefit_system = base.tax_benefit_system,
             ) if reform_keys is not None else base.tax_benefit_system
 
-        for yaml_path in yaml_paths:
-            filename_core = os.path.splitext(os.path.basename(yaml_path))[0]
-            with open(yaml_path) as yaml_file:
-                tests = yaml.load(yaml_file)
-            tests, error = conv.pipe(
-                conv.make_item_to_singleton(),
-                conv.uniform_sequence(
-                    conv.noop,
-                    drop_none_items = True,
-                    ),
-                )(tests)
-            if error is not None:
-                embedding_error = conv.embed_error(tests, u'errors', error)
-                assert embedding_error is None, embedding_error
-                raise ValueError("Error in test {}:\n{}".format(yaml_path, yaml.dump(tests, allow_unicode = True,
-                    default_flow_style = False, indent = 2, width = 120)))
+        test_generator = generate_tests(tax_benefit_system, path, options)
 
-            for test in tests:
-                test, error = scenarios.make_json_or_python_to_test(
-                    tax_benefit_system = tax_benefit_system_for_path,
-                    default_absolute_error_margin = options.get('default_absolute_error_margin'),
-                    default_relative_error_margin = options.get('default_relative_error_margin'),
-                    )(test)
-                if error is not None:
-                    embedding_error = conv.embed_error(test, u'errors', error)
-                    assert embedding_error is None, embedding_error
-                    raise ValueError("Error in test {}:\n{}\nYaml test content: \n{}\n".format(
-                        yaml_path, error, yaml.dump(test, allow_unicode = True,
-                        default_flow_style = False, indent = 2, width = 120)))
+        for test in test_generator:
+            yield test
 
-                if not force and test.get(u'ignore', False):
-                    continue
-                if name_filter is not None and name_filter not in filename_core \
-                        and name_filter not in (test.get('name', u'')) \
-                        and name_filter not in (test.get('keywords', [])):
-                    continue
-                checker = check_calculate_output if options['calculate_output'] else check
-                yield checker, yaml_path, test.get('name') or filename_core, unicode(test['scenario'].period), test, \
-                    force
-
-def main():
-    import argparse
-    import logging
-    import sys
-
-    parser = argparse.ArgumentParser(description = __doc__)
-    parser.add_argument('paths', help = "path (file or directory) of tests to execute", metavar = 'PATH', nargs = '*')
-    parser.add_argument('-f', '--force', action = 'store_true', default = False,
-        help = 'force testing of tests with "ignore" flag and formulas belonging to "ignore_output_variables" list')
-    parser.add_argument('-n', '--name', default = None, help = "partial name of tests to execute")
-    parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = "increase output verbosity")
-    args = parser.parse_args()
-    logging.basicConfig(level = logging.DEBUG if args.verbose else logging.WARNING, stream = sys.stdout)
-
-    if args.paths:
-        options_by_path = collections.OrderedDict()
-        for path in args.paths:
-            path = os.path.abspath(path).rstrip(os.sep)
-            dir = path if os.path.isdir(path) else os.path.dirname(path)
-            options = options_by_dir.get(dir)
-            if options is None:
-                options = dict(
-                    calculate_output = False,
-                    default_absolute_error_margin = 0.005,
-                    )
-            options_by_path[path] = options
-    else:
-        options_by_path = None
-
-    tests_found = False
-    for test_index, (checker, yaml_path, name, period_str, test, force) in enumerate(
-            run_test(
-                force = args.force,
-                name_filter = args.name,
-                options_by_path = options_by_path,
-                ),
-            1):
-        keywords = test.get('keywords', [])
-        title = "Test {}: {} {}{} - {}".format(
-            test_index,
-            yaml_path,
-            u'[{}] '.format(u', '.join(keywords)).encode('utf-8') if keywords else '',
-            name.encode('utf-8'),
-            period_str,
-            )
-        print("=" * len(title))
-        print(title)
-        print("=" * len(title))
-        checker(yaml_path, name, period_str, test, force, args.verbose)
-        tests_found = True
-    if not tests_found:
-        print("No test found!")
-        sys.exit(1)
-
-    sys.exit(0)
-
-if __name__ == "__main__":
-    main()

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Babel >= 0.9.4',
         'Biryani[datetimeconv] >= 0.10.4',
         'numpy >= 1.11',
-        'OpenFisca-Core >= 4.1.5, < 5.0',
+        'OpenFisca-Core >= 4.2.0, < 5.0',
         'PyYAML >= 3.10',
         'requests >= 2.8',
         ],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '11.1.0',
+    version = '12.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,6 @@ setup(
         ('share/locale/fr/LC_MESSAGES', ['openfisca_france/i18n/fr/LC_MESSAGES/openfisca-france.mo']),
         ('share/openfisca/openfisca-france', ['CHANGELOG.md', 'LICENSE', 'README.md']),
         ],
-    entry_points = {
-        'console_scripts': ['openfisca-run-test=openfisca_france.tests.test_yaml:main'],
-        },
     extras_require = {
         'inversion_revenus': [
             'scipy >= 0.17',


### PR DESCRIPTION
Connected to https://github.com/openfisca/openfisca-core/pull/429

For variables `acs`, `bourse_college`, `bourse_lycee`, return a yearly amount instead of artificially divide it by 12 (breaking change) as:

- These concepts are legally defined for a year
- A significant part of the yaml runner complexity (`calculate_output`) was just here to handle these 3 cases in `mes-aides` tests.
- We anyway multiply back the amount by 12 in `mes-aides`.