### PR TITLE
Ipp 2 :  Update taxation des revenus du capital dans IR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-# Changelog
-
 ### 20.3.0 [#908](https://github.com/openfisca/openfisca-france/pull/908)
 
 * Évolution du système socio-fiscal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+# Changelog
+
+### 20.3.0 [#908](https://github.com/openfisca/openfisca-france/pull/908)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : 2009 - 2016
+* Détails :
+- Correction de la formule de l'IR : A partir de 2013, une partie des plus-values est taxé au barème alors qu'avant elles étaient taxées forfaitairement.
+- Correction de la formule du RFR : Les plus-values et revenus du capital (taxées forfaitairement ou au barème ou éxonérées) doivent entrer en compte dans le calcul du RFR
+- Création de la variable 'rfr_pv' qui regroupe l'ensemble des plus-values entrant dans le calcul du RFR, hormis celles taxées au barème (qui entrent dans le RFR également mais via le revenu net imposable 'rni')
+- Correction d'un des taux forfaitaires
+- Ajout de nouvelles inputs variables associées aux nouvelles cases des déclarations fiscales se rapportant aux plus-values
 
 ### 20.2.0 [#907](https://github.com/openfisca/openfisca-france/pull/907)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1440,6 +1440,7 @@ class plus_values(Variable):
         """
         Taxation des plus value
         """
+        f3sa = foyer_fiscal('f3sa', period)
         f3vg = foyer_fiscal('f3vg', period)
         f3vh = foyer_fiscal('f3vh', period)
         f3vl = foyer_fiscal('f3vl', period)
@@ -1462,6 +1463,7 @@ class plus_values(Variable):
                plus_values.taux_pv_mob_pro * f3vl +
                plus_values.pea.taux_avant_2_ans * f3vm +
                plus_values.pea.taux_posterieur * f3vt +
+               plus_values.taux_pv_entrep * f3sa +
                plus_values.taux3 * f3vi +
                plus_values.taux4 * f3vf)
        
@@ -1525,6 +1527,7 @@ class rfr_pv(Variable):
         """
         Plus-values 2012 entrant dans le calcul du revenu fiscal de référence
         """
+        f3sa = foyer_fiscal('f3sa', period)
         f3vc = foyer_fiscal('f3vc', period)
         f3vd_i = foyer_fiscal.members('f3vd', period)
         f3vf_i = foyer_fiscal.members('f3vf', period)
@@ -1541,7 +1544,7 @@ class rfr_pv(Variable):
         f3vd = foyer_fiscal.sum(f3vd_i)
         f3vf = foyer_fiscal.sum(f3vf_i)
         
-        return f3vc + f3vd + f3vf + f3vg + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz
+        return f3sa+ f3vc + f3vd + f3vf + f3vg + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz
 
     def formula_2013_01_01(foyer_fiscal, period, parameters): 
         """

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1634,7 +1634,8 @@ class rfr(Variable):
         f3vg -> rev_cat_pv -> ... -> rni
         '''
         rni = foyer_fiscal('rni', period)
-        f3va_i = foyer_fiscal.members('f3va', period)
+        f3va = foyer_fiscal('f3va', period)
+        f3vb = foyer_fiscal('f3vb', period)
         f3vi_i = foyer_fiscal.members('f3vi', period)
         rfr_cd = foyer_fiscal('rfr_cd', period)
         rfr_rvcm = foyer_fiscal('rfr_rvcm', period)
@@ -1644,13 +1645,13 @@ class rfr(Variable):
         f3vz = foyer_fiscal('f3vz', period)
         microentreprise = foyer_fiscal('microentreprise', period)
 
-        f3va = foyer_fiscal.sum(f3va_i)
         f3vi = foyer_fiscal.sum(f3vi_i)
         rpns_exon = foyer_fiscal.sum(rpns_exon_i)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        return (max_(0, rni) + rfr_cd + rfr_rvcm + rev_cap_lib + f3vi + rpns_exon + rpns_pvce + f3va +
+        return (max_(0, rni) + rfr_cd + rfr_rvcm + rev_cap_lib + f3vi + rpns_exon + rpns_pvce + f3va - f3vb +
                 f3vz + microentreprise)
-
+        
+        # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)
 
 class glo(Variable):
     value_type = float

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1375,7 +1375,7 @@ class microentreprise(Variable):
 class plus_values(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Taxation des plus_values"
+    label = u"Taxation forfaitaire des plus_values"
     reference = "http://bofip.impots.gouv.fr/bofip/6957-PGP"
     definition_period = YEAR
 
@@ -1678,12 +1678,12 @@ class rfr(Variable):
     value_type = float
     entity = FoyerFiscal
     label = u"Revenu fiscal de référence"
+    reference = "http://bofip.impots.gouv.fr/bofip/5934-PGP.html?identifiant=BOI-IF-TH-10-50-30-20-20121127#5934-PGP_Calcul_du_revenu_fiscal_de__40"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
         '''
         Revenu fiscal de référence
-        f3vg -> rev_cat_pv -> ... -> rni
         '''
         rni = foyer_fiscal('rni', period)
         abattement_net_retraite_dirigeant_pme = foyer_fiscal('abattement_net_retraite_dirigeant_pme', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1516,14 +1516,12 @@ class rfr_pv(Variable):
         f3vp = foyer_fiscal('f3vp', period)
         f3vy = foyer_fiscal('f3vy', period)
         f3vz = foyer_fiscal('f3vz', period)
-        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
 
-        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
         f3vi = foyer_fiscal.sum(f3vi_i)
         f3vd = foyer_fiscal.sum(f3vd_i)
         f3vf = foyer_fiscal.sum(f3vf_i)
         
-        return f3vc + f3vd + f3vf + f3vg + f3vh + f3vi + f3vl + f3vm + f3vp + f3vy + f3vz + rpns_pvce
+        return f3vc + f3vd + f3vf + f3vg + f3vh + f3vi + f3vl + f3vm + f3vp + f3vy + f3vz
 
     def formula_2012_01_01(foyer_fiscal, period, parameters): 
         """
@@ -1541,14 +1539,12 @@ class rfr_pv(Variable):
         f3vt = foyer_fiscal('f3vt', period)
         f3vy = foyer_fiscal('f3vy', period)
         f3vz = foyer_fiscal('f3vz', period)
-        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
 
-        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
         f3vi = foyer_fiscal.sum(f3vi_i)
         f3vd = foyer_fiscal.sum(f3vd_i)
         f3vf = foyer_fiscal.sum(f3vf_i)
         
-        return f3vc + f3vd + f3vf + f3vg + f3vh + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz + rpns_pvce
+        return f3vc + f3vd + f3vf + f3vg + f3vh + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz
 
     def formula_2013_01_01(foyer_fiscal, period, parameters): 
         """
@@ -1559,13 +1555,13 @@ class rfr_pv(Variable):
         f3vi_i = foyer_fiscal.members('f3vi', period)
         f3vm = foyer_fiscal('f3vm', period)
         f3vt = foyer_fiscal('f3vt', period)
+        f3vz = foyer_fiscal('f3vz', period)
 
-        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
         f3vi = foyer_fiscal.sum(f3vi_i)
         f3vd = foyer_fiscal.sum(f3vd_i)
         f3vf = foyer_fiscal.sum(f3vf_i)
         
-        return f3vd + f3vf + f3vi + f3vm + f3vt
+        return f3vd + f3vf + f3vi + f3vm + f3vt + f3vz
 
 
 class iai(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1521,6 +1521,86 @@ class plus_values(Variable):
         # TODO: chek this 3VG
         return round_(out)
 
+class rfr_pv(Variable):
+    value_type = float
+    entity = FoyerFiscal
+    label = u"Plus-values hors RNI entrant dans le calcul du revenu fiscal de référence"
+    definition_period = YEAR
+
+    def formula_2011_01_01(foyer_fiscal, period, parameters): 
+        """
+        Plus-values 2011 entrant dans le calcul du revenu fiscal de référence
+        """
+        f3vc = foyer_fiscal('f3vc', period)
+        f3vd_i = foyer_fiscal.members('f3vd', period)
+        f3vf_i = foyer_fiscal.members('f3vf', period)
+        f3vg = foyer_fiscal('f3vg', period)
+        f3vh = foyer_fiscal('f3vh', period)
+        f3vi_i = foyer_fiscal.members('f3vi', period)
+        f3vl = foyer_fiscal('f3vl', period)
+        f3vm = foyer_fiscal('f3vm', period)
+        f3vp = foyer_fiscal('f3vp', period)
+        f3vy = foyer_fiscal('f3vy', period)
+        f3vz = foyer_fiscal('f3vz', period)
+        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
+
+        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
+        f3vi = foyer_fiscal.sum(f3vi_i)
+        f3vd = foyer_fiscal.sum(f3vd_i)
+        f3vf = foyer_fiscal.sum(f3vf_i)
+        
+        return f3vc + f3vd + f3vf + f3vg + f3vh + f3vi + f3vl + f3vm + f3vp + f3vy + f3vz + rpns_pvce
+
+    def formula_2012_01_01(foyer_fiscal, period, parameters): 
+        """
+        Plus-values 2012 et + entrant dans le calcul du revenu fiscal de référence
+        TODO: 2013 f3vg au barème
+        """
+        f3vc = foyer_fiscal('f3vc', period)
+        f3vd_i = foyer_fiscal.members('f3vd', period)
+        f3vf_i = foyer_fiscal.members('f3vf', period)
+        f3vg = foyer_fiscal('f3vg', period)
+        f3vh = foyer_fiscal('f3vh', period)
+        f3vi_i = foyer_fiscal.members('f3vi', period)
+        f3vl = foyer_fiscal('f3vl', period)
+        f3vm = foyer_fiscal('f3vm', period)
+        f3vp = foyer_fiscal('f3vp', period)
+        f3vt = foyer_fiscal('f3vt', period)
+        f3vy = foyer_fiscal('f3vy', period)
+        f3vz = foyer_fiscal('f3vz', period)
+        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
+
+        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
+        f3vi = foyer_fiscal.sum(f3vi_i)
+        f3vd = foyer_fiscal.sum(f3vd_i)
+        f3vf = foyer_fiscal.sum(f3vf_i)
+        
+        return f3vc + f3vd + f3vf + f3vg + f3vh + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz + rpns_pvce
+
+    def formula_2014_01_01(foyer_fiscal, period, parameters): 
+        """
+        Plus-values 2014 et + entrant dans le calcul du revenu fiscal de référence
+        TODO: 2013 f3vg au barème
+        """
+        f3vc = foyer_fiscal('f3vc', period)
+        f3vd_i = foyer_fiscal.members('f3vd', period)
+        f3vf_i = foyer_fiscal.members('f3vf', period)
+        f3vg = foyer_fiscal('f3vg', period)
+        f3vh = foyer_fiscal('f3vh', period)
+        f3vi_i = foyer_fiscal.members('f3vi', period)
+        f3vl = foyer_fiscal('f3vl', period)
+        f3vm = foyer_fiscal('f3vm', period)
+        f3vt = foyer_fiscal('f3vt', period)
+        f3vz = foyer_fiscal('f3vz', period)
+        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
+
+        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
+        f3vi = foyer_fiscal.sum(f3vi_i)
+        f3vd = foyer_fiscal.sum(f3vd_i)
+        f3vf = foyer_fiscal.sum(f3vf_i)
+        
+        return f3vc + f3vd + f3vf + f3vg + f3vh + f3vi + f3vl + f3vm + f3vt + f3vz + rpns_pvce
+
 
 class iai(Variable):
     value_type = float
@@ -1635,20 +1715,19 @@ class rfr(Variable):
         '''
         rni = foyer_fiscal('rni', period)
         abatnet_retraite_dirigeant_pme = foyer_fiscal('abatnet_retraite_dirigeant_pme', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
+        rfr_pv = foyer_fiscal('rfr_pv', period)
         rfr_cd = foyer_fiscal('rfr_cd', period)
         rfr_rvcm = foyer_fiscal('rfr_rvcm', period)
         rpns_exon_i = foyer_fiscal.members('rpns_exon', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rev_cap_lib = foyer_fiscal('rev_cap_lib', period, options = [ADD])
-        f3vz = foyer_fiscal('f3vz', period)
+        f2dm = foyer_fiscal('f2dm', period)
         microentreprise = foyer_fiscal('microentreprise', period)
 
-        f3vi = foyer_fiscal.sum(f3vi_i)
         rpns_exon = foyer_fiscal.sum(rpns_exon_i)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        return (max_(0, rni) + rfr_cd + rfr_rvcm + rev_cap_lib + f3vi + rpns_exon + rpns_pvce + abatnet_retraite_dirigeant_pme +
-                f3vz + microentreprise)
+        return (max_(0, rni) + rfr_cd + rfr_pv + rfr_rvcm + rev_cap_lib + rpns_exon + rpns_pvce + abatnet_retraite_dirigeant_pme +
+                f2dm +  microentreprise)
         
         # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1376,7 +1376,6 @@ class plus_values(Variable):
     def formula_2007_01_01(foyer_fiscal, period, parameters):  # f3sd is in f3vd holder
         """
         Taxation des plus values
-        TODO: 2013 f3Vg au barème / tout refaire
         """
         f3vg = foyer_fiscal('f3vg', period)
         f3vh = foyer_fiscal('f3vh', period)
@@ -1408,7 +1407,6 @@ class plus_values(Variable):
     def formula_2008_01_01(foyer_fiscal, period, parameters):  # f3sd is in f3vd holder
         """
         Taxation des plus value
-        TODO:  2013 f3Vg au barème / tout refaire
         """
         f3vg = foyer_fiscal('f3vg', period)
         f3vh = foyer_fiscal('f3vh', period)
@@ -1442,7 +1440,6 @@ class plus_values(Variable):
     def formula_2012_01_01(foyer_fiscal, period, parameters):  # f3sd is in f3vd holder
         """
         Taxation des plus value
-        TODO: 2013 f3Vg au barème / tout refaire
         """
         f3vg = foyer_fiscal('f3vg', period)
         f3vh = foyer_fiscal('f3vh', period)
@@ -1478,47 +1475,31 @@ class plus_values(Variable):
                 # TODO: chek this rpns missing ?
         return round_(out)
 
-    # Cette formule a seulement été vérifiée jusqu'au 2015-12-31
     def formula_2013_01_01(foyer_fiscal, period, parameters):  # f3sd is in f3vd holder
         """
-        Taxation des plus value
-        TODO: 2013 f3Vg au barème / tout refaire
+        Taxation des plus value (hors bareme)
         """
-        f3vg = foyer_fiscal('f3vg', period)
-        f3vh = foyer_fiscal('f3vh', period)
-        f3vl = foyer_fiscal('f3vl', period)
         f3vm = foyer_fiscal('f3vm', period)
         f3vt = foyer_fiscal('f3vt', period)
-        f3sa = foyer_fiscal('f3sa', period)
+        f3vd_i = foyer_fiscal.members('f3vd', period)
+        f3vi_i = foyer_fiscal.members('f3vi', period)
+        f3vf_i = foyer_fiscal.members('f3vf', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
-        _P = parameters(period)
-        plus_values = parameters(period).impot_revenu.plus_values
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        f3vd = foyer_fiscal.declarant_principal('f3vd', period)
-        f3sd = foyer_fiscal.conjoint('f3vd', period)
-        f3vi = foyer_fiscal.declarant_principal('f3vi', period)
-        f3si = foyer_fiscal.conjoint('f3vi', period)
-        f3vf = foyer_fiscal.declarant_principal('f3vf', period)
-        f3sf = foyer_fiscal.conjoint('f3vf', period)
-        #  TODO: remove this todo use sum for all fields after checking
-        # revenus taxés à un taux proportionnel
-        rdp = max_(0, f3vg - f3vh) + f3vl + rpns_pvce + f3vm + f3vi + f3vf
+        f3vd = foyer_fiscal.sum(f3vd_i)
+        f3vi = foyer_fiscal.sum(f3vi_i)
+        f3vf = foyer_fiscal.sum(f3vf_i)
+        _P = parameters(period)
+        plus_values = parameters(period).impot_revenu.plus_values
+       
         out = (plus_values.pvce * rpns_pvce +
-               plus_values.taux1 * max_(0, f3vg - f3vh) +
-               plus_values.taux_pv_mob_pro * f3vl +
                plus_values.pea.taux_avant_2_ans * f3vm +
+               plus_values.pea.taux_posterieur * f3vt +
+               plus_values.taux2 * f3vd +
                plus_values.taux3 * f3vi +
                plus_values.taux4 * f3vf)
 
-        # revenus taxés à un taux proportionnel
-        rdp += f3vd
-        out += plus_values.taux1 * f3vd
-        #  out = plus_values.taux2 * f3vd + plus_values.taux3 * f3vi + plus_values.taux4 * f3vf + plus_values.taux1 * max_(
-        #          0, f3vg - f3vh)
-        out = (plus_values.taux2 * (f3vd + f3sd) + plus_values.taux3 * (f3vi + f3si) +
-            plus_values.taux4 * (f3vf + f3sf) + plus_values.taux1 * max_(0, - f3vh) + plus_values.pvce * (rpns_pvce + f3sa))
-        # TODO: chek this 3VG
         return round_(out)
 
 class rfr_pv(Variable):
@@ -1553,8 +1534,7 @@ class rfr_pv(Variable):
 
     def formula_2012_01_01(foyer_fiscal, period, parameters): 
         """
-        Plus-values 2012 et + entrant dans le calcul du revenu fiscal de référence
-        TODO: 2013 f3vg au barème
+        Plus-values 2012 entrant dans le calcul du revenu fiscal de référence
         """
         f3vc = foyer_fiscal('f3vc', period)
         f3vd_i = foyer_fiscal.members('f3vd', period)
@@ -1577,29 +1557,22 @@ class rfr_pv(Variable):
         
         return f3vc + f3vd + f3vf + f3vg + f3vh + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz + rpns_pvce
 
-    def formula_2014_01_01(foyer_fiscal, period, parameters): 
+    def formula_2013_01_01(foyer_fiscal, period, parameters): 
         """
-        Plus-values 2014 et + entrant dans le calcul du revenu fiscal de référence
-        TODO: 2013 f3vg au barème
+        Plus-values 2013 et + entrant dans le calcul du revenu fiscal de référence
         """
-        f3vc = foyer_fiscal('f3vc', period)
         f3vd_i = foyer_fiscal.members('f3vd', period)
         f3vf_i = foyer_fiscal.members('f3vf', period)
-        f3vg = foyer_fiscal('f3vg', period)
-        f3vh = foyer_fiscal('f3vh', period)
         f3vi_i = foyer_fiscal.members('f3vi', period)
-        f3vl = foyer_fiscal('f3vl', period)
         f3vm = foyer_fiscal('f3vm', period)
         f3vt = foyer_fiscal('f3vt', period)
-        f3vz = foyer_fiscal('f3vz', period)
-        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
         f3vi = foyer_fiscal.sum(f3vi_i)
         f3vd = foyer_fiscal.sum(f3vd_i)
         f3vf = foyer_fiscal.sum(f3vf_i)
         
-        return f3vc + f3vd + f3vf + f3vg + f3vh + f3vi + f3vl + f3vm + f3vt + f3vz + rpns_pvce
+        return f3vd + f3vf + f3vi + f3vm + f3vt
 
 
 class iai(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1686,7 +1686,7 @@ class rfr(Variable):
         '''
         rni = foyer_fiscal('rni', period)
         abattement_retraite_dirigeant_pme = foyer_fiscal('abatnet_retraite_dirigeant_pme', period)
-        abatnet_duree_detention = foyer_fiscal('abatnet_duree_detention', period)
+        abattement_net_duree_detention = foyer_fiscal('abatnet_duree_detention', period)
         rfr_pv = foyer_fiscal('rfr_pv', period)
         rfr_cd = foyer_fiscal('rfr_cd', period)
         rfr_rvcm = foyer_fiscal('rfr_rvcm', period)
@@ -1699,7 +1699,7 @@ class rfr(Variable):
         rpns_exon = foyer_fiscal.sum(rpns_exon_i)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
         return (max_(0, rni) + rfr_cd + rfr_pv + rfr_rvcm + rev_cap_lib + rpns_exon + rpns_pvce + abattement_retraite_dirigeant_pme +
-                abatnet_duree_detention + f2dm +  microentreprise)
+                abattement_net_duree_detention + f2dm +  microentreprise)
         
         # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1376,6 +1376,7 @@ class plus_values(Variable):
     value_type = float
     entity = FoyerFiscal
     label = u"Taxation des plus_values"
+    reference = "http://bofip.impots.gouv.fr/bofip/6957-PGP"
     definition_period = YEAR
 
     def formula_2007_01_01(foyer_fiscal, period, parameters):  # f3sd is in f3vd holder
@@ -1411,7 +1412,7 @@ class plus_values(Variable):
 
     def formula_2008_01_01(foyer_fiscal, period, parameters):  # f3sd is in f3vd holder
         """
-        Taxation des plus value
+        Taxation des plus values
         """
         f3vg = foyer_fiscal('f3vg', period)
         f3vh = foyer_fiscal('f3vh', period)
@@ -1444,7 +1445,7 @@ class plus_values(Variable):
 
     def formula_2012_01_01(foyer_fiscal, period, parameters):
         """
-        Taxation des plus value
+        Taxation des plus values
         """
         f3sa = foyer_fiscal('f3sa', period)
         f3vg = foyer_fiscal('f3vg', period)
@@ -1477,7 +1478,7 @@ class plus_values(Variable):
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         """
-        Taxation des plus value (hors bareme)
+        Taxation des plus values (hors bareme)
         """
         f3vm = foyer_fiscal('f3vm', period)
         f3vt = foyer_fiscal('f3vt', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1505,7 +1505,7 @@ class plus_values(Variable):
 class rfr_pv(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Plus-values hors RNI entrant dans le calcul du revenu fiscal de référence (PV au barème, PV éxonérées ..)"
+    label = u"Plus-values hors RNI entrant dans le calcul du revenu fiscal de référence (PV taxées forfaitairement, PV éxonérées ..)"
     definition_period = YEAR
 
     def formula_2011_01_01(foyer_fiscal, period, parameters): 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1634,8 +1634,7 @@ class rfr(Variable):
         f3vg -> rev_cat_pv -> ... -> rni
         '''
         rni = foyer_fiscal('rni', period)
-        f3va = foyer_fiscal('f3va', period)
-        f3vb = foyer_fiscal('f3vb', period)
+        abatnet_retraite_dirigeant_pme = foyer_fiscal('abatnet_retraite_dirigeant_pme', period)
         f3vi_i = foyer_fiscal.members('f3vi', period)
         rfr_cd = foyer_fiscal('rfr_cd', period)
         rfr_rvcm = foyer_fiscal('rfr_rvcm', period)
@@ -1648,7 +1647,7 @@ class rfr(Variable):
         f3vi = foyer_fiscal.sum(f3vi_i)
         rpns_exon = foyer_fiscal.sum(rpns_exon_i)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        return (max_(0, rni) + rfr_cd + rfr_rvcm + rev_cap_lib + f3vi + rpns_exon + rpns_pvce + f3va - f3vb +
+        return (max_(0, rni) + rfr_cd + rfr_rvcm + rev_cap_lib + f3vi + rpns_exon + rpns_pvce + abatnet_retraite_dirigeant_pme +
                 f3vz + microentreprise)
         
         # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1433,7 +1433,7 @@ class plus_values(Variable):
                plus_values.taux4 * f3vf)
             # revenus taxés à un taux proportionnel
         rdp += f3vd
-        out += plus_values.taux1 * f3vd
+        out += plus_values.taux2 * f3vd
 
         return round_(out)
 
@@ -1509,7 +1509,6 @@ class rfr_pv(Variable):
         f3vd_i = foyer_fiscal.members('f3vd', period)
         f3vf_i = foyer_fiscal.members('f3vf', period)
         f3vg = foyer_fiscal('f3vg', period)
-        f3vh = foyer_fiscal('f3vh', period)
         f3vi_i = foyer_fiscal.members('f3vi', period)
         f3vl = foyer_fiscal('f3vl', period)
         f3vm = foyer_fiscal('f3vm', period)
@@ -1521,7 +1520,7 @@ class rfr_pv(Variable):
         f3vd = foyer_fiscal.sum(f3vd_i)
         f3vf = foyer_fiscal.sum(f3vf_i)
         
-        return f3vc + f3vd + f3vf + f3vg + f3vh + f3vi + f3vl + f3vm + f3vp + f3vy + f3vz
+        return f3vc + f3vd + f3vf + f3vg + f3vi + f3vl + f3vm + f3vp + f3vy + f3vz
 
     def formula_2012_01_01(foyer_fiscal, period, parameters): 
         """
@@ -1531,7 +1530,6 @@ class rfr_pv(Variable):
         f3vd_i = foyer_fiscal.members('f3vd', period)
         f3vf_i = foyer_fiscal.members('f3vf', period)
         f3vg = foyer_fiscal('f3vg', period)
-        f3vh = foyer_fiscal('f3vh', period)
         f3vi_i = foyer_fiscal.members('f3vi', period)
         f3vl = foyer_fiscal('f3vl', period)
         f3vm = foyer_fiscal('f3vm', period)
@@ -1544,7 +1542,7 @@ class rfr_pv(Variable):
         f3vd = foyer_fiscal.sum(f3vd_i)
         f3vf = foyer_fiscal.sum(f3vf_i)
         
-        return f3vc + f3vd + f3vf + f3vg + f3vh + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz
+        return f3vc + f3vd + f3vf + f3vg + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz
 
     def formula_2013_01_01(foyer_fiscal, period, parameters): 
         """

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1685,8 +1685,8 @@ class rfr(Variable):
         f3vg -> rev_cat_pv -> ... -> rni
         '''
         rni = foyer_fiscal('rni', period)
-        abattement_retraite_dirigeant_pme = foyer_fiscal('abatnet_retraite_dirigeant_pme', period)
-        abattement_net_duree_detention = foyer_fiscal('abatnet_duree_detention', period)
+        abattement_net_retraite_dirigeant_pme = foyer_fiscal('abattement_net_retraite_dirigeant_pme', period)
+        abattement_net_duree_detention = foyer_fiscal('abattement_net_duree_detention', period)
         rfr_pv = foyer_fiscal('rfr_pv', period)
         rfr_cd = foyer_fiscal('rfr_cd', period)
         rfr_rvcm = foyer_fiscal('rfr_rvcm', period)
@@ -1698,7 +1698,7 @@ class rfr(Variable):
 
         rpns_exon = foyer_fiscal.sum(rpns_exon_i)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        return (max_(0, rni) + rfr_cd + rfr_pv + rfr_rvcm + rev_cap_lib + rpns_exon + rpns_pvce + abattement_retraite_dirigeant_pme +
+        return (max_(0, rni) + rfr_cd + rfr_pv + rfr_rvcm + rev_cap_lib + rpns_exon + rpns_pvce + abattement_net_retraite_dirigeant_pme +
                 abattement_net_duree_detention + f2dm +  microentreprise)
         
         # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1437,7 +1437,7 @@ class plus_values(Variable):
 
         return round_(out)
 
-    def formula_2012_01_01(foyer_fiscal, period, parameters):  # f3sd is in f3vd holder
+    def formula_2012_01_01(foyer_fiscal, period, parameters):
         """
         Taxation des plus value
         """
@@ -1446,36 +1446,29 @@ class plus_values(Variable):
         f3vl = foyer_fiscal('f3vl', period)
         f3vt = foyer_fiscal('f3vt', period)
         f3vm = foyer_fiscal('f3vm', period)
+        f3vd_i = foyer_fiscal.members('f3vd', period)
+        f3vi_i = foyer_fiscal.members('f3vi', period)
+        f3vf_i = foyer_fiscal.members('f3vf', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         plus_values = parameters(period).impot_revenu.plus_values
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        f3vd = foyer_fiscal.declarant_principal('f3vd', period)
-        f3sd = foyer_fiscal.conjoint('f3vd', period)
-        f3vi = foyer_fiscal.declarant_principal('f3vi', period)
-        f3si = foyer_fiscal.conjoint('f3vi', period)
-        f3vf = foyer_fiscal.declarant_principal('f3vf', period)
-        f3sf = foyer_fiscal.conjoint('f3vf', period)
-        # TODO: remove this todo use sum for all fields after checking
-        # revenus taxés à un taux proportionnel
-        rdp = max_(0, f3vg - f3vh) + f3vl + rpns_pvce + f3vm + f3vi + f3vf
+        f3vd = foyer_fiscal.sum(f3vd_i)
+        f3vi = foyer_fiscal.sum(f3vi_i)
+        f3vf = foyer_fiscal.sum(f3vf_i)
+        
         out = (plus_values.pvce * rpns_pvce +
                plus_values.taux1 * max_(0, f3vg - f3vh) +
+               plus_values.taux2 * f3vd +
                plus_values.taux_pv_mob_pro * f3vl +
                plus_values.pea.taux_avant_2_ans * f3vm +
+               plus_values.pea.taux_posterieur * f3vt +
                plus_values.taux3 * f3vi +
                plus_values.taux4 * f3vf)
-        # revenus taxés à un taux proportionnel
-        rdp += f3vd
-        out += plus_values.taux1 * f3vd
-        #        out = plus_values.taux2 * f3vd + plus_values.taux3 * f3vi + plus_values.taux4 * f3vf + plus_values.taux1 *max_(
-        #            0, f3vg - f3vh)
-        out = (plus_values.taux2 * (f3vd + f3sd) + plus_values.taux3 * (f3vi + f3si) +
-            plus_values.taux4 * (f3vf + f3sf) + plus_values.taux1 * max_(0, f3vg - f3vh) + plus_values.pvce * rpns_pvce)
-                # TODO: chek this rpns missing ?
+       
         return round_(out)
 
-    def formula_2013_01_01(foyer_fiscal, period, parameters):  # f3sd is in f3vd holder
+    def formula_2013_01_01(foyer_fiscal, period, parameters):
         """
         Taxation des plus value (hors bareme)
         """

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -543,6 +543,12 @@ class rev_cat_pv(Variable):
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         f3vg = foyer_fiscal('f3vg', period)
+        f3vl = foyer_fiscal('f3vl', period)
+
+        return f3vg + f3vl
+
+    def formula_2014_01_01(foyer_fiscal, period, parameters):
+        f3vg = foyer_fiscal('f3vg', period)
 
         return f3vg
 
@@ -1544,7 +1550,7 @@ class rfr_pv(Variable):
         f3vd = foyer_fiscal.sum(f3vd_i)
         f3vf = foyer_fiscal.sum(f3vf_i)
         
-        return f3sa+ f3vc + f3vd + f3vf + f3vg + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz
+        return f3sa + f3vc + f3vd + f3vf + f3vg + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz
 
     def formula_2013_01_01(foyer_fiscal, period, parameters): 
         """
@@ -1555,14 +1561,16 @@ class rfr_pv(Variable):
         f3vf_i = foyer_fiscal.members('f3vf', period)
         f3vi_i = foyer_fiscal.members('f3vi', period)
         f3vm = foyer_fiscal('f3vm', period)
+        f3vp = foyer_fiscal('f3vp', period)
         f3vt = foyer_fiscal('f3vt', period)
+        f3vy = foyer_fiscal('f3vy', period)
         f3vz = foyer_fiscal('f3vz', period)
 
         f3vi = foyer_fiscal.sum(f3vi_i)
         f3vd = foyer_fiscal.sum(f3vd_i)
         f3vf = foyer_fiscal.sum(f3vf_i)
         
-        return f3vc + f3vd + f3vf + f3vi + f3vm + f3vt + f3vz
+        return f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + f3vt + f3vy + f3vz
 
 
 class iai(Variable):
@@ -1678,6 +1686,7 @@ class rfr(Variable):
         '''
         rni = foyer_fiscal('rni', period)
         abatnet_retraite_dirigeant_pme = foyer_fiscal('abatnet_retraite_dirigeant_pme', period)
+        abatnet_duree_detention = foyer_fiscal('abatnet_duree_detention', period)
         rfr_pv = foyer_fiscal('rfr_pv', period)
         rfr_cd = foyer_fiscal('rfr_cd', period)
         rfr_rvcm = foyer_fiscal('rfr_rvcm', period)
@@ -1690,7 +1699,7 @@ class rfr(Variable):
         rpns_exon = foyer_fiscal.sum(rpns_exon_i)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
         return (max_(0, rni) + rfr_cd + rfr_pv + rfr_rvcm + rev_cap_lib + rpns_exon + rpns_pvce + abatnet_retraite_dirigeant_pme +
-                f2dm +  microentreprise)
+                abatnet_duree_detention + f2dm +  microentreprise)
         
         # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1685,7 +1685,7 @@ class rfr(Variable):
         f3vg -> rev_cat_pv -> ... -> rni
         '''
         rni = foyer_fiscal('rni', period)
-        abatnet_retraite_dirigeant_pme = foyer_fiscal('abatnet_retraite_dirigeant_pme', period)
+        abattement_retraite_dirigeant_pme = foyer_fiscal('abatnet_retraite_dirigeant_pme', period)
         abatnet_duree_detention = foyer_fiscal('abatnet_duree_detention', period)
         rfr_pv = foyer_fiscal('rfr_pv', period)
         rfr_cd = foyer_fiscal('rfr_cd', period)
@@ -1698,7 +1698,7 @@ class rfr(Variable):
 
         rpns_exon = foyer_fiscal.sum(rpns_exon_i)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        return (max_(0, rni) + rfr_cd + rfr_pv + rfr_rvcm + rev_cap_lib + rpns_exon + rpns_pvce + abatnet_retraite_dirigeant_pme +
+        return (max_(0, rni) + rfr_cd + rfr_pv + rfr_rvcm + rev_cap_lib + rpns_exon + rpns_pvce + abattement_retraite_dirigeant_pme +
                 abatnet_duree_detention + f2dm +  microentreprise)
         
         # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1533,7 +1533,7 @@ class rfr_pv(Variable):
         """
         Plus-values 2012 entrant dans le calcul du revenu fiscal de référence
         """
-        f3sa = foyer_fiscal('f3sa', period)
+        f3sa = foyer_fiscal('f3sa', period) # Nouveauté 2012 : Plus values de cessions de titres réalisées par un entrepreneur (imposable forfaitairement sur option en 2012)
         f3vc = foyer_fiscal('f3vc', period)
         f3vd_i = foyer_fiscal.members('f3vd', period)
         f3vf_i = foyer_fiscal.members('f3vf', period)
@@ -1542,7 +1542,7 @@ class rfr_pv(Variable):
         f3vl = foyer_fiscal('f3vl', period)
         f3vm = foyer_fiscal('f3vm', period)
         f3vp = foyer_fiscal('f3vp', period)
-        f3vt = foyer_fiscal('f3vt', period)
+        f3vt = foyer_fiscal('f3vt', period) # Nouveauté 2012 : Le gain lors de la clôture d'un PEA est taxé à 19% si il a lieu entre la 2ème et la 5ème année (au lieu de 22.5% avant la 2ème année)
         f3vy = foyer_fiscal('f3vy', period)
         f3vz = foyer_fiscal('f3vz', period)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1498,7 +1498,7 @@ class plus_values(Variable):
 class rfr_pv(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Plus-values hors RNI entrant dans le calcul du revenu fiscal de référence"
+    label = u"Plus-values hors RNI entrant dans le calcul du revenu fiscal de référence (PV au barème, PV éxonérées ..)"
     definition_period = YEAR
 
     def formula_2011_01_01(foyer_fiscal, period, parameters): 
@@ -1548,6 +1548,7 @@ class rfr_pv(Variable):
         """
         Plus-values 2013 et + entrant dans le calcul du revenu fiscal de référence
         """
+        f3vc = foyer_fiscal('f3vc', period)
         f3vd_i = foyer_fiscal.members('f3vd', period)
         f3vf_i = foyer_fiscal.members('f3vf', period)
         f3vi_i = foyer_fiscal.members('f3vi', period)
@@ -1559,7 +1560,7 @@ class rfr_pv(Variable):
         f3vd = foyer_fiscal.sum(f3vd_i)
         f3vf = foyer_fiscal.sum(f3vf_i)
         
-        return f3vd + f3vf + f3vi + f3vm + f3vt + f3vz
+        return f3vc + f3vd + f3vf + f3vi + f3vm + f3vt + f3vz
 
 
 class iai(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -543,9 +543,8 @@ class rev_cat_pv(Variable):
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         f3vg = foyer_fiscal('f3vg', period)
-        f3vh = foyer_fiscal('f3vh', period)
 
-        return f3vg - f3vh
+        return f3vg
 
 
 class rev_cat_tspr(Variable):

--- a/openfisca_france/model/revenus/capital/financier.py
+++ b/openfisca_france/model/revenus/capital/financier.py
@@ -213,8 +213,6 @@ class f2dm(Variable):
     label = u"Impatriés: revenus de capitaux mobiliers perçus à l'étranger, abattement de 50 %"
     # start_date = date(2008, 1, 1)
     definition_period = YEAR
-    # TODO: nouvelle case à utiliser où c'est nécessaire
-    # TODO: vérifier existence avant 2012
 
 
 class f2gr(Variable):

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -191,7 +191,7 @@ class f3va(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Abattement pour durée de détention des titres en cas de départ à la retraite d'un dirigeant appliqué sur des plus-values"
+    label = u""
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
@@ -200,9 +200,23 @@ class f3vb(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Abattement pour durée de détention des titres en cas de départ à la retraite d'un dirigeant appliqué sur des moins-values"
+    label = u""
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
+
+class abatnet_retraite_dirigeant_pme(Variable):
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Abattement net pour durée de détention des titres en cas de départ à la retraite d'un dirigeant"
+    definition_period = YEAR
+
+    def formula_2006_01_01(foyer_fiscal, period):
+        f3va = foyer_fiscal('f3va', period)
+        f3vb = foyer_fiscal('f3va', period)
+
+        return f3va - f3vb
+
 
 # Plus values et gains taxables à des taux forfaitaires
 

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -187,17 +187,22 @@ class f3vj(Variable):
   # (f3vj, f3vk )
 
 class f3va(Variable):
-    cerfa_field = {QUIFOY['vous']: u"3VA",
-        QUIFOY['conj']: u"3VB",
-        }
+    cerfa_field = u"3VA"
     value_type = int
     unit = 'currency'
-    entity = Individu
+    entity = FoyerFiscal
     label = u"Abattement pour durée de détention des titres en cas de départ à la retraite d'un dirigeant appliqué sur des plus-values"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
-  # (f3va, f3vb )))
+class f3vb(Variable):
+    cerfa_field = u"3VB"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Abattement pour durée de détention des titres en cas de départ à la retraite d'un dirigeant appliqué sur des moins-values"
+    # start_date = date(2006, 1, 1)
+    definition_period = YEAR
 
 # Plus values et gains taxables à des taux forfaitaires
 

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -61,6 +61,8 @@ class f3sa(Variable):
     cerfa_field = u"3SA"
     value_type = int
     entity = FoyerFiscal
+    label = u"Plus-values de cessions de titres réalisées par un entrepreneur, taxables à 19%"
+    # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -58,13 +58,13 @@ class f3si(Variable):
 #                                    # correspond à autre chose en 2009, vérifier 2011,2010
 
 class f3sa(Variable):
+    cerfa_field = u"3SA"
     value_type = int
     entity = FoyerFiscal
-    end = '2009-12-31'
+    end = '2012-12-31'
     definition_period = YEAR
 
-  # TODO: n'existe pas en 2013 et 2012 vérifier 2011 et 2010
-
+  
 class f3sf(Variable):
     value_type = int
     entity = FoyerFiscal

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -263,10 +263,11 @@ class f3sm(Variable):
     end = '2014-12-31'
     definition_period = YEAR
 
-class abatnet_retraite_dirigeant_pme(Variable):
+class abattement_net_retraite_dirigeant_pme(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
+    reference = u"http://bofip.impots.gouv.fr/bofip/2894-PGP"
     label = u"Abattement net pour durée de détention des titres en cas de départ à la retraite d'un dirigeant"
     definition_period = YEAR
 
@@ -276,10 +277,11 @@ class abatnet_retraite_dirigeant_pme(Variable):
 
         return f3va - f3vb
 
-class abatnet_duree_detention(Variable):
+class abattement_net_duree_detention(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
+    reference = u"http://bofip.impots.gouv.fr/bofip/9540-PGP"
     label = u"Abattement net pour durée de détention"
     definition_period = YEAR
 

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -158,9 +158,9 @@ class f3vl(Variable):
     unit = 'currency'
     entity = FoyerFiscal
     label = u"Distributions par des sociétés de capital-risque taxables à 19 %"
+    end = '2013-12-31'
     definition_period = YEAR
 
-  # vérifier pour 2011 et 2010
 
 class f3vi(Variable):
     cerfa_field = {QUIFOY['vous']: u"3VI",
@@ -223,6 +223,44 @@ class f3vb(Variable):
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
+class f3sg(Variable):
+    cerfa_field = u"3SG"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Abattement net pour durée de détention : appliqué sur des plus-values"
+    # start_date = date(2013, 1, 1)
+    definition_period = YEAR
+
+class f3sh(Variable):
+    cerfa_field = u"3SH"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Abattement net pour durée de détention : appliqué sur des moins-values"
+    # start_date = date(2013, 1, 1)
+    end = '2014-12-31'
+    definition_period = YEAR
+
+class f3sl(Variable):
+    cerfa_field = u"3SL"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Abattement net pour durée de détention renforcée : appliqué sur des plus-values"
+    # start_date = date(2013, 1, 1)
+    definition_period = YEAR
+
+class f3sm(Variable):
+    cerfa_field = u"3SM"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Abattement net pour durée de détention renforcée : appliqué sur des moins-values"
+    # start_date = date(2013, 1, 1)
+    end = '2014-12-31'
+    definition_period = YEAR
+
 class abatnet_retraite_dirigeant_pme(Variable):
     value_type = int
     unit = 'currency'
@@ -235,6 +273,27 @@ class abatnet_retraite_dirigeant_pme(Variable):
         f3vb = foyer_fiscal('f3va', period)
 
         return f3va - f3vb
+
+class abatnet_duree_detention(Variable):
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Abattement net pour durée de détention"
+    definition_period = YEAR
+
+    def formula_2013_01_01(foyer_fiscal, period):
+        f3sg = foyer_fiscal('f3sg', period)
+        f3sh = foyer_fiscal('f3sh', period)
+        f3sl = foyer_fiscal('f3sl', period)
+        f3sm = foyer_fiscal('f3sm', period)
+
+        return max_(0, f3sg - f3sh) + max_(0, f3sl - f3sm)
+
+    def formula_2015_01_01(foyer_fiscal, period):
+        f3sg = foyer_fiscal('f3sg', period)
+        f3sl = foyer_fiscal('f3sl', period)
+
+        return f3sg + f3sl 
 
 
 # Plus values et gains taxables à des taux forfaitaires

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -91,6 +91,25 @@ class f3vc(Variable):
     definition_period = YEAR
 
 
+class f3vp(Variable):
+    cerfa_field = u"3VP"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Plus-values exonérées de cessions de titres de jeunes entreprises innovantes"
+    # start_date = date(2007, 1, 1)
+    definition_period = YEAR
+
+
+class f3vy(Variable):
+    cerfa_field = u"3VY"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Plus-values exonérées de cessions de participations supérieures à 25% au sein du groupe familial"
+    # start_date = date(2011, 1, 1)
+    definition_period = YEAR
+
 
 class f3vd(Variable):
     cerfa_field = {QUIFOY['vous']: u"3VD",

--- a/openfisca_france/parameters/impot_revenu/plus_values.yaml
+++ b/openfisca_france/parameters/impot_revenu/plus_values.yaml
@@ -148,7 +148,7 @@ taux2:
   reference: openfisca
   unit: /1
   values:
-    2009-01-01:
+    2008-01-01:
       value: 0.18
 taux3:
   description: Actions gratuites 30%

--- a/openfisca_france/parameters/impot_revenu/plus_values.yaml
+++ b/openfisca_france/parameters/impot_revenu/plus_values.yaml
@@ -148,7 +148,7 @@ taux2:
   reference: openfisca
   unit: /1
   values:
-    2008-01-01:
+    2009-01-01:
       value: 0.18
 taux3:
   description: Actions gratuites 30%

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -48,7 +48,7 @@ class allocations_familiales_imposables(Reform):
 
         def formula(foyer_fiscal, period, parameters):
             allocations_familiales_imposables = foyer_fiscal('allocations_familiales_imposables')
-            abatnet_retraite_dirigeant_pme = foyer_fiscal('abatnet_retraite_dirigeant_pme')
+            abattement_net_retraite_dirigeant_pme = foyer_fiscal('abattement_net_retraite_dirigeant_pme')
             f3vi_holder = foyer_fiscal.members('f3vi')
             f3vz = foyer_fiscal('f3vz')
             rfr_cd = foyer_fiscal('rfr_cd')
@@ -65,7 +65,7 @@ class allocations_familiales_imposables(Reform):
 
             return (
                 max_(0, rni - allocations_familiales_imposables) +
-                rfr_cd + rfr_rvcm + rev_cap_lib + f3vi + rpns_exon + rpns_pvce + abatnet_retraite_dirigeant_pme + f3vz + microentreprise
+                rfr_cd + rfr_rvcm + rev_cap_lib + f3vi + rpns_exon + rpns_pvce + abattement_net_retraite_dirigeant_pme + f3vz + microentreprise
                 )
 
             # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -47,18 +47,17 @@ class allocations_familiales_imposables(Reform):
         definition_period = YEAR
 
         def formula(foyer_fiscal, period, parameters):
-            allocations_familiales_imposables = foyer_fiscal('allocations_familiales_imposables', period)
-            f3va = foyer_fiscal('f3va', period)
-            f3vb = foyer_fiscal('f3vb', period)
-            f3vi_holder = foyer_fiscal.members('f3vi', period)
-            f3vz = foyer_fiscal('f3vz', period)
-            rfr_cd = foyer_fiscal('rfr_cd', period)
-            rfr_rvcm = foyer_fiscal('rfr_rvcm', period)
-            rni = foyer_fiscal('rni', period)
-            rpns_exon_holder = foyer_fiscal.members('rpns_exon', period)
-            rpns_pvce_holder = foyer_fiscal.members('rpns_pvce', period)
-            rev_cap_lib = foyer_fiscal_add('rev_cap_lib', period, options = [ADD])
-            microentreprise = foyer_fiscal('microentreprise', period)
+            allocations_familiales_imposables = foyer_fiscal('allocations_familiales_imposables')
+            abatnet_retraite_dirigeant_pme = foyer_fiscal('abatnet_retraite_dirigeant_pme')
+            f3vi_holder = foyer_fiscal.members('f3vi')
+            f3vz = foyer_fiscal('f3vz')
+            rfr_cd = foyer_fiscal('rfr_cd')
+            rfr_rvcm = foyer_fiscal('rfr_rvcm')
+            rni = foyer_fiscal('rni')
+            rpns_exon_holder = foyer_fiscal.members('rpns_exon')
+            rpns_pvce_holder = foyer_fiscal.members('rpns_pvce')
+            rev_cap_lib = simulation.calculate_add('rev_cap_lib')
+            microentreprise = foyer_fiscal('microentreprise')
 
             f3vi = foyer_fiscal.sum(f3vi_holder)
             rpns_exon = foyer_fiscal.sum(rpns_exon_holder)
@@ -66,7 +65,7 @@ class allocations_familiales_imposables(Reform):
 
             return (
                 max_(0, rni - allocations_familiales_imposables) +
-                rfr_cd + rfr_rvcm + rev_cap_lib + f3vi + rpns_exon + rpns_pvce + f3va - f3vb + f3vz + microentreprise
+                rfr_cd + rfr_rvcm + rev_cap_lib + f3vi + rpns_exon + rpns_pvce + abatnet_retraite_dirigeant_pme + f3vz + microentreprise
                 )
 
             # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -47,27 +47,29 @@ class allocations_familiales_imposables(Reform):
         definition_period = YEAR
 
         def formula(foyer_fiscal, period, parameters):
-            allocations_familiales_imposables = foyer_fiscal('allocations_familiales_imposables')
-            f3va_i = foyer_fiscal.members('f3va', period)
-            f3vi_i = foyer_fiscal.members('f3vi', period)
+            allocations_familiales_imposables = foyer_fiscal('allocations_familiales_imposables', period)
+            f3va = foyer_fiscal('f3va', period)
+            f3vb = foyer_fiscal('f3vb', period)
+            f3vi_holder = foyer_fiscal.members('f3vi', period)
             f3vz = foyer_fiscal('f3vz', period)
             rfr_cd = foyer_fiscal('rfr_cd', period)
             rfr_rvcm = foyer_fiscal('rfr_rvcm', period)
             rni = foyer_fiscal('rni', period)
-            rpns_exon_i = foyer_fiscal.members('rpns_exon', period)
-            rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
-            rev_cap_lib = foyer_fiscal('rev_cap_lib', period, options = [ADD])
+            rpns_exon_holder = foyer_fiscal.members('rpns_exon', period)
+            rpns_pvce_holder = foyer_fiscal.members('rpns_pvce', period)
+            rev_cap_lib = foyer_fiscal_add('rev_cap_lib', period, options = [ADD])
             microentreprise = foyer_fiscal('microentreprise', period)
 
-            f3va = foyer_fiscal.sum(f3va_i)
-            f3vi = foyer_fiscal.sum(f3vi_i)
-            rpns_exon = foyer_fiscal.sum(rpns_exon_i)
-            rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
+            f3vi = foyer_fiscal.sum(f3vi_holder)
+            rpns_exon = foyer_fiscal.sum(rpns_exon_holder)
+            rpns_pvce = foyer_fiscal.sum(rpns_pvce_holder)
 
             return (
                 max_(0, rni - allocations_familiales_imposables) +
-                rfr_cd + rfr_rvcm + rev_cap_lib + f3vi + rpns_exon + rpns_pvce + f3va + f3vz + microentreprise
+                rfr_cd + rfr_rvcm + rev_cap_lib + f3vi + rpns_exon + rpns_pvce + f3va - f3vb + f3vz + microentreprise
                 )
+
+            # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)
 
     class allocations_familiales_imposables(Variable):
         value_type = float

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '20.2.0',
+    version = '20.3.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Les modifications de cette PR sont comparées à la branche `ipp-update-charges-deductibles` (https://github.com/openfisca/openfisca-france/pull/907)

* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2008 (mais surtout à partir du changement législatif du 01/01/2013)
* Zones impactées : 
- `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`.
-  `openfisca_france/model/revenus/capital`
-  **`openfisca_france/reforms/allocations_familiales_imposables.py`**
* Détails :
  - A partir de 2013, une partie des plus-values est taxé au barème alors qu'avant elles étaient taxées forfaitairement => correction de la formule de l'IR
  - Les plus-values et revenus du capital (taxées forfaitairement ou au barème ou éxonérées) doivent entrer en compte dans le calcul du RFR => correction de la formule du RFR
  - Correction d'un des taux forfaitaires

- - - -

Ces changements :

- Impactent l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.

