### PR TITLE
Shared enum in base

### DIFF
--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -33,6 +33,17 @@ class TypesCategorieSalarie(Enum):
     non_pertinent = u'non_pertinent'
 
 
+class TypesContratDeTravail(Enum):
+    __order__ = 'temps_plein temps_partiel forfait_heures_semaines forfait_heures_mois forfait_heures_annee forfait_jours_annee sans_objet'  # Needed to preserve the enum order in Python 2
+    temps_plein = u"temps_plein"
+    temps_partiel = u"temps_partiel"
+    forfait_heures_semaines = u"forfait_heures_semaines"
+    forfait_heures_mois = u"forfait_heures_mois"
+    forfait_heures_annee = u"forfait_heures_annee"
+    forfait_jours_annee = u"forfait_jours_annee"
+    sans_objet = u"sans_objet"
+
+
 class TypesStatutMarital(Enum):
     __order__ = 'non_renseigne marie celibataire divorce veuf pacse jeune_veuf'  # Needed to preserve the enum order in Python 2
     non_renseigne = u'Non renseigné'

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -105,6 +105,13 @@ class TypesTailleEntreprise(Enum):
     plus_de_250 = u"Plus de 250 salariés"
 
 
+class TypesTnsTypeActivite(Enum):
+    __order__ = 'achat_revente bic bnc'  # Needed to preserve the enum order in Python 2
+    achat_revente = u'achat_revente'
+    bic = u'bic'
+    bnc = u'bnc'
+
+
 TAUX_DE_PRIME = 1 / 4  # primes_fonction_publique (hors suppl. familial et indemnité de résidence)/rémunération brute
 
 # Legacy roles. To be removed when they are not used by formulas anymore.

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -65,6 +65,13 @@ class TypesExpositionAccident(Enum):
     tres_eleve = u"Très élevé"
 
 
+class TypesExpositionPenibilite(Enum):
+    __order__ = 'nulle simple multiple'  # Needed to preserve the enum order in Python 2
+    nulle = u"Nulle, pas d'exposition de l'employé à un facteur de pénibilité"
+    simple = u"Simple, exposition à un seul facteur de pénibilité"
+    multiple = u"Multiple, exposition à plusieurs facteurs de pénibilité"
+
+
 class TypesStatutMarital(Enum):
     __order__ = 'non_renseigne marie celibataire divorce veuf pacse jeune_veuf'  # Needed to preserve the enum order in Python 2
     non_renseigne = u'Non renseigné'

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -14,6 +14,13 @@ class TypesActivite(Enum):
     inactif = u'Autre, inactif'
 
 
+class TypesAllegementModeRecouvrement(Enum):
+    __order__ = 'fin_d_annee anticipe progressif'  # Needed to preserve the enum order in Python 2
+    fin_d_annee = u"fin_d_annee"
+    anticipe = u"anticipe_regularisation_fin_de_periode"
+    progressif = u"progressif"
+
+
 class TypesCategorieSalarie(Enum):
     __order__ = 'prive_non_cadre prive_cadre public_titulaire_etat public_titulaire_militaire public_titulaire_territoriale public_titulaire_hospitaliere public_non_titulaire non_pertinent'  # Needed to preserve the enum order in Python 2
     prive_non_cadre = u'prive_non_cadre'

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -44,6 +44,12 @@ class TypesContratDeTravail(Enum):
     sans_objet = u"sans_objet"
 
 
+class TypesContratDeTravailDuree(Enum):
+    __order__ = 'cdi cdd'  # Needed to preserve the enum order in Python 2
+    cdi = u"CDI"
+    cdd = u"CDD"
+
+
 class TypesStatutMarital(Enum):
     __order__ = 'non_renseigne marie celibataire divorce veuf pacse jeune_veuf'  # Needed to preserve the enum order in Python 2
     non_renseigne = u'Non renseigné'

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -50,6 +50,13 @@ class TypesContratDeTravailDuree(Enum):
     cdd = u"CDD"
 
 
+class TypesCotisationSocialeModeRecouvrement(Enum):
+    __order__ = 'mensuel annuel mensuel_strict'  # Needed to preserve the enum order in Python 2
+    mensuel = u"Mensuel avec régularisation en fin d'année"
+    annuel = u"Annuel"
+    mensuel_strict = u"Mensuel strict"
+
+
 class TypesStatutMarital(Enum):
     __order__ = 'non_renseigne marie celibataire divorce veuf pacse jeune_veuf'  # Needed to preserve the enum order in Python 2
     non_renseigne = u'Non renseigné'

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -112,6 +112,14 @@ class TypesTnsTypeActivite(Enum):
     bnc = u'bnc'
 
 
+class TypesZoneApl(Enum):
+    __order__ = 'non_renseigne zone_1 zone_2 zone_3'  # Needed to preserve the enum order in Python 2
+    non_renseigne = u"Non renseigné"
+    zone_1 = u"Zone 1"
+    zone_2 = u"Zone 2"
+    zone_3 = u"Zone 3"
+
+
 TAUX_DE_PRIME = 1 / 4  # primes_fonction_publique (hors suppl. familial et indemnité de résidence)/rémunération brute
 
 # Legacy roles. To be removed when they are not used by formulas anymore.

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -57,6 +57,14 @@ class TypesCotisationSocialeModeRecouvrement(Enum):
     mensuel_strict = u"Mensuel strict"
 
 
+class TypesExpositionAccident(Enum):
+    __order__ = 'faible moyen eleve tres_eleve'  # Needed to preserve the enum order in Python 2
+    faible = u"Faible"
+    moyen = u"Moyen"
+    eleve = u"Élevé"
+    tres_eleve = u"Très élevé"
+
+
 class TypesStatutMarital(Enum):
     __order__ = 'non_renseigne marie celibataire divorce veuf pacse jeune_veuf'  # Needed to preserve the enum order in Python 2
     non_renseigne = u'Non renseigné'

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -96,6 +96,15 @@ class TypesStatutOccupationLogement(Enum):
     sans_domicile = u"Sans domicile stable"
 
 
+class TypesTailleEntreprise(Enum):
+    __order__ = 'non_pertinent moins_de_10 de_10_a_19 de_20_a_249 plus_de_250'  # Needed to preserve the enum order in Python 2
+    non_pertinent = u"Non pertinent"
+    moins_de_10 = u"Moins de 10 salariés"
+    de_10_a_19 = u"De 10 à 19 salariés"
+    de_20_a_249 = u"De 20 à 249 salariés"
+    plus_de_250 = u"Plus de 250 salariés"
+
+
 TAUX_DE_PRIME = 1 / 4  # primes_fonction_publique (hors suppl. familial et indemnité de résidence)/rémunération brute
 
 # Legacy roles. To be removed when they are not used by formulas anymore.

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -220,7 +220,6 @@ class aide_embauche_pme(Variable):
         effectif_entreprise = simulation.calculate('effectif_entreprise', period)
         apprenti = simulation.calculate('apprenti', period)
         contrat_de_travail_duree = simulation.calculate('contrat_de_travail_duree', period)
-        TypesContratDeTravailDuree = contrat_de_travail_duree.possible_values
         contrat_de_travail_debut = simulation.calculate('contrat_de_travail_debut', period)
         contrat_de_travail_fin = simulation.calculate('contrat_de_travail_fin', period)
         coefficient_proratisation = simulation.calculate('coefficient_proratisation', period)
@@ -336,7 +335,6 @@ def compute_allegement_fillon(simulation, period):
     assiette = simulation.calculate_add('assiette_allegement', period)
     smic_proratise = simulation.calculate_add('smic_proratise', period)
     taille_entreprise = simulation.calculate('taille_entreprise', first_month)
-    TypesTailleEntreprise = taille_entreprise.possible_values
     majoration = (
         (taille_entreprise == TypesTailleEntreprise.non_pertinent)
         + (taille_entreprise == TypesTailleEntreprise.moins_de_10)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -429,7 +429,6 @@ def switch_on_allegement_mode(simulation, period, mode_recouvrement, variable_na
         should precisely be the variable name prefixed with 'compute_'
     """
     compute_function = globals()['compute_' + variable_name]
-    TypesAllegementModeRecouvrement = mode_recouvrement.possible_values
     recouvrement_fin_annee = (mode_recouvrement == TypesAllegementModeRecouvrement.fin_d_annee)
     recouvrement_anticipe = (mode_recouvrement == TypesAllegementModeRecouvrement.anticipe)
     recouvrement_progressif = (mode_recouvrement == TypesAllegementModeRecouvrement.progressif)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -44,7 +44,6 @@ class coefficient_proratisation(Variable):
 
         # Les types de contrats gérés
         contrat_de_travail = simulation.calculate('contrat_de_travail', period)
-        TypesContratDeTravail = contrat_de_travail.possible_values
         # [ temps_plein
         #   temps_partiel
         #   forfait_heures_semaines
@@ -158,7 +157,6 @@ class aide_premier_salarie(Variable):
         effectif_entreprise = simulation.calculate('effectif_entreprise', period)
         apprenti = simulation.calculate('apprenti', period)
         contrat_de_travail_duree = simulation.calculate('contrat_de_travail_duree', period)
-        TypesContratDeTravailDuree = contrat_de_travail_duree.possible_values
         contrat_de_travail_debut = simulation.calculate('contrat_de_travail_debut', period)
         contrat_de_travail_fin = simulation.calculate('contrat_de_travail_fin', period)
         coefficient_proratisation = simulation.calculate('coefficient_proratisation', period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/base.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/base.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from openfisca_france.model.base import *  # noqa analysis:ignore
+
 DEFAULT_ROUND_BASE_DECIMALS = 2
 
 
@@ -40,7 +42,6 @@ def apply_bareme_for_relevant_type_sal(
 
 def apply_bareme(simulation, period, cotisation_type = None, bareme_name = None, variable_name = None):
     cotisation_mode_recouvrement = simulation.calculate('cotisation_sociale_mode_recouvrement', period)
-    TypesCotisationSocialeModeRecouvrement = cotisation_mode_recouvrement.possible_values
     cotisation = (
         # anticipé (mensuel avec recouvrement en fin d'année)
         cotisation_mode_recouvrement == TypesCotisationSocialeModeRecouvrement.mensuel) * (

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -147,7 +147,6 @@ class exoneration_cotisations_employeur_zfu(Variable):
     def formula(self, simulation, period):
         assiette_allegement = simulation.calculate('assiette_allegement', period)
         contrat_de_travail_duree = simulation.calculate('contrat_de_travail_duree', period)
-        TypesContratDeTravailDuree = contrat_de_travail_duree.possible_values
         contrat_de_travail_debut = simulation.calculate('contrat_de_travail_debut', period)
         contrat_de_travail_fin = simulation.calculate('contrat_de_travail_fin', period)
         effectif_entreprise = simulation.calculate('effectif_entreprise', period)
@@ -298,7 +297,6 @@ class exoneration_cotisations_employeur_zrr(Variable):
     def formula(self, simulation, period):
         assiette_allegement = simulation.calculate('assiette_allegement', period)
         contrat_de_travail_duree = simulation.calculate('contrat_de_travail_duree', period)
-        TypesContratDeTravailDuree = contrat_de_travail_duree.possible_values
         contrat_de_travail_debut = simulation.calculate('contrat_de_travail_debut', period)
         contrat_de_travail_fin = simulation.calculate('contrat_de_travail_fin', period)
         effectif_entreprise = simulation.calculate('effectif_entreprise', period)
@@ -346,8 +344,6 @@ class exoneration_is_creation_zrr(Variable):
         entreprise_benefice = simulation.calculate_add('entreprise_benefice', period)
         # TODO: MODIFIER avec création d'entreprise
         contrat_de_travail_duree = simulation.calculate('contrat_de_travail_duree', decembre)
-        TypesContratDeTravailDuree = contrat_de_travail_duree.possible_values
-
         contrat_de_travail_debut = simulation.calculate('contrat_de_travail_debut', decembre)
         contrat_de_travail_fin = simulation.calculate('contrat_de_travail_fin', decembre)
         duree_eligible = contrat_de_travail_fin > contrat_de_travail_debut + timedelta64(365, 'D')

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/preprocessing.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/preprocessing.py
@@ -7,7 +7,6 @@ import copy
 import logging
 
 from openfisca_france.model.base import *  # noqa
-from openfisca_france.model.revenus.activite.salarie import TypesCategorieSalarie
 
 DEBUG_SAL_TYPE = 'public_titulaire_etat'
 log = logging.getLogger(__name__)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -80,7 +80,6 @@ class indemnite_fin_contrat(Variable):
 
     def formula(self, simulation, period):
         contrat_de_travail_duree = simulation.calculate('contrat_de_travail_duree', period)
-        TypesContratDeTravailDuree = contrat_de_travail_duree.possible_values
         salaire_de_base = simulation.calculate('salaire_de_base', period)
         categorie_salarie = simulation.calculate('categorie_salarie', period)
         apprenti = simulation.calculate('apprenti', period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -151,7 +151,7 @@ class penibilite(Variable):
 
     def formula_2015_01_01(self, simulation, period):
         exposition_penibilite = simulation.calculate('exposition_penibilite', period)
-        TypesExpositionPenibilite = exposition_penibilite.possible_values
+
         multiplicateur = simulation.parameters_at(period.start).cotsoc.cotisations_employeur.prive_cadre.penibilite_multiplicateur_exposition_multiple
 
         cotisation_base = apply_bareme(

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -799,7 +799,6 @@ class taux_accident_travail(Variable):
 
     def formula_2012_01_01(self, simulation, period):
         exposition_accident = simulation.calculate('exposition_accident', period)
-        TypesExpositionAccident = exposition_accident.possible_values
         accident = simulation.parameters_at(period.start).cotsoc.accident
 
         return (exposition_accident == TypesExpositionAccident.faible) * accident.faible + (exposition_accident == TypesExpositionAccident.moyen) * accident.moyen \

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -750,18 +750,9 @@ class complementaire_sante_salarie(Variable):
         return cotisation
 
 
-class TypesTailleEntreprise(Enum):
-    __order__ = 'non_pertinent moins_de_10 de_10_a_19 de_20_a_249 plus_de_250'  # Needed to preserve the enum order in Python 2
-    non_pertinent = u"Non pertinent"
-    moins_de_10 = u"Moins de 10 salariés"
-    de_10_a_19 = u"De 10 à 19 salariés"
-    de_20_a_249 = u"De 20 à 249 salariés"
-    plus_de_250 = u"Plus de 250 salariés"
-
-
 class taille_entreprise(Variable):
     value_type = Enum
-    possible_values = TypesTailleEntreprise
+    possible_values = TypesTailleEntreprise  # defined in model/base.py
     default_value = TypesTailleEntreprise.non_pertinent
     entity = Individu
     label = u"Catégorie de taille d'entreprise"

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -668,7 +668,6 @@ class plafond_securite_sociale(Variable):
     def formula(self, simulation, period):
         plafond_temps_plein = simulation.parameters_at(period.start).cotsoc.gen.plafond_securite_sociale
         contrat_de_travail = simulation.calculate('contrat_de_travail', period)
-        TypesContratDeTravail = contrat_de_travail.possible_values
         heures_remunerees_volume = simulation.calculate('heures_remunerees_volume', period)
         forfait_jours_remuneres_volume = simulation.calculate('forfait_jours_remuneres_volume', period)
         heures_duree_collective_entreprise = simulation.calculate('heures_duree_collective_entreprise', period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -173,7 +173,6 @@ class fnal_tranche_a(Variable):
 
     def formula(self, simulation, period):
         taille_entreprise = simulation.calculate('taille_entreprise', period)
-        TypesTailleEntreprise = taille_entreprise.possible_values
         cotisation = apply_bareme(
             simulation,
             period,
@@ -197,7 +196,6 @@ class fnal_tranche_a_plus_20(Variable):
 
     def formula(self, simulation, period):
         taille_entreprise = simulation.calculate('taille_entreprise', period)
-        TypesTailleEntreprise = taille_entreprise.possible_values
         cotisation = apply_bareme(
             simulation,
             period,
@@ -245,7 +243,6 @@ class formation_professionnelle(Variable):
 
     def formula(self, simulation, period):
         taille_entreprise = simulation.calculate('taille_entreprise', period)
-        TypesTailleEntreprise = taille_entreprise.possible_values
         cotisation_0_9 = (taille_entreprise == TypesTailleEntreprise.moins_de_10) * apply_bareme(
             simulation,
             period, cotisation_type = 'employeur',

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -37,7 +37,6 @@ class conge_individuel_formation_cdd(Variable):
     # TODO: date de début
     def formula(self, simulation, period):
         contrat_de_travail_duree = simulation.calculate('contrat_de_travail_duree', period)
-        TypesContratDeTravailDuree = contrat_de_travail_duree.possible_values
         assiette_cotisations_sociales = simulation.calculate('assiette_cotisations_sociales', period)
         law = simulation.parameters_at(period.start).cotsoc.conge_individuel_formation
 

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -820,17 +820,9 @@ class crds_logement(Variable):
         return -aide_logement_montant_brut * crds
 
 
-class TypesZoneApl(Enum):
-    __order__ = 'non_renseigne zone_1 zone_2 zone_3'  # Needed to preserve the enum order in Python 2
-    non_renseigne = u"Non renseigné"
-    zone_1 = u"Zone 1"
-    zone_2 = u"Zone 2"
-    zone_3 = u"Zone 3"
-
-
 class zone_apl(Variable):
     value_type = Enum
-    possible_values = TypesZoneApl
+    possible_values = TypesZoneApl   # defined in model/base.py
     default_value = TypesZoneApl.zone_2
     entity = Menage
     label = u"Zone APL"

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -760,7 +760,6 @@ class rsa_eligibilite_tns(Variable):
             plaf_vente = P_micro.specialbnc.marchandises.max
             plaf_service = P_micro.specialbnc.services.max
 
-            TypesTnsTypeActivite = type_activite.possible_values
             achat_revente = (type_activite == TypesTnsTypeActivite.achat_revente)
 
 

--- a/openfisca_france/model/revenus/activite/non_salarie.py
+++ b/openfisca_france/model/revenus/activite/non_salarie.py
@@ -1602,17 +1602,11 @@ class tns_micro_entreprise_chiffre_affaires(Variable):
     definition_period = YEAR
 
 
-class TypesTnsTypeActivite(Enum):
-    __order__ = 'achat_revente bic bnc'  # Needed to preserve the enum order in Python 2
-    achat_revente = u'achat_revente'
-    bic = u'bic'
-    bnc = u'bnc'
-
 
 # TODO remove this ugly ETERNITY
 class tns_auto_entrepreneur_type_activite(Variable):
     value_type = Enum
-    possible_values = TypesTnsTypeActivite
+    possible_values = TypesTnsTypeActivite  # defined in model/base.py
     default_value = TypesTnsTypeActivite.achat_revente
     entity = Individu
     label = u"Type d'activité de l'auto-entrepreneur"
@@ -1622,7 +1616,7 @@ class tns_auto_entrepreneur_type_activite(Variable):
 # TODO remove this ugly ETERNITY
 class tns_micro_entreprise_type_activite(Variable):
     value_type = Enum
-    possible_values = TypesTnsTypeActivite
+    possible_values = TypesTnsTypeActivite  # defined in model/base.py
     default_value = TypesTnsTypeActivite.achat_revente
     entity = Individu
     label = u"Type d'activité de la micro-entreprise"

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -260,15 +260,9 @@ class contrat_de_travail_fin(Variable):
     set_input = set_input_dispatch_by_period
 
 
-class TypesContratDeTravailDuree(Enum):
-    __order__ = 'cdi cdd'  # Needed to preserve the enum order in Python 2
-    cdi = u"CDI"
-    cdd = u"CDD"
-
-
 class contrat_de_travail_duree(Variable):
     value_type = Enum
-    possible_values = TypesContratDeTravailDuree
+    possible_values = TypesContratDeTravailDuree  # defined in model/base.py
     default_value = TypesContratDeTravailDuree.cdi
     entity = Individu
     label = u"Type (durée determinée ou indéterminée) du contrat de travail"

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -232,20 +232,9 @@ class indemnite_fin_contrat_due(Variable):
     definition_period = MONTH
 
 
-class TypesContratDeTravail(Enum):
-    __order__ = 'temps_plein temps_partiel forfait_heures_semaines forfait_heures_mois forfait_heures_annee forfait_jours_annee sans_objet'  # Needed to preserve the enum order in Python 2
-    temps_plein = u"temps_plein"
-    temps_partiel = u"temps_partiel"
-    forfait_heures_semaines = u"forfait_heures_semaines"
-    forfait_heures_mois = u"forfait_heures_mois"
-    forfait_heures_annee = u"forfait_heures_annee"
-    forfait_jours_annee = u"forfait_jours_annee"
-    sans_objet = u"sans_objet"
-
-
 class contrat_de_travail(Variable):
     value_type = Enum
-    possible_values = TypesContratDeTravail
+    possible_values = TypesContratDeTravail  # defined in model/base.py
     default_value = TypesContratDeTravail.temps_plein
     entity = Individu
     label = u"Type contrat de travail"

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -126,17 +126,10 @@ class ppe_tp_sa(Variable):
             indicateur = indicateur & (individu('contrat_de_travail', mois) == 0)
         return indicateur
 
-class TypesExpositionAccident(Enum):
-    __order__ = 'faible moyen eleve tres_eleve'  # Needed to preserve the enum order in Python 2
-    faible = u"Faible"
-    moyen = u"Moyen"
-    eleve = u"Élevé"
-    tres_eleve = u"Très élevé"
-
 
 class exposition_accident(Variable):
     value_type = Enum
-    possible_values = TypesExpositionAccident
+    possible_values = TypesExpositionAccident  # defined in model/base.py
     default_value = TypesExpositionAccident.faible
     entity = Individu
     label = u"Exposition au risque pour les accidents du travail"

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -670,7 +670,6 @@ class indemnite_residence(Variable):
         salaire_de_base = individu('salaire_de_base', period)
         categorie_salarie = individu('categorie_salarie', period)
         zone_apl = individu.menage('zone_apl', period)
-        TypesZoneApl = zone_apl.possible_values
         _P = parameters(period)
 
         P = _P.fonc.indem_resid

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -270,16 +270,10 @@ class contrat_de_travail_duree(Variable):
     set_input = set_input_dispatch_by_period
 
 
-class TypesCotisationSocialeModeRecouvrement(Enum):
-    __order__ = 'mensuel annuel mensuel_strict'  # Needed to preserve the enum order in Python 2
-    mensuel = u"Mensuel avec régularisation en fin d'année"
-    annuel = u"Annuel"
-    mensuel_strict = u"Mensuel strict"
-
 
 class cotisation_sociale_mode_recouvrement(Variable):
     value_type = Enum
-    possible_values = TypesCotisationSocialeModeRecouvrement
+    possible_values = TypesCotisationSocialeModeRecouvrement   # defined in model/base.py
     default_value = TypesCotisationSocialeModeRecouvrement.mensuel
     entity = Individu
     label = u"Mode de recouvrement des cotisations sociales"

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -136,16 +136,10 @@ class exposition_accident(Variable):
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
-class TypesExpositionPenibilite(Enum):
-    __order__ = 'nulle simple multiple'  # Needed to preserve the enum order in Python 2
-    nulle = u"Nulle, pas d'exposition de l'employé à un facteur de pénibilité"
-    simple = u"Simple, exposition à un seul facteur de pénibilité"
-    multiple = u"Multiple, exposition à plusieurs facteurs de pénibilité"
-
 
 class exposition_penibilite(Variable):
     value_type = Enum
-    possible_values = TypesExpositionPenibilite
+    possible_values = TypesExpositionPenibilite   # defined in model/base.py
     default_value = TypesExpositionPenibilite.nulle
     entity = Individu
     label = u"Exposition à un ou plusieurs facteurs de pénibilité"

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -160,16 +160,9 @@ class exposition_penibilite(Variable):
     set_input = set_input_dispatch_by_period
 
 
-class TypesAllegementModeRecouvrement(Enum):
-    __order__ = 'fin_d_annee anticipe progressif'  # Needed to preserve the enum order in Python 2
-    fin_d_annee = u"fin_d_annee"
-    anticipe = u"anticipe_regularisation_fin_de_periode"
-    progressif = u"progressif"
-
-
 class allegement_fillon_mode_recouvrement(Variable):
     value_type = Enum
-    possible_values = TypesAllegementModeRecouvrement
+    possible_values = TypesAllegementModeRecouvrement  # defined in model/base.py
     default_value = TypesAllegementModeRecouvrement.fin_d_annee
     entity = Individu
     label = u"Mode de recouvrement des allègements Fillon"
@@ -179,7 +172,7 @@ class allegement_fillon_mode_recouvrement(Variable):
 
 class allegement_cotisation_allocations_familiales_mode_recouvrement(Variable):
     value_type = Enum
-    possible_values = TypesAllegementModeRecouvrement
+    possible_values = TypesAllegementModeRecouvrement  # defined in model/base.py
     default_value = TypesAllegementModeRecouvrement.fin_d_annee
     entity = Individu
     label = u"Mode de recouvrement de l'allègement de la cotisation d'allocations familiales"


### PR DESCRIPTION
Cette PR propose de mettre dans base.py l'ensemble des enums partagés.
Cela permetrait d'offrir un choix simple au créateur de formule : 
- soit l'enum est dans le fichier qui le reference
- soit l'enum est dans base.py

Il me semble que l'option : 
- importer l'enum avec `nom_de_la_variable.possible_values` apporte une complexité supplémentaire qu'il serait plus délicat à communiquer aux utilisateurs.