### PR TITLE
Mise à jour du RSA au 1er avril et au 1er septembre 2017 et de la BMAF au 1er avril 2017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+### 18.3.1 - [#767](https://github.com/openfisca/openfisca-france/pull/767)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/04/2017.
+* Zones impactées :
+  - `prestations.minima_sociaux.rsa`
+  - `prestations.prestations_familiales.af`
+* Détails :
+  - Mise à jour du montant du montant de base pour le RSA aux 1er avril, 1er septembre 2017.
+    - [Source](https://www.legifrance.gouv.fr/eli/decret/2017/5/4/2017-739/jo/article_1)
+  - Mise à jour de la BMAF au 1er avril 2017
+    - [Source](http://circulaire.legifrance.gouv.fr/pdf/2017/03/cir_41970.pdf)
+  - Correction mineure du taux de la BMAF au 1er avril 2015
+    - [Source](http://circulaire.legifrance.gouv.fr/pdf/2016/03/cir_40664.pdf) cf. valeur initiale (valeur erronée 406.21274, valeur corrigée 406.21)
+
 ### 18.3.0 - [#746](https://github.com/openfisca/openfisca-france/pull/746)
 
 * Amélioration technique

--- a/openfisca_france/parameters/prestations.xml
+++ b/openfisca_france/parameters/prestations.xml
@@ -3704,6 +3704,8 @@
         </CODE>
       </NODE>
       <CODE code="montant_de_base_du_rsa" conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2001-01-01,openfisca_fin=2001-12-31,openfisca_valeur=397.6,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2005-01-01,openfisca_fin=2005-12-31,openfisca_valeur=425.4,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2002-01-01,openfisca_fin=2002-12-31,openfisca_valeur=405.62,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2003-01-01,openfisca_fin=2003-12-31,openfisca_valeur=411.7,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2009-01-01,openfisca_fin=2009-12-31,openfisca_valeur=454.63,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2007-01-01,openfisca_fin=2007-12-31,openfisca_valeur=440.86,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2006-01-01,openfisca_fin=2006-12-31,openfisca_valeur=433.06,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2008-01-01,openfisca_fin=2008-12-31,openfisca_valeur=447.91,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2004-01-01,openfisca_fin=2004-12-31,openfisca_valeur=417.88,ipp_valeur=unknown)" description="Rsa socle" format="float" origin="ipp" type="monetary">
+        <VALUE deb="2017-09-01" valeur="545.48" />
+        <VALUE deb="2017-04-01" valeur="536.78" />
         <VALUE deb="2016-09-01" valeur="535.17" />
         <VALUE deb="2016-04-01" valeur="524.68" />
         <VALUE deb="2015-09-01" valeur="524.16" />

--- a/openfisca_france/parameters/prestations.xml
+++ b/openfisca_france/parameters/prestations.xml
@@ -4031,8 +4031,9 @@
         <VALUE deb="2003-07-01" valeur="20" />
       </CODE>
       <CODE code="bmaf" conflicts="children:openfisca-not-fully-included-in-ipp(openfisca_deb=2001-01-01,openfisca_fin=2001-12-31,openfisca_valeur=334.84,ipp_valeur=2196.38),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2011-01-01,openfisca_fin=2012-03-31,openfisca_valeur=395.04,ipp_valeur=unknown),children:openfisca-not-fully-included-in-ipp(openfisca_deb=2014-04-01,openfisca_fin=2016-03-31,openfisca_valeur=406.21,ipp_valeur=406.21274)" description="Base mensuelle des allocations familiales" format="float" origin="ipp" type="monetary">
+        <VALUE deb="2017-04-01" valeur="407.84" />
         <VALUE deb="2016-04-01" valeur="406.62" />
-        <VALUE deb="2014-04-01" valeur="406.21274" />
+        <VALUE deb="2014-04-01" valeur="406.21" />
         <VALUE deb="2013-04-01" valeur="403.79" />
         <VALUE deb="2012-01-01" valeur="399" />
         <VALUE deb="2011-01-01" valeur="395.04" />

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '18.3.0',
+    version = '18.3.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
# Changelog

### 18.2.8 - [#767](https://github.com/openfisca/openfisca-france/pull/767)

* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/04/2017.
* Zones impactées :
  - `prestations.minima_sociaux.rsa.montant_de_base_du_rsa`
  - `prestations.prestations_familiales.af.bmaf`
* Détails :
  - Mise à jour du montant du montant de base pour le RSA aux 1er avril, 1er septembre 2017.
    - [Source](https://www.legifrance.gouv.fr/eli/decret/2017/5/4/2017-739/jo/article_1)
  - Mise à jour de la BMAF au 1er avril 2017
    - [Source](http://circulaire.legifrance.gouv.fr/pdf/2017/03/cir_41970.pdf)
  - Correction mineure du taux de la BMAF au 1er avril 2015
    - [Source](http://circulaire.legifrance.gouv.fr/pdf/2016/03/cir_40664.pdf) cf. valeur initiale (valeur erronée 406.21274, valeur corrigée 406.21)