### PR TITLE
Ne pas considérer un demandeur handicapé comme une personne à charge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.0.2
+
+* Don't consider handicaped demandeur/conjoint as personne à charge in aides logement.
+
 ## 12.0.1
 
 * Fix `aide_logement_montant_brut_avant_degressivite` returned `period` to month.

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -74,7 +74,9 @@ class al_nb_personnes_a_charge(Variable):
                 (base_ressources_i <= plafond_ressource)
                 )
 
-            return famille.sum(adulte_handicape)
+            # Par convention les adultes handicapé à charge de la famille ont le role ENFANT dans la famille
+            # Le demandeur et son conjoint ne sont jamais considérés comme à charge
+            return famille.sum(adulte_handicape, role = Famille.ENFANT)
 
         nb_pac = al_nb_enfants() + al_nb_adultes_handicapes()
         nb_pac = where(residence_dom, min_(nb_pac, 6), nb_pac)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '12.0.1',
+    version = '12.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Détecté suite à un retour utilisateur de mes-aides (mail du 2 janvier 2017 à 13:27)


Quand le demandeur se déclarait handicapé, il était compté à tort dans les personnes à charge, augmentant le montant de la prestation à tort.