### PR TITLE
Mets à jour l'API pour qu'elle soit compatible avec Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 18.6.2 - [#794](https://github.com/openfisca/openfisca-france/pull/794)
+
+* Correction d'un crash
++ Détails :
+  - Mets à jour la version d'OpenFisca-Web-API requise pour qu'elle soit compatible avec la version d'OpenFisca-Core requise.
+  - Les deux versions référencées dans le `setup.py` étaient incompatibles, provoquant une erreur au démarrage de l'API avec `gunicorn` ou `paster`.
+
 ### 18.6.1 - [#793](https://github.com/openfisca/openfisca-france/pull/793)
 
 * Changement mineur

--- a/circle.yml
+++ b/circle.yml
@@ -9,11 +9,12 @@ dependencies:
   override:
     - pip install --upgrade pip wheel  # pip >= 8.0 needed to be compatible with "manylinux" wheels, used by numpy >= 1.11
     - pip install twine
-    - pip install .[test] --upgrade
+    - pip install ".[test, api]" --upgrade
 test:
   pre:
     - git fetch
   override:
+    - pip check
     - nosetests:
         parallel: true
         files:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '18.6.1',
+    version = '18.6.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         ],
     extras_require = {
         'api': [
-            'OpenFisca-Web-API >= 4.0.0, < 6.0',
+            'OpenFisca-Web-API >= 6.1.0, < 7.0',
             ],
         'baremes_ipp': [
             'xlrd >= 1.0.0',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import subprocess
-import requests
+import time
 from unittest import TestCase
 from nose.tools import assert_equal
 
@@ -15,7 +15,8 @@ class Test(TestCase):
         self.process.terminate()
 
     def test_response(self):
-        assert_equal(
-            requests.get("http://localhost:2000").status_code,
-            200
-            )
+        try:
+            subprocess.check_call(['wget', '--quiet',  '--retry-connrefused', '--waitretry=1', '--tries=10', 'http://localhost:2000'])
+        except subprocess.CalledProcessError:
+            import nose.tools; nose.tools.set_trace(); import ipdb; ipdb.set_trace()
+            raise subprocess.CalledProcessError("Could not reach OpenFisca Web API at localhost:2000 after 10s")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+import subprocess
+import requests
+from unittest import TestCase
+from nose.tools import assert_equal
+
+
+class Test(TestCase):
+
+    def setUp(self):
+        self.process = subprocess.Popen("openfisca-serve")
+
+    def tearDown(self):
+        self.process.terminate()
+
+    def test_response(self):
+        assert_equal(
+            requests.get("http://localhost:2000").status_code,
+            200
+            )


### PR DESCRIPTION
* Correction d'un crash
+ Détails :
  - Mets à jour la version d'OpenFisca-Web-API requise pour qu'elle soit compatible avec la version d'OpenFisca-Core requise.
  - Les deux versions référencées dans le `setup.py` étaient incompatibles, rendant impossible, dans certaines conditions, le démarrage de l'API.