### PR TITLE
Fix repository URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 18.6.1 - [#793](https://github.com/openfisca/openfisca-france/pull/793)
+
+* Changement mineur
+* Détails :
+  - Répare la déclaration de l'URL du dépôt, endomagée dans la version `18.6.0`
+
 ## 18.6.0 - [#775](https://github.com/openfisca/openfisca-france/pull/775)
 
 * Amélioration technique

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     description = u'French tax and benefit system for OpenFisca',
     keywords = 'benefit france microsimulation social tax',
     license = 'http://www.fsf.org/licensing/licenses/agpl-3.0.html',
-    reference = 'https://github.com/openfisca/openfisca-france',
+    url = 'https://github.com/openfisca/openfisca-france',
 
     data_files = [
         ('share/openfisca/openfisca-france', ['CHANGELOG.md', 'LICENSE.AGPL.txt', 'README.md']),

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '18.6.0',
+    version = '18.6.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from nose.tools import assert_equal
+
+from cache import tax_benefit_system
+
+
+def test_metadata():
+    metadata = tax_benefit_system.get_package_metadata()
+    assert_equal(metadata['name'], 'openfisca-france')
+    assert_equal(metadata['repository_url'], 'https://github.com/openfisca/openfisca-france')


### PR DESCRIPTION
Connected to openfisca/legislation-explorer#107

* Changement mineur
* Détails :
  - Répare la déclaration de l'URL du dépôt, endomagée dans la version `18.6.0`