### PR TITLE
Ipp 5 : Mise à jour de la réduction d'IR pour investissements forestiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 20.8.0 [#911](https://github.com/openfisca/openfisca-france/pull/911)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : 2002 - 2016
+* Détails :
+- Mise à jour des formules (2014-2016) de la réduction d'impôt 'invfor'
+- Correction d'une erreur dans la formule précédente : les reports de dépenses entrent dans le plafonnement de la réduction
+
 ## 20.7.0 [#895](https://github.com/openfisca/openfisca-france/pull/895)
 
 * Amélioration technique

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -1275,7 +1275,7 @@ class domlog(Variable):
         f7ua = foyer_fiscal('f7ua', period)
         f7ub = foyer_fiscal('f7ub', period)
         f7uc = foyer_fiscal('f7uc', period)
-        f7ui = foyer_fiscal('f7ui', period)
+        f7ui = foyer_fiscal('f7ui_2008', period)
         f7uj = foyer_fiscal('f7uj', period)
         P = parameters(period).impot_revenu.reductions_impots.domlog
 
@@ -1289,7 +1289,7 @@ class domlog(Variable):
         f7ua = foyer_fiscal('f7ua', period)
         f7ub = foyer_fiscal('f7ub', period)
         f7uc = foyer_fiscal('f7uc', period)
-        f7ui = foyer_fiscal('f7ui', period)
+        f7ui = foyer_fiscal('f7ui_2008', period)
         f7uj = foyer_fiscal('f7uj', period)
         P = parameters(period).impot_revenu.reductions_impots.domlog
 
@@ -1300,7 +1300,7 @@ class domlog(Variable):
         Investissements OUTRE-MER dans le secteur du logement et autres secteurs d’activité
         2008
         '''
-        f7ui = foyer_fiscal('f7ui', period)
+        f7ui = foyer_fiscal('f7ui_2008', period)
 
         return f7ui
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -1837,7 +1837,7 @@ class invfor(Variable):
         P = parameters(period).impot_revenu.reductions_impots.invfor
 
         max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
-        max1 = max_(0, max0 - f7uu + f7te + f7uv + f7tf)
+        max1 = max_(0, max0 - f7uu - f7te - f7uv - f7tf)
         return (P.taux * (
             min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
             min_(f7up, max1) +
@@ -1863,7 +1863,7 @@ class invfor(Variable):
         P = parameters(period).impot_revenu.reductions_impots.invfor
 
         max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
-        max1 = max_(0, max0 - f7uu + f7te + f7uv + f7tf)
+        max1 = max_(0, max0 - f7uu - f7te - f7uv - f7tf)
         max2 = max_(0, max1 - f7tg - f7uw)
         return (P.taux * (
             min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
@@ -1893,7 +1893,7 @@ class invfor(Variable):
         P = parameters(period).impot_revenu.reductions_impots.invfor
 
         max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
-        max1 = max_(0, max0 - f7uu + f7te + f7uv + f7tf)
+        max1 = max_(0, max0 - f7uu - f7te - f7uv - f7tf)
         max2 = max_(0, max1 - f7tg - f7uw)
         max3 = max_(0, max2 - f7th - f7ux)
         return (P.taux * (

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -1903,24 +1903,24 @@ class invfor(Variable):
             P.report12 * min_(f7th + f7ux, max2) +
             P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)))
 
-    def formula_2014_01_01(self, simulation, period):
+    def formula_2014_01_01(foyer_fiscal, period, parameters):
         '''
         Investissements forestiers pour 2014 cf. 2041 GK
         '''
-        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
-        f7te = simulation.calculate('f7te', period)
-        f7tf = simulation.calculate('f7tf', period)
-        f7tg = simulation.calculate('f7tg', period)
-        f7th = simulation.calculate('f7th', period)
-        f7ti = simulation.calculate('f7ti', period)
-        f7ul = simulation.calculate('f7ul', period)
-        f7un = simulation.calculate('f7un', period)
-        f7uu = simulation.calculate('f7uu', period)
-        f7uv = simulation.calculate('f7uv', period)
-        f7uw = simulation.calculate('f7uw', period)
-        f7ux = simulation.calculate('f7ux', period)
-        _P = simulation.parameters_at(period.start)
-        P = simulation.parameters_at(period.start).impot_revenu.reductions_impots.invfor
+        maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        f7te = foyer_fiscal('f7te', period)
+        f7tf = foyer_fiscal('f7tf', period)
+        f7tg = foyer_fiscal('f7tg', period)
+        f7th = foyer_fiscal('f7th', period)
+        f7ti = foyer_fiscal('f7ti', period)
+        f7ul = foyer_fiscal('f7ul', period)
+        f7un = foyer_fiscal('f7un', period)
+        f7uu = foyer_fiscal('f7uu', period)
+        f7uv = foyer_fiscal('f7uv', period)
+        f7uw = foyer_fiscal('f7uw', period)
+        f7ux = foyer_fiscal('f7ux', period)
+        _P = parameters(period)
+        P = parameters(period).impot_revenu.reductions_impots.invfor
 
         max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
         max1 = max_(0, max0 - f7uu - f7te - f7tf)
@@ -1932,23 +1932,23 @@ class invfor(Variable):
             P.report11 * min_(f7tg + f7uv, max1) +
             P.report12 * min_(f7th + f7uw + f7ux + f7ti, max2))
 
-    def formula_2015_01_01(self, simulation, period):
+    def formula_2015_01_01(foyer_fiscal, period, parameters):
         '''
         Investissements forestiers pour 2015 cf. 2041 GK
         '''
-        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
-        f7te = simulation.calculate('f7te', period)
-        f7tf = simulation.calculate('f7tf', period)
-        f7tg = simulation.calculate('f7tg', period)
-        f7th = simulation.calculate('f7th', period)
-        f7ti = simulation.calculate('f7ti', period)
-        f7ul = simulation.calculate('f7ul', period)
-        f7un = simulation.calculate('f7un', period)
-        f7uu = simulation.calculate('f7uu', period)
-        f7uv = simulation.calculate('f7uv', period)
-        f7uw = simulation.calculate('f7uw', period)
-        _P = simulation.parameters_at(period.start)
-        P = simulation.parameters_at(period.start).impot_revenu.reductions_impots.invfor
+        maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        f7te = foyer_fiscal('f7te', period)
+        f7tf = foyer_fiscal('f7tf', period)
+        f7tg = foyer_fiscal('f7tg', period)
+        f7th = foyer_fiscal('f7th', period)
+        f7ti = foyer_fiscal('f7ti', period)
+        f7ul = foyer_fiscal('f7ul', period)
+        f7un = foyer_fiscal('f7un', period)
+        f7uu = foyer_fiscal('f7uu', period)
+        f7uv = foyer_fiscal('f7uv', period)
+        f7uw = foyer_fiscal('f7uw', period)
+        _P = parameters(period)
+        P = parameters(period).impot_revenu.reductions_impots.invfor
 
         max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
         max1 = max_(0, max0 - f7te - f7tf)
@@ -1960,22 +1960,22 @@ class invfor(Variable):
             P.report11 * min_(f7tg + f7uu, max1) +
             P.report12 * min_(f7th + f7uv + f7uw + f7ti, max2))
 
-    def formula_2016_01_01(self, simulation, period):
+    def formula_2016_01_01(foyer_fiscal, period, parameters):
         '''
         Investissements forestiers pour 2016 cf. 2041 GK
         '''
-        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
-        f7te = simulation.calculate('f7te', period)
-        f7tf = simulation.calculate('f7tf', period)
-        f7tg = simulation.calculate('f7tg', period)
-        f7th = simulation.calculate('f7th', period)
-        f7ti = simulation.calculate('f7ti', period)
-        f7ul = simulation.calculate('f7ul', period)
-        f7un = simulation.calculate('f7un', period)
-        f7uu = simulation.calculate('f7uu', period)
-        f7uv = simulation.calculate('f7uv', period)
-        _P = simulation.parameters_at(period.start)
-        P = simulation.parameters_at(period.start).impot_revenu.reductions_impots.invfor
+        maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        f7te = foyer_fiscal('f7te', period)
+        f7tf = foyer_fiscal('f7tf', period)
+        f7tg = foyer_fiscal('f7tg', period)
+        f7th = foyer_fiscal('f7th', period)
+        f7ti = foyer_fiscal('f7ti', period)
+        f7ul = foyer_fiscal('f7ul', period)
+        f7un = foyer_fiscal('f7un', period)
+        f7uu = foyer_fiscal('f7uu', period)
+        f7uv = foyer_fiscal('f7uv', period)
+        _P = parameters(period)
+        P = parameters(period).impot_revenu.reductions_impots.invfor
 
         max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
         max1 = max_(0, max0 - f7te - f7tf)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -1768,8 +1768,6 @@ class invfor(Variable):
     label = u"Réduction d'impôt au titre des investissements forestiers"
     reference = "http://bofip.impots.gouv.fr/bofip/5537-PGP"
     definition_period = YEAR
-    end = '2016-12-31'
-
 
     def formula_2002_01_01(foyer_fiscal, period, parameters):
         '''

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -1919,7 +1919,6 @@ class invfor(Variable):
         f7uv = foyer_fiscal('f7uv', period)
         f7uw = foyer_fiscal('f7uw', period)
         f7ux = foyer_fiscal('f7ux', period)
-        _P = parameters(period)
         P = parameters(period).impot_revenu.reductions_impots.invfor
 
         max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
@@ -1947,7 +1946,6 @@ class invfor(Variable):
         f7uu = foyer_fiscal('f7uu', period)
         f7uv = foyer_fiscal('f7uv', period)
         f7uw = foyer_fiscal('f7uw', period)
-        _P = parameters(period)
         P = parameters(period).impot_revenu.reductions_impots.invfor
 
         max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
@@ -1974,7 +1972,6 @@ class invfor(Variable):
         f7un = foyer_fiscal('f7un', period)
         f7uu = foyer_fiscal('f7uu', period)
         f7uv = foyer_fiscal('f7uv', period)
-        _P = parameters(period)
         P = parameters(period).impot_revenu.reductions_impots.invfor
 
         max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -2646,6 +2646,255 @@ class locmeu(Variable):
                 report_invest_anterieur + report_non_impute
             )
 
+    def formula_2014_01_01(self, simulation, period):
+        '''
+        Investissement en vue de la location meublée non professionnelle dans certains établissements ou résidences
+        2014
+        '''
+        f7ia = simulation.calculate('f7ia', period)
+        f7ib = simulation.calculate('f7ib', period)
+        f7ic = simulation.calculate('f7ic', period)
+        f7id = simulation.calculate('f7id', period)
+        f7ie = simulation.calculate('f7ie', period)
+        f7if = simulation.calculate('f7if', period)
+        f7ig = simulation.calculate('f7ig', period)
+        f7ih = simulation.calculate('f7ih', period)
+        f7ij = simulation.calculate('f7ij', period)
+        f7ik = simulation.calculate('f7ik', period)
+        f7il = simulation.calculate('f7il', period)
+        f7im = simulation.calculate('f7im', period)
+        f7in = simulation.calculate('f7in', period)
+        f7io = simulation.calculate('f7io', period)
+        f7ip = simulation.calculate('f7ip', period)
+        f7iq = simulation.calculate('f7iq', period)
+        f7ir = simulation.calculate('f7ir', period)
+        f7is = simulation.calculate('f7is', period)
+        f7it = simulation.calculate('f7it', period)
+        f7iu = simulation.calculate('f7iu', period)
+        f7iv = simulation.calculate('f7iv', period)
+        f7iw = simulation.calculate('f7iw', period)
+        f7ix = simulation.calculate('f7ix', period)
+        f7iy = simulation.calculate('f7iy', period)
+        f7iz = simulation.calculate('f7iz', period)
+        f7jc = simulation.calculate('f7jc', period)
+        f7ji = simulation.calculate('f7ji', period)
+        f7js = simulation.calculate('f7js', period)
+        f7jt = simulation.calculate('f7jt', period)
+        f7ju = simulation.calculate('f7ju', period)
+        f7jv = simulation.calculate('f7jv', period)
+        f7jw = simulation.calculate('f7jw', period)
+        f7jx = simulation.calculate('f7jx', period)
+        f7jy = simulation.calculate('f7jy', period)
+        f7oa = simulation.calculate('f7oa', period)
+        f7ob = simulation.calculate('f7ob', period)
+        f7oc = simulation.calculate('f7oc', period)
+        f7od = simulation.calculate('f7od', period)
+        f7oe = simulation.calculate('f7oe', period)
+        f7ou = simulation.calculate('f7ou', period)
+        f7pa = simulation.calculate('f7pa', period)
+        f7pb = simulation.calculate('f7pb', period)
+        f7pc = simulation.calculate('f7pc', period)
+        f7pd = simulation.calculate('f7pd', period)
+        f7pe = simulation.calculate('f7pe', period)
+
+        P = simulation.parameters_at(period.start).impot_revenu.reductions_impots.locmeu
+
+        m18 = (maxi(f7id, f7ie, f7if, f7ig) == max_(f7ie, f7if)) 
+        m20 = (maxi(f7ij, f7il, f7in, f7iv) == max_(f7il, f7in))         
+        report_invest_anterieur = (P.taux * max_(f7ik + f7ip, f7ir + f7iq) +
+            f7ia + f7ib + f7ic + 
+            f7jv + f7jw + f7jx + f7jy + 
+            f7oa + f7ob + f7oc + f7od + f7oe)
+        report_non_impute = (f7is + f7iu + f7ix + f7iy + f7pa +
+            f7it + f7ih + f7jc + f7pb +
+            f7iz + f7ji + f7pc +
+            f7js + f7pd +
+            f7pe)
+
+        return ((min_(P.max, maxi(f7ij, f7il, f7in, f7iv)) * (P.taux20 * m20 + P.taux18 * not_(m20)) + # to check : impossible de remplir à la fois f7ij et f7il par exemple ?
+                min_(P.max, maxi(f7id, f7ie, f7if, f7ig)) * (P.taux18 * m18 + P.taux11 * not_(m18)) +
+                P.taux11 * (min_(P.max, f7jt + f7ju) + min_(P.max, f7ou)) + 
+                P.taux * (min_(P.max, max_(f7im, f7iw)) + min_(P.max, f7io))
+                ) / 9 +
+                report_invest_anterieur + report_non_impute)
+
+    def formula_2015_01_01(self, simulation, period):
+        '''
+        Investissement en vue de la location meublée non professionnelle dans certains établissements ou résidences
+        2015
+        '''
+        f7ia = simulation.calculate('f7ia', period)
+        f7ib = simulation.calculate('f7ib', period)
+        f7ic = simulation.calculate('f7ic', period)
+        f7id = simulation.calculate('f7id', period)
+        f7ie = simulation.calculate('f7ie', period)
+        f7if = simulation.calculate('f7if', period)
+        f7ig = simulation.calculate('f7ig', period)
+        f7ih = simulation.calculate('f7ih', period)
+        f7ij = simulation.calculate('f7ij', period)
+        f7ik = simulation.calculate('f7ik', period)
+        f7il = simulation.calculate('f7il', period)
+        f7im = simulation.calculate('f7im', period)
+        f7in = simulation.calculate('f7in', period)
+        f7io = simulation.calculate('f7io', period)
+        f7ip = simulation.calculate('f7ip', period)
+        f7iq = simulation.calculate('f7iq', period)
+        f7ir = simulation.calculate('f7ir', period)
+        f7is = simulation.calculate('f7is', period)
+        f7it = simulation.calculate('f7it', period)
+        f7iu = simulation.calculate('f7iu', period)
+        f7iv = simulation.calculate('f7iv', period)
+        f7iw = simulation.calculate('f7iw', period)
+        f7ix = simulation.calculate('f7ix', period)
+        f7iy = simulation.calculate('f7iy', period)
+        f7iz = simulation.calculate('f7iz', period)
+        f7jc = simulation.calculate('f7jc', period)
+        f7ji = simulation.calculate('f7ji', period)
+        f7js = simulation.calculate('f7js', period)
+        f7jt = simulation.calculate('f7jt', period)
+        f7ju = simulation.calculate('f7ju', period)
+        f7jv = simulation.calculate('f7jv', period)
+        f7jw = simulation.calculate('f7jw', period)
+        f7jx = simulation.calculate('f7jx', period)
+        f7jy = simulation.calculate('f7jy', period)
+        f7oa = simulation.calculate('f7oa', period)
+        f7ob = simulation.calculate('f7ob', period)
+        f7oc = simulation.calculate('f7oc', period)
+        f7od = simulation.calculate('f7od', period)
+        f7oe = simulation.calculate('f7oe', period)
+        f7of = simulation.calculate('f7of', period)
+        f7og = simulation.calculate('f7og', period)
+        f7oh = simulation.calculate('f7oh', period)
+        f7oi = simulation.calculate('f7oi', period)
+        f7oj = simulation.calculate('f7oj', period)
+        f7ou = simulation.calculate('f7ou', period)
+        f7ov = simulation.calculate('f7ov', period)
+        f7pa = simulation.calculate('f7pa', period)
+        f7pb = simulation.calculate('f7pb', period)
+        f7pc = simulation.calculate('f7pc', period)
+        f7pd = simulation.calculate('f7pd', period)
+        f7pe = simulation.calculate('f7pe', period)
+        f7pf = simulation.calculate('f7pf', period)
+        f7pg = simulation.calculate('f7pg', period)
+        f7ph = simulation.calculate('f7ph', period)
+        f7pi = simulation.calculate('f7pi', period)
+        f7pj = simulation.calculate('f7pj', period)
+
+        P = simulation.parameters_at(period.start).impot_revenu.reductions_impots.locmeu
+
+        m18 = (maxi(f7id, f7ie, f7if, f7ig) == max_(f7ie, f7if)) 
+        m20 = (maxi(f7ij, f7il, f7in, f7iv) == max_(f7il, f7in))         
+        report_invest_anterieur = (P.taux * max_(f7ik + f7ip, f7ir + f7iq) +
+            f7ia + f7ib + f7ic + 
+            f7jv + f7jw + f7jx + f7jy + 
+            f7oa + f7ob + f7oc + f7od + f7oe + 
+            f7of + f7og + f7oh + f7oi + f7oj)
+        report_non_impute = (f7is + f7iu + f7ix + f7iy + f7pa + f7pf +
+            f7it + f7ih + f7jc + f7pb + f7pg +
+            f7iz + f7ji + f7pc + f7ph +
+            f7js + f7pd + f7pi +
+            f7pe + f7pj)
+
+        return ((min_(P.max, maxi(f7ij, f7il, f7in, f7iv)) * (P.taux20 * m20 + P.taux18 * not_(m20)) + # to check : impossible de remplir à la fois f7ij et f7il par exemple ?
+                min_(P.max, maxi(f7id, f7ie, f7if, f7ig)) * (P.taux18 * m18 + P.taux11 * not_(m18)) +
+                P.taux11 * (min_(P.max, f7jt + f7ju) + min_(P.max, f7ou) + min_(P.max, f7ov)) +
+                P.taux * (min_(P.max, max_(f7im, f7iw)) + min_(P.max, f7io))
+                ) / 9 +
+                report_invest_anterieur + report_non_impute)
+
+    def formula_2016_01_01(self, simulation, period):
+        '''
+        Investissement en vue de la location meublée non professionnelle dans certains établissements ou résidences
+        2016
+        '''
+        f7ia = simulation.calculate('f7ia', period)
+        f7ib = simulation.calculate('f7ib', period)
+        f7ic = simulation.calculate('f7ic', period)
+        f7id = simulation.calculate('f7id', period)
+        f7ie = simulation.calculate('f7ie', period)
+        f7if = simulation.calculate('f7if', period)
+        f7ig = simulation.calculate('f7ig', period)
+        f7ih = simulation.calculate('f7ih', period)
+        f7ij = simulation.calculate('f7ij', period)
+        f7ik = simulation.calculate('f7ik', period)
+        f7il = simulation.calculate('f7il', period)
+        f7im = simulation.calculate('f7im', period)
+        f7in = simulation.calculate('f7in', period)
+        f7ip = simulation.calculate('f7ip', period)
+        f7iq = simulation.calculate('f7iq', period)
+        f7ir = simulation.calculate('f7ir', period)
+        f7it = simulation.calculate('f7it', period)
+        f7iu = simulation.calculate('f7iu', period)
+        f7iv = simulation.calculate('f7iv', period)
+        f7iw = simulation.calculate('f7iw', period)
+        f7ix = simulation.calculate('f7ix', period)
+        f7iy = simulation.calculate('f7iy', period)
+        f7iz = simulation.calculate('f7iz', period)
+        f7jc = simulation.calculate('f7jc', period)
+        f7ji = simulation.calculate('f7ji', period)
+        f7js = simulation.calculate('f7js', period)
+        f7jt = simulation.calculate('f7jt', period)
+        f7ju = simulation.calculate('f7ju', period)
+        f7jv = simulation.calculate('f7jv', period)
+        f7jw = simulation.calculate('f7jw', period)
+        f7jx = simulation.calculate('f7jx', period)
+        f7jy = simulation.calculate('f7jy', period)
+        f7oa = simulation.calculate('f7oa', period)
+        f7ob = simulation.calculate('f7ob', period)
+        f7oc = simulation.calculate('f7oc', period)
+        f7od = simulation.calculate('f7od', period)
+        f7oe = simulation.calculate('f7oe', period)
+        f7of = simulation.calculate('f7of', period)
+        f7og = simulation.calculate('f7og', period)
+        f7oh = simulation.calculate('f7oh', period)
+        f7oi = simulation.calculate('f7oi', period)
+        f7oj = simulation.calculate('f7oj', period)
+        f7ok = simulation.calculate('f7ok', period)
+        f7ol = simulation.calculate('f7ol', period)
+        f7om = simulation.calculate('f7om', period)
+        f7on = simulation.calculate('f7on', period)
+        f7oo = simulation.calculate('f7oo', period)
+        f7ou = simulation.calculate('f7ou', period)
+        f7ov = simulation.calculate('f7ov', period)
+        f7ow = simulation.calculate('f7ow', period)
+        f7pa = simulation.calculate('f7pa', period)
+        f7pb = simulation.calculate('f7pb', period)
+        f7pc = simulation.calculate('f7pc', period)
+        f7pd = simulation.calculate('f7pd', period)
+        f7pe = simulation.calculate('f7pe', period)
+        f7pf = simulation.calculate('f7pf', period)
+        f7pg = simulation.calculate('f7pg', period)
+        f7ph = simulation.calculate('f7ph', period)
+        f7pi = simulation.calculate('f7pi', period)
+        f7pj = simulation.calculate('f7pj', period)
+        f7pk = simulation.calculate('f7pk', period)
+        f7pl = simulation.calculate('f7pl', period)
+        f7pm = simulation.calculate('f7pm', period)
+        f7pn = simulation.calculate('f7pn', period)
+        f7po = simulation.calculate('f7po', period)
+
+        P = simulation.parameters_at(period.start).impot_revenu.reductions_impots.locmeu
+
+        m18 = (maxi(f7id, f7ie, f7if, f7ig) == max_(f7ie, f7if)) 
+        m20 = (maxi(f7ij, f7il, f7in, f7iv) == max_(f7il, f7in))         
+        report_invest_anterieur = (P.taux * max_(f7ik + f7ip, f7ir + f7iq) +
+            f7ia + f7ib + f7ic + 
+            f7jv + f7jw + f7jx + f7jy + 
+            f7oa + f7ob + f7oc + f7od + f7oe + 
+            f7of + f7og + f7oh + f7oi + f7oj +
+            f7ok + f7ol + f7om + f7on + f7oo)
+        report_non_impute = (f7iu + f7ix + f7iy + f7pa + f7pf + f7pk +
+            f7it + f7ih + f7jc + f7pb + f7pg + f7pl +
+            f7iz + f7ji + f7pc + f7ph + f7pm +
+            f7js + f7pd + f7pi + f7pn +
+            f7pe + f7pj + f7po)
+
+        return ((min_(P.max, maxi(f7ij, f7il, f7in, f7iv)) * (P.taux20 * m20 + P.taux18 * not_(m20)) + # to check : impossible de remplir à la fois f7ij et f7il par exemple ?
+                min_(P.max, maxi(f7id, f7ie, f7if, f7ig)) * (P.taux18 * m18 + P.taux11 * not_(m18)) +
+                P.taux11 * (min_(P.max, f7jt + f7ju) + min_(P.max, f7ou) + min_(P.max, f7ov) + min_(P.max, f7ow)) +
+                P.taux * (min_(P.max, max_(f7im, f7iw)))
+                ) / 9 +
+                report_invest_anterieur + report_non_impute)
 
 class mohist(Variable):
     value_type = float

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -1836,12 +1836,14 @@ class invfor(Variable):
 
         max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
         max1 = max_(0, max0 - f7uu - f7te - f7uv - f7tf)
-        return (P.taux * (
-            min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
-            min_(f7up, max1) +
-            min_(f7uq, P.iforges_seuil * (maries_ou_pacses + 1))) +
-            P.report10 * min_(f7uu + f7te + f7uv + f7tf, max0) +
-            P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)))
+        return (
+            P.taux * (
+                min_(f7un, P.seuil * (maries_ou_pacses + 1))
+                + min_(f7up, max1)
+                + min_(f7uq, P.iforges_seuil * (maries_ou_pacses + 1)))
+            + P.report10 * min_(f7uu + f7te + f7uv + f7tf, max0)
+            + P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1))
+            )
 
     def formula_2012_01_01(foyer_fiscal, period, parameters):
         '''
@@ -1863,13 +1865,15 @@ class invfor(Variable):
         max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
         max1 = max_(0, max0 - f7uu - f7te - f7uv - f7tf)
         max2 = max_(0, max1 - f7tg - f7uw)
-        return (P.taux * (
-            min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
-            min_(f7up, max2) +
-            min_(f7uq, P.iforges_seuil * (maries_ou_pacses + 1))) +
-            P.report10 * min_(f7uu + f7te + f7uv + f7tf, max0) +
-            P.report11 * min_(f7tg + f7uw, max1) +
-            P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)))
+        return (
+            P.taux * (
+                min_(f7un, P.seuil * (maries_ou_pacses + 1))
+                + min_(f7up, max2)
+                + min_(f7uq, P.iforges_seuil * (maries_ou_pacses + 1)))
+            + P.report10 * min_(f7uu + f7te + f7uv + f7tf, max0) +
+            + P.report11 * min_(f7tg + f7uw, max1) +
+            + P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1))
+            )
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         '''
@@ -1894,14 +1898,16 @@ class invfor(Variable):
         max1 = max_(0, max0 - f7uu - f7te - f7uv - f7tf)
         max2 = max_(0, max1 - f7tg - f7uw)
         max3 = max_(0, max2 - f7th - f7ux)
-        return (P.taux * (
-            min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
-            min_(f7up, max3) +
-            min_(f7uq, P.iforges_seuil * (maries_ou_pacses + 1))) +
-            P.report10 * min_(f7uu + f7te + f7uv + f7tf, max0) +
-            P.report11 * min_(f7tg + f7uw, max1) +
-            P.report12 * min_(f7th + f7ux, max2) +
-            P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)))
+        return (
+            P.taux * (
+                min_(f7un, P.seuil * (maries_ou_pacses + 1))
+                + min_(f7up, max3)
+                + min_(f7uq, P.iforges_seuil * (maries_ou_pacses + 1))) 
+            + P.report10 * min_(f7uu + f7te + f7uv + f7tf, max0)
+            + P.report11 * min_(f7tg + f7uw, max1)
+            + P.report12 * min_(f7th + f7ux, max2)
+            + P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1))
+            )
 
     def formula_2014_01_01(foyer_fiscal, period, parameters):
         '''
@@ -1925,11 +1931,13 @@ class invfor(Variable):
         max1 = max_(0, max0 - f7uu - f7te - f7tf)
         max2 = max_(0, max1 - f7tg - f7uv)
         max3 = max_(0, max2 - f7th - f7uw - f7ux - f7ti)
-        return (P.taux * min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
-            P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)) +
-            P.report10 * min_(f7uu + f7te + f7tf, max0) +
-            P.report11 * min_(f7tg + f7uv, max1) +
-            P.report12 * min_(f7th + f7uw + f7ux + f7ti, max2))
+        return (
+            P.taux * min_(f7un, P.seuil * (maries_ou_pacses + 1))
+            + P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1))
+            + P.report10 * min_(f7uu + f7te + f7tf, max0)
+            + P.report11 * min_(f7tg + f7uv, max1)
+            + P.report12 * min_(f7th + f7uw + f7ux + f7ti, max2)
+            )
 
     def formula_2015_01_01(foyer_fiscal, period, parameters):
         '''
@@ -1952,11 +1960,12 @@ class invfor(Variable):
         max1 = max_(0, max0 - f7te - f7tf)
         max2 = max_(0, max1 - f7tg - f7uu)
         max3 = max_(0, max2 - f7th - f7uv - f7uw - f7ti)
-        return (P.taux * min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
-            P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)) +
-            P.report10 * min_(f7te + f7tf, max0) +
-            P.report11 * min_(f7tg + f7uu, max1) +
-            P.report12 * min_(f7th + f7uv + f7uw + f7ti, max2))
+        return (
+            P.taux * min_(f7un, P.seuil * (maries_ou_pacses + 1))
+            + P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1))
+            + P.report10 * min_(f7te + f7tf, max0)
+            + P.report11 * min_(f7tg + f7uu, max1)
+            + P.report12 * min_(f7th + f7uv + f7uw + f7ti, max2))
 
     def formula_2016_01_01(foyer_fiscal, period, parameters):
         '''
@@ -1978,11 +1987,13 @@ class invfor(Variable):
         max1 = max_(0, max0 - f7te - f7tf)
         max2 = max_(0, max1 - f7tg)
         max3 = max_(0, max2 - f7th - f7uu - f7uv - f7ti)
-        return (P.taux * min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
-            P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)) +
-            P.report10 * min_(f7te + f7tf, max0) +
-            P.report11 * min_(f7tg, max1) +
-            P.report12 * min_(f7th + f7uu + f7uv + f7ti, max2))
+        return (
+            P.taux * min_(f7un, P.seuil * (maries_ou_pacses + 1))
+            + P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1))
+            + P.report10 * min_(f7te + f7tf, max0)
+            + P.report11 * min_(f7tg, max1)
+            + P.report12 * min_(f7th + f7uu + f7uv + f7ti, max2)
+            )
 
 
 class invlst(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -1768,7 +1768,7 @@ class invfor(Variable):
     label = u"Réduction d'impôt au titre des investissements forestiers"
     reference = "http://bofip.impots.gouv.fr/bofip/5537-PGP"
     definition_period = YEAR
-    end = '2013-12-31'
+    end = '2016-12-31'
 
 
     def formula_2002_01_01(foyer_fiscal, period, parameters):
@@ -1904,6 +1904,90 @@ class invfor(Variable):
             P.report11 * min_(f7tg + f7uw, max1) +
             P.report12 * min_(f7th + f7ux, max2) +
             P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)))
+
+    def formula_2014_01_01(self, simulation, period):
+        '''
+        Investissements forestiers pour 2014 cf. 2041 GK
+        '''
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
+        f7te = simulation.calculate('f7te', period)
+        f7tf = simulation.calculate('f7tf', period)
+        f7tg = simulation.calculate('f7tg', period)
+        f7th = simulation.calculate('f7th', period)
+        f7ti = simulation.calculate('f7ti', period)
+        f7ul = simulation.calculate('f7ul', period)
+        f7un = simulation.calculate('f7un', period)
+        f7uu = simulation.calculate('f7uu', period)
+        f7uv = simulation.calculate('f7uv', period)
+        f7uw = simulation.calculate('f7uw', period)
+        f7ux = simulation.calculate('f7ux', period)
+        _P = simulation.parameters_at(period.start)
+        P = simulation.parameters_at(period.start).impot_revenu.reductions_impots.invfor
+
+        max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
+        max1 = max_(0, max0 - f7uu - f7te - f7tf)
+        max2 = max_(0, max1 - f7tg - f7uv)
+        max3 = max_(0, max2 - f7th - f7uw - f7ux - f7ti)
+        return (P.taux * min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
+            P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)) +
+            P.report10 * min_(f7uu + f7te + f7tf, max0) +
+            P.report11 * min_(f7tg + f7uv, max1) +
+            P.report12 * min_(f7th + f7uw + f7ux + f7ti, max2))
+
+    def formula_2015_01_01(self, simulation, period):
+        '''
+        Investissements forestiers pour 2015 cf. 2041 GK
+        '''
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
+        f7te = simulation.calculate('f7te', period)
+        f7tf = simulation.calculate('f7tf', period)
+        f7tg = simulation.calculate('f7tg', period)
+        f7th = simulation.calculate('f7th', period)
+        f7ti = simulation.calculate('f7ti', period)
+        f7ul = simulation.calculate('f7ul', period)
+        f7un = simulation.calculate('f7un', period)
+        f7uu = simulation.calculate('f7uu', period)
+        f7uv = simulation.calculate('f7uv', period)
+        f7uw = simulation.calculate('f7uw', period)
+        _P = simulation.parameters_at(period.start)
+        P = simulation.parameters_at(period.start).impot_revenu.reductions_impots.invfor
+
+        max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
+        max1 = max_(0, max0 - f7te - f7tf)
+        max2 = max_(0, max1 - f7tg - f7uu)
+        max3 = max_(0, max2 - f7th - f7uv - f7uw - f7ti)
+        return (P.taux * min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
+            P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)) +
+            P.report10 * min_(f7te + f7tf, max0) +
+            P.report11 * min_(f7tg + f7uu, max1) +
+            P.report12 * min_(f7th + f7uv + f7uw + f7ti, max2))
+
+    def formula_2016_01_01(self, simulation, period):
+        '''
+        Investissements forestiers pour 2016 cf. 2041 GK
+        '''
+        maries_ou_pacses = simulation.calculate('maries_ou_pacses', period)
+        f7te = simulation.calculate('f7te', period)
+        f7tf = simulation.calculate('f7tf', period)
+        f7tg = simulation.calculate('f7tg', period)
+        f7th = simulation.calculate('f7th', period)
+        f7ti = simulation.calculate('f7ti', period)
+        f7ul = simulation.calculate('f7ul', period)
+        f7un = simulation.calculate('f7un', period)
+        f7uu = simulation.calculate('f7uu', period)
+        f7uv = simulation.calculate('f7uv', period)
+        _P = simulation.parameters_at(period.start)
+        P = simulation.parameters_at(period.start).impot_revenu.reductions_impots.invfor
+
+        max0 = max_(0, P.ifortra_seuil * (maries_ou_pacses + 1) - f7ul)
+        max1 = max_(0, max0 - f7te - f7tf)
+        max2 = max_(0, max1 - f7tg)
+        max3 = max_(0, max2 - f7th - f7uu - f7uv - f7ti)
+        return (P.taux * min_(f7un, P.seuil * (maries_ou_pacses + 1)) +
+            P.taux_ass * min_(f7ul, P.ifortra_seuil * (maries_ou_pacses + 1)) +
+            P.report10 * min_(f7te + f7tf, max0) +
+            P.report11 * min_(f7tg, max1) +
+            P.report12 * min_(f7th + f7uu + f7uv + f7ti, max2))
 
 
 class invlst(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -2884,8 +2884,27 @@ class resimm(Variable):
         max3 = max_(max2 - f7rb, 0)
         max4 = max_(max3 - f7rc - f7sy - f7rf, 0)
         max5 = max_(max4 - f7ra, 0)
-        return (P.taux_rd * min_(f7rd, max1) + P.taux_rb * min_(f7rb, max2) + P.taux_rc * min_(f7sy + f7rf + f7rc, max3) 
-            + P.taux_ra * min_(f7ra, max4) + P.taux_re * min_(f7re + f7sx, max5))
+        return (P.taux_rd * min_(f7rd, max1) + P.taux_rb * min_(f7rb, max2) + P.taux_rc * min_(f7sy + f7rf + f7rc, max3) +
+                P.taux_ra * min_(f7ra, max4) + P.taux_re * min_(f7re + f7sx, max5))
+
+    def formula_2016_01_01(self, simulation, period):
+        '''
+        Travaux de restauration immobilière
+        2016
+        '''
+        f7nx = simulation.calculate('f7nx', period)
+        f7ny = simulation.calculate('f7ny', period)
+        f7re = simulation.calculate('f7re', period)
+        f7rf = simulation.calculate('f7rf', period)
+        f7sx = simulation.calculate('f7sx', period)
+        f7sy = simulation.calculate('f7sy', period)
+        P = simulation.parameters_at(period.start).impot_revenu.reductions_impots.resimm
+
+        max1 = P.max
+        max2 = max_(max1 - f7nx - f7sy - f7rf, 0)
+        return (P.taux_rc * min_(f7sy + f7rf + f7nx, max1) +
+                 P.taux_re * min_(f7re + f7sx + f7ny, max2))
+
 
     def formula_2016_01_01(foyer_fiscal, period, parameters):
         '''

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -2286,7 +2286,7 @@ class f7ui(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    end = '2008-12-31'
+    # end = '2008-12-31'
     definition_period = YEAR
 
 
@@ -3129,6 +3129,23 @@ class f7vm(Variable):
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
+class f7vn(Variable):
+    cerfa_field = u"7VN"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements forestiers"
+#    start_date = date(2016, 1, 1)
+    definition_period = YEAR
+
+class f7vp(Variable):
+    cerfa_field = u"7VP"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements forestiers"
+#    start_date = date(2016, 1, 1)
+    definition_period = YEAR
 
 class f7tg(Variable):
     cerfa_field = u"7TG"

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -2281,12 +2281,22 @@ class f7uc(Variable):
     definition_period = YEAR
 
 
+class f7ui_2008(Variable):
+    cerfa_field = u"7UI"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    end = '2008-12-31'
+    definition_period = YEAR
+
+
 class f7ui(Variable):
     cerfa_field = u"7UI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    # end = '2008-12-31' changes meaning in 2014
+    label = u"Investissements forestiers : contrat de gestion avec adhésion à une organisation de producteurs "
+#    start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -3117,7 +3117,7 @@ class f7to(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report 2015, après sinistre, avec adhésion à une association de producteurs
+    label = u"Investissements forestiers : report 2015, après sinistre, avec adhésion à une association de producteurs"
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -4649,10 +4649,6 @@ class f7oj(Variable):
 #    start_date = date(2015, 1, 1)
     definition_period = YEAR
 
-<<<<<<< HEAD
-
-=======
->>>>>>> Update formula, parameters and variables for tax reduction 'locmeu' for years 2014-2016
 class f7jc(Variable):
     cerfa_field = u"7JC"
     value_type = int

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -4153,7 +4153,10 @@ class f7yu(Variable):
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
+class f7yo(Variable):
     cerfa_field = u"7YO"
+    value_type = int
+    entity = FoyerFiscal
     label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2010 ou réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2014 en métropole et dans les DOM-COM"
 #    start_date = date(2015, 1, 1)
     definition_period = YEAR

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -3346,6 +3346,15 @@ class f7lj(Variable):
 #    start_date = date(2015, 1, 1)
     definition_period = YEAR
 
+class f7lp(Variable):
+    cerfa_field = u"7LP"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés en 2012 et achevés de 2012 à 2015 : report du solde de réduction d'impôt de l'année 2015"
+#    start_date = date(2016, 1, 1)
+    definition_period = YEAR
+
 
 class f7lp(Variable):
     cerfa_field = u"7LP"
@@ -4041,7 +4050,6 @@ class f7ym(Variable):
 #    start_date = date(2015, 1, 1)
     definition_period = YEAR
 
-
 class f7yt(Variable):
     cerfa_field = u"7YT"
     value_type = int
@@ -4049,7 +4057,6 @@ class f7yt(Variable):
     label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2012 ou réalisés du 1.1.2013 au 31.3.2013 avec promesse d'achat en 2012 et achevés en 2015 en métropole et dans les DOM-COM"
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
-
 
 class f7yn(Variable):
     cerfa_field = u"7YN"
@@ -4059,7 +4066,6 @@ class f7yn(Variable):
 #    start_date = date(2015, 1, 1)
     definition_period = YEAR
 
-
 class f7yu(Variable):
     cerfa_field = u"7YU"
     value_type = int
@@ -4068,15 +4074,10 @@ class f7yu(Variable):
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
-
-class f7yo(Variable):
     cerfa_field = u"7YO"
-    value_type = int
-    entity = FoyerFiscal
     label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2010 ou réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2014 en métropole et dans les DOM-COM"
 #    start_date = date(2015, 1, 1)
     definition_period = YEAR
-
 
 class f7yv(Variable):
     cerfa_field = u"7YV"
@@ -4086,7 +4087,6 @@ class f7yv(Variable):
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
-
 class f7yp(Variable):
     cerfa_field = u"7YP"
     value_type = int
@@ -4094,7 +4094,6 @@ class f7yp(Variable):
     label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2009 ou réalisés en 2010 avec promesse d'achat en 2010 et achevés en 2014 en métropole et dans les DOM-COM"
 #    start_date = date(2015, 1, 1)
     definition_period = YEAR
-
 
 class f7yw(Variable):
     cerfa_field = u"7YW"
@@ -4104,7 +4103,6 @@ class f7yw(Variable):
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
-
 class f7yq(Variable):
     cerfa_field = u"7YQ"
     value_type = int
@@ -4112,7 +4110,6 @@ class f7yq(Variable):
     label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2012 ou réalisés du 1.1.2013 au 31.3.2013 avec promesse d'achat en 2012 et achevés en 2014 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
 #    start_date = date(2015, 1, 1)
     definition_period = YEAR
-
 
 class f7yx(Variable):
     cerfa_field = u"7YX"
@@ -4122,7 +4119,6 @@ class f7yx(Variable):
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
-
 class f7yr(Variable):
     cerfa_field = u"7YR"
     value_type = int
@@ -4130,7 +4126,6 @@ class f7yr(Variable):
     label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2014 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
 #    start_date = date(2015, 1, 1)
     definition_period = YEAR
-
 
 class f7yy(Variable):
     cerfa_field = u"7YY"
@@ -4140,13 +4135,20 @@ class f7yy(Variable):
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
-
 class f7ys(Variable):
     cerfa_field = u"7YS"
     value_type = int
     entity = FoyerFiscal
     label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2014 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
 #    start_date = date(2015, 1, 1)
+    definition_period = YEAR
+
+class f7yz(Variable):
+    cerfa_field = u"7YZ"
+    value_type = int
+    entity = FoyerFiscal
+    label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2015 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
+#    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -2286,7 +2286,7 @@ class f7ui(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    # end = '2008-12-31'
+    # end = '2008-12-31' changes meaning in 2014
     definition_period = YEAR
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -929,7 +929,7 @@ class f7pc_2011(Variable):
     unit = 'currency'
     entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
-    end = '2011-12-31'
+    # end = '2011-12-31' changes meaning in 2014
     definition_period = YEAR
 
 
@@ -4570,7 +4570,10 @@ class f7oj(Variable):
 #    start_date = date(2015, 1, 1)
     definition_period = YEAR
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> Update formula, parameters and variables for tax reduction 'locmeu' for years 2014-2016
 class f7jc(Variable):
     cerfa_field = u"7JC"
     value_type = int

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -3013,7 +3013,7 @@ class f7un(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers: acquisition"
+    label = u"Investissements forestiers: frais d'acquisition"
     definition_period = YEAR
 
 
@@ -3022,7 +3022,7 @@ class f7ul(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : frais d'assurance"
 #    start_date = date(2011, 1, 1)
     definition_period = YEAR
 
@@ -3032,7 +3032,7 @@ class f7uu(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report N-4, hors sinistre"
 #    start_date = date(2010, 1, 1)
     definition_period = YEAR
 
@@ -3042,7 +3042,7 @@ class f7uv(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report N-3, hors sinistre"
 #    start_date = date(2011, 1, 1)
     definition_period = YEAR
 
@@ -3052,7 +3052,7 @@ class f7uw(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report N-2, hors sinistre"
 #    start_date = date(2012, 1, 1)
     definition_period = YEAR
 
@@ -3062,7 +3062,7 @@ class f7th(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report N-3, après sinistre"
 #    start_date = date(2013, 1, 1)
     definition_period = YEAR
 
@@ -3071,7 +3071,7 @@ class f7ti(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report N-2, après sinistre"
 #    start_date = date(2014, 1, 1)
     definition_period = YEAR
 
@@ -3080,7 +3080,7 @@ class f7tj(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report N-1, après sinistre"
 #    start_date = date(2015, 1, 1)
     definition_period = YEAR
 
@@ -3089,7 +3089,7 @@ class f7tk(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report N-1, après sinistre,  avec adhésion à une organisation de producteurs"
 #    start_date = date(2015, 1, 1)
     definition_period = YEAR
 
@@ -3098,7 +3098,7 @@ class f7tm(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report 2015, après sinistre"
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
@@ -3107,7 +3107,7 @@ class f7to(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report 2015, après sinistre, avec adhésion à une association de producteurs""
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
@@ -3116,7 +3116,7 @@ class f7ux(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report N-1, hors sinistre"
 #    start_date = date(2013, 1, 1)
     definition_period = YEAR
 
@@ -3125,7 +3125,7 @@ class f7vm(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report 2015, hors sinistre"
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
@@ -3134,7 +3134,7 @@ class f7vn(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report 2015, hors sinistre, avec adhésion à une association de producteurs""
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
@@ -3143,7 +3143,7 @@ class f7vp(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report 2014, hors sinistre, avec adhésion à une association de producteurs"
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
@@ -3152,7 +3152,7 @@ class f7tg(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report 2011, après sinistre"
 #    start_date = date(2012, 1, 1)
     definition_period = YEAR
 
@@ -3162,9 +3162,8 @@ class f7tf(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : report 2010, après sinistre"
 #    start_date = date(2011, 1, 1)
-#    end = '2013-12-31'
     definition_period = YEAR
 
 
@@ -3173,7 +3172,7 @@ class f7ut(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers"
+    label = u"Investissements forestiers : indicatrice travaux consécutifs à un sinistre"
 #    start_date = date(2009, 1, 1)
     definition_period = YEAR
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -3066,6 +3066,50 @@ class f7th(Variable):
 #    start_date = date(2013, 1, 1)
     definition_period = YEAR
 
+class f7ti(Variable):
+    cerfa_field = u"7TI"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements forestiers"
+#    start_date = date(2014, 1, 1)
+    definition_period = YEAR
+
+class f7tj(Variable):
+    cerfa_field = u"7TJ"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements forestiers"
+#    start_date = date(2015, 1, 1)
+    definition_period = YEAR
+
+class f7tk(Variable):
+    cerfa_field = u"7TK"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements forestiers"
+#    start_date = date(2015, 1, 1)
+    definition_period = YEAR
+
+class f7tm(Variable):
+    cerfa_field = u"7TM"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements forestiers"
+#    start_date = date(2016, 1, 1)
+    definition_period = YEAR
+
+class f7to(Variable):
+    cerfa_field = u"7TO"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements forestiers"
+#    start_date = date(2016, 1, 1)
+    definition_period = YEAR
 
 class f7ux(Variable):
     cerfa_field = u"7UX"
@@ -3074,6 +3118,15 @@ class f7ux(Variable):
     entity = FoyerFiscal
     label = u"Investissements forestiers"
 #    start_date = date(2013, 1, 1)
+    definition_period = YEAR
+
+class f7vm(Variable):
+    cerfa_field = u"7VM"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements forestiers"
+#    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -3117,7 +3117,7 @@ class f7to(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report 2015, après sinistre, avec adhésion à une association de producteurs""
+    label = u"Investissements forestiers : report 2015, après sinistre, avec adhésion à une association de producteurs
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 
@@ -3144,7 +3144,7 @@ class f7vn(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report 2015, hors sinistre, avec adhésion à une association de producteurs""
+    label = u"Investissements forestiers : report 2015, hors sinistre, avec adhésion à une association de producteurs
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -3144,7 +3144,7 @@ class f7vn(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report 2015, hors sinistre, avec adhésion à une association de producteurs
+    label = u"Investissements forestiers : report 2015, hors sinistre, avec adhésion à une association de producteurs"
 #    start_date = date(2016, 1, 1)
     definition_period = YEAR
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '20.7.0',
+    version = '20.8.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Les modifications de cette PR sont comparées à la branche `ipp-update-tax-reductions_immobiliers` (https://github.com/openfisca/openfisca-france/pull/910)

* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2002
* Zones impactées : 
- `openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impots.py`.
- `openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py`

* Détails :
   - Mise à jour des formules (2014-2016) de la réduction d'impôt 'invfor' 
   - Correction d'une erreur dans la formule précédente : les reports de dépenses entrent dans le plafonnement de la réduction
   - TODO : une partie de la réduction d'impôt pour investissement forestier devient un crédit d'impôt en 2014 (Brochure Pratique IR revenus 2014, page 36)
- - - -

Ces changements :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.