### PR TITLE
Ipp 13 : Update des crédits/réductions d'impôt restants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 21.8.0 [#919](https://github.com/openfisca/openfisca-france/pull/919)
+
+* Evolution du système socio-fiscal
+* Périodes concernées : toutes
+* Zones impactées :
+  - `prelevements_obligatoires/impot_revenu/credits_impot`
+  - `prelevements_obligatoires/impot_revenu/reductions_impot`
+  - `revenus/autres`
+* Détails :
+  - Les avantages fiscaux pour mécénat d'entreprises (depuis 2003) et pour acquisition de biens culturels (depuis 2002) sont définies comme des réductions d'impôt et non plus des crédits d'impôt
+  - Mise à jour de 'creimp' pour 2014-2016, et correction d'une petite erreur pour 2012
+
 ### 21.7.0 [#918](https://github.com/openfisca/openfisca-france/pull/918)
 
 * Correction du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -19,18 +19,16 @@ class credits_impot(Variable):
 
     def formula_2002_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2002 """
-        accult = foyer_fiscal('accult', period)
         acqgpl = foyer_fiscal('acqgpl', period)
         aidper = foyer_fiscal('aidper', period)
         creimp = foyer_fiscal('creimp', period)
         drbail = foyer_fiscal('drbail', period)
         prlire = foyer_fiscal('prlire', period)
 
-        return accult + acqgpl + aidper + creimp + drbail + prlire
+        return acqgpl + aidper + creimp + drbail + prlire
 
     def formula_2003_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2003 et 2004 """
-        accult = foyer_fiscal('accult', period)
         acqgpl = foyer_fiscal('acqgpl', period)
         aidper = foyer_fiscal('aidper', period)
         creimp = foyer_fiscal('creimp', period)
@@ -41,7 +39,6 @@ class credits_impot(Variable):
 
     def formula_2005_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2005 et 2006 """
-        accult = foyer_fiscal('accult', period)
         acqgpl = foyer_fiscal('acqgpl', period)
         aidmob = foyer_fiscal('aidmob', period)
         aidper = foyer_fiscal('aidper', period)
@@ -61,7 +58,6 @@ class credits_impot(Variable):
 
     def formula_2007_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2007 """
-        accult = foyer_fiscal('accult', period)
         acqgpl = foyer_fiscal('acqgpl', period)
         aidmob = foyer_fiscal('aidmob', period)
         aidper = foyer_fiscal('aidper', period)
@@ -83,7 +79,6 @@ class credits_impot(Variable):
 
     def formula_2008_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2008 """
-        accult = foyer_fiscal('accult', period)
         aidmob = foyer_fiscal('aidmob', period)
         aidper = foyer_fiscal('aidper', period)
         assloy = foyer_fiscal('assloy', period)
@@ -105,7 +100,6 @@ class credits_impot(Variable):
 
     def formula_2009_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2009 """
-        accult = foyer_fiscal('accult', period)
         aidper = foyer_fiscal('aidper', period)
         assloy = foyer_fiscal('assloy', period)
         ci_garext = foyer_fiscal('ci_garext', period)
@@ -124,7 +118,6 @@ class credits_impot(Variable):
 
     def formula_2010_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2010 """
-        accult = foyer_fiscal('accult', period)
         aidper = foyer_fiscal('aidper', period)
         assloy = foyer_fiscal('assloy', period)
         autent = foyer_fiscal('autent', period)
@@ -145,7 +138,6 @@ class credits_impot(Variable):
 
     def formula_2011_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2011 """
-        accult = foyer_fiscal('accult', period)
         aidper = foyer_fiscal('aidper', period)
         assloy = foyer_fiscal('assloy', period)
         autent = foyer_fiscal('autent', period)
@@ -164,7 +156,6 @@ class credits_impot(Variable):
 
     def formula_2012_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2012 """
-        accult = foyer_fiscal('accult', period)
         aidper = foyer_fiscal('aidper', period)
         assloy = foyer_fiscal('assloy', period)
         autent = foyer_fiscal('autent', period)
@@ -184,7 +175,6 @@ class credits_impot(Variable):
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt crédités l'impôt sur les revenus de 2013 """
-        accult = foyer_fiscal('accult', period)
         aidper = foyer_fiscal('aidper', period)
         assloy = foyer_fiscal('assloy', period)
         autent = foyer_fiscal('autent', period)
@@ -204,7 +194,6 @@ class credits_impot(Variable):
 
     def formula_2014_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt crédités l'impôt sur les revenus de 2014 et + (non vérifié)"""
-        accult = foyer_fiscal('accult', period)
         aidper = foyer_fiscal('aidper', period)
         assloy = foyer_fiscal('assloy', period)
         autent = foyer_fiscal('autent', period)
@@ -236,24 +225,6 @@ class nb_pac2(Variable):
         nbH = foyer_fiscal('nbH', period)
 
         return nbF + nbJ + nbpac_invalideR - nbH / 2
-
-
-class accult(Variable):
-    value_type = float
-    entity = FoyerFiscal
-    label = u"Acquisition de biens culturels"
-    reference = "http://bofip.impots.gouv.fr/bofip/5741-PGP"
-    definition_period = YEAR
-
-    def formula_2002(foyer_fiscal, period, parameters):
-        '''
-        Acquisition de biens culturels (case 7UO)
-        2002-
-        '''
-        f7uo = foyer_fiscal('f7uo', period)
-        P = parameters(period).impot_revenu.credits_impot.accult
-
-        return P.taux * f7uo
 
 
 class acqgpl(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -748,6 +748,7 @@ class creimp(Variable):
         f8uz = foyer_fiscal('f8uz', period)
         f8wa = foyer_fiscal('f8wa', period)
         f8wb = foyer_fiscal('f8wb', period)
+        f8wc = foyer_fiscal('f8wc', period)
         f8wd = foyer_fiscal('f8wd', period)
         f8we = foyer_fiscal('f8we', period)
         f8wr = foyer_fiscal('f8wr', period)
@@ -756,7 +757,7 @@ class creimp(Variable):
         f8wv = foyer_fiscal('f8wv', period)
 
         return (f2ab + f8ta + f8tb + f8tc +f8te - f8tf + f8tg + f8th + f8to - f8tp + f8ts + f8tz + f8uz + f8wa + f8wb +
-                f8wd + f8we + f8wr + f8wt + f8wu + f8wv)
+                f8wc + f8wd + f8we + f8wr + f8wt + f8wu + f8wv)
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         f2ab = foyer_fiscal('f2ab', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -35,10 +35,9 @@ class credits_impot(Variable):
         aidper = foyer_fiscal('aidper', period)
         creimp = foyer_fiscal('creimp', period)
         drbail = foyer_fiscal('drbail', period)
-        mecena = foyer_fiscal('mecena', period)
         prlire = foyer_fiscal('prlire', period)
 
-        return accult + acqgpl + aidper + creimp + drbail + mecena + prlire
+        return acqgpl + aidper + creimp + drbail + prlire
 
     def formula_2005_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2005 et 2006 """
@@ -53,13 +52,12 @@ class credits_impot(Variable):
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
         jeunes = foyer_fiscal('jeunes', period)
-        mecena = foyer_fiscal('mecena', period)
         preetu = foyer_fiscal('preetu', period)
         prlire = foyer_fiscal('prlire', period)
         quaenv = foyer_fiscal('quaenv', period)
 
-        return (accult + acqgpl + aidmob + aidper + assloy + ci_garext + creimp + divide + direpa + drbail + jeunes +
-                mecena + preetu + prlire + quaenv)
+        return (acqgpl + aidmob + aidper + assloy + ci_garext + creimp + divide + direpa + drbail + jeunes +
+                preetu + prlire + quaenv)
 
     def formula_2007_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2007 """
@@ -75,14 +73,13 @@ class credits_impot(Variable):
         drbail = foyer_fiscal('drbail', period)
         inthab = foyer_fiscal('inthab', period)
         jeunes = foyer_fiscal('jeunes', period)
-        mecena = foyer_fiscal('mecena', period)
         preetu = foyer_fiscal('preetu', period)
         prlire = foyer_fiscal('prlire', period)
         quaenv = foyer_fiscal('quaenv', period)
         saldom2 = foyer_fiscal('saldom2', period)
 
-        return (accult + acqgpl + aidmob + aidper + assloy + ci_garext + creimp + divide + direpa + drbail + inthab +
-                jeunes + mecena + preetu + prlire + quaenv + saldom2)
+        return (acqgpl + aidmob + aidper + assloy + ci_garext + creimp + divide + direpa + drbail + inthab +
+                jeunes + preetu + prlire + quaenv + saldom2)
 
     def formula_2008_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2008 """
@@ -98,14 +95,13 @@ class credits_impot(Variable):
         drbail = foyer_fiscal('drbail', period)
         inthab = foyer_fiscal('inthab', period)
         jeunes = foyer_fiscal('jeunes', period)
-        mecena = foyer_fiscal('mecena', period)
         preetu = foyer_fiscal('preetu', period)
         prlire = foyer_fiscal('prlire', period)
         quaenv = foyer_fiscal('quaenv', period)
         saldom2 = foyer_fiscal('saldom2', period)
 
-        return (accult + aidmob + aidper + assloy + ci_garext + creimp + creimp_exc_2008 + divide + direpa + drbail +
-                inthab + jeunes + mecena + preetu + prlire + quaenv + saldom2)
+        return (aidmob + aidper + assloy + ci_garext + creimp + creimp_exc_2008 + divide + direpa + drbail +
+                inthab + jeunes + preetu + prlire + quaenv + saldom2)
 
     def formula_2009_01_01(foyer_fiscal, period, parameters):
         """ Crédits d'impôt pour l'impôt sur les revenus de 2009 """
@@ -118,13 +114,12 @@ class credits_impot(Variable):
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
         inthab = foyer_fiscal('inthab', period)
-        mecena = foyer_fiscal('mecena', period)
         preetu = foyer_fiscal('preetu', period)
         prlire = foyer_fiscal('prlire', period)
         quaenv = foyer_fiscal('quaenv', period)
         saldom2 = foyer_fiscal('saldom2', period)
 
-        return (accult + aidper + assloy + ci_garext + creimp + divide + direpa + drbail + inthab + mecena + preetu +
+        return (aidper + assloy + ci_garext + creimp + divide + direpa + drbail + inthab + preetu +
                 prlire + quaenv + saldom2)
 
     def formula_2010_01_01(foyer_fiscal, period, parameters):
@@ -139,14 +134,13 @@ class credits_impot(Variable):
         drbail = foyer_fiscal('drbail', period)
         inthab = foyer_fiscal('inthab', period)
         jeunes = foyer_fiscal('jeunes', period)
-        mecena = foyer_fiscal('mecena', period)
         percvm = foyer_fiscal('percvm', period)
         preetu = foyer_fiscal('preetu', period)
         prlire = foyer_fiscal('prlire', period)
         quaenv = foyer_fiscal('quaenv', period)
         saldom2 = foyer_fiscal('saldom2', period)
 
-        return (accult + aidper + assloy + autent + ci_garext + creimp + direpa + drbail + inthab + mecena + percvm +
+        return (aidper + assloy + autent + ci_garext + creimp + direpa + drbail + inthab + percvm +
                 preetu + prlire + quaenv + saldom2)
 
     def formula_2011_01_01(foyer_fiscal, period, parameters):
@@ -160,13 +154,12 @@ class credits_impot(Variable):
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
         inthab = foyer_fiscal('inthab', period)
-        mecena = foyer_fiscal('mecena', period)
         preetu = foyer_fiscal('preetu', period)
         prlire = foyer_fiscal('prlire', period)
         quaenv = foyer_fiscal('quaenv', period)
         saldom2 = foyer_fiscal('saldom2', period)
 
-        return (accult + aidper + assloy + autent + ci_garext + creimp + direpa + drbail + inthab + mecena + preetu +
+        return (aidper + assloy + autent + ci_garext + creimp + direpa + drbail + inthab + preetu +
                 prlire + quaenv + saldom2)
 
     def formula_2012_01_01(foyer_fiscal, period, parameters):
@@ -181,13 +174,12 @@ class credits_impot(Variable):
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
         inthab = foyer_fiscal('inthab', period)
-        mecena = foyer_fiscal('mecena', period)
         preetu = foyer_fiscal('preetu', period)
         prlire = foyer_fiscal('prlire', period)
         quaenv = foyer_fiscal('quaenv', period)
         saldom2 = foyer_fiscal('saldom2', period)
 
-        return (accult + aidper + assloy + autent + ci_garext + cotsyn + creimp + direpa + drbail + inthab + mecena +
+        return (aidper + assloy + autent + ci_garext + cotsyn + creimp + direpa + drbail + inthab +
                 preetu + prlire + quaenv + saldom2)
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
@@ -202,13 +194,12 @@ class credits_impot(Variable):
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
         inthab = foyer_fiscal('inthab', period)
-        mecena = foyer_fiscal('mecena', period)
         preetu = foyer_fiscal('preetu', period)
         prlire = foyer_fiscal('prlire', period)
         quaenv = foyer_fiscal('quaenv', period)
         saldom2 = foyer_fiscal('saldom2', period)
 
-        return (accult + aidper + assloy + autent + ci_garext + cotsyn + creimp + direpa + drbail + inthab + mecena +
+        return (aidper + assloy + autent + ci_garext + cotsyn + creimp + direpa + drbail + inthab +
                 preetu + prlire + quaenv + saldom2)
 
     def formula_2014_01_01(foyer_fiscal, period, parameters):
@@ -223,13 +214,12 @@ class credits_impot(Variable):
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
         inthab = foyer_fiscal('inthab', period)
-        mecena = foyer_fiscal('mecena', period)
         preetu = foyer_fiscal('preetu', period)
         prlire = foyer_fiscal('prlire', period)
         quaenv = foyer_fiscal('quaenv', period)
         saldom2 = foyer_fiscal('saldom2', period)
 
-        return (accult + aidper + assloy + autent + ci_garext + cotsyn + creimp + direpa + drbail + inthab + mecena +
+        return (aidper + assloy + autent + ci_garext + cotsyn + creimp + direpa + drbail + inthab +
                 preetu + prlire + quaenv + saldom2)
 
 
@@ -1308,23 +1298,7 @@ class jeunes_ind(Variable):
 
 
                                 # somme calculée sur formulaire 2041
-
-
-class mecena(Variable):
-    value_type = float
-    entity = FoyerFiscal
-    label = u"Mécénat d'entreprise"
-    definition_period = YEAR
-
-    def formula_2003_01_01(foyer_fiscal, period, parameters):
-        '''
-        Mécénat d'entreprise (case 7US)
-        2003-
-        '''
-        f7us = foyer_fiscal('f7us', period)
-
-        return f7us
-
+                                
 
 class percvm(Variable):
     value_type = float

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -531,7 +531,7 @@ class creimp(Variable):
     entity = FoyerFiscal
     label = u"Avoirs fiscaux et crédits d'impôt"
     definition_period = YEAR
-    end = '2013-12-31'
+    end = '2016-12-31'
 
     def formula_2002_01_01(foyer_fiscal, period, parameters):
         f2ab = foyer_fiscal('f2ab', period)
@@ -786,6 +786,9 @@ class creimp(Variable):
 
         return (f2ab + f2ck + f8ta + f8tb + f8tc + f8te - f8tf + f8tg + f8th + f8to - f8tp + f8tl + f8ts + f8tz + f8uw +
                 f8uz + f8wa + f8wb + f8wc + f8wd + f8we + f8wr + f8wt + f8wu)
+  
+    # TODO : add tax credit 8VM and 8VL (2016) 
+    # TODO: add tax credit 8TK for all years ?
 
 
 class direpa(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -786,6 +786,38 @@ class creimp(Variable):
 
         return (f2ab + f2ck + f8ta + f8tb + f8tc + f8te - f8tf + f8tg + f8th + f8to - f8tp + f8tl + f8ts + f8tz + f8uw +
                 f8uz + f8wa + f8wb + f8wc + f8wd + f8we + f8wr + f8wt + f8wu)
+
+    def formula_2016_01_01(foyer_fiscal, period, parameters):
+        f2ab = foyer_fiscal('f2ab', period)
+        f2ck = foyer_fiscal('f2ck', period)
+        f8ta = foyer_fiscal('f8ta', period)
+        f8tb = foyer_fiscal('f8tb', period)
+        f8tc = foyer_fiscal('f8tc', period)
+        f8te = foyer_fiscal('f8te', period)
+        f8tf = foyer_fiscal('f8tf', period)
+        f8tg = foyer_fiscal('f8tg', period)
+        f8th = foyer_fiscal('f8th', period)
+        f8tl = foyer_fiscal('f8tl', period)
+        f8to = foyer_fiscal('f8to', period)
+        f8tp = foyer_fiscal('f8tp', period)
+        f8ts = foyer_fiscal('f8ts', period)
+        f8tz = foyer_fiscal('f8tz', period)
+        f8uw = foyer_fiscal('f8uw', period)
+        f8uz = foyer_fiscal('f8uz', period)
+        f8wa = foyer_fiscal('f8wa', period)
+        f8wb = foyer_fiscal('f8wb', period)
+        f8wc = foyer_fiscal('f8wc', period)
+        f8wd = foyer_fiscal('f8wd', period)
+        f8we = foyer_fiscal('f8we', period)
+        f8wr = foyer_fiscal('f8wr', period)
+        f8wt = foyer_fiscal('f8wt', period)
+        f8wu = foyer_fiscal('f8wu', period)
+
+        f8vm_i = foyer_fiscal.members('f8vm', period)
+        f8vm = foyer_fiscal.sum(f8vm_i)
+
+        return (f2ab + f2ck + f8ta + f8tb + f8tc + f8te - f8tf + f8tg + f8th + f8to - f8tp + f8tl + f8ts + f8tz + f8uw +
+                f8uz + f8vm + f8wa + f8wb + f8wc + f8wd + f8we + f8wr + f8wt + f8wu)
   
     # TODO : add tax credit 8VM and 8VL (2016) 
     # TODO: add tax credit 8TK for all years ?

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -3321,130 +3321,6 @@ class locmeu(Variable):
                 ) / 9 + report_invest_anterieur + report_non_impute
             )
 
-
-    def formula_2015_01_01(foyer_fiscal, period, parameters):
-        '''
-        Investissement en vue de la location meublée non professionnelle dans certains établissements ou résidences
-        2015
-        '''
-        f7ia = foyer_fiscal('f7ia', period)
-        f7ib = foyer_fiscal('f7ib', period)
-        f7ic = foyer_fiscal('f7ic', period)
-        f7id = foyer_fiscal('f7id', period)
-        f7ie = foyer_fiscal('f7ie', period)
-        f7if = foyer_fiscal('f7if', period)
-        f7ig = foyer_fiscal('f7ig', period)
-        f7ih = foyer_fiscal('f7ih', period)
-        f7ij = foyer_fiscal('f7ij', period)
-        f7ik = foyer_fiscal('f7ik', period)
-        f7il = foyer_fiscal('f7il', period)
-        f7im = foyer_fiscal('f7im', period)
-        f7in = foyer_fiscal('f7in', period)
-        f7io = foyer_fiscal('f7io', period)
-        f7ip = foyer_fiscal('f7ip', period)
-        f7iq = foyer_fiscal('f7iq', period)
-        f7ir = foyer_fiscal('f7ir', period)
-        f7is = foyer_fiscal('f7is', period)
-        f7it = foyer_fiscal('f7it', period)
-        f7iu = foyer_fiscal('f7iu', period)
-        f7iv = foyer_fiscal('f7iv', period)
-        f7iw = foyer_fiscal('f7iw', period)
-        f7ix = foyer_fiscal('f7ix', period)
-        f7iy = foyer_fiscal('f7iy', period)
-        f7iz = foyer_fiscal('f7iz', period)
-        f7jc = foyer_fiscal('f7jc', period)
-        f7ji = foyer_fiscal('f7ji', period)
-        f7js = foyer_fiscal('f7js', period)
-        f7jt = foyer_fiscal('f7jt', period)
-        f7ju = foyer_fiscal('f7ju', period)
-        f7jv = foyer_fiscal('f7jv', period)
-        f7jw = foyer_fiscal('f7jw', period)
-        f7jx = foyer_fiscal('f7jx', period)
-        f7jy = foyer_fiscal('f7jy', period)
-        P = parameters(period).impot_revenu.reductions_impots.locmeu
-
-        m18 = (maxi(f7id, f7ie, f7if, f7ig) == max_(f7ie, f7if))
-        m20 = (maxi(f7ij, f7il, f7in, f7iv) == max_(f7il, f7in))
-        return ((min_(P.max, maxi(f7ij, f7il, f7in, f7iv)) * (P.taux20 * m20 + P.taux18 * not_(m20)) +
-                min_(P.max, maxi(f7id, f7ie, f7if, f7ig)) * (P.taux18 * m18 + P.taux11 * not_(m18)) +
-                P.taux11 * min_(P.max, f7jt + f7ju) +
-                P.taux * (min_(P.max, max_(f7im, f7iw)) + min_(P.max, f7io))) / 9 +
-            P.taux * max_(f7ik + f7ip, f7ir + f7iq) +
-            f7ia + f7ib + f7ic + f7ih + f7is + f7iu + f7it + f7ix + f7iy + f7iz + f7jv + f7jw + f7jx + f7jy + f7jc +
-                f7ji + f7js)
-
-    def formula_2014_01_01(foyer_fiscal, period, parameters):
-        '''
-        Investissement en vue de la location meublée non professionnelle dans certains établissements ou résidences
-        2014
-        '''
-        f7ia = foyer_fiscal('f7ia', period)
-        f7ib = foyer_fiscal('f7ib', period)
-        f7ic = foyer_fiscal('f7ic', period)
-        f7id = foyer_fiscal('f7id', period)
-        f7ie = foyer_fiscal('f7ie', period)
-        f7if = foyer_fiscal('f7if', period)
-        f7ig = foyer_fiscal('f7ig', period)
-        f7ih = foyer_fiscal('f7ih', period)
-        f7ij = foyer_fiscal('f7ij', period)
-        f7ik = foyer_fiscal('f7ik', period)
-        f7il = foyer_fiscal('f7il', period)
-        f7im = foyer_fiscal('f7im', period)
-        f7in = foyer_fiscal('f7in', period)
-        f7io = foyer_fiscal('f7io', period)
-        f7ip = foyer_fiscal('f7ip', period)
-        f7iq = foyer_fiscal('f7iq', period)
-        f7ir = foyer_fiscal('f7ir', period)
-        f7is = foyer_fiscal('f7is', period)
-        f7it = foyer_fiscal('f7it', period)
-        f7iu = foyer_fiscal('f7iu', period)
-        f7iv = foyer_fiscal('f7iv', period)
-        f7iw = foyer_fiscal('f7iw', period)
-        f7ix = foyer_fiscal('f7ix', period)
-        f7iy = foyer_fiscal('f7iy', period)
-        f7iz = foyer_fiscal('f7iz', period)
-        f7jc = foyer_fiscal('f7jc', period)
-        f7ji = foyer_fiscal('f7ji', period)
-        f7js = foyer_fiscal('f7js', period)
-        f7jt = foyer_fiscal('f7jt', period)
-        f7ju = foyer_fiscal('f7ju', period)
-        f7jv = foyer_fiscal('f7jv', period)
-        f7jw = foyer_fiscal('f7jw', period)
-        f7jx = foyer_fiscal('f7jx', period)
-        f7jy = foyer_fiscal('f7jy', period)
-        f7oa = foyer_fiscal('f7oa', period)
-        f7ob = foyer_fiscal('f7ob', period)
-        f7oc = foyer_fiscal('f7oc', period)
-        f7od = foyer_fiscal('f7od', period)
-        f7oe = foyer_fiscal('f7oe', period)
-        f7ou = foyer_fiscal('f7ou', period)
-        f7pa = foyer_fiscal('f7pa', period)
-        f7pb = foyer_fiscal('f7pb', period)
-        f7pc = foyer_fiscal('f7pc', period)
-        f7pd = foyer_fiscal('f7pd', period)
-        f7pe = foyer_fiscal('f7pe', period)
-
-        P = parameters(period).impot_revenu.reductions_impots.locmeu
-
-        m18 = (maxi(f7id, f7ie, f7if, f7ig) == max_(f7ie, f7if)) 
-        m20 = (maxi(f7ij, f7il, f7in, f7iv) == max_(f7il, f7in))         
-        report_invest_anterieur = (P.taux * max_(f7ik + f7ip, f7ir + f7iq) +
-            f7ia + f7ib + f7ic + 
-            f7jv + f7jw + f7jx + f7jy + 
-            f7oa + f7ob + f7oc + f7od + f7oe)
-        report_non_impute = (f7is + f7iu + f7ix + f7iy + f7pa +
-            f7it + f7ih + f7jc + f7pb +
-            f7iz + f7ji + f7pc +
-            f7js + f7pd +
-            f7pe)
-
-        return ((min_(P.max, maxi(f7ij, f7il, f7in, f7iv)) * (P.taux20 * m20 + P.taux18 * not_(m20)) + # to check : impossible de remplir à la fois f7ij et f7il par exemple ?
-                min_(P.max, maxi(f7id, f7ie, f7if, f7ig)) * (P.taux18 * m18 + P.taux11 * not_(m18)) +
-                P.taux11 * (min_(P.max, f7jt + f7ju) + min_(P.max, f7ou)) + 
-                P.taux * (min_(P.max, max_(f7im, f7iw)) + min_(P.max, f7io))
-                ) / 9 +
-                report_invest_anterieur + report_non_impute)
-
     def formula_2015_01_01(foyer_fiscal, period, parameters):
         '''
         Investissement en vue de la location meublée non professionnelle dans certains établissements ou résidences
@@ -3635,7 +3511,6 @@ class locmeu(Variable):
                 ) / 9 +
                 report_invest_anterieur + report_non_impute
             )
-
 
 
 class mecena(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -22,6 +22,7 @@ class reductions(Variable):
         '''
         Renvoie la somme des réductions d'impôt à intégrer pour l'année 2002
         '''
+        accult = foyer_fiscal('accult', period)
         adhcga = foyer_fiscal('adhcga', period)
         assvie = foyer_fiscal('assvie', period)
         cappme = foyer_fiscal('cappme', period)
@@ -42,7 +43,7 @@ class reductions(Variable):
         saldom = foyer_fiscal('saldom', period)
         spfcpi = foyer_fiscal('spfcpi', period)
 
-        total_reductions = (adhcga + assvie + cappme + cotsyn + dfppce + daepad + doment + domlog + donapd + ecpess +
+        total_reductions = (accult + adhcga + assvie + cappme + cotsyn + dfppce + daepad + doment + domlog + donapd + ecpess +
                 garext + intemp + invfor + invrev + prcomp + rsceha + saldom + spfcpi)
         return min_(impot_net, total_reductions)
 
@@ -50,6 +51,7 @@ class reductions(Variable):
         '''
         Renvoie la somme des réductions d'impôt à intégrer pour l'année 2003 et 2004
         '''
+        accult = foyer_fiscal('accult', period)
         adhcga = foyer_fiscal('adhcga', period)
         assvie = foyer_fiscal('assvie', period)
         cappme = foyer_fiscal('cappme', period)
@@ -80,6 +82,7 @@ class reductions(Variable):
         '''
         Renvoie la somme des réductions d'impôt à intégrer pour l'année 2005
         '''
+        accult = foyer_fiscal('accult', period)
         adhcga = foyer_fiscal('adhcga', period)
         cappme = foyer_fiscal('cappme', period)
         cotsyn = foyer_fiscal('cotsyn', period)
@@ -109,6 +112,7 @@ class reductions(Variable):
         '''
         Renvoie la somme des réductions d'impôt à intégrer pour l'année 2006
         '''
+        accult = foyer_fiscal('accult', period)
         adhcga = foyer_fiscal('adhcga', period)
         cappme = foyer_fiscal('cappme', period)
         cotsyn = foyer_fiscal('cotsyn', period)
@@ -140,6 +144,7 @@ class reductions(Variable):
         '''
         Renvoie la somme des réductions d'impôt à intégrer pour l'année 2007
         '''
+        accult = foyer_fiscal('accult', period)
         adhcga = foyer_fiscal('adhcga', period)
         cappme = foyer_fiscal('cappme', period)
         cotsyn = foyer_fiscal('cotsyn', period)
@@ -172,6 +177,7 @@ class reductions(Variable):
         '''
         Renvoie la somme des réductions d'impôt à intégrer pour l'année 2008
         '''
+        accult = foyer_fiscal('accult', period)
         adhcga = foyer_fiscal('adhcga', period)
         cappme = foyer_fiscal('cappme', period)
         cotsyn = foyer_fiscal('cotsyn', period)
@@ -204,6 +210,7 @@ class reductions(Variable):
         '''
         Renvoie la somme des réductions d'impôt à intégrer pour l'année 2009
         '''
+        accult = foyer_fiscal('accult', period)
         adhcga = foyer_fiscal('adhcga', period)
         cappme = foyer_fiscal('cappme', period)
         cotsyn = foyer_fiscal('cotsyn', period)
@@ -244,6 +251,7 @@ class reductions(Variable):
         '''
         Renvoie la somme des réductions d'impôt à intégrer pour l'année 2010
         '''
+        accult = foyer_fiscal('accult', period)
         adhcga = foyer_fiscal('adhcga', period)
         cappme = foyer_fiscal('cappme', period)
         cotsyn = foyer_fiscal('cotsyn', period)
@@ -283,6 +291,7 @@ class reductions(Variable):
         '''
         Renvoie la somme des réductions d'impôt à intégrer pour l'année 2011
         '''
+        accult = foyer_fiscal('accult', period)
         adhcga = foyer_fiscal('adhcga', period)
         cappme = foyer_fiscal('cappme', period)
         cotsyn = foyer_fiscal('cotsyn', period)
@@ -322,6 +331,7 @@ class reductions(Variable):
         '''
         Renvoie la somme des réductions d'impôt à intégrer pour l'année 2012
         '''
+        accult = foyer_fiscal('accult', period)
         adhcga = foyer_fiscal('adhcga', period)
         cappme = foyer_fiscal('cappme', period)
         creaen = foyer_fiscal('creaen', period)
@@ -479,6 +489,23 @@ class reductions(Variable):
         # pour tous les dfppce:
         # : note de bas de page
         # TODO: plafonnement pour parti politiques depuis 2012 P.impot_revenu.reductions_impots.dons.max_niv
+
+
+class accult(Variable):
+    value_type = float
+    entity = FoyerFiscal
+    label = u"Acquisition de biens culturels"
+    definition_period = YEAR
+
+    def formula_2002(foyer_fiscal, period, parameters):
+        '''
+        Acquisition de biens culturels (case 7UO)
+        2002-
+        '''
+        f7uo = foyer_fiscal('f7uo', period)
+        P = parameters(period).impot_revenu.credits_impot.accult
+
+        return P.taux * f7uo
 
 
 class adhcga(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -3325,6 +3325,129 @@ class locmeu(Variable):
         f7jw = foyer_fiscal('f7jw', period)
         f7jx = foyer_fiscal('f7jx', period)
         f7jy = foyer_fiscal('f7jy', period)
+        P = parameters(period).impot_revenu.reductions_impots.locmeu
+
+        m18 = (maxi(f7id, f7ie, f7if, f7ig) == max_(f7ie, f7if))
+        m20 = (maxi(f7ij, f7il, f7in, f7iv) == max_(f7il, f7in))
+        return ((min_(P.max, maxi(f7ij, f7il, f7in, f7iv)) * (P.taux20 * m20 + P.taux18 * not_(m20)) +
+                min_(P.max, maxi(f7id, f7ie, f7if, f7ig)) * (P.taux18 * m18 + P.taux11 * not_(m18)) +
+                P.taux11 * min_(P.max, f7jt + f7ju) +
+                P.taux * (min_(P.max, max_(f7im, f7iw)) + min_(P.max, f7io))) / 9 +
+            P.taux * max_(f7ik + f7ip, f7ir + f7iq) +
+            f7ia + f7ib + f7ic + f7ih + f7is + f7iu + f7it + f7ix + f7iy + f7iz + f7jv + f7jw + f7jx + f7jy + f7jc +
+                f7ji + f7js)
+
+    def formula_2014_01_01(foyer_fiscal, period, parameters):
+        '''
+        Investissement en vue de la location meublée non professionnelle dans certains établissements ou résidences
+        2014
+        '''
+        f7ia = foyer_fiscal('f7ia', period)
+        f7ib = foyer_fiscal('f7ib', period)
+        f7ic = foyer_fiscal('f7ic', period)
+        f7id = foyer_fiscal('f7id', period)
+        f7ie = foyer_fiscal('f7ie', period)
+        f7if = foyer_fiscal('f7if', period)
+        f7ig = foyer_fiscal('f7ig', period)
+        f7ih = foyer_fiscal('f7ih', period)
+        f7ij = foyer_fiscal('f7ij', period)
+        f7ik = foyer_fiscal('f7ik', period)
+        f7il = foyer_fiscal('f7il', period)
+        f7im = foyer_fiscal('f7im', period)
+        f7in = foyer_fiscal('f7in', period)
+        f7io = foyer_fiscal('f7io', period)
+        f7ip = foyer_fiscal('f7ip', period)
+        f7iq = foyer_fiscal('f7iq', period)
+        f7ir = foyer_fiscal('f7ir', period)
+        f7is = foyer_fiscal('f7is', period)
+        f7it = foyer_fiscal('f7it', period)
+        f7iu = foyer_fiscal('f7iu', period)
+        f7iv = foyer_fiscal('f7iv', period)
+        f7iw = foyer_fiscal('f7iw', period)
+        f7ix = foyer_fiscal('f7ix', period)
+        f7iy = foyer_fiscal('f7iy', period)
+        f7iz = foyer_fiscal('f7iz', period)
+        f7jc = foyer_fiscal('f7jc', period)
+        f7ji = foyer_fiscal('f7ji', period)
+        f7js = foyer_fiscal('f7js', period)
+        f7jt = foyer_fiscal('f7jt', period)
+        f7ju = foyer_fiscal('f7ju', period)
+        f7jv = foyer_fiscal('f7jv', period)
+        f7jw = foyer_fiscal('f7jw', period)
+        f7jx = foyer_fiscal('f7jx', period)
+        f7jy = foyer_fiscal('f7jy', period)
+        f7oa = foyer_fiscal('f7oa', period)
+        f7ob = foyer_fiscal('f7ob', period)
+        f7oc = foyer_fiscal('f7oc', period)
+        f7od = foyer_fiscal('f7od', period)
+        f7oe = foyer_fiscal('f7oe', period)
+        f7ou = foyer_fiscal('f7ou', period)
+        f7pa = foyer_fiscal('f7pa', period)
+        f7pb = foyer_fiscal('f7pb', period)
+        f7pc = foyer_fiscal('f7pc', period)
+        f7pd = foyer_fiscal('f7pd', period)
+        f7pe = foyer_fiscal('f7pe', period)
+
+        P = parameters(period).impot_revenu.reductions_impots.locmeu
+
+        m18 = (maxi(f7id, f7ie, f7if, f7ig) == max_(f7ie, f7if)) 
+        m20 = (maxi(f7ij, f7il, f7in, f7iv) == max_(f7il, f7in))         
+        report_invest_anterieur = (P.taux * max_(f7ik + f7ip, f7ir + f7iq) +
+            f7ia + f7ib + f7ic + 
+            f7jv + f7jw + f7jx + f7jy + 
+            f7oa + f7ob + f7oc + f7od + f7oe)
+        report_non_impute = (f7is + f7iu + f7ix + f7iy + f7pa +
+            f7it + f7ih + f7jc + f7pb +
+            f7iz + f7ji + f7pc +
+            f7js + f7pd +
+            f7pe)
+
+        return ((min_(P.max, maxi(f7ij, f7il, f7in, f7iv)) * (P.taux20 * m20 + P.taux18 * not_(m20)) + # to check : impossible de remplir à la fois f7ij et f7il par exemple ?
+                min_(P.max, maxi(f7id, f7ie, f7if, f7ig)) * (P.taux18 * m18 + P.taux11 * not_(m18)) +
+                P.taux11 * (min_(P.max, f7jt + f7ju) + min_(P.max, f7ou)) + 
+                P.taux * (min_(P.max, max_(f7im, f7iw)) + min_(P.max, f7io))
+                ) / 9 +
+                report_invest_anterieur + report_non_impute)
+
+    def formula_2015_01_01(foyer_fiscal, period, parameters):
+        '''
+        Investissement en vue de la location meublée non professionnelle dans certains établissements ou résidences
+        2015
+        '''
+        f7ia = foyer_fiscal('f7ia', period)
+        f7ib = foyer_fiscal('f7ib', period)
+        f7ic = foyer_fiscal('f7ic', period)
+        f7id = foyer_fiscal('f7id', period)
+        f7ie = foyer_fiscal('f7ie', period)
+        f7if = foyer_fiscal('f7if', period)
+        f7ig = foyer_fiscal('f7ig', period)
+        f7ih = foyer_fiscal('f7ih', period)
+        f7ij = foyer_fiscal('f7ij', period)
+        f7ik = foyer_fiscal('f7ik', period)
+        f7il = foyer_fiscal('f7il', period)
+        f7im = foyer_fiscal('f7im', period)
+        f7in = foyer_fiscal('f7in', period)
+        f7io = foyer_fiscal('f7io', period)
+        f7ip = foyer_fiscal('f7ip', period)
+        f7iq = foyer_fiscal('f7iq', period)
+        f7ir = foyer_fiscal('f7ir', period)
+        f7is = foyer_fiscal('f7is', period)
+        f7it = foyer_fiscal('f7it', period)
+        f7iu = foyer_fiscal('f7iu', period)
+        f7iv = foyer_fiscal('f7iv', period)
+        f7iw = foyer_fiscal('f7iw', period)
+        f7ix = foyer_fiscal('f7ix', period)
+        f7iy = foyer_fiscal('f7iy', period)
+        f7iz = foyer_fiscal('f7iz', period)
+        f7jc = foyer_fiscal('f7jc', period)
+        f7ji = foyer_fiscal('f7ji', period)
+        f7js = foyer_fiscal('f7js', period)
+        f7jt = foyer_fiscal('f7jt', period)
+        f7ju = foyer_fiscal('f7ju', period)
+        f7jv = foyer_fiscal('f7jv', period)
+        f7jw = foyer_fiscal('f7jw', period)
+        f7jx = foyer_fiscal('f7jx', period)
+        f7jy = foyer_fiscal('f7jy', period)
         f7oa = foyer_fiscal('f7oa', period)
         f7ob = foyer_fiscal('f7ob', period)
         f7oc = foyer_fiscal('f7oc', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -65,14 +65,15 @@ class reductions(Variable):
         invfor = foyer_fiscal('invfor', period)
         invrev = foyer_fiscal('invrev', period)
         impot_net = foyer_fiscal('ip_net', period)
+        mecena = foyer_fiscal('mecena', period)
         prcomp = foyer_fiscal('prcomp', period)
         repsoc = foyer_fiscal('repsoc', period)
         rsceha = foyer_fiscal('rsceha', period)
         saldom = foyer_fiscal('saldom', period)
         spfcpi = foyer_fiscal('spfcpi', period)
 
-        total_reductions = (adhcga + assvie + cappme + cotsyn + dfppce + daepad + doment + domlog + donapd + ecpess +
-                garext + intemp + invfor + invrev + prcomp + repsoc + rsceha + saldom + spfcpi)
+        total_reductions = (accult + adhcga + assvie + cappme + cotsyn + dfppce + daepad + doment + domlog + donapd + ecpess +
+                garext + intemp + invfor + invrev + mecena + prcomp + repsoc + rsceha + saldom + spfcpi)
         return min_(impot_net, total_reductions)
 
     def formula_2005_01_01(foyer_fiscal, period, parameters):
@@ -93,14 +94,15 @@ class reductions(Variable):
         invfor = foyer_fiscal('invfor', period)
         invlst = foyer_fiscal('invlst', period)
         impot_net = foyer_fiscal('ip_net', period)
+        mecena = foyer_fiscal('mecena', period)
         prcomp = foyer_fiscal('prcomp', period)
         repsoc = foyer_fiscal('repsoc', period)
         rsceha = foyer_fiscal('rsceha', period)
         saldom = foyer_fiscal('saldom', period)
         spfcpi = foyer_fiscal('spfcpi', period)
 
-        total_reductions = (adhcga + cappme + cotsyn + daepad + dfppce + doment + domlog + donapd + ecpess + intagr +
-                intcon + invfor + invlst + prcomp + repsoc + rsceha + saldom + spfcpi)
+        total_reductions = (accult + adhcga + cappme + cotsyn + daepad + dfppce + doment + domlog + donapd + ecpess + intagr +
+                intcon + invfor + invlst + mecena + prcomp + repsoc + rsceha + saldom + spfcpi)
         return min_(impot_net, total_reductions)
 
     def formula_2006_01_01(foyer_fiscal, period, parameters):
@@ -122,6 +124,7 @@ class reductions(Variable):
         invfor = foyer_fiscal('invfor', period)
         invlst = foyer_fiscal('invlst', period)
         impot_net = foyer_fiscal('ip_net', period)
+        mecena = foyer_fiscal('mecena', period)
         prcomp = foyer_fiscal('prcomp', period)
         repsoc = foyer_fiscal('repsoc', period)
         rsceha = foyer_fiscal('rsceha', period)
@@ -129,8 +132,8 @@ class reductions(Variable):
         sofica = foyer_fiscal('sofica', period)
         spfcpi = foyer_fiscal('spfcpi', period)
 
-        total_reductions = (adhcga + cappme + cotsyn + creaen + daepad + deffor + dfppce + doment + domlog + donapd +
-        ecpess + intagr + invfor + invlst + prcomp + repsoc + rsceha + saldom + sofica + spfcpi)
+        total_reductions = (accult + adhcga + cappme + cotsyn + creaen + daepad + deffor + dfppce + doment + domlog + donapd +
+        ecpess + intagr + invfor + invlst + mecena + prcomp + repsoc + rsceha + saldom + sofica + spfcpi)
         return min_(impot_net, total_reductions)
 
     def formula_2007_01_01(foyer_fiscal, period, parameters):
@@ -152,6 +155,7 @@ class reductions(Variable):
         invfor = foyer_fiscal('invfor', period)
         invlst = foyer_fiscal('invlst', period)
         impot_net = foyer_fiscal('ip_net', period)
+        mecena = foyer_fiscal('mecena', period)
         prcomp = foyer_fiscal('prcomp', period)
         repsoc = foyer_fiscal('repsoc', period)
         rsceha = foyer_fiscal('rsceha', period)
@@ -159,8 +163,8 @@ class reductions(Variable):
         sofica = foyer_fiscal('sofica', period)
         spfcpi = foyer_fiscal('spfcpi', period)
 
-        total_reductions = (adhcga + cappme + cotsyn + creaen + daepad + deffor + dfppce + doment + domlog + donapd +
-        ecpess + intagr + invfor + invlst + prcomp + repsoc + rsceha + saldom + sofica + spfcpi)
+        total_reductions = (accult + adhcga + cappme + cotsyn + creaen + daepad + deffor + dfppce + doment + domlog + donapd +
+        ecpess + intagr + invfor + invlst + mecena + prcomp + repsoc + rsceha + saldom + sofica + spfcpi)
 
         return min_(impot_net, total_reductions)
 
@@ -183,6 +187,7 @@ class reductions(Variable):
         invfor = foyer_fiscal('invfor', period)
         invlst = foyer_fiscal('invlst', period)
         impot_net = foyer_fiscal('ip_net', period)
+        mecena = foyer_fiscal('mecena', period)
         mohist = foyer_fiscal('mohist', period)
         prcomp = foyer_fiscal('prcomp', period)
         repsoc = foyer_fiscal('repsoc', period)
@@ -191,8 +196,8 @@ class reductions(Variable):
         sofica = foyer_fiscal('sofica', period)
         spfcpi = foyer_fiscal('spfcpi', period)
 
-        total_reductions = (adhcga + cappme + cotsyn + creaen + daepad + deffor + dfppce + doment + domlog + donapd +
-        ecpess + intagr + invfor + invlst + mohist + prcomp + repsoc + rsceha + saldom + sofica + spfcpi)
+        total_reductions = (accult + adhcga + cappme + cotsyn + creaen + daepad + deffor + dfppce + doment + domlog + donapd +
+        ecpess + intagr + invfor + invlst + mohist + mecena + prcomp + repsoc + rsceha + saldom + sofica + spfcpi)
         return min_(impot_net, total_reductions)
 
     def formula_2009_01_01(foyer_fiscal, period, parameters):
@@ -217,6 +222,7 @@ class reductions(Variable):
         invlst = foyer_fiscal('invlst', period)
         impot_net = foyer_fiscal('ip_net', period)
         locmeu = foyer_fiscal('locmeu', period)
+        mecena = foyer_fiscal('mecena', period)
         mohist = foyer_fiscal('mohist', period)
         prcomp = foyer_fiscal('prcomp', period)
         repsoc = foyer_fiscal('repsoc', period)
@@ -228,8 +234,8 @@ class reductions(Variable):
         sofipe = foyer_fiscal('sofipe', period)
         spfcpi = foyer_fiscal('spfcpi', period)
 
-        total_reductions = (adhcga + cappme + cotsyn + creaen + daepad + deffor + dfppce + doment + domlog + domsoc +
-        donapd + ecodev + ecpess + intagr + invfor + invlst + locmeu + mohist + prcomp + repsoc + resimm + rsceha +
+        total_reductions = (accult + adhcga + cappme + cotsyn + creaen + daepad + deffor + dfppce + doment + domlog + domsoc +
+        donapd + ecodev + ecpess + intagr + invfor + invlst + locmeu + mecena + mohist + prcomp + repsoc + resimm + rsceha +
         saldom + scelli + sofica + sofipe + spfcpi)
         return min_(impot_net, total_reductions)
 
@@ -255,6 +261,7 @@ class reductions(Variable):
         invlst = foyer_fiscal('invlst', period)
         impot_net = foyer_fiscal('ip_net', period)
         locmeu = foyer_fiscal('locmeu', period)
+        mecena = foyer_fiscal('mecena', period)
         mohist = foyer_fiscal('mohist', period)
         patnat = foyer_fiscal('patnat', period)
         prcomp = foyer_fiscal('prcomp', period)
@@ -267,8 +274,8 @@ class reductions(Variable):
         sofipe = foyer_fiscal('sofipe', period)
         spfcpi = foyer_fiscal('spfcpi', period)
 
-        total_reductions = (adhcga + cappme + cotsyn + creaen + daepad + deffor + dfppce + doment + domlog + domsoc +
-        donapd + ecpess + intagr + invfor + invlst + locmeu + mohist + patnat + prcomp + repsoc + resimm + rsceha +
+        total_reductions = (accult + adhcga + cappme + cotsyn + creaen + daepad + deffor + dfppce + doment + domlog + domsoc +
+        donapd + ecpess + intagr + invfor + invlst + locmeu + mecena + mohist + patnat + prcomp + repsoc + resimm + rsceha +
         saldom + scelli + sofica + sofipe + spfcpi)  # TODO: check (sees checked) and report in Niches.xls
         return min_(impot_net, total_reductions)
 
@@ -293,6 +300,7 @@ class reductions(Variable):
         invlst = foyer_fiscal('invlst', period)
         impot_net = foyer_fiscal('ip_net', period)
         locmeu = foyer_fiscal('locmeu', period)
+        mecena = foyer_fiscal('mecena', period)
         mohist = foyer_fiscal('mohist', period)
         patnat = foyer_fiscal('patnat', period)
         prcomp = foyer_fiscal('prcomp', period)
@@ -305,8 +313,8 @@ class reductions(Variable):
         sofipe = foyer_fiscal('sofipe', period)
         spfcpi = foyer_fiscal('spfcpi', period)
 
-        total_reductions = (adhcga + cappme + cotsyn + creaen + daepad + deffor + dfppce + doment + domlog + domsoc +
-        donapd + ecpess + intagr + invfor + invlst + locmeu + mohist + patnat + prcomp + repsoc + resimm + rsceha +
+        total_reductions = (accult + adhcga + cappme + cotsyn + creaen + daepad + deffor + dfppce + doment + domlog + domsoc +
+        donapd + ecpess + intagr + invfor + invlst + locmeu + mecena + mohist + patnat + prcomp + repsoc + resimm + rsceha +
         saldom + scelli + sofica + sofipe + spfcpi)
         return min_(impot_net, total_reductions)
 
@@ -330,6 +338,7 @@ class reductions(Variable):
         invlst = foyer_fiscal('invlst', period)
         impot_net = foyer_fiscal('ip_net', period)
         locmeu = foyer_fiscal('locmeu', period)
+        mecena = foyer_fiscal('mecena', period)
         mohist = foyer_fiscal('mohist', period)
         patnat = foyer_fiscal('patnat', period)
         prcomp = foyer_fiscal('prcomp', period)
@@ -341,8 +350,8 @@ class reductions(Variable):
         sofica = foyer_fiscal('sofica', period)
         spfcpi = foyer_fiscal('spfcpi', period)
 
-        total_reductions = (adhcga + cappme + creaen + daepad + deffor + dfppce + doment + domlog + domsoc +
-        donapd + ecpess + intagr + invfor + invlst + locmeu + mohist + patnat + prcomp + repsoc + resimm + rsceha +
+        total_reductions = (accult + adhcga + cappme + creaen + daepad + deffor + dfppce + doment + domlog + domsoc +
+        donapd + ecpess + intagr + invfor + invlst + locmeu + mecena + mohist + patnat + prcomp + repsoc + resimm + rsceha +
         saldom + scelli + sofica + spfcpi)
         return min_(impot_net, total_reductions)
 
@@ -3599,6 +3608,23 @@ class locmeu(Variable):
                 ) / 9 +
                 report_invest_anterieur + report_non_impute
             )
+
+
+
+class mecena(Variable):
+    value_type = float
+    entity = FoyerFiscal
+    label = u"Mécénat d'entreprise"
+    definition_period = YEAR
+
+    def formula_2003_01_01(foyer_fiscal, period, parameters):
+        '''
+        Mécénat d'entreprise (case 7US)
+        2003-
+        '''
+        f7us = foyer_fiscal('f7us', period)
+
+        return f7us
 
 
 class mohist(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -1297,7 +1297,7 @@ class f7pc_2011(Variable):
     unit = 'currency'
     entity = FoyerFiscal
     label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
-    # end = '2011-12-31' changes meaning in 2014
+    end = '2011-12-31'
     definition_period = YEAR
 
 

--- a/openfisca_france/model/revenus/autres.py
+++ b/openfisca_france/model/revenus/autres.py
@@ -124,6 +124,29 @@ class f8ta(Variable):
     definition_period = YEAR
 
 
+class f8vl(Variable):
+    cerfa_field = u"8VL"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Impôt payé à l'étranger sur revenus de capitaux mobiliers et plus-values ouvrant droit à un crédit d'impôt"
+    # start_date = date(2016, 1, 1)
+    definition_period = YEAR
+
+
+class f8vm(Variable):
+    cerfa_field = {QUIFOY['vous']: u"8VM",
+        QUIFOY['conj']: u"8WM",
+        QUIFOY['pac1']: u"8UM",
+        }
+    value_type = int
+    unit = 'currency'
+    entity = Individu
+    label = u"Impôt payé à l'étranger sur revenus de capitaux mobiliers et plus-values ouvrant droit à un crédit d'impôt"
+    # start_date = date(2016, 1, 1)
+    definition_period = YEAR
+
+
 class f8th(Variable):
     cerfa_field = u"8TH"
     value_type = int

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '21.7.0',
+    version = '21.8.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Les modifications de cette PR sont comparées à la branche `ipp-update-calcul-ip-net` (https://github.com/openfisca/openfisca-france/pull/918)

* Evolution du système socio-fiscal
* Périodes concernées : toutes 
- `  openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py`
- `  openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py`
-`  openfisca_france/model/revenus/autres.py`

* Détails :
   - Les avantages fiscaux pour mécénat d'entreprises (depuis 2003) et pour acquisition de biens culturels (depuis 2002) sont définies comme des réductions d'impôt et non plus des crédits d'impôt
   - Mise à jour de 'creimp' pour 2014-2016, et correction d'une petite erreur pour 2012
 
- - - -

Ces changements :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.