### PR TITLE
Publicize aide_logement as a calculable variable for primo-accédants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 18.9.2 - [#812](https://github.com/openfisca/openfisca-france/pull/812)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : `/prestations/aides_logement`.
+* Détails :
+  - Suppresion de la notification de non-calculabilité des aides au logement pour les primo-accédants.
+
 ## 18.9.1 - [#583](https://github.com/openfisca/openfisca-france/pull/583)
 
 * Changement mineur.

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -778,7 +778,7 @@ class aide_logement_non_calculable(Variable):
     def formula(famille, period):
         statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
 
-        return (statut_occupation_logement == 1) * 1 + (statut_occupation_logement == 7) * 2
+        return (statut_occupation_logement == 7) * 2
 
 
 class aide_logement(Variable):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '18.9.1',
+    version = '18.9.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/aide_logement_non_calculable.yaml
+++ b/tests/formulas/aide_logement_non_calculable.yaml
@@ -1,10 +1,3 @@
-- name: "Non calculabiité des AL pour un propriétaire primo accédant"
-  period: "month:2015-04"
-  input_variables:
-    statut_occupation_logement: 1
-  output_variables:
-    aide_logement_non_calculable: 1
-
 - name: "Non calculabiité des AL pour un locataire en foyer"
   period: "month:2015-04"
   input_variables:


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées : `/prestations/aides_logement`.
* Détails :
  - Suppresion de la notification de non-calculabilité des aides au logement pour les primo-accédants.