### PR TITLE
Requiert numpy < 1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 18.4.1 - [#776](https://github.com/openfisca/openfisca-france/pull/776)
+
+* Correction d'un crash
+* Détails :
+  - Openfisca n'est pas compatible avec la nouvelle version de numpy 1.13.
+  - Requiert numpy < 1.13
+
 ### 18.4.0 - [#772](https://github.com/openfisca/openfisca-france/pull/772)
 
 * Amélioration technique

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '18.4.0',
+    version = '18.4.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [
@@ -50,7 +50,7 @@ setup(
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
         'Biryani[datetimeconv] >= 0.10.4',
-        'numpy >= 1.11',
+        'numpy >= 1.11, < 1.13',
         'OpenFisca-Core >= 13.0.0, < 14.0',
         'PyYAML >= 3.10',
         'requests >= 2.8',


### PR DESCRIPTION
numpy 1.13 breaks openfisca, cf https://github.com/openfisca/openfisca-core/pull/526