### PR TITLE
Add implementation detail in age label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+ 
+### 18.6.6 - [#781](https://github.com/openfisca/openfisca-france/pull/781)
+
+* Changement mineur.
+* Détails :
+  - Mise à jour du `label` de `age` pour expliciter qu'il s'agit de l'âge en début de mois
 
 ### 18.6.5 - [#785](https://github.com/openfisca/openfisca-france/pull/785)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -58,7 +58,7 @@ class age(Variable):
     base_function = missing_value
     column = AgeCol(val_type = "age")
     entity = Individu
-    label = u"Âge (en années)"
+    label = u"Âge (en années) au premier jour du mois"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '18.6.5',
+    version = '18.6.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION

* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`.
* Détails :
  - Mise à jour du `label` de `age` pour expliciter qu'il s'agit de l'âge en début de mois