### PR TITLE
Enforce period to month in aide_logmement_avant_degression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.0.1
+
+* Fix `aide_logement_montant_brut_avant_degressivite` returned `period` to month.
+
 ## 12.0.0
 
 * Use core `test_runner` for yaml tests

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -598,6 +598,7 @@ class aide_logement_montant_brut(DatedVariable):
 
     @dated_function(stop = date(2016, 6, 30))
     def function_avant_degression(famille, period):
+        period = period.this_month
         montant_avant_degressivite = famille('aide_logement_montant_brut_avant_degressivite', period)
         return period, montant_avant_degressivite
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '12.0.0',
+    version = '12.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
I run into trouble with runs calculating doing calculate at the year level.
@fpagnoux @michelbl : please check that you really intend to compute on the month period