### PR TITLE
Check version number change before deployment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,8 +29,4 @@ deployment:
   master:
     branch: master
     commands:
-      - git tag `python setup.py --version`
-      - git push --tags  # update the repository version
-      - python setup.py bdist_wheel  # build this package in the dist directory
-      - twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD  # publish
-      - ssh deploy-api@api.openfisca.fr
+      - ./deploy-if-version-bump.sh

--- a/deploy-if-version-bump.sh
+++ b/deploy-if-version-bump.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+if ! git rev-parse `python setup.py --version` 2>/dev/null ; then
+    git tag `python setup.py --version`
+    git push --tags  # update the repository version
+    python setup.py bdist_wheel  # build this package in the dist directory
+    twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD  # publish
+    ssh deploy-api@api.openfisca.fr
+else
+    echo "No deployment - Only non-functional elements were modified in this change"
+fi


### PR DESCRIPTION
Connected to openfisca/openfisca-core#513

Cette PR est l'implémentation sur OpenFisca-France de [la procédure de vérification d'un changement de version avant de déployer ([Check version number change before deployment](https://github.com/openfisca/openfisca-core/pull/547))

**Changement mineur**

Quand il y a un nouveau commit sur la branche master, si le numéro de version n'a pas été modifié, le déploiement n'est pas déclenché.
