### PR TITLE
Mise à jours des bourses de collège et lycée

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 16.1.0 - [#707](https://github.com/openfisca/openfisca-france/pull/707))
+
+* Évolution du système socio-fiscal
+* Périodes concernées : à partir du 01/07/2016.
+    - Les changements prennent effet à partir de la rentrée scolaire 2016
+* Zones impactées: `prestations/education`
+* Détails :
+    - Met à jour le mode de calcul des bourses de collège et lycée, entré en vigueur à la rentrée 2016.
+    - Introduit les variables `bourse_college_echelon` et `bourse_lycee_echelon`
+
 ## 16.0.0 - [#710](https://github.com/openfisca/openfisca-france/pull/710)
 * Amélioration technique **non-rétrocompatible**
 * Détails :
@@ -43,7 +53,7 @@
 > Version précédemment publiée à tort en tant que 14.1.0
 
 * Amélioration technique **non-rétrocompatible**
-* Détails:
+* Détails :
   - Renforce le contrôle de cohérence des entrées d'une simulation.
   - Interdit de déclarer, pour une entrée de la simulation, à la fois un montant annuel et les douze montants mensuels correspondants s'ils ne sont pas parfaitement cohérents.
 

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -129,17 +129,20 @@ class bourse_lycee_points_de_charge(Variable):
     label = u"Nombre de points de charge pour la bourse de lycée"
     entity = Famille
     definition_period = MONTH
+    stop_date = date(2016, 7, 1)
 
     def function(famille, period, legislation):
         isole = not_(famille('en_couple', period))
         age_i = famille.members('age', period)
         nb_enfants = famille.sum(age_i >= 0, role = Famille.ENFANT)
 
-        points_de_charge = 11 * (nb_enfants >= 1)
-        points_de_charge += 1 * (nb_enfants >= 2) # 1 point de charge pour le 2ème enfant
-        points_de_charge += 2 * (nb_enfants >= 3) + 2 * (nb_enfants >= 4) # 2 points de charge pour les 3ème et 4ème enfants
-        points_de_charge += 3 * (nb_enfants >= 5) * (nb_enfants - 4) # 3 points de charge pour chaque enfant au-dessus de 4 enfants
-        points_de_charge += 3 * isole # 3 points de charge en plus si parent isolé
+        points_de_charge = (
+            11 * (nb_enfants >= 1) +
+            1 * (nb_enfants >= 2) + # 1 point de charge pour le 2ème enfant
+            2 * (nb_enfants >= 3) + 2 * (nb_enfants >= 4) + # 2 points de charge pour les 3ème et 4ème enfants
+            3 * (nb_enfants >= 5) * (nb_enfants - 4) + # 3 points de charge pour chaque enfant au-dessus de 4 enfants
+            3 * isole # 3 points de charge en plus si parent isolé
+            )
 
         return points_de_charge
 
@@ -149,12 +152,13 @@ class bourse_lycee_nombre_parts(Variable):
     label = u"Nombre de parts pour le calcul du montant de la bourse de lycée"
     entity = Famille
     definition_period = MONTH
+    stop_date = date(2016, 7, 1)
 
     def function(famille, period, legislation):
         points_de_charge = famille('bourse_lycee_points_de_charge', period)
         rfr = famille.demandeur.foyer_fiscal('rfr', period.n_2)
-        plafonds_reference = legislation(period).bourses_education.bourse_lycee.plafonds_reference
-        increments_par_point_de_charge = legislation(period).bourses_education.bourse_lycee.increments_par_point_de_charge
+        plafonds_reference = legislation(period).bourses_education.bourse_lycee.avant_2016.plafonds_reference
+        increments_par_point_de_charge = legislation(period).bourses_education.bourse_lycee.avant_2016.increments_par_point_de_charge
 
         choices = [10, 9, 8, 7, 6, 5, 4, 3]
         nombre_parts = apply_thresholds(
@@ -172,16 +176,125 @@ class bourse_lycee_nombre_parts(Variable):
         return nombre_parts
 
 
-class bourse_lycee(Variable):
+class bourse_lycee_echelon(Variable):
+    column = IntCol
+    label = u"Échelon de la bourse de collège attribuée"
+    entity = Famille
+    definition_period = MONTH
+
+    def function(famille, period, legislation):
+        """
+        Références législatives :
+        Arrêté du 22 mars 2016 fixant les modalités de détermination des plafonds de ressources ouvrant droit...
+        https://www.legifrance.gouv.fr/eli/arrete/2016/3/22/MENE1606432A/jo
+        """
+
+        rfr = famille.demandeur.foyer_fiscal('rfr', period.n_2)
+        age_i = famille.members('age', period)
+        nb_enfants = famille.sum(age_i >= 0, role = Famille.ENFANT)
+        P = legislation(period).bourses_education.bourse_lycee.apres_2016
+
+        # Les plafonds sont estimés en multiples du SMIC au 1er juillet de l'année n_2
+        juillet_n_2 = period.n_2.first_month.offset(6, MONTH)
+        smic_juillet_n_2 = legislation(juillet_n_2).cotsoc.gen.smic_h_b
+
+        P_e6 = P.echelon_6
+        plafonds_echelon_6_en_pourcent_smic = select(
+            [nb_enfants <= i for i in range(1, 8)],
+            [P_e6.plafond_1e, P_e6.plafond_2e, P_e6.plafond_3e, P_e6.plafond_4e, P_e6.plafond_5e, P_e6.plafond_6e, P_e6.plafond_7e],
+            P_e6.plafond_8e
+            )
+        P_e5 = P.echelon_5
+        plafonds_echelon_5_en_pourcent_smic = select(
+            [nb_enfants <= i for i in range(1, 8)],
+            [P_e5.plafond_1e, P_e5.plafond_2e, P_e5.plafond_3e, P_e5.plafond_4e, P_e5.plafond_5e, P_e5.plafond_6e, P_e5.plafond_7e],
+            P_e5.plafond_8e
+            )
+        P_e4 = P.echelon_4
+        plafonds_echelon_4_en_pourcent_smic = select(
+            [nb_enfants <= i for i in range(1, 8)],
+            [P_e4.plafond_1e, P_e4.plafond_2e, P_e4.plafond_3e, P_e4.plafond_4e, P_e4.plafond_5e, P_e4.plafond_6e, P_e4.plafond_7e],
+            P_e4.plafond_8e
+            )
+        P_e3 = P.echelon_3
+        plafonds_echelon_3_en_pourcent_smic = select(
+            [nb_enfants <= i for i in range(1, 8)],
+            [P_e3.plafond_1e, P_e3.plafond_2e, P_e3.plafond_3e, P_e3.plafond_4e, P_e3.plafond_5e, P_e3.plafond_6e, P_e3.plafond_7e],
+            P_e3.plafond_8e
+            )
+        P_e2 = P.echelon_2
+        plafonds_echelon_2_en_pourcent_smic = select(
+            [nb_enfants <= i for i in range(1, 8)],
+            [P_e2.plafond_1e, P_e2.plafond_2e, P_e2.plafond_3e, P_e2.plafond_4e, P_e2.plafond_5e, P_e2.plafond_6e, P_e2.plafond_7e],
+            P_e2.plafond_8e
+            )
+        P_e1 = P.echelon_1
+        plafonds_echelon_1_en_pourcent_smic = select(
+            [nb_enfants <= i for i in range(1, 8)],
+            [P_e1.plafond_1e, P_e1.plafond_2e, P_e1.plafond_3e, P_e1.plafond_4e, P_e1.plafond_5e, P_e1.plafond_6e, P_e1.plafond_7e],
+            P_e1.plafond_8e
+            )
+
+        plafonds_echelon_6 = round_(plafonds_echelon_6_en_pourcent_smic * smic_juillet_n_2)
+        plafonds_echelon_5 = round_(plafonds_echelon_5_en_pourcent_smic * smic_juillet_n_2)
+        plafonds_echelon_4 = round_(plafonds_echelon_4_en_pourcent_smic * smic_juillet_n_2)
+        plafonds_echelon_3 = round_(plafonds_echelon_3_en_pourcent_smic * smic_juillet_n_2)
+        plafonds_echelon_2 = round_(plafonds_echelon_2_en_pourcent_smic * smic_juillet_n_2)
+        plafonds_echelon_1 = round_(plafonds_echelon_1_en_pourcent_smic * smic_juillet_n_2)
+
+        return apply_thresholds(
+            rfr,
+            thresholds = [
+                plafonds_echelon_6,
+                plafonds_echelon_5,
+                plafonds_echelon_4,
+                plafonds_echelon_3,
+                plafonds_echelon_2,
+                plafonds_echelon_1,
+                ],
+            choices = [6, 5, 4, 3, 2, 1]
+            )
+
+
+class bourse_lycee(DatedVariable):
     column = FloatCol
     label = u"Montant annuel de la bourse de lycée"
     entity = Famille
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
-    def function(famille, period, legislation):
+    @dated_function(start = date(2016, 7, 1))
+    def function_apres_2016(famille, period, legislation):
+        """
+        Références legislatives :
+            Article Article D531-29 du code de l'éducation
+            https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006071191&idArticle=LEGIARTI000020663350&dateTexte=&categorieLien=cid
+        """
+        P = legislation(period).bourses_education.bourse_lycee.apres_2016
+
+        # On prends en compte la BMAF du premier janvier de l'année de la rentrée scolaire
+        bmaf_1er_janvier = legislation(period.this_year.first_month).prestations.prestations_familiales.af.bmaf
+
+        scolarite_i = famille.members('scolarite', period)
+        nb_enfants_lycee = famille.sum(scolarite_i == SCOLARITE_LYCEE, role = Famille.ENFANT)
+
+        echelon = famille('bourse_lycee_echelon', period)
+
+        montant_par_enfant_en_pourcent_bmaf = select(
+            [echelon == 6, echelon == 5, echelon == 4, echelon == 3, echelon == 2, echelon == 1],
+            [P.echelon_6.montant, P.echelon_5.montant, P.echelon_4.montant, P.echelon_3.montant, P.echelon_2.montant, P.echelon_1.montant],
+            )
+
+        # Arrondi au multiple de 3 le plus proche, car 3 trimestres
+        montant_par_enfant = round_(montant_par_enfant_en_pourcent_bmaf * bmaf_1er_janvier / 3) * 3
+
+        return nb_enfants_lycee * montant_par_enfant
+
+
+    @dated_function(stop = date(2016, 6, 30))
+    def function_avant_2016(famille, period, legislation):
         nombre_parts = famille('bourse_lycee_nombre_parts', period)
-        valeur_part = legislation(period).bourses_education.bourse_lycee.valeur_part
+        valeur_part = legislation(period).bourses_education.bourse_lycee.avant_2016.valeur_part
 
         scolarite_i = famille.members('scolarite', period)
         nb_enfants_lycee = famille.sum(scolarite_i == SCOLARITE_LYCEE, role = Famille.ENFANT)

--- a/openfisca_france/parameters/bourses_education.xml
+++ b/openfisca_france/parameters/bourses_education.xml
@@ -1,38 +1,112 @@
 <NODE code="bourses_education" description="Bourses de l'Éducation nationale" origin="openfisca">
   <NODE code="bourse_college" description="Bourse des collèges" origin="openfisca">
-    <CODE code="coeff_enfant_supplementaire" description="Coefficient à rajouter aux plafonds pour chaque enfant à charge" format="percent" origin="openfisca">
-      <VALUE deb="2016-07-01" fuzzy="true" valeur="0.3" />
-      <VALUE deb="2014-01-01" fin="2016-06-30" valeur="0.3" />
+    <CODE code="montant_taux_1" description="Montant échelon 1, en multiple de la BMAF" format="float" origin="openfisca" type="monetary">
+      <VALUE deb="2009-05-15" fuzzy="true" valeur="0.2048" />
     </CODE>
-    <CODE code="montant_taux_1" description="Montant taux 1" format="float" origin="openfisca" type="monetary">
-      <VALUE deb="2016-07-01" fuzzy="true" valeur="84" />
-      <VALUE deb="2014-01-01" fin="2016-06-30" valeur="84" />
+    <CODE code="montant_taux_2" description="Montant échelon 2, en multiple de la BMAF" format="float" origin="openfisca" type="monetary">
+      <VALUE deb="2009-05-15" fuzzy="true" valeur="0.5673" />
     </CODE>
-    <CODE code="montant_taux_2" description="Montant taux 2" format="float" origin="openfisca" type="monetary">
-      <VALUE deb="2016-07-01" fuzzy="true" valeur="231" />
-      <VALUE deb="2015-07-01" fin="2016-06-30" valeur="231" />
-      <VALUE deb="2014-01-01" fin="2015-06-30" valeur="228" />
+    <CODE code="montant_taux_3" description="Montant échelon 3, en multiple de la BMAF" format="float" origin="openfisca" type="monetary">
+      <VALUE deb="2009-05-15" fuzzy="true" valeur="0.8860" />
     </CODE>
-    <CODE code="montant_taux_3" description="Montant taux 3" format="float" origin="openfisca" type="monetary">
-      <VALUE deb="2016-07-01" fuzzy="true" valeur="360" />
-      <VALUE deb="2015-07-01" fin="2016-06-30" valeur="360" />
-      <VALUE deb="2014-01-01" fin="2015-06-30" valeur="357" />
-    </CODE>
-    <CODE code="plafond_taux_1" description="Plafond de référence pour le taux 1" format="float" origin="openfisca" type="monetary">
-      <VALUE deb="2016-07-01" fuzzy="true" valeur="11288" />
-      <VALUE deb="2015-07-01" fin="2016-06-30" valeur="11288" />
-      <VALUE deb="2014-01-01" fin="2015-06-30" valeur="11252" />
-    </CODE>
-    <CODE code="plafond_taux_2" description="Plafond de référence pour le taux 2" format="float" origin="openfisca" type="monetary">
-      <VALUE deb="2016-07-01" fuzzy="true" valeur="6102" />
-      <VALUE deb="2015-07-01" fin="2016-06-30" valeur="6102" />
-      <VALUE deb="2014-01-01" fin="2015-06-30" valeur="6083" />
-    </CODE>
-    <CODE code="plafond_taux_3" description="Plafond de référence pour le taux 3" format="float" origin="openfisca" type="monetary">
-      <VALUE deb="2016-07-01" fuzzy="true" valeur="2153" />
-      <VALUE deb="2015-07-01" fin="2016-06-30" valeur="2153" />
-      <VALUE deb="2014-01-01" fin="2015-06-30" valeur="2146" />
-    </CODE>
+    <NODE code="avant_2016">
+      <CODE code="coeff_enfant_supplementaire" description="Coefficient à rajouter aux plafonds pour chaque enfant à charge" format="percent" origin="openfisca">
+        <VALUE deb="2016-07-01" fuzzy="true" valeur="0.3" />
+        <VALUE deb="2014-01-01" fin="2016-06-30" valeur="0.3" />
+      </CODE>
+      <CODE code="plafond_taux_1" description="Plafond de référence pour le taux 1" format="percent" origin="openfisca" type="monetary">
+        <VALUE deb="2015-07-01" fin="2016-06-30" valeur="11288" />
+        <VALUE deb="2014-01-01" fin="2015-06-30" valeur="11252" />
+      </CODE>
+      <CODE code="plafond_taux_2" description="Plafond de référence pour le taux 2" format="float" origin="openfisca" type="monetary">
+        <VALUE deb="2015-07-01" fin="2016-06-30" valeur="6102" />
+        <VALUE deb="2014-01-01" fin="2015-06-30" valeur="6083" />
+      </CODE>
+      <CODE code="plafond_taux_3" description="Plafond de référence pour le taux 3" format="float" origin="openfisca" type="monetary">
+        <VALUE deb="2015-07-01" fin="2016-06-30" valeur="2153" />
+        <VALUE deb="2014-01-01" fin="2015-06-30" valeur="2146" />
+      </CODE>
+    </NODE>
+    <NODE code="apres_2016">
+      <NODE code="echelon_1">
+        <CODE code="plafond_1e" description="Plafond de référence pour l'échelon 1, pour une famille avec un enfant, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1556.2" />
+        </CODE>
+        <CODE code="plafond_2e" description="Plafond de référence pour l'échelon 1, pour une famille avec 2 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1915.3" />
+        </CODE>
+        <CODE code="plafond_3e" description="Plafond de référence pour l'échelon 1, pour une famille avec 3 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2274.4" />
+        </CODE>
+        <CODE code="plafond_4e" description="Plafond de référence pour l'échelon 1, pour une famille avec 4 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2633.5" />
+        </CODE>
+        <CODE code="plafond_5e" description="Plafond de référence pour l'échelon 1, pour une famille avec 5 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2992.7" />
+        </CODE>
+        <CODE code="plafond_6e" description="Plafond de référence pour l'échelon 1, pour une famille avec 6 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="3351.8" />
+        </CODE>
+        <CODE code="plafond_7e" description="Plafond de référence pour l'échelon 1, pour une famille avec 7 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="3710.9" />
+        </CODE>
+        <CODE code="plafond_8e" description="Plafond de référence pour l'échelon 1, pour une famille avec 8 enfants ou plus, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="4070.0" />
+        </CODE>
+      </NODE>
+      <NODE code="echelon_2">
+        <CODE code="plafond_1e" description="Plafond de référence pour l'échelon 2, pour une famille avec un enfant, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="841.2" />
+        </CODE>
+        <CODE code="plafond_2e" description="Plafond de référence pour l'échelon 2, pour une famille avec 2 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1035.4" />
+        </CODE>
+        <CODE code="plafond_3e" description="Plafond de référence pour l'échelon 2, pour une famille avec 3 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1229.5" />
+        </CODE>
+        <CODE code="plafond_4e" description="Plafond de référence pour l'échelon 2, pour une famille avec 4 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1423.7" />
+        </CODE>
+        <CODE code="plafond_5e" description="Plafond de référence pour l'échelon 2, pour une famille avec 5 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1617.8" />
+        </CODE>
+        <CODE code="plafond_6e" description="Plafond de référence pour l'échelon 2, pour une famille avec 6 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1811.9" />
+        </CODE>
+        <CODE code="plafond_7e" description="Plafond de référence pour l'échelon 2, pour une famille avec 7 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2006.1" />
+        </CODE>
+        <CODE code="plafond_8e" description="Plafond de référence pour l'échelon 2, pour une famille avec 8 enfants ou plus, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2200.2" />
+        </CODE>
+      </NODE>
+      <NODE code="echelon_3">
+        <CODE code="plafond_1e" description="Plafond de référence pour l'échelon 3, pour une famille avec un enfant, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="296.8" />
+        </CODE>
+        <CODE code="plafond_2e" description="Plafond de référence pour l'échelon 3, pour une famille avec 2 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="365.3" />
+        </CODE>
+        <CODE code="plafond_3e" description="Plafond de référence pour l'échelon 3, pour une famille avec 3 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="433.8" />
+        </CODE>
+        <CODE code="plafond_4e" description="Plafond de référence pour l'échelon 3, pour une famille avec 4 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="502.3" />
+        </CODE>
+        <CODE code="plafond_5e" description="Plafond de référence pour l'échelon 3, pour une famille avec 5 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="570.8" />
+        </CODE>
+        <CODE code="plafond_6e" description="Plafond de référence pour l'échelon 3, pour une famille avec 6 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="639.3" />
+        </CODE>
+        <CODE code="plafond_7e" description="Plafond de référence pour l'échelon 3, pour une famille avec 7 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="707.8" />
+        </CODE>
+        <CODE code="plafond_8e" description="Plafond de référence pour l'échelon 3, pour une famille avec 8 enfants ou plus, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="776.3" />
+        </CODE>
+      </NODE>
+    </NODE>
   </NODE>
   <NODE code="bourse_lycee" description="Bourse de lycée" origin="openfisca">
     <NODE code="increments_par_point_de_charge" description="Incrément à ajouter au plafond par point de charge supplémentaire" origin="openfisca">

--- a/openfisca_france/parameters/bourses_education.xml
+++ b/openfisca_france/parameters/bourses_education.xml
@@ -109,77 +109,255 @@
     </NODE>
   </NODE>
   <NODE code="bourse_lycee" description="Bourse de lycée" origin="openfisca">
-    <NODE code="increments_par_point_de_charge" description="Incrément à ajouter au plafond par point de charge supplémentaire" origin="openfisca">
-      <CODE code="10_parts" description="Incrément pour 10 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="654.39" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="654.39" />
-      </CODE>
-      <CODE code="3_parts" description="Incrément pour 3 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="1344.26" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="1344.26" />
-      </CODE>
-      <CODE code="4_parts" description="Incrément pour 4 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="1257.82" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="1257.82" />
-      </CODE>
-      <CODE code="5_parts" description="Incrément pour 5 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="1169.47" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="1169.47" />
-      </CODE>
-      <CODE code="6_parts" description="Incrément pour 6 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="1068.15" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="1068.15" />
-      </CODE>
-      <CODE code="7_parts" description="Incrément pour 7 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="945.92" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="945.92" />
-      </CODE>
-      <CODE code="8_parts" description="Incrément pour 8 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="861.49" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="861.49" />
-      </CODE>
-      <CODE code="9_parts" description="Incrément pour 9 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="728.27" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="728.27" />
+    <NODE code="avant_2016">
+      <NODE code="increments_par_point_de_charge" description="Incrément à ajouter au plafond par point de charge supplémentaire" origin="openfisca">
+        <CODE code="10_parts" description="Incrément pour 10 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="654.39" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="654.39" />
+        </CODE>
+        <CODE code="3_parts" description="Incrément pour 3 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="1344.26" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="1344.26" />
+        </CODE>
+        <CODE code="4_parts" description="Incrément pour 4 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="1257.82" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="1257.82" />
+        </CODE>
+        <CODE code="5_parts" description="Incrément pour 5 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="1169.47" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="1169.47" />
+        </CODE>
+        <CODE code="6_parts" description="Incrément pour 6 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="1068.15" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="1068.15" />
+        </CODE>
+        <CODE code="7_parts" description="Incrément pour 7 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="945.92" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="945.92" />
+        </CODE>
+        <CODE code="8_parts" description="Incrément pour 8 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="861.49" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="861.49" />
+        </CODE>
+        <CODE code="9_parts" description="Incrément pour 9 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="728.27" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="728.27" />
+        </CODE>
+      </NODE>
+      <NODE code="plafonds_reference" description="Plafonds de référence pour chaque nombre de parts avec 9 points de charge" origin="openfisca">
+        <CODE code="10_parts" description="Plafond de référence pour 10 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="5889" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="5889" />
+        </CODE>
+        <CODE code="3_parts" description="Plafond de référence pour 3 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="12098" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="12098" />
+        </CODE>
+        <CODE code="4_parts" description="Plafond de référence pour 4 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="11319" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="11319" />
+        </CODE>
+        <CODE code="5_parts" description="Plafond de référence pour 5 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="10525" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="10525" />
+        </CODE>
+        <CODE code="6_parts" description="Plafond de référence pour 6 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="9612" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="9612" />
+        </CODE>
+        <CODE code="7_parts" description="Plafond de référence pour 7 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="8513" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="8513" />
+        </CODE>
+        <CODE code="8_parts" description="Plafond de référence pour 8 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="7753" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="7753" />
+        </CODE>
+        <CODE code="9_parts" description="Plafond de référence pour 9 parts" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-01-02" fuzzy="true" valeur="6554" />
+          <VALUE deb="2014-01-01" fin="2016-01-01" valeur="6554" />
+        </CODE>
+      </NODE>
+      <CODE code="valeur_part" description="Valeur de la part" format="float" origin="openfisca" type="monetary">
+        <VALUE deb="2016-01-02" fuzzy="true" valeur="45.3" />
+        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="45.3" />
       </CODE>
     </NODE>
-    <NODE code="plafonds_reference" description="Plafonds de référence pour chaque nombre de parts avec 9 points de charge" origin="openfisca">
-      <CODE code="10_parts" description="Plafond de référence pour 10 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="5889" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="5889" />
-      </CODE>
-      <CODE code="3_parts" description="Plafond de référence pour 3 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="12098" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="12098" />
-      </CODE>
-      <CODE code="4_parts" description="Plafond de référence pour 4 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="11319" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="11319" />
-      </CODE>
-      <CODE code="5_parts" description="Plafond de référence pour 5 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="10525" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="10525" />
-      </CODE>
-      <CODE code="6_parts" description="Plafond de référence pour 6 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="9612" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="9612" />
-      </CODE>
-      <CODE code="7_parts" description="Plafond de référence pour 7 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="8513" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="8513" />
-      </CODE>
-      <CODE code="8_parts" description="Plafond de référence pour 8 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="7753" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="7753" />
-      </CODE>
-      <CODE code="9_parts" description="Plafond de référence pour 9 parts" format="float" origin="openfisca" type="monetary">
-        <VALUE deb="2016-01-02" fuzzy="true" valeur="6554" />
-        <VALUE deb="2014-01-01" fin="2016-01-01" valeur="6554" />
-      </CODE>
+    <NODE code="apres_2016">
+      <NODE code="echelon_1">
+        <CODE code="montant" description="Montant de la bourse de lycée échelon 1, en multiple de la BMAF" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1.0642" />
+        </CODE>
+        <CODE code="plafond_1e" description="Plafond de référence pour l'échelon 1, pour une famille avec un enfant, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1855.0" />
+        </CODE>
+        <CODE code="plafond_2e" description="Plafond de référence pour l'échelon 1, pour une famille avec 2 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1997.6" />
+        </CODE>
+        <CODE code="plafond_3e" description="Plafond de référence pour l'échelon 1, pour une famille avec 3 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2282.9" />
+        </CODE>
+        <CODE code="plafond_4e" description="Plafond de référence pour l'échelon 1, pour une famille avec 4 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2639.7" />
+        </CODE>
+        <CODE code="plafond_5e" description="Plafond de référence pour l'échelon 1, pour une famille avec 5 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2996.4" />
+        </CODE>
+        <CODE code="plafond_6e" description="Plafond de référence pour l'échelon 1, pour une famille avec 6 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="3424.6" />
+        </CODE>
+        <CODE code="plafond_7e" description="Plafond de référence pour l'échelon 1, pour une famille avec 7 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="3852.6" />
+        </CODE>
+        <CODE code="plafond_8e" description="Plafond de référence pour l'échelon 1, pour une famille avec 8 enfants ou plus, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="4280.7" />
+        </CODE>
+      </NODE>
+      <NODE code="echelon_2">
+        <CODE code="montant" description="Montant de la bourse de lycée échelon 2, en multiple de la BMAF" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1.3079" />
+        </CODE>
+        <CODE code="plafond_1e" description="Plafond de référence pour l'échelon 2, pour une famille avec un enfant, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1468.4" />
+        </CODE>
+        <CODE code="plafond_2e" description="Plafond de référence pour l'échelon 2, pour une famille avec 2 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1602.1" />
+        </CODE>
+        <CODE code="plafond_3e" description="Plafond de référence pour l'échelon 2, pour une famille avec 3 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1869.0" />
+        </CODE>
+        <CODE code="plafond_4e" description="Plafond de référence pour l'échelon 2, pour une famille avec 4 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2136.2" />
+        </CODE>
+        <CODE code="plafond_5e" description="Plafond de référence pour l'échelon 2, pour une famille avec 5 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2536.7" />
+        </CODE>
+        <CODE code="plafond_6e" description="Plafond de référence pour l'échelon 2, pour une famille avec 6 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2937.1" />
+        </CODE>
+        <CODE code="plafond_7e" description="Plafond de référence pour l'échelon 2, pour une famille avec 7 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="3337.7" />
+        </CODE>
+        <CODE code="plafond_8e" description="Plafond de référence pour l'échelon 2, pour une famille avec 8 enfants ou plus, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="3738.4" />
+        </CODE>
+      </NODE>
+      <NODE code="echelon_3">
+        <CODE code="montant" description="Montant de la bourse de lycée échelon 3, en multiple de la BMAF" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1.5435" />
+        </CODE>
+        <CODE code="plafond_1e" description="Plafond de référence pour l'échelon 3, pour une famille avec un enfant, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1247.1" />
+        </CODE>
+        <CODE code="plafond_2e" description="Plafond de référence pour l'échelon 3, pour une famille avec 2 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1360.4" />
+        </CODE>
+        <CODE code="plafond_3e" description="Plafond de référence pour l'échelon 3, pour une famille avec 3 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1587.2" />
+        </CODE>
+        <CODE code="plafond_4e" description="Plafond de référence pour l'échelon 3, pour une famille avec 4 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1814.0" />
+        </CODE>
+        <CODE code="plafond_5e" description="Plafond de référence pour l'échelon 3, pour une famille avec 5 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2154.1" />
+        </CODE>
+        <CODE code="plafond_6e" description="Plafond de référence pour l'échelon 3, pour une famille avec 6 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2494.3" />
+        </CODE>
+        <CODE code="plafond_7e" description="Plafond de référence pour l'échelon 3, pour une famille avec 7 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2834.5" />
+        </CODE>
+        <CODE code="plafond_8e" description="Plafond de référence pour l'échelon 3, pour une famille avec 8 enfants ou plus, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="3174.7" />
+        </CODE>
+      </NODE>
+      <NODE code="echelon_4">
+        <CODE code="montant" description="Montant de la bourse de lycée échelon 4, en multiple de la BMAF" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1.7791" />
+        </CODE>
+        <CODE code="plafond_1e" description="Plafond de référence pour l'échelon 4, pour une famille avec un enfant, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1005.8" />
+        </CODE>
+        <CODE code="plafond_2e" description="Plafond de référence pour l'échelon 4, pour une famille avec 2 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1097.1" />
+        </CODE>
+        <CODE code="plafond_3e" description="Plafond de référence pour l'échelon 4, pour une famille avec 3 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1280.1" />
+        </CODE>
+        <CODE code="plafond_4e" description="Plafond de référence pour l'échelon 4, pour une famille avec 4 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1463.0" />
+        </CODE>
+        <CODE code="plafond_5e" description="Plafond de référence pour l'échelon 4, pour une famille avec 5 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1737.3" />
+        </CODE>
+        <CODE code="plafond_6e" description="Plafond de référence pour l'échelon 4, pour une famille avec 6 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2011.8" />
+        </CODE>
+        <CODE code="plafond_7e" description="Plafond de référence pour l'échelon 4, pour une famille avec 7 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2285.9" />
+        </CODE>
+        <CODE code="plafond_8e" description="Plafond de référence pour l'échelon 4, pour une famille avec 8 enfants ou plus, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2560.2" />
+        </CODE>
+      </NODE>
+      <NODE code="echelon_5">
+        <CODE code="montant" description="Montant de la bourse de lycée échelon 5, en multiple de la BMAF" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2.0147" />
+        </CODE>
+        <CODE code="plafond_1e" description="Plafond de référence pour l'échelon 5, pour une famille avec un enfant, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="625.1" />
+        </CODE>
+        <CODE code="plafond_2e" description="Plafond de référence pour l'échelon 5, pour une famille avec 2 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="694.6" />
+        </CODE>
+        <CODE code="plafond_3e" description="Plafond de référence pour l'échelon 5, pour une famille avec 3 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="833.5" />
+        </CODE>
+        <CODE code="plafond_4e" description="Plafond de référence pour l'échelon 5, pour une famille avec 4 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="972.3" />
+        </CODE>
+        <CODE code="plafond_5e" description="Plafond de référence pour l'échelon 5, pour une famille avec 5 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1180.7" />
+        </CODE>
+        <CODE code="plafond_6e" description="Plafond de référence pour l'échelon 5, pour une famille avec 6 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1389.2" />
+        </CODE>
+        <CODE code="plafond_7e" description="Plafond de référence pour l'échelon 5, pour une famille avec 7 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1597.5" />
+        </CODE>
+        <CODE code="plafond_8e" description="Plafond de référence pour l'échelon 5, pour une famille avec 8 enfants ou plus, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1805.9" />
+        </CODE>
+      </NODE>
+      <NODE code="echelon_6">
+        <CODE code="montant" description="Montant de la bourse de lycée échelon 6, en multiple de la BMAF" format="float" origin="openfisca" type="monetary">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="2.2584" />
+        </CODE>
+        <CODE code="plafond_1e" description="Plafond de référence pour l'échelon 6, pour une famille avec un enfant, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="244.3" />
+        </CODE>
+        <CODE code="plafond_2e" description="Plafond de référence pour l'échelon 6, pour une famille avec 2 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="291.9" />
+        </CODE>
+        <CODE code="plafond_3e" description="Plafond de référence pour l'échelon 6, pour une famille avec 3 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="386.9" />
+        </CODE>
+        <CODE code="plafond_4e" description="Plafond de référence pour l'échelon 6, pour une famille avec 4 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="481.7" />
+        </CODE>
+        <CODE code="plafond_5e" description="Plafond de référence pour l'échelon 6, pour une famille avec 5 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="624.1" />
+        </CODE>
+        <CODE code="plafond_6e" description="Plafond de référence pour l'échelon 6, pour une famille avec 6 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="766.4" />
+        </CODE>
+        <CODE code="plafond_7e" description="Plafond de référence pour l'échelon 6, pour une famille avec 7 enfants, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="909.0" />
+        </CODE>
+        <CODE code="plafond_8e" description="Plafond de référence pour l'échelon 6, pour une famille avec 8 enfants ou plus, en multiple du SMIC horaire brut" format="percent" origin="openfisca">
+          <VALUE deb="2016-07-01" fuzzy="true" valeur="1051.3" />
+        </CODE>
+      </NODE>
     </NODE>
-    <CODE code="valeur_part" description="Valeur de la part" format="float" origin="openfisca" type="monetary">
-      <VALUE deb="2016-01-02" fuzzy="true" valeur="45.3" />
-      <VALUE deb="2014-01-01" fin="2016-01-01" valeur="45.3" />
-    </CODE>
   </NODE>
 </NODE>

--- a/openfisca_france/tests/formulas/bourse.yaml
+++ b/openfisca_france/tests/formulas/bourse.yaml
@@ -130,6 +130,148 @@
     bourse_college_echelon: 1
     bourse_college: 84 * 2
 
+
+- name: "Rentrée 2016 : bourse de lycée, 3 enfants, rfr = 17810"
+  period: 2016-09
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1", "enfant2", "enfant3"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1", "enfant2", "enfant3"]
+    rfr:
+      2014: 17810
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1", "enfant2", "enfant3"]
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 10
+    - id: "enfant3"
+      age: 10
+    - id: "enfant2"
+      age: 11
+      scolarite: 2 # Lycée
+  output_variables:
+    bourse_lycee_echelon: 2
+    bourse_lycee: 531
+
+- name: "Rentrée 2016 : bourse de lycée, 4 enfants, rfr = 12500"
+  period: 2017-09
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1", "enfant2", "enfant3", "enfant4"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1", "enfant2", "enfant3", "enfant4"]
+    rfr:
+      2015: 12500
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1", "enfant2", "enfant3", "enfant4"]
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 10
+    - id: "enfant3"
+      age: 10
+    - id: "enfant4"
+      age: 10
+    - id: "enfant2"
+      age: 11
+      scolarite: 2 # Lycée
+  output_variables:
+    bourse_lycee_echelon: 4
+    bourse_lycee: 723
+
+
+- name: "Rentrée 2016 : bourse de lycée, 2 enfants, rfr = 15000"
+  period: 2017-09
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1", "enfant2"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1", "enfant2"]
+    rfr:
+      2015: 15000
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1", "enfant2"]
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 10
+    - id: "enfant2"
+      age: 11
+      scolarite: 2 # Lycée
+  output_variables:
+    bourse_lycee_echelon: 2
+    bourse_lycee: 531
+
+- name: "Rentrée 2017 : bourse de lycée, 4 enfants, rfr = 4625"
+  period: 2017-09
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1", "enfant2", "enfant3", "enfant4"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1", "enfant2", "enfant3", "enfant4"]
+    rfr:
+      2015: 4625
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1", "enfant2", "enfant3", "enfant4"]
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 10
+    - id: "enfant3"
+      age: 10
+    - id: "enfant4"
+      age: 10
+    - id: "enfant2"
+      age: 11
+      scolarite: 2 # Lycée
+  output_variables:
+    bourse_lycee_echelon: 6
+    bourse_lycee: 918
+
+- name: "Rentrée 2017 : bourse de lycée, 4 enfants, rfr = 4630"
+  period: 2017-09
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1", "enfant2", "enfant3", "enfant4"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1", "enfant2", "enfant3", "enfant4"]
+    rfr:
+      2015: 4630
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1", "enfant2", "enfant3", "enfant4"]
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 10
+    - id: "enfant3"
+      age: 10
+    - id: "enfant4"
+      age: 10
+    - id: "enfant2"
+      age: 11
+      scolarite: 2 # Lycée
+  output_variables:
+    bourse_lycee_echelon: 5
+    bourse_lycee: 819
+
+
 - name: "Bourse collège taux 3, 2 enfants, pas de ressources"
   period: 2015-09
   familles:

--- a/openfisca_france/tests/formulas/bourse.yaml
+++ b/openfisca_france/tests/formulas/bourse.yaml
@@ -1,3 +1,135 @@
+- name: "Rentrée 2016 : bourse collège taux 3, 2 enfants, rfr = 18260"
+  period: 2016-09
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1", "enfant2"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1", "enfant2"]
+    rfr:
+      2014: 18260
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1", "enfant2"]
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 10
+    - id: "enfant2"
+      age: 11
+      scolarite: 1 # Collège
+  output_variables:
+    bourse_college_echelon: 0 # non boursier
+    bourse_college: 0
+
+- name: "Rentrée 2016 : bourse collège taux 3, 2 enfants, rfr = 18250"
+  period: 2016-09
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1", "enfant2"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1", "enfant2"]
+    rfr:
+      2014: 18250
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1", "enfant2"]
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 10
+    - id: "enfant2"
+      age: 11
+      scolarite: 1 # Collège
+  output_variables:
+    bourse_college_echelon: 1
+    bourse_college: 84
+
+- name: "Rentrée 2016 : bourse collège taux 3, 3 enfants, rfr = 11700"
+  period: 2016-09
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1", "enfant2", "enfant3"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1", "enfant2", "enfant3"]
+    rfr:
+      2014: 11700
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1", "enfant2", "enfant3"]
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 10
+    - id: "enfant3"
+      age: 10
+    - id: "enfant2"
+      age: 11
+      scolarite: 1 # Collège
+  output_variables:
+    bourse_college_echelon: 2
+    bourse_college: 231
+
+- name: "Rentrée 2016 : bourse collège taux 3, 3 enfants, rfr = 11720"
+  period: 2016-09
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1", "enfant2", "enfant3"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1", "enfant2", "enfant3"]
+    rfr:
+      2014: 11720
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1", "enfant2", "enfant3"]
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 10
+    - id: "enfant3"
+      age: 10
+    - id: "enfant2"
+      age: 11
+      scolarite: 1 # Collège
+  output_variables:
+    bourse_college_echelon: 1
+    bourse_college: 84
+
+- name: "Rentrée 2016 : deux enfants au collège, rfr = 11720"
+  period: 2016-09
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1", "enfant2", "enfant3"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1", "enfant2", "enfant3"]
+    rfr:
+      2014: 11720
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1", "enfant2", "enfant3"]
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 10
+    - id: "enfant3"
+      age: 10
+      scolarite: 1 # Collège
+    - id: "enfant2"
+      age: 11
+      scolarite: 1 # Collège
+  output_variables:
+    bourse_college_echelon: 1
+    bourse_college: 84 * 2
+
 - name: "Bourse collège taux 3, 2 enfants, pas de ressources"
   period: 2015-09
   familles:
@@ -20,8 +152,8 @@
       age: 11
       scolarite: 1 # Collège
   output_variables:
-    bourse_college:
-      2015-09: 360
+    bourse_college_echelon: 3
+    bourse_college: 360
 
 - name: "Bourse collège taux 2, 2 enfants, rfr = 4000"
   period: 2015-09

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '16.0.0',
+    version = '16.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Fixes sgmap/openfisca-france#73

* Évolution du système socio-fiscal
* Périodes concernées : à partir du 01/07/2016.
    - Les changements prennent effet à partir de la rentrée scolaire 2016
* Zones impactées: `prestations/education`
* Détails:
    - Met à jour le mode de calcul des bourses de collège et lycée, entrés en vigueur à la rentrée 2016.
    - Introduit les variables `bourse_college_echelon` et `bourse_lycee_echelon`