### PR TITLE
Definit une version précise de OpenFisca-Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 20.0.2 [#878](https://github.com/openfisca/openfisca-france/pull/878)
+
+* Amélioration technique
+* Détails :
+  - Réduit la version d'OpenFisca-Core en attente de l'adaptation de France à Core v21.2
+
 ### 20.0.1 [#875](https://github.com/openfisca/openfisca-france/pull/875)
 
 * Évolution du système socio-fiscal.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '20.0.1',
+    version = '20.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
         'numpy >= 1.11, < 1.13',
-        'OpenFisca-Core >= 21.0.2, < 22.0',
+        'OpenFisca-Core >= 21.0.2, < 21.2',
         'PyYAML >= 3.10',
         'requests >= 2.8',
         ],


### PR DESCRIPTION
* Correction d'un crash
* Périodes concernées : toutes.
* Zones impactées : `setup.py`.
* Détails :
  - Définit une version stricte pour l'import d' OpenFisca-Core
- - - -
Ces changements sécurisent les calculs existants.
