### PR TITLE
Corrige la release précédence

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '15.1.1',
+    version = '16.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
#710 contient une erreur : le changelog mentionne la version `16.0.0` mais `setup.py` mentionne `15.1.1`.

Devons-nous dépublier https://pypi.python.org/pypi/OpenFisca-France `==15.1.1` ?