### PR TITLE
Corrige des URLs vers la documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,6 @@ Chaque évolution sera documentée par les élements suivants :
 >
 > * Détails :
 >   - Déplacement du test runner depuis `france` vers `core`.
->   - _Il devient possible d'exécuter `openfisca-run-test` sur un fichier YAML. [Plus d'informations](http://openfisca.readthedocs.io/en/latest/openfisca-run-test.html)._
+>   - _Il devient possible d'exécuter `openfisca-run-test` sur un fichier YAML. [Plus d'informations](https://openfisca.readthedocs.io/en/latest/openfisca-run-test.html)._
 
 Dans le cas où une Pull Request contient plusieurs évolutions distinctes, plusieurs paragraphes peuvent être ajoutés au Changelog.

--- a/openfisca_france/extensions/README.md
+++ b/openfisca_france/extensions/README.md
@@ -1,3 +1,3 @@
 Put here the extensions you want to add to Openfisca-France, they will be automatically loaded.
 
-More info on extensions [here](http://doc.openfisca.fr/en/contribute/extensions.html).
+More info on extensions [here](https://doc.openfisca.fr/contribute/extensions.html).

--- a/travis-run-tests.sh
+++ b/travis-run-tests.sh
@@ -2,8 +2,12 @@
 
 current_version=`python setup.py --version`
 
-# Run this part only when merging a branch in master.
+# This part is executed only when merging a branch in master.
 if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" != false ]]; then
+    # A version bump is requested by default, except:
+    # - when changing a Markdown (.md) file
+    # - or when only blank lines are added/removed
+
     # Note: git diff-index does not work with --ignore-blank-lines option.
     bumping_changes=`git --no-pager diff --ignore-blank-lines master openfisca_france | grep "^diff" | grep -v "\.md$"`
 

--- a/travis-run-tests.sh
+++ b/travis-run-tests.sh
@@ -2,19 +2,19 @@
 
 current_version=`python setup.py --version`
 
-if ! git diff-index --quiet master openfisca_france
-then
-    if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" != false ]]
-    then
-        if git rev-parse $current_version
-        then
+# Run this part only when merging a branch in master.
+if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" != false ]]; then
+    # Note: git diff-index does not work with --ignore-blank-lines option.
+    bumping_changes=`git --no-pager diff --ignore-blank-lines master openfisca_france | grep "^diff" | grep -v "\.md$"`
+
+    if [[ -n "$bumping_changes" ]]; then
+        if git rev-parse $current_version; then
             set +x
             echo "Version $version already exists. Please update version number in setup.py before merging this branch into master."
             exit 1
         fi
 
-        if git diff-index master --quiet CHANGELOG.md
-        then
+        if git diff-index master --quiet CHANGELOG.md; then
             set +x
             echo "CHANGELOG.md has not been modified. Please update it before merging this branch into master."
             exit 1


### PR DESCRIPTION
Connected to https://github.com/openfisca/openfisca-core/issues/471

* Changement mineur
* Détails :
  - Corrige des URLs vers la documentation.
  - Supprime "/en" de l'URL, utilise HTTPS.

- - - -

Ces changements :
- Modifient des éléments non fonctionnels de ce dépôt.