### PR TITLE
Ajout des pensions d'invalidité au revenu imposable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 13.0.2
+
+* Add `pensions_invalidite` to pensions imposables
+
 ## 13.0.1
 
-* Fix ppe
+* Fix `ppe`
 
 ## 13.0.0
 
@@ -25,7 +29,7 @@ These changes are low impact since the two deprecated variables were not used.
 
 ## 12.0.3
 
-* Rename CAT to CATEGORIE_SALARIE to be more explicit.
+* Rename `CAT` to `CATEGORIE_SALARIE` to be more explicit.
 
 ## 12.0.2
 

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -220,6 +220,7 @@ class pensions(Variable):
         chomage_net = individu('chomage_net', period)
         retraite_nette = individu('retraite_nette', period)
         pensions_alimentaires_percues = individu('pensions_alimentaires_percues', period)
+        pensions_invalidite = individu('pensions_invalidite', period)
 
         # Revenus du foyer fiscal, que l'on projette uniquement sur le 1er déclarant
         foyer_fiscal = individu.foyer_fiscal
@@ -228,7 +229,7 @@ class pensions(Variable):
         pen_foyer_fiscal = pensions_alimentaires_versees + retraite_titre_onereux
         pen_foyer_fiscal_projetees = pen_foyer_fiscal * (individu.has_role(foyer_fiscal.DECLARANT_PRINCIPAL))
 
-        return period, (chomage_net + retraite_nette + pensions_alimentaires_percues + pen_foyer_fiscal_projetees)
+        return period, (chomage_net + retraite_nette + pensions_alimentaires_percues + pensions_invalidite + pen_foyer_fiscal_projetees)
 
 
 class cotsoc_bar(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -373,13 +373,14 @@ class revenu_assimile_pension(Variable):
     entity = Individu
     label = u"Revenu imposé comme des pensions (retraites, pensions alimentaires, etc.)"
 
-    def function(self, simulation, period):
+    def function(individu, period):
         period = period.this_year
-        pensions_alimentaires_percues = simulation.calculate_add('pensions_alimentaires_percues', period)
-        pensions_alimentaires_percues_decl = simulation.calculate_add('pensions_alimentaires_percues_decl', period)
-        retraite_imposable = simulation.calculate_add('retraite_imposable', period)
+        pensions_alimentaires_percues = individu('pensions_alimentaires_percues', period, options = [ADD])
+        pensions_alimentaires_percues_decl = individu('pensions_alimentaires_percues_decl', period, options = [ADD])
+        retraite_imposable = individu('retraite_imposable', period, options = [ADD])
+        pension_invalidite = individu('pensions_invalidite', period, options = [ADD])
 
-        return period, pensions_alimentaires_percues * pensions_alimentaires_percues_decl + retraite_imposable
+        return period, pensions_alimentaires_percues * pensions_alimentaires_percues_decl + retraite_imposable + pension_invalidite
 
 
 class revenu_assimile_pension_apres_abattements(Variable):

--- a/openfisca_france/model/revenus/autres.py
+++ b/openfisca_france/model/revenus/autres.py
@@ -76,6 +76,14 @@ class pensions_invalidite(Variable):
     column = FloatCol
     entity = Individu
     label = u"Pensions d'invalidité"
+    # Cette case est apparue dans la déclaration 2014
+    # Auparavant, les pensions d'invalidité étaient incluses dans la case 1AS
+    cerfa_field = {
+        QUIFOY['vous']: u"1AZ",
+        QUIFOY['conj']: u"1BZ",
+        QUIFOY['pac1']: u"1CZ",
+        QUIFOY['pac2']: u"1DZ",
+        }
 
 
 class bourse_enseignement_sup(Variable):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '13.0.1',
+    version = '13.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Détecté suite à un retour utilisateur de mes-aides.

Les pensions d'invalidité sont imposables, et doivent donc être entre autres prises en compte dans les aides au logement.

- [x] Vérifier dans la notice que c'est bien là qu'il faut les ajouter.