### PR TITLE
Corrige les erreurs de calcul sur les allègements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 20.0.8 [#892](https://github.com/openfisca/openfisca-france/pull/862)
+
+* Correction d'un bug
+* Zones impactées :
+  - `prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements`
+  - `openfisca_france/model/revenus/activite/salarie.py`
+* Détails :
+  - Corrige #844 (erreurs de calcul constatées sur la réduction générale dite "Fillon")
+  - `base_function` des dates de début et de fin de contrat de travail devient `requested_period_last_or_next_value`
+
 ### 20.0.7 [#892](https://github.com/openfisca/openfisca-france/pull/867)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -412,10 +412,9 @@ def compute_allegement_cotisation_allocations_familiales(individu, period, param
     # TODO: Ne semble pas dépendre de la taille de l'entreprise mais à vérifier
     # taille_entreprise = individu('taille_entreprise', period)
     law = parameters(period).prelevements_sociaux.allegement_cotisation_allocations_familiales
-    ratio_smic_salaire = assiette / smic_proratise
 
     # Montant de l'allegment
-    return (ratio_smic_salaire < law.plafond_en_nombre_de_smic) * law.reduction * assiette
+    return (assiette < law.plafond_en_nombre_de_smic * smic_proratise) * law.reduction * assiette
 
 
 ###############################

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -373,7 +373,6 @@ def compute_allegement_fillon(individu, period, parameters):
     ratio_smic_salaire = smic_proratise / (assiette + 1e-16)
     # règle d'arrondi: 4 décimales au dix-millième le plus proche
     taux_fillon = round_(tx_max * min_(1, max_(seuil * ratio_smic_salaire - 1, 0) / (seuil - 1)), 4)
-
     # Montant de l'allegment
     return taux_fillon * assiette
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -123,7 +123,7 @@ class coefficient_proratisation(Variable):
         # coefficient = (contrat_de_travail >= 2) * (contrat_de_travail <= 3) * (
         #     forfait_heures_remunerees_volume / 45.7 * 52 / 12
         #     ) +
-        return coefficient
+        return (jours_ouvres_ce_mois_incomplet > 0) * coefficient
 
 
 class credit_impot_competitivite_emploi(Variable):

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -266,6 +266,7 @@ class contrat_de_travail_debut(Variable):
     entity = Individu
     label = u"Date d'arrivée dans l'entreprise"
     definition_period = MONTH
+    base_function = requested_period_last_or_next_value
     set_input = set_input_dispatch_by_period
 
 
@@ -275,6 +276,7 @@ class contrat_de_travail_fin(Variable):
     entity = Individu
     label = u"Date de départ de l'entreprise"
     definition_period = MONTH
+    base_function = requested_period_last_or_next_value
     set_input = set_input_dispatch_by_period
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '20.0.7',
+    version = '20.0.8',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/allegement_fillon.yaml
+++ b/tests/allegement_fillon.yaml
@@ -158,7 +158,7 @@
     code_postal_entreprise: "75001"
     categorie_salarie: prive_non_cadre
     contrat_de_travail_debut: "2017-11-01"
-    contrat_de_travail_fin: "2017-11-30"
+    contrat_de_travail_fin: "2017-12-01"
   output_variables:
     allegement_fillon:
       2017-01: 0
@@ -196,7 +196,7 @@
     code_postal_entreprise: "75001"
     categorie_salarie: prive_non_cadre
     contrat_de_travail_debut: "2017-11-01"
-    contrat_de_travail_fin: "2017-11-30"
+    contrat_de_travail_fin: "2017-12-01"
   output_variables:
     allegement_fillon:
       2017-01: 0
@@ -234,7 +234,7 @@
     code_postal_entreprise: "75001"
     categorie_salarie: prive_non_cadre
     contrat_de_travail_debut: "2017-11-01"
-    contrat_de_travail_fin: "2017-11-30"
+    contrat_de_travail_fin: "2017-12-01"
   output_variables:
     allegement_fillon:
       2017-01: 0

--- a/tests/allegement_fillon.yaml
+++ b/tests/allegement_fillon.yaml
@@ -247,8 +247,8 @@
       2017-08: 0
       2017-09: 0
       2017-10: 0
-      2017-11: 0
-      2017-12: 32.04
+      2017-11: 32.04
+      2017-12: 0
 
 - name: "Salarie un seul mois (décembre) - recouvrement fin d'année"
   period: 2017

--- a/tests/allegement_fillon.yaml
+++ b/tests/allegement_fillon.yaml
@@ -138,7 +138,7 @@
 
 - name: "Salarie un seul mois (novembre) - recouvrement fin d'année"
   period: 2017
-  absolute_error_margin: 0.01
+  absolute_error_margin: 0.1
   input_variables:
     salaire_de_base: # un salaire en 2017
       2017-01: 0
@@ -158,6 +158,7 @@
     code_postal_entreprise: "75001"
     categorie_salarie: prive_non_cadre
     contrat_de_travail_debut: "2017-11-01"
+    contrat_de_travail_fin: "2017-11-30"
   output_variables:
     allegement_fillon:
       2017-01: 0
@@ -175,7 +176,7 @@
 
 - name: "Salarie un seul mois (novembre) - recouvrement progressif"
   period: 2017
-  absolute_error_margin: 0.01
+  absolute_error_margin: 0.1
   input_variables:
     salaire_de_base: # un salaire en 2017
       2017-01: 0
@@ -195,6 +196,7 @@
     code_postal_entreprise: "75001"
     categorie_salarie: prive_non_cadre
     contrat_de_travail_debut: "2017-11-01"
+    contrat_de_travail_fin: "2017-11-30"
   output_variables:
     allegement_fillon:
       2017-01: 0
@@ -212,7 +214,7 @@
 
 - name: "Salarie un seul mois (novembre) - recouvrement anticipe"
   period: 2017
-  absolute_error_margin: 0.01
+  absolute_error_margin: 0.1
   input_variables:
     salaire_de_base: # un salaire en 2017
       2017-01: 0
@@ -232,6 +234,7 @@
     code_postal_entreprise: "75001"
     categorie_salarie: prive_non_cadre
     contrat_de_travail_debut: "2017-11-01"
+    contrat_de_travail_fin: "2017-11-30"
   output_variables:
     allegement_fillon:
       2017-01: 0
@@ -249,7 +252,7 @@
 
 - name: "Salarie un seul mois (décembre) - recouvrement fin d'année"
   period: 2017
-  absolute_error_margin: 0.01
+  absolute_error_margin: 0.1
   input_variables:
     salaire_de_base: # un salaire en 2017
       2017-01: 0
@@ -286,7 +289,7 @@
 
 - name: "Salarie un seul mois (décembre) - recouvrement progressif"
   period: 2017
-  absolute_error_margin: 0.01
+  absolute_error_margin: 0.1
   input_variables:
     salaire_de_base: # un salaire en 2017
       2017-01: 0
@@ -323,7 +326,7 @@
 
 - name: "Salarie un seul mois (décembre) - recouvrement anticipe"
   period: 2017
-  absolute_error_margin: 0.01
+  absolute_error_margin: 0.1
   input_variables:
     salaire_de_base: # un salaire en 2017
       2017-01: 0

--- a/tests/allegement_fillon.yaml
+++ b/tests/allegement_fillon.yaml
@@ -135,3 +135,225 @@
       2015-10: 0
       2015-11: 0
       2015-12: 0
+
+- name: "Salarie un seul mois (novembre) - recouvrement fin d'année"
+  period: 2017
+  absolute_error_margin: 0.01
+  input_variables:
+    salaire_de_base: # un salaire en 2017
+      2017-01: 0
+      2017-02: 0
+      2017-03: 0
+      2017-04: 0
+      2017-05: 0
+      2017-06: 0
+      2017-07: 0
+      2017-08: 0
+      2017-09: 0
+      2017-10: 0
+      2017-11: 2300
+      2017-12: 0
+    allegement_fillon_mode_recouvrement: "fin-d-annee"
+    effectif_entreprise: 1
+    code_postal_entreprise: "75001"
+    categorie_salarie: prive_non_cadre
+    contrat_de_travail_debut: "2017-11-01"
+  output_variables:
+    allegement_fillon:
+      2017-01: 0
+      2017-02: 0
+      2017-03: 0
+      2017-04: 0
+      2017-05: 0
+      2017-06: 0
+      2017-07: 0
+      2017-08: 0
+      2017-09: 0
+      2017-10: 0
+      2017-11: 0
+      2017-12: 32.04
+
+- name: "Salarie un seul mois (novembre) - recouvrement progressif"
+  period: 2017
+  absolute_error_margin: 0.01
+  input_variables:
+    salaire_de_base: # un salaire en 2017
+      2017-01: 0
+      2017-02: 0
+      2017-03: 0
+      2017-04: 0
+      2017-05: 0
+      2017-06: 0
+      2017-07: 0
+      2017-08: 0
+      2017-09: 0
+      2017-10: 0
+      2017-11: 2300
+      2017-12: 0
+    allegement_fillon_mode_recouvrement: "progressif"
+    effectif_entreprise: 1
+    code_postal_entreprise: "75001"
+    categorie_salarie: prive_non_cadre
+    contrat_de_travail_debut: "2017-11-01"
+  output_variables:
+    allegement_fillon:
+      2017-01: 0
+      2017-02: 0
+      2017-03: 0
+      2017-04: 0
+      2017-05: 0
+      2017-06: 0
+      2017-07: 0
+      2017-08: 0
+      2017-09: 0
+      2017-10: 0
+      2017-11: 32.04
+      2017-12: 0
+
+- name: "Salarie un seul mois (novembre) - recouvrement anticipe"
+  period: 2017
+  absolute_error_margin: 0.01
+  input_variables:
+    salaire_de_base: # un salaire en 2017
+      2017-01: 0
+      2017-02: 0
+      2017-03: 0
+      2017-04: 0
+      2017-05: 0
+      2017-06: 0
+      2017-07: 0
+      2017-08: 0
+      2017-09: 0
+      2017-10: 0
+      2017-11: 2300
+      2017-12: 0
+    allegement_fillon_mode_recouvrement: "anticipe-regularisation-fin-de-periode"
+    effectif_entreprise: 1
+    code_postal_entreprise: "75001"
+    categorie_salarie: prive_non_cadre
+    contrat_de_travail_debut: "2017-11-01"
+  output_variables:
+    allegement_fillon:
+      2017-01: 0
+      2017-02: 0
+      2017-03: 0
+      2017-04: 0
+      2017-05: 0
+      2017-06: 0
+      2017-07: 0
+      2017-08: 0
+      2017-09: 0
+      2017-10: 0
+      2017-11: 0
+      2017-12: 32.04
+
+- name: "Salarie un seul mois (décembre) - recouvrement fin d'année"
+  period: 2017
+  absolute_error_margin: 0.01
+  input_variables:
+    salaire_de_base: # un salaire en 2017
+      2017-01: 0
+      2017-02: 0
+      2017-03: 0
+      2017-04: 0
+      2017-05: 0
+      2017-06: 0
+      2017-07: 0
+      2017-08: 0
+      2017-09: 0
+      2017-10: 0
+      2017-11: 0
+      2017-12: 2300
+    allegement_fillon_mode_recouvrement: "fin-d-annee"
+    effectif_entreprise: 1
+    code_postal_entreprise: "75001"
+    categorie_salarie: prive_non_cadre
+    contrat_de_travail_debut: "2017-12-01"
+  output_variables:
+    allegement_fillon:
+      2017-01: 0
+      2017-02: 0
+      2017-03: 0
+      2017-04: 0
+      2017-05: 0
+      2017-06: 0
+      2017-07: 0
+      2017-08: 0
+      2017-09: 0
+      2017-10: 0
+      2017-11: 0
+      2017-12: 32.04
+
+- name: "Salarie un seul mois (décembre) - recouvrement progressif"
+  period: 2017
+  absolute_error_margin: 0.01
+  input_variables:
+    salaire_de_base: # un salaire en 2017
+      2017-01: 0
+      2017-02: 0
+      2017-03: 0
+      2017-04: 0
+      2017-05: 0
+      2017-06: 0
+      2017-07: 0
+      2017-08: 0
+      2017-09: 0
+      2017-10: 0
+      2017-11: 0
+      2017-12: 2300
+    allegement_fillon_mode_recouvrement: "progressif"
+    effectif_entreprise: 1
+    code_postal_entreprise: "75001"
+    categorie_salarie: prive_non_cadre
+    contrat_de_travail_debut: "2017-12-01"
+  output_variables:
+    allegement_fillon:
+      2017-01: 0
+      2017-02: 0
+      2017-03: 0
+      2017-04: 0
+      2017-05: 0
+      2017-06: 0
+      2017-07: 0
+      2017-08: 0
+      2017-09: 0
+      2017-10: 0
+      2017-11: 0
+      2017-12: 32.04
+
+- name: "Salarie un seul mois (décembre) - recouvrement anticipe"
+  period: 2017
+  absolute_error_margin: 0.01
+  input_variables:
+    salaire_de_base: # un salaire en 2017
+      2017-01: 0
+      2017-02: 0
+      2017-03: 0
+      2017-04: 0
+      2017-05: 0
+      2017-06: 0
+      2017-07: 0
+      2017-08: 0
+      2017-09: 0
+      2017-10: 0
+      2017-11: 0
+      2017-12: 2300
+    allegement_fillon_mode_recouvrement: "anticipe-regularisation-fin-de-periode"
+    effectif_entreprise: 1
+    code_postal_entreprise: "75001"
+    categorie_salarie: prive_non_cadre
+    contrat_de_travail_debut: "2017-12-01"
+  output_variables:
+    allegement_fillon:
+      2017-01: 0
+      2017-02: 0
+      2017-03: 0
+      2017-04: 0
+      2017-05: 0
+      2017-06: 0
+      2017-07: 0
+      2017-08: 0
+      2017-09: 0
+      2017-10: 0
+      2017-11: 0
+      2017-12: 32.04

--- a/tests/allegement_fillon.yaml
+++ b/tests/allegement_fillon.yaml
@@ -153,7 +153,7 @@
       2017-10: 0
       2017-11: 2300
       2017-12: 0
-    allegement_fillon_mode_recouvrement: "fin-d-annee"
+    allegement_fillon_mode_recouvrement: "fin_d_annee"
     effectif_entreprise: 1
     code_postal_entreprise: "75001"
     categorie_salarie: prive_non_cadre
@@ -229,7 +229,7 @@
       2017-10: 0
       2017-11: 2300
       2017-12: 0
-    allegement_fillon_mode_recouvrement: "anticipe-regularisation-fin-de-periode"
+    allegement_fillon_mode_recouvrement: "anticipe"
     effectif_entreprise: 1
     code_postal_entreprise: "75001"
     categorie_salarie: prive_non_cadre
@@ -267,7 +267,7 @@
       2017-10: 0
       2017-11: 0
       2017-12: 2300
-    allegement_fillon_mode_recouvrement: "fin-d-annee"
+    allegement_fillon_mode_recouvrement: "fin_d_annee"
     effectif_entreprise: 1
     code_postal_entreprise: "75001"
     categorie_salarie: prive_non_cadre
@@ -341,7 +341,7 @@
       2017-10: 0
       2017-11: 0
       2017-12: 2300
-    allegement_fillon_mode_recouvrement: "anticipe-regularisation-fin-de-periode"
+    allegement_fillon_mode_recouvrement: anticipe
     effectif_entreprise: 1
     code_postal_entreprise: "75001"
     categorie_salarie: prive_non_cadre

--- a/tests/formulas/allegement_cotisation_allocations_familiales.yaml
+++ b/tests/formulas/allegement_cotisation_allocations_familiales.yaml
@@ -6,7 +6,8 @@
     # allegement mode necessary when requesting on a 1 month salary :
     allegement_cotisation_allocations_familiales_mode_recouvrement: anticipe
     allegement_fillon_mode_recouvrement: anticipe
-    contrat_de_travail_debut: 2015-07-01
+    contrat_de_travail_debut: 2015-01-01
+    contrat_de_travail_fin: 2015-12-31
     effectif_entreprise: 1
   output_variables:
     allegement_cotisation_allocations_familiales: 26.23
@@ -19,13 +20,14 @@
     # allegement mode necessary when requesting on a 1 month salary :
     allegement_cotisation_allocations_familiales_mode_recouvrement: anticipe
     allegement_fillon_mode_recouvrement: anticipe
-    contrat_de_travail_debut: 2015-07-01
+    contrat_de_travail_debut: 2015-01-01
+    contrat_de_travail_fin: 2015-12-31
     effectif_entreprise: 1
   output_variables:
     allegement_cotisation_allocations_familiales: 0
 
 - period: "2016-05"
-  name: 2xSMIC
+  name: 3.5xSMIC
   description: après avril 2016, l'allègement est étendu jusqu'à 3.5 SMIC
   relative_error_margin: 0.001
   input_variables:
@@ -33,7 +35,8 @@
     # allegement mode necessary when requesting on a 1 month salary :
     allegement_cotisation_allocations_familiales_mode_recouvrement: anticipe
     allegement_fillon_mode_recouvrement: anticipe
-    contrat_de_travail_debut: 2015-07-01
+    contrat_de_travail_debut: 2016-01-01
+    contrat_de_travail_fin: 2016-12-31
     effectif_entreprise: 1
   output_variables:
     allegement_cotisation_allocations_familiales: 52.47

--- a/tests/test_coefficient.py
+++ b/tests/test_coefficient.py
@@ -9,8 +9,8 @@ from openfisca_france import FranceTaxBenefitSystem
 def test_coefficient_proratisation_only_contract_periods():
   tax_benefit_system = FranceTaxBenefitSystem()
   scenario = tax_benefit_system.new_scenario()
-  scenario.init_single_entity(period='2017-11',
-    parent1=dict(salaire_de_base=2300,
+  scenario.init_single_entity(period='2017',
+    parent1=dict(salaire_de_base={'2017-11':2300},
     effectif_entreprise=1,
     code_postal_entreprise="75001",
     categorie_salarie=u'prive_non_cadre',

--- a/tests/test_coefficient.py
+++ b/tests/test_coefficient.py
@@ -17,7 +17,7 @@ def test_coefficient_proratisation_only_contract_periods():
     contrat_de_travail_debut='2017-11-1',
     allegement_fillon_mode_recouvrement=u'progressif'))
   simulation = scenario.new_simulation()
-  assert_equal(simulation.calculate_add('coefficient_proratisation','2017-11'),1)
-  assert_equal(simulation.calculate_add('coefficient_proratisation','2017-12'),1)
-  assert_equal(simulation.calculate_add('coefficient_proratisation','2017-10'),0)
+  assert_equal(simulation.calculate('coefficient_proratisation','2017-11'),1)
+  assert_equal(simulation.calculate('coefficient_proratisation','2017-12'),1)
+  assert_equal(simulation.calculate('coefficient_proratisation','2017-10'),0)
   assert_equal(simulation.calculate_add('coefficient_proratisation','2017'),2)

--- a/tests/test_coefficient.py
+++ b/tests/test_coefficient.py
@@ -15,9 +15,10 @@ def test_coefficient_proratisation_only_contract_periods():
     code_postal_entreprise="75001",
     categorie_salarie=u'prive_non_cadre',
     contrat_de_travail_debut='2017-11-1',
+    contrat_de_travail_fin='2017-11-30',
     allegement_fillon_mode_recouvrement=u'progressif'))
   simulation = scenario.new_simulation()
   assert_equal(simulation.calculate('coefficient_proratisation','2017-11'),1)
-  assert_equal(simulation.calculate('coefficient_proratisation','2017-12'),1)
+  assert_equal(simulation.calculate('coefficient_proratisation','2017-12'),0)
   assert_equal(simulation.calculate('coefficient_proratisation','2017-10'),0)
-  assert_equal(simulation.calculate_add('coefficient_proratisation','2017'),2)
+  assert_equal(simulation.calculate_add('coefficient_proratisation','2017'),1)

--- a/tests/test_coefficient.py
+++ b/tests/test_coefficient.py
@@ -15,7 +15,7 @@ def test_coefficient_proratisation_only_contract_periods():
     code_postal_entreprise="75001",
     categorie_salarie=u'prive_non_cadre',
     contrat_de_travail_debut='2017-11-1',
-    contrat_de_travail_fin='2017-11-30',
+    contrat_de_travail_fin='2017-12-01',
     allegement_fillon_mode_recouvrement=u'progressif'))
   simulation = scenario.new_simulation()
   assert_equal(simulation.calculate('coefficient_proratisation','2017-11'),1)

--- a/tests/test_coefficient.py
+++ b/tests/test_coefficient.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from nose.tools import assert_equal
+
+from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotisations_sociales.allegements import *
+from openfisca_core.periods import *
+from openfisca_france import FranceTaxBenefitSystem
+
+def test_coefficient_proratisation_only_contract_periods():
+  tax_benefit_system = FranceTaxBenefitSystem()
+  scenario = tax_benefit_system.new_scenario()
+  scenario.init_single_entity(period='2017-11',
+    parent1=dict(salaire_de_base=2300,
+    effectif_entreprise=1,
+    code_postal_entreprise="75001",
+    categorie_salarie=u'prive_non_cadre',
+    contrat_de_travail_debut='2017-11-1',
+    allegement_fillon_mode_recouvrement=u'progressif'))
+  simulation = scenario.new_simulation()
+  assert_equal(simulation.calculate_add('coefficient_proratisation','2017-11'),1)
+  assert_equal(simulation.calculate_add('coefficient_proratisation','2017-12'),1)
+  assert_equal(simulation.calculate_add('coefficient_proratisation','2017-10'),0)
+  assert_equal(simulation.calculate_add('coefficient_proratisation','2017'),2)

--- a/tests/test_coefficient.py
+++ b/tests/test_coefficient.py
@@ -9,7 +9,7 @@ from openfisca_france import FranceTaxBenefitSystem
 def test_coefficient_proratisation_only_contract_periods():
   tax_benefit_system = FranceTaxBenefitSystem()
   scenario = tax_benefit_system.new_scenario()
-  scenario.init_single_entity(period='2017-11',
+  scenario.init_single_entity(period='2017',
     parent1=dict(salaire_de_base=2300,
     effectif_entreprise=1,
     code_postal_entreprise="75001",

--- a/tests/test_coefficient.py
+++ b/tests/test_coefficient.py
@@ -9,7 +9,7 @@ from openfisca_france import FranceTaxBenefitSystem
 def test_coefficient_proratisation_only_contract_periods():
   tax_benefit_system = FranceTaxBenefitSystem()
   scenario = tax_benefit_system.new_scenario()
-  scenario.init_single_entity(period='2017',
+  scenario.init_single_entity(period='2017-11',
     parent1=dict(salaire_de_base=2300,
     effectif_entreprise=1,
     code_postal_entreprise="75001",

--- a/tests/test_coefficient.py
+++ b/tests/test_coefficient.py
@@ -7,35 +7,35 @@ from openfisca_core.periods import *
 from openfisca_france import FranceTaxBenefitSystem
 
 def test_coefficient_proratisation_only_contract_periods_wide():
-  tax_benefit_system = FranceTaxBenefitSystem()
-  scenario = tax_benefit_system.new_scenario()
-  scenario.init_single_entity(period='2017', # wide: we simulate for the year
-    parent1=dict(salaire_de_base={'2017-11':2300},
-    effectif_entreprise=1,
-    code_postal_entreprise="75001",
-    categorie_salarie=u'prive_non_cadre',
-    contrat_de_travail_debut='2017-11-1',
-    contrat_de_travail_fin='2017-12-01',
-    allegement_fillon_mode_recouvrement=u'progressif'))
-  simulation = scenario.new_simulation()
-  assert_equal(simulation.calculate('coefficient_proratisation','2017-11'),1)
-  assert_equal(simulation.calculate('coefficient_proratisation','2017-12'),0)
-  assert_equal(simulation.calculate('coefficient_proratisation','2017-10'),0)
-  assert_equal(simulation.calculate_add('coefficient_proratisation','2017'),1)
+    tax_benefit_system = FranceTaxBenefitSystem()
+    scenario = tax_benefit_system.new_scenario()
+    scenario.init_single_entity(period='2017', # wide: we simulate for the year
+        parent1=dict(salaire_de_base={'2017-11':2300},
+        effectif_entreprise=1,
+        code_postal_entreprise="75001",
+        categorie_salarie=u'prive_non_cadre',
+        contrat_de_travail_debut='2017-11-1',
+        contrat_de_travail_fin='2017-12-01',
+        allegement_fillon_mode_recouvrement=u'progressif'))
+    simulation = scenario.new_simulation()
+    assert_equal(simulation.calculate('coefficient_proratisation','2017-11'),1)
+    assert_equal(simulation.calculate('coefficient_proratisation','2017-12'),0)
+    assert_equal(simulation.calculate('coefficient_proratisation','2017-10'),0)
+    assert_equal(simulation.calculate_add('coefficient_proratisation','2017'),1)
 
 def test_coefficient_proratisation_only_contract_periods_narrow():
-  tax_benefit_system = FranceTaxBenefitSystem()
-  scenario = tax_benefit_system.new_scenario()
-  scenario.init_single_entity(period='2017-11', # narrow: we simulate for the month
-    parent1=dict(salaire_de_base={'2017-11':2300},
-    effectif_entreprise=1,
-    code_postal_entreprise="75001",
-    categorie_salarie=u'prive_non_cadre',
-    contrat_de_travail_debut='2017-11-1',
-    contrat_de_travail_fin='2017-12-01',
-    allegement_fillon_mode_recouvrement=u'progressif'))
-  simulation = scenario.new_simulation()
-  assert_equal(simulation.calculate('coefficient_proratisation','2017-11'),1)
-  assert_equal(simulation.calculate('coefficient_proratisation','2017-12'),0)
-  assert_equal(simulation.calculate('coefficient_proratisation','2017-10'),0)
-  assert_equal(simulation.calculate_add('coefficient_proratisation','2017'),1)
+    tax_benefit_system = FranceTaxBenefitSystem()
+    scenario = tax_benefit_system.new_scenario()
+    scenario.init_single_entity(period='2017-11', # narrow: we simulate for the month
+        parent1=dict(salaire_de_base={'2017-11':2300},
+        effectif_entreprise=1,
+        code_postal_entreprise="75001",
+        categorie_salarie=u'prive_non_cadre',
+        contrat_de_travail_debut='2017-11-1',
+        contrat_de_travail_fin='2017-12-01',
+        allegement_fillon_mode_recouvrement=u'progressif'))
+    simulation = scenario.new_simulation()
+    assert_equal(simulation.calculate('coefficient_proratisation','2017-11'),1)
+    assert_equal(simulation.calculate('coefficient_proratisation','2017-12'),0)
+    assert_equal(simulation.calculate('coefficient_proratisation','2017-10'),0)
+    assert_equal(simulation.calculate_add('coefficient_proratisation','2017'),1)

--- a/tests/test_coefficient.py
+++ b/tests/test_coefficient.py
@@ -6,10 +6,27 @@ from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotis
 from openfisca_core.periods import *
 from openfisca_france import FranceTaxBenefitSystem
 
-def test_coefficient_proratisation_only_contract_periods():
+def test_coefficient_proratisation_only_contract_periods_wide():
   tax_benefit_system = FranceTaxBenefitSystem()
   scenario = tax_benefit_system.new_scenario()
-  scenario.init_single_entity(period='2017',
+  scenario.init_single_entity(period='2017', # wide: we simulate for the year
+    parent1=dict(salaire_de_base={'2017-11':2300},
+    effectif_entreprise=1,
+    code_postal_entreprise="75001",
+    categorie_salarie=u'prive_non_cadre',
+    contrat_de_travail_debut='2017-11-1',
+    contrat_de_travail_fin='2017-12-01',
+    allegement_fillon_mode_recouvrement=u'progressif'))
+  simulation = scenario.new_simulation()
+  assert_equal(simulation.calculate('coefficient_proratisation','2017-11'),1)
+  assert_equal(simulation.calculate('coefficient_proratisation','2017-12'),0)
+  assert_equal(simulation.calculate('coefficient_proratisation','2017-10'),0)
+  assert_equal(simulation.calculate_add('coefficient_proratisation','2017'),1)
+
+def test_coefficient_proratisation_only_contract_periods_narrow():
+  tax_benefit_system = FranceTaxBenefitSystem()
+  scenario = tax_benefit_system.new_scenario()
+  scenario.init_single_entity(period='2017-11', # narrow: we simulate for the month
     parent1=dict(salaire_de_base={'2017-11':2300},
     effectif_entreprise=1,
     code_postal_entreprise="75001",


### PR DESCRIPTION
* Correction d'un bug.
* Périodes concernées : toutes.
* Zones impactées : `prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements`.
* Détails :
  - Corrige les erreurs de calculs constatés sur la réduction générale ("Fillon").
  - (Fixes #844)

- - - -

Ces changements _(effacez les lignes ne correspondant pas à votre cas)_ :
- Corrigent ou améliorent un calcul déjà existant.
