### PR TITLE
Unify period formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 16.0.0 - [#710](https://github.com/openfisca/openfisca-france/pull/710)
+* Amélioration technique **non-rétrocompatible**
+* Détails :
+    - Restreint les périodes acceptées par OpenFisca
+    - La liste des périodes autorisées est disponible dans la [documentation](https://doc.openfisca.fr/periodsinstants.html)
+
+<!-- -->
+
+* Amélioration technique
+* Détails :
+  - Adapte `france` à  la version `9.0.0` de `core`.
+
 ## 15.1.0 - [#699](https://github.com/openfisca/openfisca-france/pull/699)
 
 > Version précédemment publiée à tort en tant que 14.2.0

--- a/openfisca_france/reforms/plf2015.py
+++ b/openfisca_france/reforms/plf2015.py
@@ -30,7 +30,7 @@ def modify_legislation_json(reference_legislation_json_copy):
             },
         }
     reform_year = 2013
-    reform_period = periods.period('year', reform_year)
+    reform_period = periods.period(reform_year)
 
     reference_legislation_json_copy = update_legislation(
         legislation_json = reference_legislation_json_copy,

--- a/openfisca_france/reforms/plf2016.py
+++ b/openfisca_france/reforms/plf2016.py
@@ -194,7 +194,7 @@ def counterfactual_2014_modify_legislation_json(reference_legislation_json_copy)
     # TODO: inflater les paramètres de la décote le barème de l'IR
     inflator = 1 + .001 + .005
     reform_year = 2015
-    reform_period = periods.period('year', reform_year)
+    reform_period = periods.period(reform_year)
     # reference_legislation_json_copy = reforms.update_legislation(
     #     legislation_json = reference_legislation_json_copy,
     #     path = ('children', 'ir', 'children', 'reductions_impots', 'children', 'reduction_impot_exceptionnelle',

--- a/openfisca_france/tests/formulas/exoneration_cotisations_employeur_zfu.yaml
+++ b/openfisca_france/tests/formulas/exoneration_cotisations_employeur_zfu.yaml
@@ -2,10 +2,10 @@
   period: "2015"
   input_variables:
     contrat_de_travail_debut:
-      "2015-01-01": "2010-01-01"
+      "2015-01": "2010-01-01"
     depcom_entreprise: 69381
     effectif_entreprise:
-      "2014:15": 21
+      "year:2014:15": 21
     salaire_de_base:
       "2015": 35 * 52 * 9.61
     zone_franche_urbaine:

--- a/openfisca_france/tests/formulas/exoneration_cotisations_employeur_zrd.yaml
+++ b/openfisca_france/tests/formulas/exoneration_cotisations_employeur_zrd.yaml
@@ -7,14 +7,14 @@
   input_variables:
     entreprise_creation: "2014-01-01"
     effectif_entreprise:
-      "2014:15": 20
+      "year:2014:15": 20
     salaire_de_base:
       "2014": 35 * 52 * 9.53
       "2015": 35 * 52 * 9.61
       "2016": 35 * 52 * 9.67
       "2017": 35 * 52 * 9.67
     zone_restructuration_defense:
-      "2014:15": True
+      "year:2014:15": True
     categorie_salarie: 0
   output_variables:
     exoneration_cotisations_employeur_zrd:

--- a/openfisca_france/tests/formulas/exoneration_cotisations_employeur_zrr.yaml
+++ b/openfisca_france/tests/formulas/exoneration_cotisations_employeur_zrr.yaml
@@ -7,7 +7,7 @@
       "2014": 35 * 52 * 9.53
       "2015": 35 * 52 * 9.61
     zone_revitalisation_rurale:
-      "2014:5": True
+      "year:2014:5": True
     categorie_salarie: 0
   output_variables:
     exoneration_cotisations_employeur_zrr:
@@ -20,10 +20,10 @@
     contrat_de_travail_debut: "2014-05-01"
     effectif_entreprise: 20
     salaire_de_base:
-      "2014-05:8": 35 * 52 * 9.53 * 1.4 * 8 / 12
+      "month:2014-05:8": 35 * 52 * 9.53 * 1.4 * 8 / 12
       "2015": 35 * 52 * 9.61 * 1.4
     zone_revitalisation_rurale:
-      "2014:5": True
+      "year:2014:5": True
     categorie_salarie: 0
   output_variables:
     exoneration_cotisations_employeur_zrr:
@@ -41,7 +41,7 @@
       "2014": 35 * 52 * 9.53 * 2.5
       "2015": 35 * 52 * 9.61 * 2.5
     zone_revitalisation_rurale:
-      "2014:5": True
+      "year:2014:5": True
     categorie_salarie: 0
   output_variables:
     exoneration_cotisations_employeur_zrr:

--- a/openfisca_france/tests/formulas/exoneration_is_creation_zrr.yaml
+++ b/openfisca_france/tests/formulas/exoneration_is_creation_zrr.yaml
@@ -5,7 +5,7 @@
     contrat_de_travail_debut: "2014-01-01"
     effectif_entreprise: 20
     entreprise_benefice:
-      "2014:10": 1 * 10
+      "year:2014:10": 1 * 10
     salaire_de_base:
       "2014": 35 * 52 * 9.53 * 2.5
       "2015": 35 * 52 * 9.61 * 2.5

--- a/openfisca_france/tests/reforms/test_allocations_familliales_imposables.py
+++ b/openfisca_france/tests/reforms/test_allocations_familliales_imposables.py
@@ -23,7 +23,7 @@ def test_allocations_familiales_imposables():
                 name = 'salaire_imposable',
                 ),
             ],
-        period = periods.period('year', year),
+        period = periods.period(year),
         parent1 = dict(date_naissance = datetime.date(year - 40, 1, 1)),
         parent2 = dict(date_naissance = datetime.date(year - 40, 1, 1)),
         enfants = [

--- a/openfisca_france/tests/reforms/test_cesthra.py
+++ b/openfisca_france/tests/reforms/test_cesthra.py
@@ -9,7 +9,7 @@ from openfisca_france.tests import base
 
 def test_cesthra_invalidee():
     year = 2012
-    period = periods.period('year', year)
+    period = periods.period(year)
     reform = base.get_cached_reform(
         reform_key = 'cesthra_invalidee',
         tax_benefit_system = base.tax_benefit_system,

--- a/openfisca_france/tests/reforms/test_landais_piketty_saez.py
+++ b/openfisca_france/tests/reforms/test_landais_piketty_saez.py
@@ -22,7 +22,7 @@ def test():
                 name = 'salaire_de_base',
                 ),
             ],
-        period = periods.period('year', year),
+        period = periods.period(year),
         parent1 = dict(date_naissance = datetime.date(year - 40, 1, 1)),
         # parent2 = dict(date_naissance = datetime.date(year - 40, 1, 1)),
         # enfants = [

--- a/openfisca_france/tests/reforms/test_parametric_reform.py
+++ b/openfisca_france/tests/reforms/test_parametric_reform.py
@@ -8,7 +8,7 @@ from openfisca_core.reforms import Reform
 from openfisca_france.tests.base import assert_near, tax_benefit_system
 
 simulation_year = 2013
-simulation_period = periods.period('year', simulation_year)
+simulation_period = periods.period(simulation_year)
 
 
 def modify_legislation_json(reference_legislation_json_copy):

--- a/openfisca_france/tests/reforms/test_plf2015.py
+++ b/openfisca_france/tests/reforms/test_plf2015.py
@@ -25,7 +25,7 @@ def test(year = 2013):
                 name = 'salaire_imposable',
                 ),
             ],
-        period = periods.period('year', year),
+        period = periods.period(year),
         parent1 = dict(date_naissance = datetime.date(year - 40, 1, 1)),
         parent2 = dict(date_naissance = datetime.date(year - 40, 1, 1)) if people >= 2 else None,
         enfants = [

--- a/openfisca_france/tests/reforms/test_plf2016.py
+++ b/openfisca_france/tests/reforms/test_plf2016.py
@@ -28,7 +28,7 @@ def run(reform_key, year):
                 name = 'salaire_imposable',
                 ),
             ],
-        period = periods.period('year', year),
+        period = periods.period(year),
         parent1 = dict(date_naissance = datetime.date(year - 40, 1, 1)),
         parent2 = dict(date_naissance = datetime.date(year - 40, 1, 1)) if people >= 2 else None,
         enfants = [

--- a/openfisca_france/tests/reforms/test_plf2016_ayrault_muet.py
+++ b/openfisca_france/tests/reforms/test_plf2016_ayrault_muet.py
@@ -29,7 +29,7 @@ def run(reform_key, year):
                 name = 'salaire_imposable',
                 ),
             ],
-        period = periods.period('year', year),
+        period = periods.period(year),
         parent1 = dict(date_naissance = datetime.date(year - 40, 1, 1)),
         parent2 = dict(date_naissance = datetime.date(year - 40, 1, 1)) if people >= 2 else None,
         enfants = [

--- a/openfisca_france/tests/reforms/test_plfr2014.py
+++ b/openfisca_france/tests/reforms/test_plfr2014.py
@@ -23,7 +23,7 @@ def test(year = 2013):
                 name = 'salaire_imposable',
                 ),
             ],
-        period = periods.period('year', year),
+        period = periods.period(year),
         parent1 = dict(date_naissance = datetime.date(year - 40, 1, 1)),
         parent2 = dict(date_naissance = datetime.date(year - 40, 1, 1)) if people >= 2 else None,
         enfants = [

--- a/openfisca_france/tests/reforms/test_trannoy_wasmer.py
+++ b/openfisca_france/tests/reforms/test_trannoy_wasmer.py
@@ -23,7 +23,7 @@ def test_charge_loyer():
                 name = 'salaire_de_base',
                 ),
             ],
-        period = periods.period('year', year),
+        period = periods.period(year),
         parent1 = dict(date_naissance = datetime.date(year - 40, 1, 1)),
         parent2 = dict(date_naissance = datetime.date(year - 40, 1, 1)),
         enfants = [

--- a/openfisca_france/tests/test_allegement_fillon.py
+++ b/openfisca_france/tests/test_allegement_fillon.py
@@ -15,7 +15,7 @@ def modify_legislation_json(reference_legislation_json_copy):
     reform_legislation_json = update_legislation(
         legislation_json = reference_legislation_json_copy,
         path = ['children', 'cotsoc', 'children', 'gen', 'children', 'smic_h_b', 'values'],
-        period = periods.period("year", 2013),
+        period = periods.period(2013),
         value = 9,
         )
     return reform_legislation_json

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'Babel >= 0.9.4',
         'Biryani[datetimeconv] >= 0.10.4',
         'numpy >= 1.11',
-        'OpenFisca-Core >= 6.1.0, < 9.0',
+        'OpenFisca-Core >= 6.1.0, < 10.0',
         'PyYAML >= 3.10',
         'requests >= 2.8',
         ],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '15.1.0',
+    version = '15.1.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Amélioration technique **non-rétrocompatible**
* Détails :
    - Restreint les périodes acceptées par OpenFisca
    - La liste des périodes autorisées est disponible dans la [documentation](https://doc.openfisca.fr/periodsinstants.html)

<!-- -->

* Amélioration technique
* Détails :
  - Adapte `france` à  la version `9.0.0` de `core`.