### PR TITLE
Corrige l'erreur 500 en prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 20.0.6 [#892](https://github.com/openfisca/openfisca-france/pull/892)
+
+* Correction d'un crash
+* Détails :
+  - Corrige l'erreur 500 qui apparaît dans les calculs de la PPA et du RSA depuis février 2018.
+  - Vérifie dans les tests que le revenu disponible peut être calculé jusuqu'à 2020 pour éviter qu'un problème similaire se reproduise.
+
 ### 20.0.5 [#857](https://github.com/openfisca/openfisca-france/pull/857)
 
 * Changement mineur.

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -250,6 +250,7 @@ class paje_clca(Variable):
     entity = Famille
     label = u"PAJE - Complément de libre choix d'activité"
     reference = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
+    end = '2017-04-01'
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -469,6 +470,7 @@ class paje_colca(Variable):
     value_type = float
     entity = Famille
     label = u"PAJE - Complément optionnel de libre choix d'activité"
+    end = '2017-04-01'
     set_input = set_input_divide_by_period
     reference = "http://vosdroits.service-public.fr/particuliers/F15110.xhtml"
     definition_period = MONTH

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '20.0.5',
+    version = '20.0.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -23,7 +23,7 @@ scenarios_arguments = [
             zone_apl = "zone_1",
             ),
         )
-    for year in range(2006, 2017)
+    for year in range(2006, 2020)
     ]
 
 


### PR DESCRIPTION
Fixes #880 

* Correction d'un crash
* Détails :
  - Corrige l'erreur 500 qui apparaît dans les calculs de la PPA et du RSA depuis février 2018.
  - Vérifie dans les tests que le revenu disponible peut être calculé jusuqu'à 2020 pour éviter qu'un problème similaire se reproduise.