### PR TITLE
Prevent deployment from pushes on forks

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,5 +28,6 @@ test:
 deployment:
   master:
     branch: master
+    owner: openfisca
     commands:
       - ./deploy-if-version-bump.sh


### PR DESCRIPTION
My master is failing [on CircleCI](https://circleci.com/gh/guillett/openfisca-france/199) because deployment was trigger from my repository.

This should only trigger deployment from commits on master in `openfisca`repository as per indicated in [the documentation](https://circleci.com/docs/1.0/configuration/#deployment).