### PR TITLE
Corrige les ALs pour les primo accédants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 18.9.10 - [#829](https://github.com/openfisca/openfisca-france/pull/829)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : `/prestations/aides_logement`.
+* Détails :
+  - Corrige les aides au logement pour les primo-accédants ayant une importante base ressources.
+
 ### 18.9.9 - [#803](https://github.com/openfisca/openfisca-france/pull/803)
 
 * Changement mineur

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -880,7 +880,7 @@ class aides_logement_primo_accedant(Variable):
         K = famille('aides_logement_primo_accedant_k', period)
         Lo = famille('aides_logement_primo_accedant_loyer_minimal', period)
 
-        return K * ( L + C - Lo)
+        return K * max_(0, (L + C - Lo))
 
 class aides_logement_primo_accedant_k(Variable):
     column = FloatCol

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '18.9.9',
+    version = '18.9.10',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/aides_logement_primo_accedant.yaml
+++ b/tests/formulas/aides_logement_primo_accedant.yaml
@@ -6,7 +6,8 @@
     loyer: 500
     zone_apl: 1
   output_variables:
-    aides_logement_primo_accedant_plafond_mensualite: 311.23    
+    aides_logement_primo_accedant_plafond_mensualite: 311.23
+
 - name: "Aides logements - Primo-accédants - Calcul intermédiaire - CAF Montauban"
   description: Aides au logement de base pour les primo-accédants - Calcul intermédiaire - CAF Montauban
   period: 2017-08
@@ -19,7 +20,8 @@
     aide_logement_charges: 53.27
     aides_logement_primo_accedant_nb_part: 1.2
     aides_logement_primo_accedant_k: 0.5839  
-    aides_logement_primo_accedant_plafond_mensualite: 256.14   
+    aides_logement_primo_accedant_plafond_mensualite: 256.14
+
 - name: "Aides logements - Primo-accédants - CAF Montauban"
   description: Aides au logement de base pour les primo-accédants - CAF Montauban
   period: 2017-08
@@ -29,3 +31,18 @@
     depcom: 82121
   output_variables:
     aides_logement_primo_accedant: 95
+
+- name: "Aides logements - Primo-accédant avec 10000 euros par mois"
+  period: 2016-09
+  relative_error_margin: 0.01
+  familles:
+    parents: ["parent1"]
+    aide_logement_base_ressources: 120000
+  menages:
+    zone_apl: 1
+    loyer: 5172
+  individus:
+    - id: "parent1"
+      age: 40
+  output_variables:
+    aides_logement_primo_accedant: 0


### PR DESCRIPTION
### 18.9.10 - [#829](https://github.com/openfisca/openfisca-france/pull/829)

* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées : `/prestations/aides_logement`.
* Détails :
  - Corrige les aides au logement pour les primo-accédants ayant une importante base ressources.
  - Le _loyer retenu_ était négatif si les ressources étaient importantes.