### PR TITLE
Remplace paje_clca par page_prepare dans le calcul de la paje.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Périodes concernées : A partir de 04/2017
 * Zones impactées : `prestations_familiales/paje.py`
 * Détails :
-- Remplace la `paje_clca` par la `page_prepare` dans le calcul de la `paje` à partir d'avril 2017.
+  - Remplace la `paje_clca` par la `page_prepare` dans le calcul de la `paje` à partir d'avril 2017.
 
 ### 20.0.9 [#906](https://github.com/openfisca/openfisca-france/pull/906)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 20.1.0 [#884](https://github.com/openfisca/openfisca-france/pull/884)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : A partir de 04/2017
+* Zones impactées : `prestations_familiales/paje.py`
+* Détails :
+- Remplace la `paje_clca` par la `page_prepare` dans le calcul de la `paje` à partir d'avril 2017.
+
 ### 20.0.9 [#906](https://github.com/openfisca/openfisca-france/pull/906)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -228,6 +228,27 @@ class ppa_base_ressources_prestations_familiales(Variable):
     label = u"Prestations familiales prises en compte dans le calcul de la PPA"
     definition_period = MONTH
 
+    def formula_2017_04(famille, period, parameters, mois_demande):
+        prestations_calculees = [
+            'rsa_forfait_asf',
+            'paje_base',
+            ]
+
+        result = sum(famille(prestation, mois_demande) for prestation in prestations_calculees)
+        result += famille('paje_prepare', period)
+        cf_non_majore_avant_cumul = famille('cf_non_majore_avant_cumul', mois_demande)
+        cf = famille('cf', mois_demande)
+        # Seul le montant non majoré est pris en compte dans la base de ressources du RSA
+        cf_non_majore = (cf > 0) * cf_non_majore_avant_cumul
+
+        af_base = famille('af_base', mois_demande)
+        af = famille('af', mois_demande)
+
+        result = result + cf_non_majore + min_(af_base, af)
+
+        return result
+
+
     def formula(famille, period, parameters, mois_demande):
         prestations_calculees = [
             'rsa_forfait_asf',

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -228,27 +228,6 @@ class ppa_base_ressources_prestations_familiales(Variable):
     label = u"Prestations familiales prises en compte dans le calcul de la PPA"
     definition_period = MONTH
 
-    def formula_2017_04(famille, period, parameters, mois_demande):
-        prestations_calculees = [
-            'rsa_forfait_asf',
-            'paje_base',
-            ]
-
-        result = sum(famille(prestation, mois_demande) for prestation in prestations_calculees)
-        result += famille('paje_prepare', period)
-        cf_non_majore_avant_cumul = famille('cf_non_majore_avant_cumul', mois_demande)
-        cf = famille('cf', mois_demande)
-        # Seul le montant non majoré est pris en compte dans la base de ressources du RSA
-        cf_non_majore = (cf > 0) * cf_non_majore_avant_cumul
-
-        af_base = famille('af_base', mois_demande)
-        af = famille('af', mois_demande)
-
-        result = result + cf_non_majore + min_(af_base, af)
-
-        return result
-
-
     def formula(famille, period, parameters, mois_demande):
         prestations_calculees = [
             'rsa_forfait_asf',

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -236,34 +236,6 @@ class rsa_base_ressources_prestations_familiales(Variable):
 
         return result
 
-    def formula_2017_01_01(famille, mois_demande, parameters, mois_courant):
-        # TODO : Neutraliser les ressources de type prestations familiales quand elles sont interrompues
-        prestations_calculees = [
-            'rsa_forfait_asf',
-            'paje_base',
-           ]
-        prestations_autres = [
-            'paje_clca',
-            'paje_prepare',
-            'paje_colca',
-            ]
-
-        # On réinjecte le montant des prestations calculées
-        result = sum(famille(prestation, mois_demande) for prestation in prestations_calculees)
-
-        result += sum(famille(prestation, mois_courant) for prestation in prestations_autres)
-
-        cf_non_majore_avant_cumul = famille('cf_non_majore_avant_cumul', mois_demande)
-        cf = famille('cf', mois_demande)
-        # Seul le montant non majoré est pris en compte dans la base de ressources du RSA
-        cf_non_majore = (cf > 0) * cf_non_majore_avant_cumul
-
-        af_base = famille('af_base', mois_demande)
-        af = famille('af', mois_demande)
-
-        result = result + cf_non_majore + min_(af_base, af)  # Si des AF on été injectées et sont plus faibles que le cf
-
-        return result
 
     def formula_2017_04_01(famille, mois_demande, parameters, mois_courant):
         prestations_calculees = [

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -237,30 +237,6 @@ class rsa_base_ressources_prestations_familiales(Variable):
         return result
 
 
-    def formula_2017_04_01(famille, mois_demande, parameters, mois_courant):
-        prestations_calculees = [
-            'rsa_forfait_asf',
-            'paje_base',
-           ]
-
-        # On réinjecte le montant des prestations calculées
-        result = sum(famille(prestation, mois_demande) for prestation in prestations_calculees)
-
-        result += famille('paje_prepare', mois_courant)
-
-        cf_non_majore_avant_cumul = famille('cf_non_majore_avant_cumul', mois_demande)
-        cf = famille('cf', mois_demande)
-        # Seul le montant non majoré est pris en compte dans la base de ressources du RSA
-        cf_non_majore = (cf > 0) * cf_non_majore_avant_cumul
-
-        af_base = famille('af_base', mois_demande)
-        af = famille('af', mois_demande)
-
-        result = result + cf_non_majore + min_(af_base, af)  # Si des AF on été injectées et sont plus faibles que le cf
-
-        return result
-
-
 class crds_mini(Variable):
     value_type = float
     entity = Famille

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -265,6 +265,29 @@ class rsa_base_ressources_prestations_familiales(Variable):
 
         return result
 
+    def formula_2017_04_01(famille, mois_demande, parameters, mois_courant):
+        prestations_calculees = [
+            'rsa_forfait_asf',
+            'paje_base',
+           ]
+
+        # On réinjecte le montant des prestations calculées
+        result = sum(famille(prestation, mois_demande) for prestation in prestations_calculees)
+
+        result += famille('paje_prepare', mois_courant)
+
+        cf_non_majore_avant_cumul = famille('cf_non_majore_avant_cumul', mois_demande)
+        cf = famille('cf', mois_demande)
+        # Seul le montant non majoré est pris en compte dans la base de ressources du RSA
+        cf_non_majore = (cf > 0) * cf_non_majore_avant_cumul
+
+        af_base = famille('af_base', mois_demande)
+        af = famille('af', mois_demande)
+
+        result = result + cf_non_majore + min_(af_base, af)  # Si des AF on été injectées et sont plus faibles que le cf
+
+        return result
+
 
 class crds_mini(Variable):
     value_type = float

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -328,13 +328,14 @@ class paje_cmg(Variable):
         hsup_i = famille.members('hsup', period)
         hsup = famille.sum(hsup_i, role = Famille.PARENT)
 
-        # condition de revenu minimal
+    # condition de revenu minimal
+
+        cond_age_enf = (nb_enf(famille, period, 0, P.paje.clmg.age2 - 1) > 0)
 
         bmaf_n_2 = P_n_2.af.bmaf
-        cond_age_enf = (nb_enf(famille, period, P.paje.clmg.age1, P.paje.clmg.age2 - 1) > 0)
         cond_sal = (
-            salaire_imposable + hsup >
-            12 * bmaf_n_2 * (1 + en_couple)
+            salaire_imposable +
+            hsup > 12 * bmaf_n_2 * (1 + en_couple)
             )
         # TODO:    cond_rpns    =
         # TODO: RSA insertion, alloc insertion, ass
@@ -351,16 +352,17 @@ class paje_cmg(Variable):
 
     # Les plafonds de ressource
 
-        seuil_revenus_bas = (
+        seuil_revenus_1 = (
                 (nombre_enfants == 1) * P.paje.clmg.seuil11 +
                 (nombre_enfants >= 2) * P.paje.clmg.seuil12 +
                 max_(nombre_enfants - 2, 0) * P.paje.clmg.seuil1sup
         )
-        seuil_revenus_hauts = (
+        seuil_revenus_2 = (
                 (nombre_enfants == 1) * P.paje.clmg.seuil21 +
                 (nombre_enfants >= 2) * P.paje.clmg.seuil22 +
                 max_(nombre_enfants - 2, 0) * P.paje.clmg.seuil2sup
         )
+
 
     #        Si vous bénéficiez du PreParE taux partiel (= vous travaillez entre 50 et 80% de la durée du travail fixée
     #        dans l'entreprise), vous cumulez intégralement la PreParE et le Cmg.
@@ -368,10 +370,11 @@ class paje_cmg(Variable):
     #        du travail fixée dans l'entreprise), le montant des plafonds Cmg est divisé par 2.
 
         paje_prepare_temps_partiel = (paje_prepare > 0) * partiel1
-        seuil_revenus_bas = seuil_revenus_bas * (1 - .5 * paje_prepare_temps_partiel)
-        seuil_revenus_hauts = seuil_revenus_hauts * (1 - .5 * paje_prepare_temps_partiel)
+        seuil_revenus_1 = seuil_revenus_1 * (1 - .5 * paje_prepare_temps_partiel)
+        seuil_revenus_2 = seuil_revenus_2 * (1 - .5 * paje_prepare_temps_partiel)
 
     # calcul du montant
+
         montant_cmg = (
                 P.af.bmaf *
                 (
@@ -380,17 +383,17 @@ class paje_cmg(Variable):
                 ) *
                 (
             emploi_direct * (
-                (base_ressources < seuil_revenus_bas) * P.paje.clmg.taux_recours_emploi_1er_plafond +
-                ((base_ressources >= seuil_revenus_bas) & (base_ressources < seuil_revenus_hauts)) * P.paje.clmg.taux_recours_emploi_2e_plafond +
-                (base_ressources >= seuil_revenus_hauts) * P.paje.clmg.taux_recours_emploi_supp_2e_plafond) +
+                (base_ressources < seuil_revenus_1) * P.paje.clmg.taux_recours_emploi_1er_plafond +
+                ((base_ressources >= seuil_revenus_1) & (base_ressources < seuil_revenus_2)) * P.paje.clmg.taux_recours_emploi_2e_plafond +
+                (base_ressources >= seuil_revenus_2) * P.paje.clmg.taux_recours_emploi_supp_2e_plafond) +
             assistant_maternel * (
-                (base_ressources < seuil_revenus_bas) * P.paje.clmg.ass_mat1 +
-                ((base_ressources >= seuil_revenus_bas) & (base_ressources < seuil_revenus_hauts)) * P.paje.clmg.ass_mat2 +
-                (base_ressources >= seuil_revenus_hauts) * P.paje.clmg.ass_mat3) +
+                (base_ressources < seuil_revenus_1) * P.paje.clmg.ass_mat1 +
+                ((base_ressources >= seuil_revenus_1) & (base_ressources < seuil_revenus_2)) * P.paje.clmg.ass_mat2 +
+                (base_ressources >= seuil_revenus_2) * P.paje.clmg.ass_mat3) +
             garde_a_domicile * (
-                (base_ressources < seuil_revenus_bas) * P.paje.clmg.domi1 +
-                ((base_ressources >= seuil_revenus_bas) & (base_ressources < seuil_revenus_hauts)) * P.paje.clmg.domi2 +
-                (base_ressources >= seuil_revenus_hauts) * P.paje.clmg.domi3))
+                (base_ressources < seuil_revenus_1) * P.paje.clmg.domi1 +
+                ((base_ressources >= seuil_revenus_1) & (base_ressources < seuil_revenus_2)) * P.paje.clmg.domi2 +
+                (base_ressources >= seuil_revenus_2) * P.paje.clmg.domi3))
         )
 
         paje_cmg = eligible * montant_cmg
@@ -453,7 +456,7 @@ class paje_cmg(Variable):
         # condition de revenu minimal
 
         bmaf_n_2 = P_n_2.af.bmaf
-        cond_age_enf = (nb_enf(famille, period, P.paje.clmg.age1, P.paje.clmg.age2 - 1) > 0)
+        cond_age_enf = (nb_enf(famille, period, 0, P.paje.clmg.age2 - 1) > 0)
         cond_sal = (
             salaire_imposable + hsup >
             12 * bmaf_n_2 * (1 + en_couple)

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -74,9 +74,8 @@ class paje(Variable):
         paje_naissance = famille('paje_naissance', period)
         paje_prepare = famille('paje_prepare', period)
         paje_cmg = famille('paje_cmg', period)
-        paje_colca = famille('paje_colca', period)
 
-        return paje_base + (paje_naissance + paje_prepare + paje_cmg + paje_colca) / 12
+        return paje_base + (paje_naissance + paje_prepare + paje_cmg) / 12
 
     def formula_2004_01_01(famille, period):
         '''

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -413,7 +413,7 @@ class paje_cmg(Variable):
         emploi_direct = famille('empl_dir', period)
         assistant_maternel = famille('ass_mat', period)
         garde_a_domicile = famille('gar_dom', period)
-        paje_prepare = famille('page_prepare', period)
+        paje_prepare = famille('paje_prepare', period)
         P = parameters(period).prestations.prestations_familiales
         P_n_2 = parameters(period.offset(-2, 'year')).prestations.prestations_familiales
 
@@ -437,11 +437,11 @@ class paje_cmg(Variable):
             salaire_imposable + hsup >
             12 * bmaf_n_2 * (1 + en_couple)
             )
-    # TODO:    cond_rpns    =
+        # TODO:    cond_rpns    =
+        # TODO: RSA insertion, alloc insertion, ass
         cond_act = cond_sal  # | cond_rpns
-
         cond_nonact = (aah > 0) | parent_etudiant  # | (ass>0)
-    #  TODO: RSA insertion, alloc insertion, ass
+
         cond_eligibilite = cond_age_enf & (cond_act | cond_nonact)
 
         # Si vous bénéficiez de la PreParE taux plein
@@ -471,7 +471,7 @@ class paje_cmg(Variable):
         paje_prepare_temps_partiel = (paje_prepare > 0) * partiel1
         seuil_revenus_bas = seuil_revenus_bas * (1 - .5 * paje_prepare_temps_partiel)
         seuil_revenus_hauts = seuil_revenus_hauts * (1 - .5 * paje_prepare_temps_partiel)
-        
+
     # calcul du montant
         montant_cmg = (
                 P.af.bmaf *

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -403,15 +403,16 @@ class paje_cmg(Variable):
         soit au max 45,00 €.
         Vous ne devez pas bénéficier de l'exonération des cotisations sociales dues pour la personne employée.
         """
+        # Récupération des données
 
         en_couple = famille('en_couple', period)
         inactif = famille('inactif', period)
         partiel1 = famille('partiel1', period)
-        af_nbenf = famille('af_nbenf', period)
+        nombre_enfants = famille('af_nbenf', period)
         base_ressources = famille('prestations_familiales_base_ressources', period.first_month)
-        empl_dir = famille('empl_dir', period)
-        ass_mat = famille('ass_mat', period)
-        gar_dom = famille('gar_dom', period)
+        emploi_direct = famille('empl_dir', period)
+        assistant_maternel = famille('ass_mat', period)
+        garde_a_domicile = famille('gar_dom', period)
         paje_prepare = famille('page_prepare', period)
         P = parameters(period).prestations.prestations_familiales
         P_n_2 = parameters(period.offset(-2, 'year')).prestations.prestations_familiales
@@ -441,42 +442,60 @@ class paje_cmg(Variable):
 
         cond_nonact = (aah > 0) | parent_etudiant  # | (ass>0)
     #  TODO: RSA insertion, alloc insertion, ass
-        eligible = cond_age_enf & (cond_act | cond_nonact)
-        nbenf = af_nbenf
-        seuil1 = (P.paje.clmg.seuil11 * (nbenf == 1) + P.paje.clmg.seuil12 * (nbenf >= 2) +
-                 max_(nbenf - 2, 0) * P.paje.clmg.seuil1sup)
-        seuil2 = (P.paje.clmg.seuil21 * (nbenf == 1) + P.paje.clmg.seuil22 * (nbenf >= 2) +
-                 max_(nbenf - 2, 0) * P.paje.clmg.seuil2sup)
+        cond_eligibilite = cond_age_enf & (cond_act | cond_nonact)
 
-    #        Si vous bénéficiez du Clca taux partiel (= vous travaillez entre 50 et 80% de la durée du travail fixée
-    #        dans l'entreprise), vous cumulez intégralement le Clca et le Cmg.
-    #        Si vous bénéficiez du Clca taux partiel (= vous travaillez à 50% ou moins de la durée
-    #        du travail fixée dans l'entreprise), le montant des plafonds Cmg est divisé par 2.
-        paje_prepare_temps_partiel = (paje_clca > 0) * partiel1
-        seuil1 = seuil1 * (1 - .5 * paje_prepare_temps_partiel)
-        seuil2 = seuil2 * (1 - .5 * paje_prepare_temps_partiel)
-
-        clmg = P.af.bmaf * ((nb_enf(famille, period, 0, P.paje.clmg.age1 - 1) > 0) +
-                            0.5 * (nb_enf(famille, period, P.paje.clmg.age1, P.paje.clmg.age2 - 1) > 0)
-                            ) * (
-            empl_dir * (
-                (base_ressources < seuil1) * P.paje.clmg.taux_recours_emploi_1er_plafond +
-                ((base_ressources >= seuil1) & (base_ressources < seuil2)) * P.paje.clmg.taux_recours_emploi_2e_plafond +
-                (base_ressources >= seuil2) * P.paje.clmg.taux_recours_emploi_supp_2e_plafond) +
-            ass_mat * (
-                (base_ressources < seuil1) * P.paje.clmg.ass_mat1 +
-                ((base_ressources >= seuil1) & (base_ressources < seuil2)) * P.paje.clmg.ass_mat2 +
-                (base_ressources >= seuil2) * P.paje.clmg.ass_mat3) +
-            gar_dom * (
-                (base_ressources < seuil1) * P.paje.clmg.domi1 +
-                ((base_ressources >= seuil1) & (base_ressources < seuil2)) * P.paje.clmg.domi2 +
-                (base_ressources >= seuil2) * P.paje.clmg.domi3))
-        # TODO: connecter avec le crédit d'impôt
-        # Si vous bénéficiez du Clca taux plein
+        # Si vous bénéficiez de la PreParE taux plein
         # (= vous ne travaillez plus ou interrompez votre activité professionnelle),
         # vous ne pouvez pas bénéficier du Cmg.
-        paje_prepare_inactif =  (paje_prepare > 0) * inactif
-        paje_cmg = eligible * not_(paje_prepare_inactif) * clmg
+        paje_prepare_inactif = (paje_prepare > 0) * inactif
+        eligible = cond_eligibilite * not_(paje_prepare_inactif)
+
+    # Les plafonds de ressource
+
+        seuil_revenus_bas = (
+                (nombre_enfants == 1) * P.paje.clmg.seuil11 +
+                (nombre_enfants >= 2) * P.paje.clmg.seuil12 +
+                max_(nombre_enfants - 2, 0) * P.paje.clmg.seuil1sup
+        )
+        seuil_revenus_hauts = (
+                (nombre_enfants == 1) * P.paje.clmg.seuil21 +
+                (nombre_enfants >= 2) * P.paje.clmg.seuil22 +
+                max_(nombre_enfants - 2, 0) * P.paje.clmg.seuil2sup
+        )
+
+    #        Si vous bénéficiez du PreParE taux partiel (= vous travaillez entre 50 et 80% de la durée du travail fixée
+    #        dans l'entreprise), vous cumulez intégralement la PreParE et le Cmg.
+    #        Si vous bénéficiez du PreParE taux partiel (= vous travaillez à 50% ou moins de la durée
+    #        du travail fixée dans l'entreprise), le montant des plafonds Cmg est divisé par 2.
+
+        paje_prepare_temps_partiel = (paje_prepare > 0) * partiel1
+        seuil_revenus_bas = seuil_revenus_bas * (1 - .5 * paje_prepare_temps_partiel)
+        seuil_revenus_hauts = seuil_revenus_hauts * (1 - .5 * paje_prepare_temps_partiel)
+        
+    # calcul du montant
+        montant_cmg = (
+                P.af.bmaf *
+                (
+                    1.0 * (nb_enf(famille, period, 0, P.paje.clmg.age1 - 1) > 0) +
+                    0.5 * (nb_enf(famille, period, P.paje.clmg.age1, P.paje.clmg.age2 - 1) > 0)
+                ) *
+                (
+            emploi_direct * (
+                (base_ressources < seuil_revenus_bas) * P.paje.clmg.taux_recours_emploi_1er_plafond +
+                ((base_ressources >= seuil_revenus_bas) & (base_ressources < seuil_revenus_hauts)) * P.paje.clmg.taux_recours_emploi_2e_plafond +
+                (base_ressources >= seuil_revenus_hauts) * P.paje.clmg.taux_recours_emploi_supp_2e_plafond) +
+            assistant_maternel * (
+                (base_ressources < seuil_revenus_bas) * P.paje.clmg.ass_mat1 +
+                ((base_ressources >= seuil_revenus_bas) & (base_ressources < seuil_revenus_hauts)) * P.paje.clmg.ass_mat2 +
+                (base_ressources >= seuil_revenus_hauts) * P.paje.clmg.ass_mat3) +
+            garde_a_domicile * (
+                (base_ressources < seuil_revenus_bas) * P.paje.clmg.domi1 +
+                ((base_ressources >= seuil_revenus_bas) & (base_ressources < seuil_revenus_hauts)) * P.paje.clmg.domi2 +
+                (base_ressources >= seuil_revenus_hauts) * P.paje.clmg.domi3))
+        )
+
+        paje_cmg = eligible * montant_cmg
+        # TODO: connecter avec le crédit d'impôt
         # TODO vérfiez les règles de cumul
         return paje_cmg
 

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -342,12 +342,6 @@ class paje_clca_taux_plein(Variable):
     reference = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
     definition_period = MONTH
 
-    def formula_2017_04_01(famille, period):
-        paje_clca = famille('paje_prepare', period)
-        partiel1 = famille('inactif', period)
-
-        return (paje_clca > 0) * partiel1
-
     def formula_2004_01_01(famille, period):
         paje_clca = famille('paje_clca', period)
         inactif = famille('inactif', period)
@@ -361,12 +355,6 @@ class paje_clca_taux_partiel(Variable):
     label = u"Indicatrice Clca taux partiel"
     reference = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
     definition_period = MONTH
-
-    def formula_2017_04_01(famille, period):
-        paje_clca = famille('paje_prepare', period)
-        partiel1 = famille('partiel1', period)
-
-        return (paje_clca > 0) * partiel1
 
     def formula_2004_01_01(famille, period):
         paje_clca = famille('paje_clca', period)

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -375,7 +375,7 @@ class paje_cmg(Variable):
     definition_period = MONTH
 
     def formula_2017_04_01(famille, period, parameters):
-        """"
+        """
         Prestation d accueil du jeune enfant - Complément de libre choix du mode de garde
 
         Les conditions
@@ -402,7 +402,7 @@ class paje_cmg(Variable):
         Son salaire brut ne doit pas dépasser par jour de garde et par enfant 5 fois le montant du Smic horaire brut,
         soit au max 45,00 €.
         Vous ne devez pas bénéficier de l'exonération des cotisations sociales dues pour la personne employée.
-        """"
+        """
 
         en_couple = famille('en_couple', period)
         inactif = famille('inactif', period)

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -332,7 +332,7 @@ class paje_prepare(Variable):
     entity = Famille
     set_input = set_input_divide_by_period
     label = u"Prestation Partagée d’éducation de l’Enfant (PreParE)"
-    reference = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
+    reference = "https://www.service-public.fr/particuliers/vosdroits/F32485"
     definition_period = MONTH
 
 

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -75,7 +75,7 @@ class paje(Variable):
         paje_prepare = famille('paje_prepare', period)
         paje_cmg = famille('paje_cmg', period)
 
-        return paje_base + (paje_naissance + paje_prepare + paje_cmg) / 12
+        return paje_base + (paje_naissance + paje_prepare + paje_cmg)
 
     def formula_2004_01_01(famille, period):
         '''
@@ -87,7 +87,7 @@ class paje(Variable):
         paje_cmg = famille('paje_cmg', period)
         paje_colca = famille('paje_colca', period)
 
-        return paje_base + (paje_naissance + paje_clca + paje_cmg + paje_colca) / 12
+        return paje_base + (paje_naissance + paje_clca + paje_cmg + paje_colca)
 
 
 class paje_base(Variable):

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -66,6 +66,18 @@ class paje(Variable):
     reference = "http://www.caf.fr/aides-et-services/s-informer-sur-les-aides/petite-enfance/la-prestation-d-accueil-du-jeune-enfant-paje"  # noqa
     definition_period = MONTH
 
+    def formula_2017_04(famille, period):
+        '''
+        Prestation d'accueil du jeune enfant
+        '''
+        paje_base = famille('paje_base', period)
+        paje_naissance = famille('paje_naissance', period)
+        paje_prepare = famille('paje_prepare', period)
+        paje_cmg = famille('paje_cmg', period)
+        paje_colca = famille('paje_colca', period)
+
+        return paje_base + (paje_naissance + paje_prepare + paje_cmg + paje_colca) / 12
+
     def formula_2004_01_01(famille, period):
         '''
         Prestation d'accueil du jeune enfant

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -320,6 +320,7 @@ class paje_prepare(Variable):
     entity = Famille
     set_input = set_input_divide_by_period
     label = u"Prestation Partagée d’éducation de l’Enfant (PreParE)"
+    reference = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
     definition_period = MONTH
 
 

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -63,7 +63,7 @@ class paje(Variable):
     value_type = float
     entity = Famille
     label = u"PAJE - Ensemble des prestations"
-    reference = "http://www.caf.fr/aides-et-services/s-informer-sur-les-aides/petite-enfance/la-prestation-d-accueil-du-jeune-enfant-paje-0"  # noqa
+    reference = "http://www.caf.fr/aides-et-services/s-informer-sur-les-aides/petite-enfance/la-prestation-d-accueil-du-jeune-enfant-paje"  # noqa
     definition_period = MONTH
 
     def formula_2004_01_01(famille, period):

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -343,6 +343,12 @@ class paje_clca_taux_plein(Variable):
     reference = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
     definition_period = MONTH
 
+    def formula_2017_04_01(famille, period):
+        paje_clca = famille('paje_prepare', period)
+        partiel1 = famille('inactif', period)
+
+        return (paje_clca > 0) * partiel1
+
     def formula_2004_01_01(famille, period):
         paje_clca = famille('paje_clca', period)
         inactif = famille('inactif', period)
@@ -356,6 +362,12 @@ class paje_clca_taux_partiel(Variable):
     label = u"Indicatrice Clca taux partiel"
     reference = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
     definition_period = MONTH
+
+    def formula_2017_04_01(famille, period):
+        paje_clca = famille('paje_prepare', period)
+        partiel1 = famille('partiel1', period)
+
+        return (paje_clca > 0) * partiel1
 
     def formula_2004_01_01(famille, period):
         paje_clca = famille('paje_clca', period)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '20.0.9',
+    version = '20.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/paje.yaml
+++ b/tests/formulas/paje.yaml
@@ -86,6 +86,93 @@
     paje: 703.81 + 0.45950 * 406.62
 
 
+- name: "Au 1er avril 2017, avec un temps partiel la paje_clca et la paje_colca sont supprimées au profit de la paje_prepare"
+  period: 2018-02
+  relative_error_margin: 0.01
+  individus:
+    - id: "parent1"
+      age: 40
+      salaire_imposable: 10000
+      aah: 0
+      etudiant: 0
+      hsup: 0
+    - id: "enfant1"
+      date_naissance: 2017-01-01
+      age: 1
+      salaire_imposable: 0
+      aah: 0
+      etudiant: 0
+      hsup: 0
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1"]
+    en_couple:
+    inactif:
+    partiel1: True
+    af_nbenf: 1
+    prestations_familiales_base_ressources: 10000
+    empl_dir: 0
+    ass_mat: 1
+    gar_dom: 0
+    paje_prepare: 0.3603 * 407.84
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1"]
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1"]
+  output_variables:
+    paje_cmg: 703.81
+    # BMAF 2017-04-01 = 407.84
+    paje_base: 0.45950 * 407.84
+    paje_naissance: 0
+    paje: 703.81 + (0.45950 * 407.84) + (0.3603 * 407.84)
+
+
+- name: "Avant 1er avril 2017, avec un temps partiel donc avant que paje_clca et la paje_colca soient supprimées au profit de la paje_prepare"
+  period: 2017-02
+  relative_error_margin: 0.01
+  individus:
+    - id: "parent1"
+      age: 40
+      salaire_imposable: 20000
+      aah: 0
+      etudiant: 0
+      hsup: 0
+    - id: "enfant1"
+      date_naissance: 2017-01-01
+      age: 1
+      salaire_imposable: 0
+      aah: 0
+      etudiant: 0
+      hsup: 0
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1"]
+    en_couple:
+    inactif:
+    partiel1: True
+    af_nbenf: 1
+    prestations_familiales_base_ressources: 10000
+    empl_dir: 0
+    ass_mat: 1
+    gar_dom: 0
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1"]
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1"]
+  output_variables:
+    paje_colca: 0
+    paje_clca: 0.6246 * 407.84
+    paje_cmg: 703.81
+#    # BMAF 2017-02 = 406.62
+#    paje_base: 0.45950 * 406.62
+#    paje_naissance: 0
+#    paje_prepare: 0
+#    paje: 703.81 + 0.45950 * 406.62
+
 - name: "Avant le 1er avril 2014, le montant de la PAJE est proprotionnel à la BMAF"
   period: 2012-11
   familles:

--- a/tests/formulas/paje.yaml
+++ b/tests/formulas/paje.yaml
@@ -9,7 +9,7 @@
   familles:
     parents: ["parent1"]
     enfants: ["enfant1"]
-    inactif: true
+    inactif: false
     ass_mat: true
   foyers_fiscaux:
     declarants: ["parent1"]
@@ -18,12 +18,40 @@
     personne_de_reference: "parent1"
     enfants: ["enfant1"]
   output_variables:
+    paje_cmg: 462.78
     # BMAF 2017-04-01 = 407.84
     paje_base: 0.45950 * 407.84
     paje_naissance: 0
-    paje_cmg: 462.78
     paje_prepare: 0
     paje: 187.40248 + 462.78
+
+- name: "Avant 1er avril 2017, donc avant que paje_clca et la paje_colca soient supprimées au profit de la paje_prepare"
+  period: 2017-02
+  individus:
+    - id: "parent1"
+      age: 40
+      salaire_de_base: 20000
+    - id: "enfant1"
+      date_naissance: 2017-01-01
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1"]
+    inactif: false
+    ass_mat: true
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1"]  
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1"]
+  output_variables:
+    paje_cmg: 462.78
+    # BMAF 2017-02 = 406.62
+    paje_base: 0.45950 * 406.62
+    paje_naissance: 0
+    paje_prepare: 0
+    paje: 186.84189 + 462.78
+
 
 - name: "Avant le 1er avril 2014, le montant de la PAJE est proprotionnel à la BMAF"
   period: 2012-11

--- a/tests/formulas/paje.yaml
+++ b/tests/formulas/paje.yaml
@@ -1,16 +1,31 @@
 - name: "Au 1er avril 2017, la paje_clca et la paje_colca sont supprimées au profit de la paje_prepare"
   period: 2018-02
+  relative_error_margin: 0.01
   individus:
     - id: "parent1"
       age: 40
-      salaire_de_base: 20000
+      salaire_imposable: 20000
+      aah: 0
+      etudiant: 0
+      hsup: 0
     - id: "enfant1"
       date_naissance: 2017-01-01
+      age: 1
+      salaire_imposable: 0
+      aah: 0
+      etudiant: 0
+      hsup: 0
   familles:
     parents: ["parent1"]
     enfants: ["enfant1"]
-    inactif: false
-    ass_mat: true
+    en_couple:
+    inactif:
+    partiel1: False
+    af_nbenf: 1
+    prestations_familiales_base_ressources: 20000
+    empl_dir: 0
+    ass_mat: 1
+    gar_dom: 0
   foyers_fiscaux:
     declarants: ["parent1"]
     personnes_a_charge: ["enfant1"]  
@@ -18,39 +33,57 @@
     personne_de_reference: "parent1"
     enfants: ["enfant1"]
   output_variables:
-    paje_cmg: 462.78
+    paje_cmg: 703.81
     # BMAF 2017-04-01 = 407.84
     paje_base: 0.45950 * 407.84
     paje_naissance: 0
     paje_prepare: 0
-    paje: 187.40248 + 462.78
+    paje: 703.81 + (0.45950 * 407.84)
+
 
 - name: "Avant 1er avril 2017, donc avant que paje_clca et la paje_colca soient supprimées au profit de la paje_prepare"
   period: 2017-02
+  relative_error_margin: 0.01
   individus:
     - id: "parent1"
       age: 40
-      salaire_de_base: 20000
+      salaire_imposable: 20000
+      aah: 0
+      etudiant: 0
+      hsup: 0
     - id: "enfant1"
       date_naissance: 2017-01-01
+      age: 1
+      salaire_imposable: 0
+      aah: 0
+      etudiant: 0
+      hsup: 0
   familles:
     parents: ["parent1"]
     enfants: ["enfant1"]
-    inactif: false
-    ass_mat: true
+    en_couple:
+    inactif:
+    partiel1: False
+    af_nbenf: 1
+    prestations_familiales_base_ressources: 20000
+    empl_dir: 0
+    ass_mat: 1
+    gar_dom: 0
   foyers_fiscaux:
     declarants: ["parent1"]
-    personnes_a_charge: ["enfant1"]  
+    personnes_a_charge: ["enfant1"]
   menages:
     personne_de_reference: "parent1"
     enfants: ["enfant1"]
   output_variables:
-    paje_cmg: 462.78
+    paje_clca: 0
+    paje_colca: 0
+    paje_cmg: 703.81
     # BMAF 2017-02 = 406.62
     paje_base: 0.45950 * 406.62
     paje_naissance: 0
     paje_prepare: 0
-    paje: 186.84189 + 462.78
+    paje: 703.81 + 0.45950 * 406.62
 
 
 - name: "Avant le 1er avril 2014, le montant de la PAJE est proprotionnel à la BMAF"

--- a/tests/formulas/paje.yaml
+++ b/tests/formulas/paje.yaml
@@ -1,3 +1,30 @@
+- name: "Au 1er avril 2017, la paje_clca et la paje_colca sont supprimées au profit de la paje_prepare"
+  period: 2018-02
+  individus:
+    - id: "parent1"
+      age: 40
+      salaire_de_base: 20000
+    - id: "enfant1"
+      date_naissance: 2017-01-01
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1"]
+    inactif: true
+    ass_mat: true
+  foyers_fiscaux:
+    declarants: ["parent1"]
+    personnes_a_charge: ["enfant1"]  
+  menages:
+    personne_de_reference: "parent1"
+    enfants: ["enfant1"]
+  output_variables:
+    # BMAF 2017-04-01 = 407.84
+    paje_base: 0.45950 * 407.84
+    paje_naissance: 0
+    paje_cmg: 462.78
+    paje_prepare: 0
+    paje: 187.40248 + 462.78
+
 - name: "Avant le 1er avril 2014, le montant de la PAJE est proprotionnel à la BMAF"
   period: 2012-11
   familles:


### PR DESCRIPTION
Fixes #880 
This PR is one solution to the issue bellow. #884 is another one
A partir d'avril 2017, la page_clca n'existe plus .
* Évolution du système socio-fiscal. 
* Périodes concernées : A partir du 04/2017
* Zones impactées : `prestations_familiales/paje.py`.
* Détails :
  - Description de la fonctionnalité ajoutée ou du nouveau comportement adopté.
  - Cas dans lesquels une erreur était constatée.

- - - -

Ces changements  :
- Corrigent ou améliorent un calcul déjà existant.

