### PR TITLE
Rename aide_logement_participation_personelle to aide_logement_partic…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -670,7 +670,7 @@ It is included in the bases of the following variables.
 	* `aide_logement_R0`
 	* `aide_logement_taux_famille`
 	* `aide_logement_taux_loyer`
-	* `aide_logement_participation_personelle`
+	* `aide_logement_participation_personnelle`
 
 ## 1.2.0 – [diff](https://github.com/openfisca/openfisca-france/compare/1.1.0...1.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 18.0.0 - [#718](https://github.com/openfisca/openfisca-france/pull/718)
+
+* Évolution du système socio-fiscal
+* Périodes concernées : toutes
+* Zones impactées: `prestations/aides_logement`
+* Détails :
+    - Corrige l'erreur de frappe sur le nom de la variable `aide_logement_participation_personelle` qui devient donc `aide_logement_participation_personnelle`
+
 ## 17.2.0 - [#726](https://github.com/openfisca/openfisca-france/pull/726)
 
 * Évolution du système socio-fiscal

--- a/openfisca_france/conf/cache_blacklist.py
+++ b/openfisca_france/conf/cache_blacklist.py
@@ -7,7 +7,7 @@ cache_blacklist = set([
     'aide_logement_R0',
     'aide_logement_taux_famille',
     'aide_logement_taux_loyer',
-    'aide_logement_participation_personelle',
+    'aide_logement_participation_personnelle',
     'aide_logement_loyer_seuil_degressivite',
     'aide_logement_loyer_seuil_suppression',
     'aide_logement_montant_brut_avant_degressivite',

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -207,14 +207,14 @@ class aide_logement_base_ressources_defaut(Variable):
         abattement_depart_retraite = self.sum_by_entity(abattement_depart_retraite_holder, roles = [CHEF, PART])
         neutralisation_rsa = simulation.calculate('aide_logement_neutralisation_rsa', period)
         abattement_ressources_enfant = simulation.legislation_at(period.n_2.stop).prestations.minima_sociaux.aspa.plafond_ressources_seul * 1.25
-        br_enfants = self.sum_by_entity(
+        base_ressources_enfants = self.sum_by_entity(
             max_(0, base_ressources_holder.array - abattement_ressources_enfant), roles = ENFS)
 
         # Revenus du foyer fiscal
         rev_coll = simulation.famille.demandeur.foyer_fiscal('rev_coll', period.n_2)
 
         ressources = (
-            base_ressources_parents + br_enfants + rev_coll -
+            base_ressources_parents + base_ressources_enfants + rev_coll -
             (abattement_chomage_indemnise + abattement_depart_retraite + neutralisation_rsa)
             )
 
@@ -283,6 +283,7 @@ class aide_logement_base_ressources(Variable):
 
         return ressources
 
+
 class aide_logement_loyer_plafond(Variable):
     column = FloatCol
     entity = Famille
@@ -296,7 +297,6 @@ class aide_logement_loyer_plafond(Variable):
         coloc = famille.demandeur.menage('coloc', period)
         chambre = famille.demandeur.menage('logement_chambre', period)
         zone_apl = famille.demandeur.menage('zone_apl', period)
-
 
         # Preprocessing pour pouvoir accéder aux paramètres dynamiquement par zone.
         plafonds_by_zone = [
@@ -545,7 +545,7 @@ class aide_logement_taux_loyer(Variable):
         return TL
 
 
-class aide_logement_participation_personelle(Variable):
+class aide_logement_participation_personnelle(Variable):
     column = FloatCol
     entity = Famille
     label = u"Participation personelle de la famille au loyer"
@@ -570,6 +570,7 @@ class aide_logement_participation_personelle(Variable):
 
         return P0 + Tp * Rp
 
+
 class aide_logement_montant_brut_avant_degressivite(Variable):
     column = FloatCol
     label = u"Montant des aides aux logements en secteur locatif avant degressivité et brut de CRDS"
@@ -584,9 +585,9 @@ class aide_logement_montant_brut_avant_degressivite(Variable):
 
         loyer_retenu = famille('aide_logement_loyer_retenu', period)
         charges_retenues = famille('aide_logement_charges', period)
-        participation_personelle = famille('aide_logement_participation_personelle', period)
+        participation_personnelle = famille('aide_logement_participation_personnelle', period)
 
-        montant_locataire = max_(0, loyer_retenu + charges_retenues - participation_personelle)
+        montant_locataire = max_(0, loyer_retenu + charges_retenues - participation_personnelle)
         montant_accedants = 0  # TODO: APL pour les accédants à la propriété
 
         montant = select([locataire, accedant], [montant_locataire, montant_accedants])

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '17.2.0',
+    version = '18.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/aides_logement.yaml
+++ b/tests/formulas/aides_logement.yaml
@@ -168,7 +168,7 @@
     # taux de participation T_p : 0.03235
     # P0: 34.73
     # Rp: 7438
-    aide_logement_participation_personelle: 34.73 + (0.0283 + 0.00405) * 7438  # 275.35
+    aide_logement_participation_personnelle: 34.73 + (0.0283 + 0.00405) * 7438  # 275.35
     aide_logement_montant_brut: 292.85 + 53.27 - 275.35 # 70.77
 
 - name: "Personne isolée 2016-10"
@@ -196,7 +196,7 @@
     # taux de participation T_p : 0.03235
     # P0: 34.73
     # Rp: 7438
-    aide_logement_participation_personelle: 34.73 + (0.0283 + 0.00405) * 7438  # 275.35
+    aide_logement_participation_personnelle: 34.73 + (0.0283 + 0.00405) * 7438  # 275.35
     aide_logement_montant_brut: 292.85 + 53.27 - 275.35 # 70.77 brut CRDS
 
 - name: "Personne isolée, avant degressivité"


### PR DESCRIPTION
…ipation_personnelle

Typo

* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées : `prestations/aides_logement`.
* Détails :
  - Renomme `aide_logement_participation_personelle` en `aide_logement_participation_personnelle`.
  - Le nom de la variable comportait une faute d'orthographe.

- - - -

Ces changements :

- Impactent l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).

EDIT: format