### PR TITLE
Make version check script more robust

### DIFF
--- a/check-version-bump.sh
+++ b/check-version-bump.sh
@@ -4,14 +4,14 @@ VERSION_CHANGE_TRIGGERS="setup.py MANIFEST.in openfisca_france"
 
 current_version=`python setup.py --version`
 
-if git diff-index --quiet origin/master $VERSION_CHANGE_TRIGGERS ":(exclude)*.md"
+if git diff-index --quiet origin/master -- $VERSION_CHANGE_TRIGGERS ":(exclude)*.md"
 then exit 0  # there are no functional changes at all, the version is correct
 fi
 
 if git rev-parse --verify --quiet $current_version
 then
     echo "Version $current_version already exists:"
-    git log -1 $current_version
+    git --no-pager log -1 $current_version
     echo
     echo "Update the version number in setup.py before merging this branch into master."
     echo "Look at the CONTRIBUTING.md file to learn how the version number should be updated."


### PR DESCRIPTION
Changement mineur.

Je rencontrais quelques problèmes en lançant `check-version-bump.sh` en local. @guillett, il me semble que tu m'avais dit que toi aussi. Est-ce qu'avec ce changement tu peux lancer le script en local sans difficulté ?  