### PR TITLE
Removes Extensions file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,5 @@
 /dist
 /openfisca_france/assets/apl/france2014.txt
 /openfisca_france/assets/apl/france2014.zip
-openfisca_france/extensions
 /tags
 .spyproject

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 18.2.5 - [#760](https://github.com/openfisca/openfisca-france/pull/759)
+
+* Changement mineur
+* Détails :
+  - Supprime le système de chargement automatique des extensions via le dossier `extensions` . Ce système a été remplacé par l'import d'OpenFisca France dans le template de l'extension.
+
+
 ### 18.2.4 - [#759](https://github.com/openfisca/openfisca-france/pull/759)
 
 * Changement mineur

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Changement mineur
 * Détails :
-  - Supprime le système de chargement automatique des extensions via le dossier `extensions` . Ce système a été remplacé par l'import d'OpenFisca France dans le template de l'extension.
+  - Supprime le système de chargement automatique des extensions via le dossier `extensions` . Les extensions sont maintenant installées sous la forme de packages indépendants.
 
 
 ### 18.2.4 - [#759](https://github.com/openfisca/openfisca-france/pull/759)

--- a/openfisca_france/extensions/README.md
+++ b/openfisca_france/extensions/README.md
@@ -1,3 +1,0 @@
-Put here the extensions you want to add to Openfisca-France, they will be automatically loaded.
-
-More info on extensions [here](https://doc.openfisca.fr/contribute/extensions.html).

--- a/openfisca_france/france_taxbenefitsystem.py
+++ b/openfisca_france/france_taxbenefitsystem.py
@@ -15,7 +15,6 @@ from .conf.cache_blacklist import cache_blacklist as conf_cache_blacklist
 COUNTRY_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-
 class FranceTaxBenefitSystem(TaxBenefitSystem):
     """French tax benefit system"""
     CURRENCY = u"€"
@@ -57,8 +56,6 @@ class FranceTaxBenefitSystem(TaxBenefitSystem):
 
         self.add_variables_from_directory(os.path.join(COUNTRY_DIR, 'model'))
         self.cache_blacklist = conf_cache_blacklist
-
-
 
     def prefill_cache(self):
         # Compute one "zone APL" variable, to pre-load CSV of "code INSEE commune" to "Zone APL".

--- a/openfisca_france/france_taxbenefitsystem.py
+++ b/openfisca_france/france_taxbenefitsystem.py
@@ -13,8 +13,7 @@ from .conf.cache_blacklist import cache_blacklist as conf_cache_blacklist
 
 
 COUNTRY_DIR = os.path.dirname(os.path.abspath(__file__))
-EXTENSIONS_PATH = os.path.join(COUNTRY_DIR, 'extensions')
-EXTENSIONS_DIRECTORIES = glob.glob(os.path.join(EXTENSIONS_PATH, '*/'))
+
 
 
 class FranceTaxBenefitSystem(TaxBenefitSystem):
@@ -58,8 +57,7 @@ class FranceTaxBenefitSystem(TaxBenefitSystem):
 
         self.add_variables_from_directory(os.path.join(COUNTRY_DIR, 'model'))
         self.cache_blacklist = conf_cache_blacklist
-        for extension_dir in EXTENSIONS_DIRECTORIES:
-            self.load_extension(extension_dir)
+
 
 
     def prefill_cache(self):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '18.2.4',
+    version = '18.2.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Connected to #736 
* Changement mineur.
* Périodes concernées : toutes
* Zones impactées : 

Delete *openfisca-france/openfisca_france/extensions*

openfisca-france/.gitignore, line 19

````
openfisca_france/extensions
````

in openfisca-france/openfisca_france/france_taxbenefitsystem.py line 16, 17
````
EXTENSIONS_PATH = os.path.join(COUNTRY_DIR, 'extensions')
EXTENSIONS_DIRECTORIES = glob.glob(os.path.join(EXTENSIONS_PATH, ‘*/'))
````


openfisca-france/openfisca_france/france_taxbenefitsystem.py line 60
````
        for extension_dir in EXTENSIONS_DIRECTORIES:
            self.load_extension(extension_dir)
````

* Détails :
  - Supprimer le dossier Extensions
- - - -

Ces changements _(effacez les lignes ne correspondant pas à votre cas)_ :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).
