### PR TITLE
Supprime les paramètres null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 20.0.5 [#886](https://github.com/openfisca/openfisca-france/pull/886)
+
+* Correction d'un crash
+* Périodes concernées : A partir du 01/01/2018
+* Zones impactées : `parameters/prestations/prestations_familiales/paje/clca`,`parameters/prestations/prestations_familiales/paje/colca`
+* Détails :
+  - La presence de valeur `null` rendait impossible le calcul de la paje, le rsa et la ppa à partir du 01/01/2018.
+
 ### 20.0.4 [#842](https://github.com/openfisca/openfisca-france/pull/842)
 
 * Amélioration technique

--- a/openfisca_france/parameters/prestations/prestations_familiales/paje/clca/avecab_tx_inactif.yaml
+++ b/openfisca_france/parameters/prestations/prestations_familiales/paje/clca/avecab_tx_inactif.yaml
@@ -5,5 +5,4 @@ unit: /1
 values:
   2004-01-01:
     value: 0.9662
-  2018-01-01:
-    value: null
+

--- a/openfisca_france/parameters/prestations/prestations_familiales/paje/clca/avecab_tx_partiel1.yaml
+++ b/openfisca_france/parameters/prestations/prestations_familiales/paje/clca/avecab_tx_partiel1.yaml
@@ -5,5 +5,3 @@ unit: /1
 values:
   2004-01-01:
     value: 0.6246
-  2018-01-01:
-    value: null

--- a/openfisca_france/parameters/prestations/prestations_familiales/paje/clca/avecab_tx_partiel2.yaml
+++ b/openfisca_france/parameters/prestations/prestations_familiales/paje/clca/avecab_tx_partiel2.yaml
@@ -5,5 +5,3 @@ unit: /1
 values:
   2004-01-01:
     value: 0.3603
-  2018-01-01:
-    value: null

--- a/openfisca_france/parameters/prestations/prestations_familiales/paje/clca/sansab_tx_inactif.yaml
+++ b/openfisca_france/parameters/prestations/prestations_familiales/paje/clca/sansab_tx_inactif.yaml
@@ -7,5 +7,4 @@ values:
     value: 1.4257
   2014-04-01:
     value: 0.9662
-  2018-01-01:
-    value: null
+

--- a/openfisca_france/parameters/prestations/prestations_familiales/paje/clca/sansab_tx_partiel1.yaml
+++ b/openfisca_france/parameters/prestations/prestations_familiales/paje/clca/sansab_tx_partiel1.yaml
@@ -7,5 +7,4 @@ values:
     value: 1.0841
   2014-04-01:
     value: 0.6246
-  2018-01-01:
-    value: null
+

--- a/openfisca_france/parameters/prestations/prestations_familiales/paje/clca/sansab_tx_partiel2.yaml
+++ b/openfisca_france/parameters/prestations/prestations_familiales/paje/clca/sansab_tx_partiel2.yaml
@@ -7,5 +7,4 @@ values:
     value: 0.8198
   2014-04-01:
     value: 0.3603
-  2018-01-01:
-    value: null
+

--- a/openfisca_france/parameters/prestations/prestations_familiales/paje/colca/avecab.yaml
+++ b/openfisca_france/parameters/prestations/prestations_familiales/paje/colca/avecab.yaml
@@ -5,5 +5,3 @@ unit: /1
 values:
   2004-01-01:
     value: 1.5793
-  2018-01-01:
-    value: null

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '20.0.4',
+    version = '20.0.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Correction d'un crash
* Périodes concernées : A partir du 01/01/2018
* Zones impactées : `parameters/prestations/prestations_familiales/paje/clca`,`parameters/prestations/prestations_familiales/paje/colca`
* Détails :
  - La presence de valeur `null` rendait impossible le calcul de la paje, le rsa et la ppa à partir du 01/01/2018.

- - - -

Ces changements  :

- Corrigent ou améliorent un calcul déjà existant.

