### PR TITLE
Give users an actionnable install procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Clonez OpenFisca-France sur votre machine :
 ```sh
 git clone https://github.com/openfisca/openfisca-france.git
 cd openfisca-france
-pip install -e '.'
+pip install -e .
 ```
 
 Vous pouvez vous assurer que votre installation s'est bien passée en exécutant :
@@ -163,7 +163,7 @@ Pour ce faire, installez l'API Web OpenFisca :
     ```sh
     pip install 'openfisca-france[api]'
     ```
-- si vous avez installé OpenFisca-France avec git clone:
+- si vous avez installé OpenFisca-France avec git clone, dans le répertoire openfisca-france, exécutez la commande suivante :
 
     ```sh
     pip install -e '.[api]'
@@ -179,6 +179,19 @@ Testez votre installation en requêtant la commande suivante :
 
 ```sh
 curl "http://localhost:2000/api/2/formula/2017-02/cout_du_travail?salaire_de_base=2300"
+```
+Vous devriez avoir le resultat suivant :
+```JSON
+{
+    "values":{
+        "cout_du_travail": 3078.4599609375
+     },
+     "params": {
+        "salaire_de_base": 2300.0
+        },
+     "period": ["month", [2017, 2, 1], 1],
+     "apiVersion": "2.1.0"
+ }
 ```
 
 :tada: Vous servez OpenFisca-France via l'API Web OpenFisca !

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ OpenFisca is a versatile microsimulation free software. This repository contains
 
 France met à disposition une [API Web publique](https://doc.openfisca.fr/openfisca-web-api/endpoints.html) qui ne demande aucune installation.
 Utilisez l'API publique si vous souhaitez :
-- accéder à un paramètre (Ex : [le montant du SMIC horaire brut](https://api-test.openfisca.fr/parameter/cotsoc.gen.smic_h_b) ) ;
-- consulter une formule de calcul (Ex : [le calcul de l'allocations de base des allocations familiales](https://api-test.openfisca.fr/variable/af_base)) ;
+- accéder à un paramètre (Ex : [le montant du SMIC horaire brut](https://api-test.openfisca.fr/parameter/cotsoc.gen.smic_h_b)) ;
+- consulter une formule de calcul (Ex : [le calcul de l'allocation de base des allocations familiales](https://api-test.openfisca.fr/variable/af_base)) ;
 - faire des calculs ponctuels sur une situation (Ex : le calcul du coût du travail).
 
 [L'explorateur de législation](https://legislation.openfisca.fr/) contient la liste des paramètres et variables disponibles.
 
 ## Installation
 
-Ce paquet requiert [Python 2.7](https://www.python.org/downloads/) et [pip](https://pip.pypa.io/en/stable/installing/) .
+Ce paquet requiert [Python 2.7](https://www.python.org/downloads/) et [pip](https://pip.pypa.io/en/stable/installing/).
 
 Plateformes supportées :
 - distributions GNU/Linux (en particulier Debian and Ubuntu) ;
@@ -31,15 +31,15 @@ Pour les autres OS : si vous pouvez exécuter Python et Numpy, l'installation d'
 
 ### Installez un environnement virtuel avec Pew
 
-Nous recommandons l'utilisation d'un [environnement virtuel](https://virtualenv.pypa.io/en/stable/) ("_virtualenv_") avec un gestionnaire de _virtualenv_ tel que [pew](https://github.com/berdario/pew).
+Nous recommandons l'utilisation d'un [environnement virtuel](https://virtualenv.pypa.io/en/stable/) (_virtualenv_) avec un gestionnaire de _virtualenv_ tel que [Pew](https://github.com/berdario/pew).
 
 - Un _[virtualenv](https://virtualenv.pypa.io/en/stable/)_ crée un environnement pour les besoins spécifiques du projet sur lequel vous travaillez.
-- Un gestionnaire de _virtualenv_, tel que [pew](https://github.com/berdario/pew), vous permet de facilement créer, supprimer et naviguer entre différents projets.
+- Un gestionnaire de _virtualenv_, tel que [Pew](https://github.com/berdario/pew), vous permet de facilement créer, supprimer et naviguer entre différents projets.
 
 Pour installer Pew, lancez une fenêtre de terminal et suivez ces instructions : 
 
 ```sh
-python -V # Python 2.7.9 ou plus récent devrait être installé sur votre ordinateur.
+python --version # Python 2.7.9 ou plus récent devrait être installé sur votre ordinateur.
 # Si non, téléchargez-le sur http://www.python.org et téléchargez pip.
 ```
 
@@ -64,9 +64,9 @@ Informations complémentaires :
 - sortez du _virtualenv_ en tapant `exit` (or Ctrl-D) ;
 - re-rentrez en tapant `pew workon openfisca` dans votre terminal.
 
-Bravo :tada: Vous êtes prêt à installer OpenFisca-France !
+Bravo :tada: Vous êtes prêt·e à installer OpenFisca-France !
 
-Nous proposons 2 procédures d'installation. Choisissez l'installation A ou B ci-dessous en fonction de l'usage que vous souhaitez faire d'OpenFisca-France.
+Nous proposons deux procédures d'installation. Choisissez l'installation A ou B ci-dessous en fonction de l'usage que vous souhaitez faire d'OpenFisca-France.
 
 ### A. Installation minimale (pip install)
 
@@ -104,9 +104,9 @@ Félicitations :tada: OpenFisca-France est prêt à être utilisé !
 - Hébergez et servez votre instance d'OpenFisca-France avec l'[API Web OpenFisca](#servez-openfisca-france-avec-lapi-web-openfisca).
 
 En fonction de vos projets, vous pourriez bénéficier de l'installation des paquets suivants dans votre _virtualenv_ :
-- pour installer une extension or écrire une législation au dessus d'OpenFisca France, consultez la [documentation sur les extensions](https://doc.openfisca.fr/contribute/extensions.html) (en anglais);
-- pour représenter graphiquement vos résultats, essayez la librairie [matplotlib](http://matplotlib.org/) ;
-- pour gérer vos données, découvrez la librairie [pandas](http://pandas.pydata.org/).
+- pour installer une extension ou écrire une législation au-dessus d'OpenFisca-France, consultez la [documentation sur les extensions](https://doc.openfisca.fr/contribute/extensions.html) (en anglais) ;
+- pour représenter graphiquement vos résultats, essayez la bibliothèque [matplotlib](http://matplotlib.org/) ;
+- pour gérer vos données, découvrez la bibliothèque [pandas](http://pandas.pydata.org/).
 
 ### B. Installation avancée (Git Clone)
 
@@ -186,7 +186,7 @@ Pour en savoir plus, explorez _[OpenFisca Web API documentation](https://doc.ope
 
 ## Stratégie de versionnement
 
-Le code d'OpenFisca-France est versionné de manière continue et automatique. Ainsi, à chaque fois que le code de la législation évolue sur la branche principale `master`, une nouvelle version est publiée.
+Le code d'OpenFisca-France est déployé de manière continue et automatique. Ainsi, à chaque fois que le code de la législation évolue sur la branche principale `master`, une nouvelle version est publiée.
 
 De nouvelles versions sont donc publiées très régulièrement. Cependant, la différence entre deux versions consécutives étant réduite, les efforts d'adaptation pour passer de l'une à l'autre sont en général très limités.
 

--- a/README.md
+++ b/README.md
@@ -12,19 +12,24 @@ OpenFisca is a versatile microsimulation free software. This repository contains
 
 OpenFisca France met à disposition une [API Web publique](https://doc.openfisca.fr/openfisca-web-api/index.html) qui ne demande aucune installation.
 Utilisez l'API publique si :
-- Vous souhaitez accéder à un paramètre (Ex: [le montant du SMIC horaire brut](https://legislation.openfisca.fr/cotsoc.gen.smic_h_b))
-- Vous souhaitez consulter une formule de calcul (Ex: [le calcul de l'allocation de base des Allocations familiales](https://legislation.openfisca.fr/af_base)
-- Vous souhaitez faire des calculs ponctuels sur une situation (Ex: le calcul une taxe d'habitation pour un ménage)
+- vous souhaitez accéder à un paramètre (Ex : [le montant du SMIC horaire brut](https://legislation.openfisca.fr/cotsoc.gen.smic_h_b)) ;
+- vous souhaitez consulter une formule de calcul (Ex : [le calcul de l'allocation de base des Allocations familiales](https://legislation.openfisca.fr/af_base) ;
+- vous souhaitez faire des calculs ponctuels sur une situation (Ex : le calcul une taxe d'habitation pour un ménage).
 
 [L'explorateur de législation](https://legislation.openfisca.fr/) contient la liste des paramètres et variables disponibles.
 
 ## [EN] Installation
 
 This package requires Python 2.7.
-The supported operating systems are GNU/Linux distributions (in particular Debian and Ubuntu), Mac OS X and Microsoft Windows.
+
+Supported platforms:
+- GNU/Linux distributions (in particular Debian and Ubuntu);
+- Mac OS X;
+- Microsoft Windows (we recommend using [ConEmu](https://conemu.github.io/) instead of the default console).
+
 Other OS should work if they can execute Python and NumPy.
-On Microsoft Windows we recommend using [ConEmu](https://conemu.github.io/) instead of the default console.
->***A note on dependencies*** : OpenFisca-Core will be installed automatically as a requirement of OpenFisca-France. Run pip freeze to see the installed packages: openfisca_core and openfisca_france should be listed.
+
+>***A note on dependencies***: OpenFisca-Core will be installed automatically as a requirement of OpenFisca-France. Run pip freeze to see the installed packages: openfisca_core and openfisca_france should be listed.
 
 ### [EN] Setting up a virtual environment with Pew
 
@@ -39,29 +44,29 @@ To install pew, launch a terminal on your computer and follow these instructions
 pip install --upgrade pip
 pip install pew  # answer "Y" to the question about modifying your shell config file.
 ```
-To set-up and run a virtualenv named **openfisca** running python2.7, run the command bellow.
+To set-up and create a new a virtualenv named **openfisca** running python2.7:
 
 ```sh
 pew new openfisca --python=python2.7
 ```
 
 The virtualenv you just created will be automatically activated. This means you will operate in the virtualenv immediately.
-- Exit the virtualenv with **"exit"** (or Ctrl-D),
-- Re-enter with **"pew workon openfisca"**.
+- Exit the virtualenv with `exit` (or Ctrl-D).
+- Re-enter with `pew workon openfisca`.
 
 ### [EN] Minimal Installation (pip install)
 
-Follow this installation if you  wish to:
-- Run calculations on a large population ;
-- Create tax & benefits simulations ;
-- Write an extension to this legislation (e.g. city specific tax & benefits )
-- Serve this Country Package with the OpenFisca web API.
+Follow this installation if you wish to:
+- run calculations on a large population;
+- create tax & benefits simulations;
+- write an extension to this legislation (e.g. city specific tax & benefits);
+- serve this Country Package with the OpenFisca Web API.
 
-For more advanced uses, head to the [Advanced Installation](#en-advanced-installation-git-clone)
+For more advanced uses, head to the [Advanced Installation](#en-advanced-installation-git-clone).
 
 #### [EN] Install a Country Package with pip install
 
-Inside your virtualenv, check the prerequisites
+Inside your virtualenv, check the prerequisites:
 
 ```sh
 python --version  # should print "Python 2.7.xx".
@@ -72,7 +77,7 @@ python --version  # should print "Python 2.7.xx".
 pip --version  # should print at least 9.0.
 #if not, run "pip install --upgrade pip"
 ```
-Install the OpenFisca Country Package.
+Install the OpenFisca Country Package:
 
 ```sh
 #Example: Openfisca-France
@@ -81,28 +86,29 @@ pip install openfisca-france
 
 #### [EN] Next steps
 
-- To learn how to use Openfisca, follow our [tutorials](https://doc.openfisca.fr/getting-started.html) ;
-- To serve your country package with the [OpenFisca web API](#serve-your-country-package-with-the-openFisca-web-api) ;
+- To learn how to use OpenFisca, follow our [tutorials](https://doc.openfisca.fr/getting-started.html).
+- To serve your country package, serve the [OpenFisca web API](#serve-your-country-package-with-the-openFisca-web-api).
 
-Depending on what you want to do with OpenFisca, you may want to install yet other packages in your virtualenv.
-- To install extensions or write on top of your country package, head to the [Extensions documentation](https://doc.openfisca.fr/contribute/extensions.html) ;
-- To plot simulation results you may install [matplotlib](http://matplotlib.org/) ;
-- To manage data you may install [pandas](http://pandas.pydata.org/).
+Depending on what you want to do with OpenFisca, you may want to install yet other packages in your virtualenv:
+- To install extensions or write on top of your country package, head to the [Extensions documentation](https://doc.openfisca.fr/contribute/extensions.html).
+- To plot simulation results, try [matplotlib](http://matplotlib.org/).
+- To manage data, check out [pandas](http://pandas.pydata.org/).
 
 ### [EN] Advanced installation (Git Clone)
 
-Follow this tutorial if you  wish to :
-- Create or change this Country Package's legislation
-- Contribute to the source code and to develop and/or fix part of it
+Follow this tutorial if you wish to:
+- create or change this Country Package's legislation;
+- contribute to the source code.
 
->***A note on OpenFisca-Core***: If you need to modify OpenFisca-Core source code, follow this [install tutorial](https://github.com/openfisca/openfisca-core#installation) section before completing the step below. By default just continue below.
+>***A note on OpenFisca-Core***: If you need to modify OpenFisca-Core source code (e.g. you want to contribute to a Country Package agnostic feature), follow this [install tutorial](https://github.com/openfisca/openfisca-core#installation) section before completing the step below. By default just continue below.
 
 #### [EN] Clone a Country Package with Git
 
 First of all, make sure [Git](https://www.git-scm.com/) is installed on your machine.
+
 Set your working directory to the location where you want this OpenFisca Country Package cloned.
 
-Inside your virtualenv, check the prerequisites
+Inside your virtualenv, check the prerequisites:
 
 ```sh
 python --version  # should print "Python 2.7.xx".
@@ -125,24 +131,24 @@ Your OpenFisca Country Package is now installed and ready!
 #### [EN] Next steps
 
 - To write new legislation, read the [Coding the legislation](https://doc.openfisca.fr/coding-the-legislation/index.html) section to know how to write legislation.
-- To contribute to the code, read our [Contribution Guidebook](https://doc.openfisca.fr/contribute/index.html)
+- To contribute to the code, read our [Contribution Guidebook](https://doc.openfisca.fr/contribute/index.html).
 
 ## [EN] Serve your Country Package with the OpenFisca Web API
 
-If you are considering building a web application, you can plug the OpenFisca Web API to your country package.
+If you are considering building a web application, you can plug the OpenFisca Web API to your Country Package.
 
 First, install the OpenFisca web API:
 - if you completed the minimal install, run: 
     ```sh
     #Example: Openfisca-France
-    pip install openfiscafrance[api]
+    pip install openfisca-france[api]
     ```
 - if you completed the advanced install, run:
     ```sh
     pip install -e '.[api]'
     ```
 
-Then serve the Openfisca-Web-API locally by running:
+Then serve the Openfisca Web API locally:
 
 ```sh
 openfisca-serve --port 2000
@@ -151,7 +157,7 @@ openfisca-serve --port 2000
 You can make sure that the API is working by requesting:
 
 ```sh
-curl "http://localhost:2000/api/2/formula/2017-02/cout_du_travail?salaire_de_base=2300"
+curl "http://localhost:2000/api/2/entities"
 ```
 
 To learn more, go to the [OpenFisca Web API documentation](https://doc.openfisca.fr/openfisca-web-api/index.html)

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ nosetests tests/test_basics.py # Ces test peuvent prendre jusqu'à 60 secondes.
 
 #### Prochaines étapes
 
-- Pour écrire une nouvelle législation, lisez _[Coding the Legislation](https://doc.openfisca.fr/coding-the-legislation/index.html)_ (en anglais).
+- Pour enrichir ou faire évoluer la législation d'OpenFisca-France, lisez _[Coding the Legislation](https://doc.openfisca.fr/coding-the-legislation/index.html)_ (en anglais).
 - Pour contribuer au code, lisez le _[Contribution Guidebook](https://doc.openfisca.fr/contribute/index.html)_ (en anglais).
 
 ## Servez OpenFisca-France avec l'API Web OpenFisca

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Informations complémentaires :
 - sortez du _virtualenv_ en tapant `exit` (or Ctrl-D) ;
 - re-rentrez en tapant `pew workon openfisca` dans votre terminal.
 
-### Installation minimale (pip install)
+### A. Installation minimale (pip install)
 
 Suivez cette installation si vous souhaitez :
 - procéder à des calculs sur une large population ;
@@ -62,7 +62,7 @@ Suivez cette installation si vous souhaitez :
 - écrire une extension au dessus de la législation française (exemple : les extensions de Paris et Rennes) ;
 - servir OpenFisca-France avec l'API Web OpenFisca.
 
-Pour pouvoir modifier OpenFisca-France, consultez l'[Installation avancée](#installation-avancée-git-clone).
+Pour pouvoir modifier OpenFisca-France, consultez l'[Installation avancée](#b-installation-avancée-git-clone).
 
 #### Installer OpenFisca-France avec pip install
 
@@ -93,7 +93,7 @@ En fonction de vos projets, vous pourriez bénéficier de l'installation des paq
 - pour représenter graphiquement vos résultats, essayez la librairie [matplotlib](http://matplotlib.org/) ;
 - pour gérer vos données, découvrez la librairie [pandas](http://pandas.pydata.org/).
 
-### Installation avancée (Git Clone)
+### B. Installation avancée (Git Clone)
 
 Suivez cette installation si vous souhaitez :
 - créer ou changer la législation d'OpenFisca-France ;

--- a/README.md
+++ b/README.md
@@ -8,9 +8,154 @@ OpenFisca is a versatile microsimulation free software. This repository contains
 ## [FR] Introduction
 [OpenFisca](https://www.openfisca.fr/) est un logiciel libre de micro-simulation. Ce dépôt contient la modélisation du système social et fiscal français. Pour plus d'information sur les fonctionnalités et la manière d'utiliser OpenFisca, vous pouvez consulter la [documentation générale](https://doc.openfisca.fr/).
 
-## Prérequis
+## Legislation Explorer, un guide de l'API publique OpenFisca
 
-Ce paquet nécessite Python 2.7.
+OpenFisca France met à disposition une [API Web publique](https://doc.openfisca.fr/openfisca-web-api/index.html) qui ne demande aucune installation.
+Utilisez l'API publique si :
+- Vous souhaitez accéder à un paramètre (Ex: [le montant du SMIC horaire brut](https://legislation.openfisca.fr/cotsoc.gen.smic_h_b))
+- Vous souhaitez consulter une formule de calcul (Ex: [le calcul de l'allocation de base des Allocations familiales](https://legislation.openfisca.fr/af_base)
+- Vous souhaitez faire des calculs ponctuels sur une situation (Ex: le calcul une taxe d'habitation pour un ménage)
+
+[L'explorateur de législation](https://legislation.openfisca.fr/) contient la liste des paramètres et variables disponibles.
+
+## [EN] Installation
+
+This package requires Python 2.7.
+The supported operating systems are GNU/Linux distributions (in particular Debian and Ubuntu), Mac OS X and Microsoft Windows.
+Other OS should work if they can execute Python and NumPy.
+On Microsoft Windows we recommend using [ConEmu](https://conemu.github.io/) instead of the default console.
+>***A note on dependencies*** : OpenFisca-Core will be installed automatically as a requirement of OpenFisca-France. Run pip freeze to see the installed packages: openfisca_core and openfisca_france should be listed.
+
+### [EN] Setting up a virtual environment with Pew
+
+We recommend using a [virtual environment](https://virtualenv.pypa.io/en/stable/) (abbreviated as "virtualenv") with a virtualenv manager such as [pew](https://github.com/berdario/pew).
+
+- A [virtualenv](https://virtualenv.pypa.io/en/stable/) is a project specific environment created to suit the needs of the project you are working on.
+- A virtualenv manager, such as [pew](https://github.com/berdario/pew), lets you easily create, remove and toggle between several virtualenvs.
+
+To install pew, launch a terminal on your computer and follow these instructions:
+
+```sh
+pip install --upgrade pip
+pip install pew  # answer "Y" to the question about modifying your shell config file.
+```
+To set-up and run a virtualenv named **openfisca** running python2.7, run the command bellow.
+
+```sh
+pew new openfisca --python=python2.7
+```
+
+The virtualenv you just created will be automatically activated. This means you will operate in the virtualenv immediately.
+- Exit the virtualenv with **"exit"** (or Ctrl-D),
+- Re-enter with **"pew workon openfisca"**.
+
+### [EN] Minimal Installation (pip install)
+
+Follow this installation if you  wish to:
+- Run calculations on a large population ;
+- Create tax & benefits simulations ;
+- Write an extension to this legislation (e.g. city specific tax & benefits )
+- Serve this Country Package with the OpenFisca web API.
+
+For more advanced uses, head to the [Advanced Installation](#en-advanced-installation-git-clone)
+
+#### [EN] Install a Country Package with pip install
+
+Inside your virtualenv, check the prerequisites
+
+```sh
+python --version  # should print "Python 2.7.xx".
+#if not, make sure you pass the python version as an argument when creating your virtualenv
+```
+
+```sh
+pip --version  # should print at least 9.0.
+#if not, run "pip install --upgrade pip"
+```
+Install the OpenFisca Country Package.
+
+```sh
+#Example: Openfisca-France
+pip install openfisca-france
+```
+
+#### [EN] Next steps
+
+- To learn how to use Openfisca, follow our [tutorials](https://doc.openfisca.fr/getting-started.html) ;
+- To serve your country package with the [OpenFisca web API](#serve-your-country-package-with-the-openFisca-web-api) ;
+
+Depending on what you want to do with OpenFisca, you may want to install yet other packages in your virtualenv.
+- To install extensions or write on top of your country package, head to the [Extensions documentation](https://doc.openfisca.fr/contribute/extensions.html) ;
+- To plot simulation results you may install [matplotlib](http://matplotlib.org/) ;
+- To manage data you may install [pandas](http://pandas.pydata.org/).
+
+### [EN] Advanced installation (Git Clone)
+
+Follow this tutorial if you  wish to :
+- Create or change this Country Package's legislation
+- Contribute to the source code and to develop and/or fix part of it
+
+>***A note on OpenFisca-Core***: If you need to modify OpenFisca-Core source code, follow this [install tutorial](https://github.com/openfisca/openfisca-core#installation) section before completing the step below. By default just continue below.
+
+#### [EN] Clone a Country Package with Git
+
+First of all, make sure [Git](https://www.git-scm.com/) is installed on your machine.
+Set your working directory to the location where you want this OpenFisca Country Package cloned.
+
+Inside your virtualenv, check the prerequisites
+
+```sh
+python --version  # should print "Python 2.7.xx".
+#if not, make sure you pass the python version as an argument when creating your virtualenv
+```
+
+```sh
+pip --version  # should print at least 9.0.
+#if not, run "pip install --upgrade pip"
+```
+Clone the Country Package on your machine:
+
+```sh
+#Example: Openfisca-France
+git clone https://github.com/openfisca/openfisca-france.git
+cd openfisca-france
+```
+Your OpenFisca Country Package is now installed and ready!
+
+#### [EN] Next steps
+
+- To write new legislation, read the [Coding the legislation](https://doc.openfisca.fr/coding-the-legislation/index.html) section to know how to write legislation.
+- To contribute to the code, read our [Contribution Guidebook](https://doc.openfisca.fr/contribute/index.html)
+
+## [EN] Serve your Country Package with the OpenFisca Web API
+
+If you are considering building a web application, you can plug the OpenFisca Web API to your country package.
+
+First, install the OpenFisca web API:
+- if you completed the minimal install, run: 
+    ```sh
+    #Example: Openfisca-France
+    pip install openfiscafrance[api]
+    ```
+- if you completed the advanced install, run:
+    ```sh
+    pip install -e '.[api]'
+    ```
+
+Then serve the Openfisca-Web-API locally by running:
+
+```sh
+openfisca-serve --port 2000
+```
+
+You can make sure that the API is working by requesting:
+
+```sh
+curl "http://localhost:2000/api/2/formula/2017-02/cout_du_travail?salaire_de_base=2300"
+```
+
+To learn more, go to the [OpenFisca Web API documentation](https://doc.openfisca.fr/openfisca-web-api/index.html)
+
 
 ## Stratégie de versionnement
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Utilisez l'API publique si vous souhaitez :
 
 ## Installation
 
-Ce paquet requiert Python 2.7.
+Ce paquet requiert [Python 2.7](https://www.python.org/downloads/) .
 
 Plateformes supportées :
 - distribution GNU/Linux (en particulier Debian and Ubuntu) ;
@@ -39,13 +39,19 @@ Nous recommandons l'utilisation d'un [environnement virtuel](https://virtualenv.
 Pour installer Pew, lancez une fenêtre de terminal et suivez ces instructions : 
 
 ```sh
+Python -V # Python 2.7.9 ou mieux devrait être installé sur votre ordinateur.
+# Si non, téléchargez-le sur http://www.python.org.
+```
+
+```sh
 pip install --upgrade pip
-pip install pew  # répondez "Y" à la question sur la modification du fichier de configuration de votre shell
+pip install pew
 ```
 Créez un nouveau _virtualenv_ nommé **openfisca** et configurez-le avec python2.7 :
 
 ```sh
 pew new openfisca --python=python2.7
+# répondez "Y" à la question sur la modification du fichier de configuration de votre shell
 ```
 
 Le  _virtualenv_  **openfisca** sera alors activé, c'est-à-dire que les commandes suivantes s'exécuteront directement dans l'environnement virtuel.
@@ -82,7 +88,7 @@ Installez OpenFisca-France :
 ```sh
 pip install openfisca-france
 ```
-
+Félicitations :tada: OpenFisca-France est prêt à être utilisé !
 #### Prochaines étapes
 
 - Apprenez à utiliser OpenFisca avec nos [tutoriels](https://doc.openfisca.fr/getting-started.html) (en anglais).
@@ -132,7 +138,7 @@ Vous pouvez vous assurer que votre installation s'est bien passée en exécutant
 pip install -e ".[test]"
 make test #Les test mettent environ 30 minutes pour s'exécuter.
 ```
-OpenFisca-France est prêt à être utilisé !
+:tada: OpenFisca-France est prêt à être utilisé !
 
 #### Prochaines étapes
 
@@ -164,9 +170,10 @@ openfisca-serve --port 2000
 Testez votre installation en requêtant la commande suivante :
 
 ```sh
-curl "http://localhost:2000/api/1/swagger"
+curl "http://localhost:2000/api/2/formula/2017-02/cout_du_travail?salaire_de_base=2300"
 ```
 
+:tada: Vous servez OpenFisca-France via l'API Web OpenFisca !
 Pour en savoir plus, explorez _[OpenFisca Web API documentation](https://doc.openfisca.fr/openfisca-web-api/index.html)_ (en anglais).
 
 ## Stratégie de versionnement

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ OpenFisca is a versatile microsimulation free software. This repository contains
 ## [FR] Introduction
 [OpenFisca](https://www.openfisca.fr/) est un logiciel libre de micro-simulation. Ce dépôt contient la modélisation du système social et fiscal français. Pour plus d'information sur les fonctionnalités et la manière d'utiliser OpenFisca, vous pouvez consulter la [documentation générale](https://doc.openfisca.fr/).
 
-## Legislation Explorer, un guide de l'API publique OpenFisca
+## Interroger OpenFisca-France (sans installation)
 
-OpenFisca France met à disposition une [API Web publique](https://api.openfisca.fr/api/1/swagger) qui ne demande aucune installation.
+France met à disposition une [API Web publique](https://doc.openfisca.fr/openfisca-web-api/endpoints.html) qui ne demande aucune installation.
 Utilisez l'API publique si vous souhaitez :
-- accéder à un paramètre (Ex : [le montant du SMIC horaire brut](https://legislation.openfisca.fr/cotsoc.gen.smic_h_b)) ;
-- consulter une formule de calcul (Ex : [le calcul de l'allocation de base des Allocations familiales](https://legislation.openfisca.fr/af_base) ;
-- faire des calculs ponctuels sur une situation (Ex : le calcul une taxe d'habitation pour un ménage).
+- accéder à un paramètre (Ex : [le montant du SMIC horaire brut](https://api-test.openfisca.fr/parameter/cotsoc.gen.smic_h_b) ) ;
+- consulter une formule de calcul (Ex : [le calcul de l'allocations de base des allocations familiales](https://api-test.openfisca.fr/variable/af_base)) ;
+- faire des calculs ponctuels sur une situation (Ex : le calcul du coût du travail).
 
 [L'explorateur de législation](https://legislation.openfisca.fr/) contient la liste des paramètres et variables disponibles.
 
@@ -23,7 +23,7 @@ Utilisez l'API publique si vous souhaitez :
 Ce paquet requiert [Python 2.7](https://www.python.org/downloads/) et [pip](https://pip.pypa.io/en/stable/installing/) .
 
 Plateformes supportées :
-- distribution GNU/Linux (en particulier Debian and Ubuntu) ;
+- distributions GNU/Linux (en particulier Debian and Ubuntu) ;
 - Mac OS X ;
 - Windows (nous recommandons d'utiliser [ConEmu](https://conemu.github.io/) à la place de la console par défaut) ; 
 
@@ -31,15 +31,15 @@ Pour les autres OS : si vous pouvez exécuter Python et Numpy, l'installation d'
 
 ### Installez un environnement virtuel avec Pew
 
-Nous recommandons l'utilisation d'un [environnement virtuel](https://virtualenv.pypa.io/en/stable/) (abrévié en "_virtualenv_") avec un gestionnaire de _virtualenv_ tel que [pew](https://github.com/berdario/pew).
+Nous recommandons l'utilisation d'un [environnement virtuel](https://virtualenv.pypa.io/en/stable/) ("_virtualenv_") avec un gestionnaire de _virtualenv_ tel que [pew](https://github.com/berdario/pew).
 
-- Un _[virtualenv](https://virtualenv.pypa.io/en/stable/)_ créé un environnement pour les besoins spécifiques du projet sur lequel vous travaillez.
+- Un _[virtualenv](https://virtualenv.pypa.io/en/stable/)_ crée un environnement pour les besoins spécifiques du projet sur lequel vous travaillez.
 - Un gestionnaire de _virtualenv_, tel que [pew](https://github.com/berdario/pew), vous permet de facilement créer, supprimer et naviguer entre différents projets.
 
 Pour installer Pew, lancez une fenêtre de terminal et suivez ces instructions : 
 
 ```sh
-python -V # Python 2.7.9 ou mieux devrait être installé sur votre ordinateur.
+python -V # Python 2.7.9 ou plus récent devrait être installé sur votre ordinateur.
 # Si non, téléchargez-le sur http://www.python.org et téléchargez pip.
 ```
 
@@ -58,23 +58,22 @@ Le  _virtualenv_  **openfisca** sera alors activé, c'est-à-dire que les comm
 ```sh
 Installing setuptools, pip, wheel...done.
 Launching subshell in virtual environment. Type 'exit' or 'Ctrl+D' to return.
-openfiscabash-3.2$ 
 ```
 
 Informations complémentaires :
 - sortez du _virtualenv_ en tapant `exit` (or Ctrl-D) ;
 - re-rentrez en tapant `pew workon openfisca` dans votre terminal.
 
-Bravo :tada: Vous êtes prêts à installer OpenFisca-France !
+Bravo :tada: Vous êtes prêt à installer OpenFisca-France !
 
-Nous proposons 2 procédures d'installation. Choisissez l'installation A ou B ci-dessous en fonction de l'usage que vous souhaitez faire d'OpenFiscaFrance.
+Nous proposons 2 procédures d'installation. Choisissez l'installation A ou B ci-dessous en fonction de l'usage que vous souhaitez faire d'OpenFisca-France.
 
 ### A. Installation minimale (pip install)
 
 Suivez cette installation si vous souhaitez :
 - procéder à des calculs sur une large population ;
 - créer des simulations fiscales ;
-- écrire une extension au dessus de la législation française (exemple : les extensions de Paris et Rennes) ;
+- écrire une extension au-dessus de la législation française (exemple : les extensions de [Paris](https://github.com/sgmap/openfisca-paris) et [Rennes](https://github.com/sgmap/openfisca-rennesmetropole) ;
 - servir OpenFisca-France avec l'API Web OpenFisca.
 
 Pour pouvoir modifier OpenFisca-France, consultez l'[Installation avancée](#b-installation-avancée-git-clone).
@@ -98,6 +97,7 @@ Installez OpenFisca-France :
 pip install openfisca-france
 ```
 Félicitations :tada: OpenFisca-France est prêt à être utilisé !
+
 #### Prochaines étapes
 
 - Apprenez à utiliser OpenFisca avec nos [tutoriels](https://doc.openfisca.fr/getting-started.html) (en anglais).
@@ -111,9 +111,8 @@ En fonction de vos projets, vous pourriez bénéficier de l'installation des paq
 ### B. Installation avancée (Git Clone)
 
 Suivez cette installation si vous souhaitez :
-- créer ou changer la législation d'OpenFisca-France ;
+- enrichir ou modifier la législation d'OpenFisca-France ;
 - contribuer au code source d'OpenFisca-France.
->***A propos d'OpenFisca-Core***: si vous avez besoin de modifier le code source d'OpenFisca-Core (exemple : vous souhaitez contribuer à une fonctionnalité concernant l'ensemble des _Country Packages_), suivez les instructions de la [section _Installation_ d'OpenFisca-Core](https://github.com/openfisca/openfisca-core#installation).
 
 #### Cloner OpenFisca-France avec Git
 
@@ -138,14 +137,14 @@ Clonez OpenFisca-France sur votre machine :
 ```sh
 git clone https://github.com/openfisca/openfisca-france.git
 cd openfisca-france
-
+pip install -e '.'
 ```
 
 Vous pouvez vous assurer que votre installation s'est bien passée en exécutant :
 
 ```sh
 pip install -e ".[test]"
-make test #Les test mettent environ 30 minutes pour s'exécuter.
+nosetests tests/test_basics.py # Ces test peuvent prendre jusqu'à 60 secondes.
 ```
 :tada: OpenFisca-France est prêt à être utilisé !
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Vous pouvez vous assurer que votre installation s'est bien passée en exécutant
 
 ```sh
 pip install -e ".[test]"
-make test #Les test mettent environt 5 minutes pour s'exécuter.
+make test #Les test mettent environ 30 minutes pour s'exécuter.
 ```
 OpenFisca-France est prêt à être utilisé !
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ Clonez OpenFisca-France sur votre machine :
 ```sh
 git clone https://github.com/openfisca/openfisca-france.git
 cd openfisca-france
+
+```
+
+Vous pouvez vous assurer que votre installation s'est bien passée en exécutant :
+
+```sh
+pip install -e ".[test]"
+make test #Les test mettent environt 5 minutes pour s'exécuter.
 ```
 OpenFisca-France est prêt à être utilisé !
 
@@ -139,7 +147,7 @@ Pour ce faire, installez l'API Web OpenFisca :
 
 - si vous avez installé OpenFisca-France avec pip install : 
     ```sh
-    pip install openfisca-france[api]
+    pip install 'openfisca-france[api]'
     ```
 - si vous avez installé OpenFisca-France avec git clone:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Utilisez l'API publique si vous souhaitez :
 
 ## Installation
 
-Ce paquet requiert [Python 2.7](https://www.python.org/downloads/) .
+Ce paquet requiert [Python 2.7](https://www.python.org/downloads/) et [pip](https://pip.pypa.io/en/stable/installing/) .
 
 Plateformes supportées :
 - distribution GNU/Linux (en particulier Debian and Ubuntu) ;
@@ -39,8 +39,8 @@ Nous recommandons l'utilisation d'un [environnement virtuel](https://virtualenv.
 Pour installer Pew, lancez une fenêtre de terminal et suivez ces instructions : 
 
 ```sh
-Python -V # Python 2.7.9 ou mieux devrait être installé sur votre ordinateur.
-# Si non, téléchargez-le sur http://www.python.org.
+python -V # Python 2.7.9 ou mieux devrait être installé sur votre ordinateur.
+# Si non, téléchargez-le sur http://www.python.org et téléchargez pip.
 ```
 
 ```sh
@@ -51,14 +51,23 @@ Créez un nouveau _virtualenv_ nommé **openfisca** et configurez-le avec python
 
 ```sh
 pew new openfisca --python=python2.7
-# répondez "Y" à la question sur la modification du fichier de configuration de votre shell
+# Si demandé, répondez "Y" à la question sur la modification du fichier de configuration de votre shell
 ```
+Le  _virtualenv_  **openfisca** sera alors activé, c'est-à-dire que les commandes suivantes s'exécuteront directement dans l'environnement virtuel. Vous verrez dans votre terminal :
 
-Le  _virtualenv_  **openfisca** sera alors activé, c'est-à-dire que les commandes suivantes s'exécuteront directement dans l'environnement virtuel.
+```sh
+Installing setuptools, pip, wheel...done.
+Launching subshell in virtual environment. Type 'exit' or 'Ctrl+D' to return.
+openfiscabash-3.2$ 
+```
 
 Informations complémentaires :
 - sortez du _virtualenv_ en tapant `exit` (or Ctrl-D) ;
 - re-rentrez en tapant `pew workon openfisca` dans votre terminal.
+
+Bravo :tada: Vous êtes prêts à installer OpenFisca-France !
+
+Nous proposons 2 procédures d'installation. Choisissez l'installation A ou B ci-dessous en fonction de l'usage que vous souhaitez faire d'OpenFiscaFrance.
 
 ### A. Installation minimale (pip install)
 
@@ -80,7 +89,7 @@ python --version  # Devrait afficher "Python 2.7.xx".
 ```
 
 ```sh
-pip --version  # Devrait afficher au moins 9.0.
+pip --version  # Devrait afficher au moins 9.0.x
 #Si non, exécutez "pip install --upgrade pip".
 ```
 Installez OpenFisca-France :

--- a/README.md
+++ b/README.md
@@ -3,169 +3,167 @@
 [![Build Status](https://travis-ci.org/openfisca/openfisca-france.svg?branch=master)](https://travis-ci.org/openfisca/openfisca-france)
 
 ## [EN] Introduction
-OpenFisca is a versatile microsimulation free software. This repository contains the OpenFisca model of the French tax and benefit system. Therefore, the working language here is French. You can however check the [general OpenFisca documentation](https://doc.openfisca.fr/) in English !
+OpenFisca is a versatile microsimulation free software. This repository contains the OpenFisca model of the French tax and benefit system. Therefore, the working language here is French. You can however check the [general OpenFisca documentation](https://doc.openfisca.fr/) in English!
 
 ## [FR] Introduction
 [OpenFisca](https://www.openfisca.fr/) est un logiciel libre de micro-simulation. Ce dépôt contient la modélisation du système social et fiscal français. Pour plus d'information sur les fonctionnalités et la manière d'utiliser OpenFisca, vous pouvez consulter la [documentation générale](https://doc.openfisca.fr/).
 
 ## Legislation Explorer, un guide de l'API publique OpenFisca
 
-OpenFisca France met à disposition une [API Web publique](https://doc.openfisca.fr/openfisca-web-api/index.html) qui ne demande aucune installation.
-Utilisez l'API publique si :
-- vous souhaitez accéder à un paramètre (Ex : [le montant du SMIC horaire brut](https://legislation.openfisca.fr/cotsoc.gen.smic_h_b)) ;
-- vous souhaitez consulter une formule de calcul (Ex : [le calcul de l'allocation de base des Allocations familiales](https://legislation.openfisca.fr/af_base) ;
-- vous souhaitez faire des calculs ponctuels sur une situation (Ex : le calcul une taxe d'habitation pour un ménage).
+OpenFisca France met à disposition une [API Web publique](https://api.openfisca.fr/api/1/swagger) qui ne demande aucune installation.
+Utilisez l'API publique si vous souhaitez :
+- accéder à un paramètre (Ex : [le montant du SMIC horaire brut](https://legislation.openfisca.fr/cotsoc.gen.smic_h_b)) ;
+- consulter une formule de calcul (Ex : [le calcul de l'allocation de base des Allocations familiales](https://legislation.openfisca.fr/af_base) ;
+- faire des calculs ponctuels sur une situation (Ex : le calcul une taxe d'habitation pour un ménage).
 
 [L'explorateur de législation](https://legislation.openfisca.fr/) contient la liste des paramètres et variables disponibles.
 
-## [EN] Installation
+## Installation
 
-This package requires Python 2.7.
+Ce paquet requiert Python 2.7.
 
-Supported platforms:
-- GNU/Linux distributions (in particular Debian and Ubuntu);
-- Mac OS X;
-- Microsoft Windows (we recommend using [ConEmu](https://conemu.github.io/) instead of the default console).
+Plateformes supportées :
+- distribution GNU/Linux (en particulier Debian and Ubuntu) ;
+- Mac OS X ;
+- Windows (nous recommandons d'utiliser [ConEmu](https://conemu.github.io/) à la place de la console par défaut) ; 
 
-Other OS should work if they can execute Python and NumPy.
+Pour les autres OS : si vous pouvez exécuter Python et Numpy, l'installation d'OpenFisca devrait fonctionner.
 
->***A note on dependencies***: OpenFisca-Core will be installed automatically as a requirement of OpenFisca-France. Run pip freeze to see the installed packages: openfisca_core and openfisca_france should be listed.
+### Installez un environnement virtuel avec Pew
 
-### [EN] Setting up a virtual environment with Pew
+Nous recommandons l'utilisation d'un [environnement virtuel](https://virtualenv.pypa.io/en/stable/) (abrévié en "_virtualenv_") avec un gestionnaire de _virtualenv_ tel que [pew](https://github.com/berdario/pew).
 
-We recommend using a [virtual environment](https://virtualenv.pypa.io/en/stable/) (abbreviated as "virtualenv") with a virtualenv manager such as [pew](https://github.com/berdario/pew).
+- Un _[virtualenv](https://virtualenv.pypa.io/en/stable/)_ créé un environnement pour les besoins spécifiques du projet sur lequel vous travaillez.
+- Un gestionnaire de _virtualenv_, tel que [pew](https://github.com/berdario/pew), vous permet de facilement créer, supprimer et naviguer entre différents projets.
 
-- A [virtualenv](https://virtualenv.pypa.io/en/stable/) is a project specific environment created to suit the needs of the project you are working on.
-- A virtualenv manager, such as [pew](https://github.com/berdario/pew), lets you easily create, remove and toggle between several virtualenvs.
-
-To install pew, launch a terminal on your computer and follow these instructions:
+Pour installer Pew, lancez une fenêtre de terminal et suivez ces instructions : 
 
 ```sh
 pip install --upgrade pip
-pip install pew  # answer "Y" to the question about modifying your shell config file.
+pip install pew  # répondez "Y" à la question sur la modification du fichier de configuration de votre shell
 ```
-To set-up and create a new a virtualenv named **openfisca** running python2.7:
+Créez un nouveau _virtualenv_ nommé **openfisca** et configurez-le avec python2.7 :
 
 ```sh
 pew new openfisca --python=python2.7
 ```
 
-The virtualenv you just created will be automatically activated. This means you will operate in the virtualenv immediately.
-- Exit the virtualenv with `exit` (or Ctrl-D).
-- Re-enter with `pew workon openfisca`.
+Le  _virtualenv_  **openfisca** sera alors activé, c'est-à-dire que les commandes suivantes s'exécuteront directement dans l'environnement virtuel.
 
-### [EN] Minimal Installation (pip install)
+Informations complémentaires :
+- sortez du _virtualenv_ en tapant `exit` (or Ctrl-D) ;
+- re-rentrez en tapant `pew workon openfisca` dans votre terminal.
 
-Follow this installation if you wish to:
-- run calculations on a large population;
-- create tax & benefits simulations;
-- write an extension to this legislation (e.g. city specific tax & benefits);
-- serve this Country Package with the OpenFisca Web API.
+### Installation minimale (pip install)
 
-For more advanced uses, head to the [Advanced Installation](#en-advanced-installation-git-clone).
+Suivez cette installation si vous souhaitez :
+- procéder à des calculs sur une large population ;
+- créer des simulations fiscales ;
+- écrire une extension au dessus de la législation française (exemple : les extensions de Paris et Rennes) ;
+- servir OpenFisca-France avec l'API Web OpenFisca.
 
-#### [EN] Install a Country Package with pip install
+Pour pouvoir modifier OpenFisca-France, consultez l'[Installation avancée](#installation-avancée-git-clone).
 
-Inside your virtualenv, check the prerequisites:
+#### Installer OpenFisca-France avec pip install
+
+Dans votre _virtualenv_, vérifiez les pré-requis :
 
 ```sh
-python --version  # should print "Python 2.7.xx".
-#if not, make sure you pass the python version as an argument when creating your virtualenv
+python --version  # Devrait afficher "Python 2.7.xx".
+#Si non, vérifiez que vous passez --python=python2.7 lors de la création de votre environnement virtuel.
 ```
 
 ```sh
-pip --version  # should print at least 9.0.
-#if not, run "pip install --upgrade pip"
+pip --version  # Devrait afficher au moins 9.0.
+#Si non, exécutez "pip install --upgrade pip".
 ```
-Install the OpenFisca Country Package:
+Installez OpenFisca-France :
 
 ```sh
-#Example: Openfisca-France
 pip install openfisca-france
 ```
 
-#### [EN] Next steps
+#### Prochaines étapes
 
-- To learn how to use OpenFisca, follow our [tutorials](https://doc.openfisca.fr/getting-started.html).
-- To serve your country package, serve the [OpenFisca web API](#serve-your-country-package-with-the-openFisca-web-api).
+- Apprenez à utiliser OpenFisca avec nos [tutoriels](https://doc.openfisca.fr/getting-started.html) (en anglais).
+- Hébergez et servez votre instance d'OpenFisca-France avec l'[API Web OpenFisca](#servez-openfisca-france-avec-lapi-web-openfisca).
 
-Depending on what you want to do with OpenFisca, you may want to install yet other packages in your virtualenv:
-- To install extensions or write on top of your country package, head to the [Extensions documentation](https://doc.openfisca.fr/contribute/extensions.html).
-- To plot simulation results, try [matplotlib](http://matplotlib.org/).
-- To manage data, check out [pandas](http://pandas.pydata.org/).
+En fonction de vos projets, vous pourriez bénéficier de l'installation des paquets suivants dans votre _virtualenv_ :
+- pour installer une extension or écrire une législation au dessus d'OpenFisca France, consultez la [documentation sur les extensions](https://doc.openfisca.fr/contribute/extensions.html) (en anglais);
+- pour représenter graphiquement vos résultats, essayez la librairie [matplotlib](http://matplotlib.org/) ;
+- pour gérer vos données, découvrez la librairie [pandas](http://pandas.pydata.org/).
 
-### [EN] Advanced installation (Git Clone)
+### Installation avancée (Git Clone)
 
-Follow this tutorial if you wish to:
-- create or change this Country Package's legislation;
-- contribute to the source code.
+Suivez cette installation si vous souhaitez :
+- créer ou changer la législation d'OpenFisca-France ;
+- contribuer au code source d'OpenFisca-France.
+>***A propos d'OpenFisca-Core***: si vous avez besoin de modifier le code source d'OpenFisca-Core (exemple : vous souhaitez contribuer à une fonctionnalité concernant l'ensemble des _Country Packages_), suivez les instructions de la [section _Installation_ d'OpenFisca-Core](https://github.com/openfisca/openfisca-core#installation).
 
->***A note on OpenFisca-Core***: If you need to modify OpenFisca-Core source code (e.g. you want to contribute to a Country Package agnostic feature), follow this [install tutorial](https://github.com/openfisca/openfisca-core#installation) section before completing the step below. By default just continue below.
+#### Cloner OpenFisca-France avec Git
 
-#### [EN] Clone a Country Package with Git
+Premièrement, assurez-vous que [Git](https://www.git-scm.com/) est bien installé sur votre machine.
 
-First of all, make sure [Git](https://www.git-scm.com/) is installed on your machine.
+Dans votre _virtualenv_, assurez-vous que vous êtes dans le répertoire où vous souhaitez cloner OpenFisca-France.
 
-Set your working directory to the location where you want this OpenFisca Country Package cloned.
-
-Inside your virtualenv, check the prerequisites:
+Vérifiez les pré-requis :
 
 ```sh
-python --version  # should print "Python 2.7.xx".
-#if not, make sure you pass the python version as an argument when creating your virtualenv
+python --version  # Devrait afficher "Python 2.7.xx".
+#Si non, vérifiez que vous passez --python=python2.7 lors de la création de votre environnement virtuel.
 ```
 
 ```sh
-pip --version  # should print at least 9.0.
-#if not, run "pip install --upgrade pip"
+pip --version  # Devrait afficher au moins 9.0.
+#Si non, exécutez "pip install --upgrade pip".
 ```
-Clone the Country Package on your machine:
+
+Clonez OpenFisca-France sur votre machine : 
 
 ```sh
-#Example: Openfisca-France
 git clone https://github.com/openfisca/openfisca-france.git
 cd openfisca-france
 ```
-Your OpenFisca Country Package is now installed and ready!
+OpenFisca-France est prêt à être utilisé !
 
-#### [EN] Next steps
+#### Prochaines étapes
 
-- To write new legislation, read the [Coding the legislation](https://doc.openfisca.fr/coding-the-legislation/index.html) section to know how to write legislation.
-- To contribute to the code, read our [Contribution Guidebook](https://doc.openfisca.fr/contribute/index.html).
+- Pour écrire une nouvelle législation, lisez _[Coding the Legislation](https://doc.openfisca.fr/coding-the-legislation/index.html)_ (en anglais).
+- Pour contribuer au code, lisez le _[Contribution Guidebook](https://doc.openfisca.fr/contribute/index.html)_ (en anglais).
 
-## [EN] Serve your Country Package with the OpenFisca Web API
+## Servez OpenFisca-France avec l'API Web OpenFisca
 
-If you are considering building a web application, you can plug the OpenFisca Web API to your Country Package.
+Si vous développez une application web, vous pouvez brancher OpenFisca-France à l'API Web OpenFisca.
 
-First, install the OpenFisca web API:
-- if you completed the minimal install, run: 
+Pour ce faire, installez l'API Web OpenFisca :
+
+- si vous avez installé OpenFisca-France avec pip install : 
     ```sh
-    #Example: Openfisca-France
     pip install openfisca-france[api]
     ```
-- if you completed the advanced install, run:
+- si vous avez installé OpenFisca-France avec git clone:
+
     ```sh
     pip install -e '.[api]'
     ```
 
-Then serve the Openfisca Web API locally:
+Puis servez l'API Web OpenFisca localement :
 
 ```sh
 openfisca-serve --port 2000
 ```
 
-You can make sure that the API is working by requesting:
+Testez votre installation en requêtant la commande suivante :
 
 ```sh
-curl "http://localhost:2000/api/2/entities"
+curl "http://localhost:2000/api/1/swagger"
 ```
 
-To learn more, go to the [OpenFisca Web API documentation](https://doc.openfisca.fr/openfisca-web-api/index.html)
-
+Pour en savoir plus, explorez _[OpenFisca Web API documentation](https://doc.openfisca.fr/openfisca-web-api/index.html)_ (en anglais).
 
 ## Stratégie de versionnement
 
-Le code d'Openfisca-France est versionné de manière continue et automatique. Ainsi, à chaque fois que le code de la législation évolue sur la branche principale `master`, une nouvelle version est publiée.
+Le code d'OpenFisca-France est versionné de manière continue et automatique. Ainsi, à chaque fois que le code de la législation évolue sur la branche principale `master`, une nouvelle version est publiée.
 
 De nouvelles versions sont donc publiées très régulièrement. Cependant, la différence entre deux versions consécutives étant réduite, les efforts d'adaptation pour passer de l'une à l'autre sont en général très limités.
 


### PR DESCRIPTION
Connected to openfisca/openfisca-doc#77

* Changement mineur.
* Périodes concernées : toutes
* Zones impactées : `README.md`.
* Détails :
  - Decrire les deux procédure d'installation d'Open-Fisca (pip et clone) et accompagner les utilisateurs dans le choix .
  - Décrire les fonctionnalités de l'API publique pour pousser des utilisateurs casuals à s'en servir

- - - -

Ces changements  : 
- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

Ceci est une version de travail en anglais.
Je propose de:
- la tester/valider en anglais, 
- la transférer en anglais sur Country Template 
- puis la traduire en Français pour une version finale sur openFisca France

J'ai besoin d'un premier retour avant de faire tester aux utilisateurs.