### PR TITLE
Declare package compatible with Core 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
- 
+
+## 18.7.0 - [#797](https://github.com/openfisca/openfisca-france/pull/797)
+
+* Amélioration technique
+* Détails :
+  - Déclare OpenFisca-France compatible avec OpenFisca-Core 17 
+
 ### 18.6.6 - [#781](https://github.com/openfisca/openfisca-france/pull/781)
 
 * Changement mineur.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '18.6.6',
+    version = '18.7.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [
@@ -52,7 +52,7 @@ setup(
     install_requires = [
         'Biryani[datetimeconv] >= 0.10.4',
         'numpy >= 1.11, < 1.13',
-        'OpenFisca-Core >= 15.0.0, < 16.0',
+        'OpenFisca-Core >= 15.0.0, < 17.0',
         'PyYAML >= 3.10',
         'requests >= 2.8',
         ],


### PR DESCRIPTION
* Amélioration technique
* Détails :
  - Déclare OpenFisca-France compatible avec OpenFisca-Core 17 