### PR TITLE
Fix AGS duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 13.1.4
+
+* Fix AGS value in cotsoc.xml. v10.0.1's fix was ineffective.
+
 ## 13.1.3
 
 * Fix `rsa_has_ressources_substitution` `Column` attribute

--- a/openfisca_france/parameters/cotsoc.xml
+++ b/openfisca_france/parameters/cotsoc.xml
@@ -560,7 +560,8 @@
             <VALUE deb="1993-07-01" fin="2014-03-31" valeur="0" />
           </SEUIL>
           <TAUX>
-            <VALUE deb="2017-01-01" fuzzy="true" valeur="0.0025" />
+            <!-- http://www.ags-garantie-salaires.org/actualites/items/taux-de-cotisation-89.html -->
+            <VALUE deb="2017-01-01" fuzzy="true"     valeur="0.0020" />
             <VALUE deb="2016-01-01" fin="2016-12-31" valeur="0.0025" />
             <VALUE deb="2011-04-01" fin="2015-12-31" valeur="0.003" />
             <VALUE deb="2009-11-01" fin="2011-03-31" valeur="0.004" />

--- a/openfisca_france/tests/formulas/ags.yaml
+++ b/openfisca_france/tests/formulas/ags.yaml
@@ -1,0 +1,16 @@
+- period: "2016-01"
+  name: AGS 2016
+  relative_error_margin: 0.001
+  input_variables:
+    salaire_de_base: 1500
+  output_variables:
+    ags: -1500 * .25 / 100
+
+
+- period: "2017-01"
+  name: AGS 2017
+  relative_error_margin: 0.001
+  input_variables:
+    salaire_de_base: 1500
+  output_variables:
+    ags: -1500 * .2 / 100

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '13.1.3',
+    version = '13.1.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Le taux était dupliqué sous deux noms différents, chomfg et ags, dans les fichiers cotsoc.xml et prelevements-sociaux.xml...