### PR TITLE
Check versioning only if code has been updated

### DIFF
--- a/travis-run-tests.sh
+++ b/travis-run-tests.sh
@@ -1,12 +1,5 @@
 #! /usr/bin/env bash
 
-# This script is the entry point for the Travis tests platform.
-# It first checks that the package version has been updated ("bump" in the jargon),
-# then it runs tests via "make test".
-
-
-set -x
-
 current_version=`python setup.py --version`
 
 if ! git diff-index --quiet master openfisca_france

--- a/travis-run-tests.sh
+++ b/travis-run-tests.sh
@@ -8,20 +8,24 @@
 set -x
 
 current_version=`python setup.py --version`
-if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" != false ]]
-then
-    if git rev-parse $current_version
-    then
-        set +x
-        echo "Version $version already exists. Please update version number in setup.py before merging this branch into master."
-        exit 1
-    fi
 
-    if git diff-index master --quiet CHANGELOG.md
+if ! git diff-index --quiet master openfisca_france
+then
+    if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" != false ]]
     then
-        set +x
-        echo "CHANGELOG.md has not been modified. Please update it before merging this branch into master."
-        exit 1
+        if git rev-parse $current_version
+        then
+            set +x
+            echo "Version $version already exists. Please update version number in setup.py before merging this branch into master."
+            exit 1
+        fi
+
+        if git diff-index master --quiet CHANGELOG.md
+        then
+            set +x
+            echo "CHANGELOG.md has not been modified. Please update it before merging this branch into master."
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
See https://github.com/openfisca/openfisca-web-api/pull/95

I think we should merge this PR without releasing, by exceptionally un-protecting the `master` branch.