### PR TITLE
Déclenchement du forfait logement pour les primo-accédants sans AL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 19.0.2
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `prestations/minima_sociaux/ppa`
+  - `prestations/minima_sociaux/rsa`
+* Détails :
+  - Prend en compte l'avantage en nature des primo-accédants dans le calcul des aides au logement.
+
 ### 19.0.1
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -293,7 +293,8 @@ class ppa_bonification(Variable):
 class ppa_forfait_logement(Variable):
     value_type = float
     entity = Famille
-    label = u"Forfait logement intervenant dans le calcul de la primed d'activité"
+    label = u"Forfait logement intervenant dans le calcul de la prime d'activité"
+    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=9A3FFF4142B563EB5510DDE9F2870BF4.tplgfr41s_2?idArticle=LEGIARTI000031675988&cidTexte=LEGITEXT000006073189&dateTexte=20171222"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -303,8 +304,11 @@ class ppa_forfait_logement(Variable):
         participation_frais = famille.demandeur.menage('participation_frais', period)
         loyer = famille.demandeur.menage('loyer', period)
 
+        # 1 = Accédant à la propriété
+        # 2 = Propriétaire (non accédant) du logement
+        # 6 = Logé gratuitement par des parents, des amis ou l'employeur
         avantage_nature = or_(
-            (statut_occupation_logement == 2) * not_(loyer),
+            ((statut_occupation_logement == 1) + (statut_occupation_logement == 2)) * not_(loyer),
             (statut_occupation_logement == 6) * not_(participation_frais)
             )
         avantage_al = aide_logement > 0
@@ -366,6 +370,8 @@ class ppa(Variable):
     label = u"Prime Pour l'Activité"
     definition_period = MONTH
     calculate_output = calculate_output_add
+    # Prime d'activité sur service-public.fr
+    reference = u"https://www.service-public.fr/particuliers/vosdroits/F2882"
 
     def formula_2016_01_01(famille, period, parameters):
         seuil_non_versement = parameters(period).prestations.minima_sociaux.ppa.seuil_non_versement

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -792,6 +792,7 @@ class rsa_forfait_logement(Variable):
     value_type = float
     entity = Famille
     label = u"Forfait logement intervenant dans le calcul du Rmi ou du Rsa"
+    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694445&cidTexte=LEGITEXT000006074069&dateTexte=20171222&fastPos=2&fastReqId=1534790830&oldAction=rechCodeArticle"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -801,8 +802,11 @@ class rsa_forfait_logement(Variable):
         participation_frais = famille.demandeur.menage('participation_frais', period)
         loyer = famille.demandeur.menage('loyer', period)
 
+        # 1 = Accédant à la propriété
+        # 2 = Propriétaire (non accédant) du logement
+        # 6 = Logé gratuitement par des parents, des amis ou l'employeur
         avantage_nature = or_(
-            (statut_occupation_logement == 2) * not_(loyer),
+            ((statut_occupation_logement == 1) + (statut_occupation_logement == 2)) * not_(loyer),
             (statut_occupation_logement == 6) * not_(participation_frais)
             )
         avantage_al = aide_logement > 0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '19.0.1',
+    version = '19.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/ppa.yaml
+++ b/tests/formulas/ppa.yaml
@@ -358,6 +358,16 @@
     ppa_forfait_logement:
       2016-01: 155.68
 
+- name: "PPA/RSA forfait logement 1 personne accédant à la propriété"
+  period: 2017-10
+  absolute_error_margin: 0.005
+  input_variables:
+    statut_occupation_logement: 1 # Accédant à la propriété
+    age: 40
+  output_variables:
+    ppa_forfait_logement: 63.15
+    rsa_forfait_logement: 65.46
+
 - name: "Prise en compte du forfait logement"
   period: 2016-01
   relative_error_margin: 0.05


### PR DESCRIPTION
### 19.0.2

* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées :
  - `prestations/minima_sociaux/ppa`
  - `prestations/minima_sociaux/rsa`
* Détails :
  - Prend en compte l'avantage en nature des primo-accédants dans le calcul des aides au logement.