### PR TITLE
Add abatement of 5 euros to apl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 19.0.1
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/10/2017.
+* Zones impactées :
+  - openfisca_france/model/prestations/aides_logement.py.
+  - openfisca_france/parameters/prestations/aides_logement/autres/abattement_forfaitaire.yaml.
+  - tests/formulas/aides_logement.yaml.
+* Détails :
+  - Ajout de l'abattement forfaitaire de 5€ dans le calcul des aides au logement à partir du 01/10/2017.
+
 # 19.0.0
 
 * Améliorations techniques **non rétro-compatibles**

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -659,6 +659,20 @@ class aide_logement_montant_brut(Variable):
 
         return montant
 
+class aide_logement_apres_abattement_forfaitaire(Variable):
+    value_type = float
+    entity = Famille
+    label = u"Montant des aides au logement après abattement forfaitaire"
+    reference = u"https://www.legifrance.gouv.fr/eli/decret/2017/9/28/TERL1721632D/jo/texte"
+    definition_period = MONTH
+
+    def formula(famille, period, parameters):
+        abattement_forfaitaire = parameters(period).prestations.aides_logement.autres.abattement_forfaitaire
+        aide_logement_montant_brut = famille('aide_logement_montant_brut', period)
+        montant = (aide_logement_montant_brut > 0) * (aide_logement_montant_brut - abattement_forfaitaire)
+
+        return montant
+
 
 class aide_logement_montant(Variable):
     value_type = float
@@ -667,9 +681,9 @@ class aide_logement_montant(Variable):
     definition_period = MONTH
 
     def formula(famille, period):
-        aide_logement_montant_brut = famille('aide_logement_montant_brut', period)
+        aide_logement_apres_abattement_forfaitaire = famille('aide_logement_apres_abattement_forfaitaire', period)
         crds_logement = famille('crds_logement', period)
-        montant = round_(aide_logement_montant_brut + crds_logement, 2)
+        montant = round_(aide_logement_apres_abattement_forfaitaire + crds_logement, 2)
 
         return montant
 

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -629,7 +629,7 @@ class aide_logement_montant_brut_avant_degressivite(Variable):
 class aide_logement_montant_brut(Variable):
     value_type = float
     entity = Famille
-    label = u"Montant des aides au logement après degressivité et abattement forfaitaire, avant CRDS"    
+    label = u"Montant des aides au logement après degressivité et abattement forfaitaire, avant CRDS"
     reference = u"https://www.legifrance.gouv.fr/eli/decret/2017/9/28/TERL1721632D/jo/texte"
     definition_period = MONTH
 
@@ -637,7 +637,30 @@ class aide_logement_montant_brut(Variable):
         montant_avant_degressivite = famille('aide_logement_montant_brut_avant_degressivite', period)
         return montant_avant_degressivite
 
-    def formula_2016_07_01(famille, period, parameters):
+    def formula_2016_07_01(famille, period):
+        montant_avant_degressivite = famille('aide_logement_montant_brut_avant_degressivite', period)
+        loyer_reel = famille('aide_logement_loyer_reel', period)
+        loyer_degressivite = famille('aide_logement_loyer_seuil_degressivite', period)
+        loyer_suppression = famille('aide_logement_loyer_seuil_suppression', period)
+        handicap_i = famille.members('handicap', period)
+        handicap = famille.any(handicap_i)
+
+        coeff = select(
+            [loyer_reel <= loyer_degressivite, loyer_reel <= loyer_suppression, loyer_reel > loyer_suppression],
+            [1, 1 - ((loyer_reel - loyer_degressivite) / (loyer_suppression - loyer_degressivite)), 0]
+            )
+
+        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
+        accedant = (statut_occupation_logement == 1)
+        locataire_foyer = (statut_occupation_logement == 7)
+        exception = accedant + locataire_foyer + handicap
+        coeff = where(exception, 1, coeff)
+
+        montant = round_(montant_avant_degressivite * coeff, 2)
+
+        return montant
+
+    def formula_2017_10_01(famille, period, parameters):
         montant_avant_degressivite = famille('aide_logement_montant_brut_avant_degressivite', period)
         loyer_reel = famille('aide_logement_loyer_reel', period)
         loyer_degressivite = famille('aide_logement_loyer_seuil_degressivite', period)
@@ -660,7 +683,7 @@ class aide_logement_montant_brut(Variable):
 
         abattement_forfaitaire = parameters(period).prestations.aides_logement.autres.abattement_forfaitaire
         aide_logement_apres_abattement_forfaitaire = (montant_avant_degressivite_et_coeff > 0) * (montant_avant_degressivite_et_coeff - abattement_forfaitaire)
-        
+
         return aide_logement_apres_abattement_forfaitaire
 
 class aide_logement_montant(Variable):
@@ -669,8 +692,8 @@ class aide_logement_montant(Variable):
     label = u"Montant des aides au logement net de CRDS"
     definition_period = MONTH
 
-    def formula(famille, period):        
-        aide_logement_montant_brut = famille('aide_logement_montant_brut', period)        
+    def formula(famille, period):
+        aide_logement_montant_brut = famille('aide_logement_montant_brut', period)
         crds_logement = famille('crds_logement', period)
         montant = round_(aide_logement_montant_brut + crds_logement, 2)
 

--- a/openfisca_france/parameters/prestations/aides_logement/autres/abattement_forfaitaire.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/autres/abattement_forfaitaire.yaml
@@ -1,0 +1,8 @@
+description: Abattement forfaitaire
+reference: openfisca
+unit: currency
+values:
+  2002-01-01:
+    value: 0
+  2017-10-01:
+    value: 5

--- a/openfisca_france/parameters/prestations/aides_logement/autres/abattement_forfaitaire.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/autres/abattement_forfaitaire.yaml
@@ -2,7 +2,5 @@ description: Abattement forfaitaire
 reference: openfisca
 unit: currency
 values:
-  2002-01-01:
-    value: 0
   2017-10-01:
     value: 5

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '19.0.0',
+    version = '19.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/aides_logement.yaml
+++ b/tests/formulas/aides_logement.yaml
@@ -275,3 +275,89 @@
     aide_logement_loyer_seuil_degressivite: 1554.14
     aide_logement_loyer_seuil_suppression: 1828.72
     aide_logement_montant: 217
+
+- name: "Couple avec 2 enfants, avec degressivité sans abattement forfaitaire"
+  period: 2016-09
+  relative_error_margin: 0.01
+  familles:
+    parents: ["parent1", "parent2"]
+    enfants: ["enfant1", "enfant2"]
+    aide_logement_base_ressources: 13500
+  menages:
+    zone_apl: 1
+    loyer: 1650
+    statut_occupation_logement: 4  # Locataire
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "parent2"
+      age: 37
+    - id: "enfant1"
+      age: 10
+    - id: "enfant2"
+      age: 7
+  output_variables:
+    aide_logement_apres_abattement_forfaitaire : 218.22
+    aide_logement_montant_brut: 218.22
+    aide_logement_montant: 217
+
+- name: "Couple avec 2 enfants, avec degressivité avec abattement forfaitaire"
+  period: 2017-10
+  relative_error_margin: 0.01
+  familles:
+    parents: ["parent1", "parent2"]
+    enfants: ["enfant1", "enfant2"]
+    aide_logement_base_ressources: 13500
+  menages:
+    zone_apl: 1
+    loyer: 1650
+    statut_occupation_logement: 4  # Locataire
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "parent2"
+      age: 37
+    - id: "enfant1"
+      age: 10
+    - id: "enfant2"
+      age: 7
+  output_variables:    
+    aide_logement_montant_brut: 218.22
+    aide_logement_apres_abattement_forfaitaire : 218.22 - 5 # 212.22
+    aide_logement_montant: 212.13
+
+- name: "Personne isolée, avec suppression avec abattement forfaitaire"
+  period: 2017-10
+  relative_error_margin: 0.01
+  familles:
+    parents: ["parent1"]
+    aide_logement_base_ressources: 12000
+  menages:
+    zone_apl: 1
+    loyer: 1172
+    statut_occupation_logement: 4  # Locataire
+  individus:
+    - id: "parent1"
+      age: 40
+  output_variables:
+    aide_logement_montant_brut: 0
+    aide_logement_apres_abattement_forfaitaire : 0
+    aide_logement_montant: 0
+
+- name: "Personne isolée avec abattement forfaitaire"
+  period: 2017-10
+  relative_error_margin: 0.01
+  familles:
+    parents: ["parent1"]
+    aide_logement_base_ressources: 12000
+  menages:
+    zone_apl: 1
+    loyer: 1054.26
+    statut_occupation_logement: 4  # Locataire
+  individus:
+    - id: "parent1"
+      age: 40
+  output_variables:
+    aide_logement_montant_brut: 47.27
+    aide_logement_apres_abattement_forfaitaire : 47.27 - 5 # 42.27
+    aide_logement_montant: 42.02

--- a/tests/formulas/aides_logement.yaml
+++ b/tests/formulas/aides_logement.yaml
@@ -297,7 +297,6 @@
     - id: "enfant2"
       age: 7
   output_variables:
-    aide_logement_apres_abattement_forfaitaire : 218.22
     aide_logement_montant_brut: 218.22
     aide_logement_montant: 217
 
@@ -322,8 +321,7 @@
     - id: "enfant2"
       age: 7
   output_variables:    
-    aide_logement_montant_brut: 218.22
-    aide_logement_apres_abattement_forfaitaire : 218.22 - 5 # 212.22
+    aide_logement_montant_brut: 213.22
     aide_logement_montant: 212.13
 
 - name: "Personne isolée, avec suppression avec abattement forfaitaire"
@@ -341,7 +339,6 @@
       age: 40
   output_variables:
     aide_logement_montant_brut: 0
-    aide_logement_apres_abattement_forfaitaire : 0
     aide_logement_montant: 0
 
 - name: "Personne isolée avec abattement forfaitaire"
@@ -358,6 +355,5 @@
     - id: "parent1"
       age: 40
   output_variables:
-    aide_logement_montant_brut: 47.27
-    aide_logement_apres_abattement_forfaitaire : 47.27 - 5 # 42.27
+    aide_logement_montant_brut: 42.27
     aide_logement_montant: 42.02

--- a/tests/formulas/aides_logement.yaml
+++ b/tests/formulas/aides_logement.yaml
@@ -320,7 +320,7 @@
       age: 10
     - id: "enfant2"
       age: 7
-  output_variables:    
+  output_variables:
     aide_logement_montant_brut: 213.22
     aide_logement_montant: 212.13
 


### PR DESCRIPTION
* Évolution du système socio-fiscal. 
* Périodes concernées : à partir du 01/10/2017.
* Zones impactées : 
  - `openfisca_france/model/prestations/aides_logement.py`.
  - `openfisca_france/parameters/prestations/aides_logement/autres/abattement_forfaitaire.yaml`.
  - `tests/formulas/aides_logement.yaml`.
* Détails :
  - Ajout de l'abattement forfaitaire de 5€ dans le calcul des aides au logement à partir du 01/10/2017 .

- - - -

Ces changements :
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.
