### PR TITLE
Fix aide_logement_neutralisation_rsa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,18 @@
 * Périodes concernées : toutes
 * Zones impactées : `prestations/aides_logement`
 * Détails :
-  - Corrige certains calculs pour les aides logement:
+  - Corrige certains calculs pour les aides logement :
     - La neutralisation des ressources en cas de perception du RSA était sur-évaluée.
     - Les abattements des ressources en cas de chômage ou de départ en retraite étaient imprécis.
       - Non prise en compte des frais réels
       - Non prise en compte du plafond et du plancher pour l'abattement sur les frais profesionnels 
   - Ajoute les références législatives
+
+<!-- -->
+
+* Amélioration technique
+* Détails :
+  - Migre toutes les formules de `prestations/aides_logement` vers la syntaxe `v4`
 
 ## 18.2.0 - [#731](https://github.com/openfisca/openfisca-france/pull/731)
 * Amélioration technique

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### 18.2.1 - [#708](https://github.com/openfisca/openfisca-france/pull/708)
+
+* Évolution du système socio-fiscal
+* Périodes concernées : toutes
+* Zones impactées : `prestations/aides_logement`
+* Détails :
+  - Corrige certains calculs pour les aides logement:
+    - La neutralisation des ressources en cas de perception du RSA était sur-évaluée.
+    - Les abattements des ressources en cas de chômage ou de départ en retraite étaient imprécis.
+      - Non prise en compte des frais réels
+      - Non prise en compte du plafond et du plancher pour l'abattement sur les frais profesionnels 
+  - Ajoute les références législatives
+
 ## 18.2.0 - [#731](https://github.com/openfisca/openfisca-france/pull/731)
 * Amélioration technique
 * Détails :
@@ -12,7 +25,7 @@
 * Détails:
   - Rends OpenFisca-France compatible avec la version `11.0` d'OpenFisca-Core
 
-## 18.0.0 - [#718](https://github.com/openfisca/openfisca-france/pull/718)
+# 18.0.0 - [#718](https://github.com/openfisca/openfisca-france/pull/718)
 
 * Évolution du système socio-fiscal
 * Périodes concernées : toutes

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -160,13 +160,10 @@ class aide_logement_abattement_chomage_indemnise(Variable):
     entity = Individu
     label = u"Montant de l'abattement pour personnes au chômage indemnisé (R351-13 du CCH)"
     definition_period = MONTH
+    # Article R532-7 du Code de la sécurité sociale
+    url = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694522&cidTexte=LEGITEXT000006073189"
 
     def function(individu, period, legislation):
-        """
-        Références législatives :
-        Article R532-7 du Code de la sécurité sociale
-        https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694522&cidTexte=LEGITEXT000006073189&categorieLien=id&dateTexte=
-        """
         chomage_net_m_1 = individu('chomage_net', period.offset(-1))
         chomage_net_m_2 = individu('chomage_net', period.offset(-2))
         condition_abattement = (chomage_net_m_1 > 0) * (chomage_net_m_2 > 0)
@@ -181,13 +178,10 @@ class aide_logement_abattement_depart_retraite(Variable):
     entity = Individu
     label = u"Montant de l'abattement sur les salaires en cas de départ en retraite"
     definition_period = MONTH
+    # Article R532-5 du Code de la sécurité sociale
+    url = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006750910&cidTexte=LEGITEXT000006073189&dateTexte=20151231"
 
     def function(individu, period, legislation):
-        """
-        Références législatives :
-        Article R532-5 du Code de la sécurité sociale
-        https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006750910&cidTexte=LEGITEXT000006073189&dateTexte=20151231
-        """
         retraite = individu('activite', period) == 3
         retraite_n_2 = individu('retraite_imposable', period.n_2)
         condition_abattement = (retraite_n_2 == 0) * retraite
@@ -203,17 +197,14 @@ class aide_logement_neutralisation_rsa(Variable):
     entity = Famille
     label = u"Abattement sur les revenus n-2 pour les bénéficiaires du RSA"
     definition_period = MONTH
+    url = [
+        # Article R532-7 du Code de la sécurité sociale
+        u"https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694522&cidTexte=LEGITEXT000006073189",
+        # Article R351-14-1 du Code de la construction et de l'habitation
+        u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006074096&idArticle=LEGIARTI000006897410"
+        ]
 
     def function(famille, period, legislation):
-        """
-        Références législatives :
-        Article R532-7 du Code de la sécurité sociale
-        https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694522&cidTexte=LEGITEXT000006073189&categorieLien=id&dateTexte=
-
-        Article R351-14-1 du Code de la construction et de l'habitation
-        https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006074096&idArticle=LEGIARTI000006897410&categorieLien=cid
-        """
-
         # Circular definition, as rsa depends on al.
         # We don't allow it, so default value of rsa will be returned if a recursion is detected.
         rsa_mois_dernier = famille('rsa', period.last_month, max_nb_cycles = 0)

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -177,7 +177,7 @@ class aide_logement_neutralisation_rsa(Variable):
     def function(self, simulation, period):
         # Circular definition, as rsa depends on al.
         # We don't allow it, so default value of rsa will be returned if a recursion is detected.
-        rsa_last_month = simulation.calculate('rsa', period.last_month, max_nb_cycles = 0)
+        rsa_last_month = simulation.calculate('rsa', period.last_month, max_nb_cycles = 0) > 0
         activite = simulation.compute_add('salaire_imposable', period.n_2)
         chomage = simulation.compute_add('chomage_imposable', period.n_2)
         activite_n_2 = self.sum_by_entity(activite)

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -283,8 +283,9 @@ class cmu_base_ressources(Variable):
 
         P = legislation(period).cmu
 
-
-        forfait_logement = (((statut_occupation_logement == 2) + (statut_occupation_logement == 6)) * cmu_forfait_logement_base +
+        proprietaire = (statut_occupation_logement == 2)
+        heberge_titre_gratuit = (statut_occupation_logement == 6)
+        forfait_logement = ((proprietaire + heberge_titre_gratuit) * cmu_forfait_logement_base +
             cmu_forfait_logement_al)
 
         ressources_individuelles = famille.members('cmu_base_ressources_individu', period)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '18.2.0',
+    version = '18.2.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'Babel >= 0.9.4',
         'Biryani[datetimeconv] >= 0.10.4',
         'numpy >= 1.11',
-        'OpenFisca-Core >= 12.0, < 13.0',
+        'OpenFisca-Core >= 12.0.2, < 13.0',
         'PyYAML >= 3.10',
         'requests >= 2.8',
         ],


### PR DESCRIPTION
Depends on https://github.com/openfisca/openfisca-core/pull/499

* Changement mineur.
* Périodes concernées : toutes. 
* Zones impactées : `prestations/aides_logement`.
* Détails :
  - Corrige le calcul de `aide_logement_neutralisation_rsa`.

- - - -

Ces changements _(effacez les lignes ne correspondant pas à votre cas)_ :

- Corrigent ou améliorent un calcul déjà existant.
