### PR TITLE
Prevent incorrect eligibility to cheque energie in Saint Martin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 21.1.0 [#949](https://github.com/openfisca/openfisca-france/pull/949)
+
+* Changement mineur.
+* Périodes concernées : À partir de 2018
+* Détails :
+- Suppression de l'éligibilité des foyers de Saint Martin au chèque énergie
+
 # 21.0.0 [#902](https://github.com/openfisca/openfisca-france/pull/902)
 
 * Évolution du système socio-fiscal.
@@ -13,7 +20,7 @@
     + Création de `valeur_patrimoine_loue`, `valeur_immo_non_loue`, `valeur_terrains_non_loues` et `epargne_revenus_imposables`
     + Renommage de `valeur_terrains_non_loue` en `valeur_terrains_non_loues`
 
-## 20.9.1 [#954](https://github.com/openfisca/openfisca-france/pull/954)
+### 20.9.1 [#954](https://github.com/openfisca/openfisca-france/pull/954)
 
 * Correction d'un bug
 * Zones impactées : `revenus/mesures`

--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -130,3 +130,23 @@ class residence_mayotte(Variable):
     def formula(menage, period, parameters):
         depcom = menage('depcom', period)
         return startswith(depcom, '976')
+
+
+class residence_saint_bartelemy(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+
+    def formula(menage, period, parameters):
+        depcom = menage('depcom', period)
+        return startswith(depcom, '977')
+
+
+class residence_saint_martin(Variable):
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+
+    def formula(menage, period, parameters):
+        depcom = menage('depcom', period)
+        return startswith(depcom, '978')

--- a/openfisca_france/model/prestations/cheque_energie.py
+++ b/openfisca_france/model/prestations/cheque_energie.py
@@ -33,20 +33,25 @@ class cheque_energie_eligibilite_logement(Variable):
     reference = [
         u"Article L124-1 du Code de l'énergie",
         u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=5AB50D02153C9CB753729850314A2E17.tplgfr29s_1?idArticle=LEGIARTI000031057544&cidTexte=LEGITEXT000023983208&dateTexte=20180314",
+        u"Article LO6314-3 du Code général des collectivités territoriales",
+        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=6A3717E70623B148432581CC8F585C5F.tplgfr31s_1?idArticle=LEGIARTI000006394061&cidTexte=LEGITEXT000006070633&dateTexte=20180316",
     ]
     label = u"Éligibilité du logement occupé au chèque énergie"
     definition_period = MONTH
 
     def formula_2017(menage, period, parameters):
         statut_occupation_logement = menage('statut_occupation_logement', period)
+        residence_saint_martin = menage('residence_saint_martin', period)
 
         return (
+            not_(residence_saint_martin) * (
             + (statut_occupation_logement == TypesStatutOccupationLogement.primo_accedant)
             + (statut_occupation_logement == TypesStatutOccupationLogement.proprietaire)
             + (statut_occupation_logement == TypesStatutOccupationLogement.locataire_hlm)
             + (statut_occupation_logement == TypesStatutOccupationLogement.locataire_vide)
             + (statut_occupation_logement == TypesStatutOccupationLogement.locataire_meuble)
             )
+        )
 
 
 class cheque_energie_montant(Variable):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '21.0.0',
+    version = '21.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/cheque_energie/eligibilite_logement.yaml
+++ b/tests/formulas/cheque_energie/eligibilite_logement.yaml
@@ -1,0 +1,7 @@
+- name: Saint Martin n'est pas concerné par le chèque énergie
+  period: 2018-01
+  input_variables:
+    depcom: 97801
+    statut_occupation_logement: proprietaire
+  output_variables:
+    cheque_energie_eligibilite_logement: False


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : À partir de 2018
* Détails :
  - Suppression de l'éligibilité des foyers de Saint Martin au chèque énergie
