### PR TITLE
Met à jour le taux de l'ASF sur la base du décret n° 2016-398 du 1er avril 2016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,25 @@
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/04/2016.
-* Zones impactées : `prestations.prestations_familiales.asf`.
+* Zones impactées :
+  - `prestations.prestations_familiales.asf`
+  - `prestations.prestations_familiales.cf`
+  - `prestations.minima_sociaux.ass`
 * Détails :
-  - Met à jour le taux pour ASF, entré en vigueur le 1er avril 2016.
-  - Met à jour les taux pour l'ASF, CF, ASS, ATA, entré en vigueur le 1er avril 2017.
+  - Mise à jour du montant de l'ASF aux 1er avril 2016, 1er avril 2017, et 1er avril 2018.
+    - [Source pour 2016](https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000032345545&idArticle=LEGIARTI000032347447&dateTexte=20160403)
+    - [Autre source pour 2016](http://circulaire.legifrance.gouv.fr/pdf/2016/03/cir_40664.pdf)
+    - [Source pour 2017 et 2018](https://www.legifrance.gouv.fr/eli/decret/2017/4/12/2017-532/jo/texte)
+  - Mise à jour du montant du CF majoré en métropole aux 1er avril 2017 et 1er avril 2018.
+    - [Source](https://www.legifrance.gouv.fr/eli/decret/2017/4/12/2017-532/jo/texte)
+  - Mise à jour du montant du du CF majoré dans les DOM au 1er avril 2017
+    - [Source](https://www.legifrance.gouv.fr/eli/decret/2017/4/12/2017-534/jo/texte)
+  - Mise à jour du montant de l'ASS aux 1er avril 2016 et premier avril 2017
+    - [Source pour 2016](https://www.legifrance.gouv.fr/eli/decret/2016/5/3/2016-540/jo/texte) 
+    - [Source pour 2017](https://www.legifrance.gouv.fr/eli/decret/2017/5/10/2017-1022/jo/texte) 
+  - Mise à jour du montant de l'ATA aux 1er avril 2016 et premier avril 2017
+    - [Source pour 2016](https://www.legifrance.gouv.fr/eli/decret/2016/5/3/2016-540/jo/texte) 
+    - [Source pour 2017](https://www.legifrance.gouv.fr/eli/decret/2017/5/10/2017-1022/jo/texte) 
 
 ### 18.2.6 - [#747](https://github.com/openfisca/openfisca-france/pull/747)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 18.2.7 - [#728](https://github.com/openfisca/openfisca-france/pull/728)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/04/2016.
+* Zones impactées : `prestations.prestations_familiales.asf`.
+* Détails :
+  - Met à jour le taux pour ASF, entré en vigueur le 1er avril 2016.
+  - Met à jour les taux pour l'ASF, CF, ASS, ATA, entré en vigueur le 1er avril 2017.
+
 ### 18.2.6 - [#747](https://github.com/openfisca/openfisca-france/pull/747)
 
 * Évolution du système socio-fiscal.
@@ -14,7 +23,6 @@
 * Changement mineur
 * Détails :
   - Supprime le système de chargement automatique des extensions via le dossier `extensions` . Les extensions sont maintenant installées sous la forme de packages indépendants.
-
 
 ### 18.2.4 - [#759](https://github.com/openfisca/openfisca-france/pull/759)
 

--- a/openfisca_france/parameters/prestations.xml
+++ b/openfisca_france/parameters/prestations.xml
@@ -3320,6 +3320,8 @@
         <VALUE deb="2001-01-01" valeur="18.81" />
       </CODE>
       <CODE code="montant_plein" description="Montant journalier à taux plein" format="float" origin="openfisca" type="monetary">
+        <VALUE deb="2017-04-01" valeur="16.32" />
+        <VALUE deb="2016-04-01" valeur="16.27" />
         <VALUE deb="2015-01-01" valeur="16.25" />
         <VALUE deb="2014-01-01" valeur="16.11" />
         <VALUE deb="2013-01-01" valeur="15.90" />

--- a/openfisca_france/parameters/prestations.xml
+++ b/openfisca_france/parameters/prestations.xml
@@ -4601,7 +4601,7 @@
       </CODE>
       <CODE code="taux_cf_majore" conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2002-01-01,openfisca_fin=2014-03-31,openfisca_valeur=0.4165,ipp_valeur=unknown)" description="Taux du complément familial majoré" format="percent" origin="ipp">
         <VALUE deb="2018-04-01" valeur="0.6248" />
-        <VALUE deb="2017-04-01" valeur="0.5822" />
+        <VALUE deb="2017-04-01" valeur="0.5833" />
         <VALUE deb="2016-04-01" valeur="0.5416" />
         <VALUE deb="2015-04-01" valeur="0.4999" />
         <VALUE deb="2014-04-01" valeur="0.4582" />

--- a/openfisca_france/parameters/prestations.xml
+++ b/openfisca_france/parameters/prestations.xml
@@ -2340,7 +2340,7 @@
     </NODE>
   </NODE>
   <NODE code="ata" origin="ipp">
-    <CODE code="montant_journalier" format="float" origin="ipp" type="monetary">
+    <CODE code="montant_journalier" format="float" origin="ipp" type="monetary" description="Montant journalier de l'ATA">
       <END deb="2015-11-01" />
       <VALUE deb="2017-04-01" valeur="11.49" />
       <VALUE deb="2016-04-01" valeur="11.46" />
@@ -3321,7 +3321,7 @@
         <VALUE deb="2002-01-01" valeur="19.19" />
         <VALUE deb="2001-01-01" valeur="18.81" />
       </CODE>
-      <CODE code="montant_plein" description="Montant journalier à taux plein" format="float" origin="openfisca" type="monetary">
+      <CODE code="montant_plein" description="Montant journalier à taux plein de l'ASS" format="float" origin="openfisca" type="monetary">
         <VALUE deb="2017-04-01" valeur="16.32" />
         <VALUE deb="2016-04-01" valeur="16.27" />
         <VALUE deb="2015-01-01" valeur="16.25" />
@@ -4472,7 +4472,10 @@
           <VALUE deb="2009-06-01" valeur="0.3" />
         </CODE>
       </NODE>
-      <CODE code="taux_1_parent" conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2016-04-01,openfisca_fin=None,openfisca_valeur=0.2589,ipp_valeur=unknown)" description="Orphelin de père ou de mère (un seul parent manquant) ou situation assimilée: beaux parents ou pension alimentaire non versée, en pourcentage de la BMAF" format="percent" origin="ipp">
+      <CODE code="taux_1_parent"
+        conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2016-04-01,openfisca_fin=None,openfisca_valeur=0.2589,ipp_valeur=unknown)"
+        description="Montant de l'ASF, en pourcentage de la BMAF, pour un enfant orphelin de père ou de mère (un seul parent manquant) ou dans une situation assimilée: beaux parents ou pension alimentaire non versée"
+        format="percent" origin="ipp">
         <VALUE deb="2018-04-01" valeur="0.2813" />
         <VALUE deb="2017-04-01" valeur="0.2702" />
         <VALUE deb="2016-04-01" valeur="0.2589" />
@@ -4481,7 +4484,10 @@
         <VALUE deb="1978-01-01" valeur="0.225" />
         <VALUE deb="1970-12-26" valeur="0.16" />
       </CODE>
-      <CODE code="taux_2_parents" conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2016-04-01,openfisca_fin=None,openfisca_valeur=0.3450,ipp_valeur=unknown)" description="Orphelin (de père et de mère), ou situation assimilée" format="percent" origin="ipp">
+      <CODE code="taux_2_parents"
+        conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2016-04-01,openfisca_fin=None,openfisca_valeur=0.3450,ipp_valeur=unknown)"
+        description="Montant de l'ASF, en pourcentage de la BMAF, pour un enfant orphelin (de père et de mère), ou situation assimilée."
+        format="percent" origin="ipp">
         <VALUE deb="2018-04-01" valeur="0.375" />
         <VALUE deb="2017-04-01" valeur="0.36" />
         <VALUE deb="2016-04-01" valeur="0.345" />

--- a/openfisca_france/parameters/prestations.xml
+++ b/openfisca_france/parameters/prestations.xml
@@ -4597,6 +4597,7 @@
         <VALUE deb="2014-04-01" valeur="0.4582" />
       </CODE>
       <CODE code="taux_majore_dom" description="Taux du complément familial majoré dans les DOM" format="percent" origin="ipp">
+        <VALUE deb="2017-04-01" valeur="0.3331" />
         <VALUE deb="2016-04-01" valeur="0.3093" />
         <VALUE deb="2015-04-01" valeur="0.2855" />
         <VALUE deb="2014-04-01" valeur="0.2617" />

--- a/openfisca_france/parameters/prestations.xml
+++ b/openfisca_france/parameters/prestations.xml
@@ -4469,6 +4469,8 @@
         </CODE>
       </NODE>
       <CODE code="taux_1_parent" conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2016-04-01,openfisca_fin=None,openfisca_valeur=0.2589,ipp_valeur=unknown)" description="Orphelin de père ou de mère (un seul parent manquant) ou situation assimilée: beaux parents ou pension alimentaire non versée, en pourcentage de la BMAF" format="percent" origin="ipp">
+        <VALUE deb="2018-04-01" valeur="0.2813" />
+        <VALUE deb="2017-04-01" valeur="0.2702" />
         <VALUE deb="2016-04-01" valeur="0.2589" />
         <VALUE deb="2015-04-01" valeur="0.2476" />
         <VALUE deb="2014-04-01" valeur="0.2363" />
@@ -4476,6 +4478,8 @@
         <VALUE deb="1970-12-26" valeur="0.16" />
       </CODE>
       <CODE code="taux_2_parents" conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2016-04-01,openfisca_fin=None,openfisca_valeur=0.3450,ipp_valeur=unknown)" description="Orphelin (de père et de mère), ou situation assimilée" format="percent" origin="ipp">
+        <VALUE deb="2018-04-01" valeur="0.375" />
+        <VALUE deb="2017-04-01" valeur="0.36" />
         <VALUE deb="2016-04-01" valeur="0.345" />
         <VALUE deb="2015-04-01" valeur="0.33" />
         <VALUE deb="2014-04-01" valeur="0.315" />

--- a/openfisca_france/parameters/prestations.xml
+++ b/openfisca_france/parameters/prestations.xml
@@ -4469,12 +4469,14 @@
         </CODE>
       </NODE>
       <CODE code="taux_1_parent" conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2016-04-01,openfisca_fin=None,openfisca_valeur=0.2589,ipp_valeur=unknown)" description="Orphelin de père ou de mère (un seul parent manquant) ou situation assimilée: beaux parents ou pension alimentaire non versée, en pourcentage de la BMAF" format="percent" origin="ipp">
+        <VALUE deb="2016-04-01" valeur="0.2589" />
         <VALUE deb="2015-04-01" valeur="0.2476" />
         <VALUE deb="2014-04-01" valeur="0.2363" />
         <VALUE deb="1978-01-01" valeur="0.225" />
         <VALUE deb="1970-12-26" valeur="0.16" />
       </CODE>
       <CODE code="taux_2_parents" conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2016-04-01,openfisca_fin=None,openfisca_valeur=0.3450,ipp_valeur=unknown)" description="Orphelin (de père et de mère), ou situation assimilée" format="percent" origin="ipp">
+        <VALUE deb="2016-04-01" valeur="0.345" />
         <VALUE deb="2015-04-01" valeur="0.33" />
         <VALUE deb="2014-04-01" valeur="0.315" />
         <VALUE deb="1970-12-26" valeur="0.3" />

--- a/openfisca_france/parameters/prestations.xml
+++ b/openfisca_france/parameters/prestations.xml
@@ -2342,6 +2342,8 @@
   <NODE code="ata" origin="ipp">
     <CODE code="montant_journalier" format="float" origin="ipp" type="monetary">
       <END deb="2015-11-01" />
+      <VALUE deb="2017-04-01" valeur="11.49" />
+      <VALUE deb="2016-04-01" valeur="11.46" />
       <VALUE deb="2015-01-01" valeur="11.45" />
       <VALUE deb="2014-01-01" valeur="11.35" />
       <VALUE deb="2013-01-01" valeur="11.2" />

--- a/openfisca_france/parameters/prestations.xml
+++ b/openfisca_france/parameters/prestations.xml
@@ -4590,6 +4590,8 @@
         <VALUE deb="1978-01-01" valeur="0.4475" />
       </CODE>
       <CODE code="taux_cf_majore" conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2002-01-01,openfisca_fin=2014-03-31,openfisca_valeur=0.4165,ipp_valeur=unknown)" description="Taux du complément familial majoré" format="percent" origin="ipp">
+        <VALUE deb="2018-04-01" valeur="0.6248" />
+        <VALUE deb="2017-04-01" valeur="0.5822" />
         <VALUE deb="2016-04-01" valeur="0.5416" />
         <VALUE deb="2015-04-01" valeur="0.4999" />
         <VALUE deb="2014-04-01" valeur="0.4582" />

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '18.2.6',
+    version = '18.2.7',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/rsa_2017.yaml
+++ b/tests/formulas/rsa_2017.yaml
@@ -98,17 +98,18 @@
     rsa_isolement_recent: true
     parents: [1]
     enfants: [3, 4]
-    # af_base: 130 # calculé
-    # asf: 200
+    # af_base: 130.12
+    # asf: 210.54
   menages:
     personne_de_reference: 1
     enfants: [3,4]
     statut_occupation_logement: 4 # locataire
     loyer: 400
   output_variables:
-    af_base: 130
-    asf: 200
-    rsa: 986.42 - 130 - 180
+    af_base: 130.12
+    asf: 210.54
+    # RSA - AF - Forfait ASF
+    rsa: 986.42 - 130.12 - 180
 
 - name: "Les primes sur un mois ne sont pas moyennées"
   period: 2017-01


### PR DESCRIPTION
### 16.1.2 - https://github.com/openfisca/openfisca-france/pull/728

* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/04/2016.
* Zones impactées : `taux_1_parent` et `taux_2_parents` dans `prestations.prestations_familiales.asf`.
* Détails :
  - https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=1D9FEF8D527DD02D7A6666DAA945964D.tpdila23v_2?cidTexte=JORFTEXT000032345545&idArticle=LEGIARTI000032347447&dateTexte=20160403

Plus d'informations dans la circulaire
http://circulaire.legifrance.gouv.fr/pdf/2016/03/cir_40664.pdf
- - - -

