### PR TITLE
Fix chèque energie implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-### 21.8.0 [#919](https://github.com/openfisca/openfisca-france/pull/919)
+### 21.8.1 [#960](https://github.com/openfisca/openfisca-france/pull/960)
+
+* Évolution du système socio-fiscal.
+* Zones impactées : `prestations/cheque_energie`
+* Périodes concernées : À partir de 2017
+* Détails :
+  - Corrige le calcul des unités de consommation pour le chèque énergie
+  - Corrige la période de validité des variables relatives au chèque énergie
+
+## 21.8.0 [#919](https://github.com/openfisca/openfisca-france/pull/919)
 
 * Evolution du système socio-fiscal
 * Périodes concernées : toutes
@@ -12,7 +21,7 @@
   - Les avantages fiscaux pour mécénat d'entreprises (depuis 2003) et pour acquisition de biens culturels (depuis 2002) sont définies comme des réductions d'impôt et non plus des crédits d'impôt
   - Mise à jour de 'creimp' pour 2014-2016, et correction d'une petite erreur pour 2012
 
-### 21.7.0 [#918](https://github.com/openfisca/openfisca-france/pull/918)
+## 21.7.0 [#918](https://github.com/openfisca/openfisca-france/pull/918)
 
 * Correction du système socio-fiscal.
 * Périodes concernées : toutes
@@ -29,7 +38,7 @@
   - Création de paramètres spécifiques à la réduction d'impôt spécial DOM-TOM qui intervient juste après le plafonnement du quotient familial (pour l'instant non calculée mais à termes oui ?)
   - Mise à jour des paramètres
 
-### 21.6.0 [#917](https://github.com/openfisca/openfisca-france/pull/917)
+## 21.6.0 [#917](https://github.com/openfisca/openfisca-france/pull/917)
 
 * Correction du système socio-fiscal.
 * Périodes concernées : toutes
@@ -45,7 +54,7 @@
   - Correction du calcul de l'abattement appliqué aux revenus non commerciaux relevant du régime micro-bnc (34%) + Ajout de nouveaux paramètres associés à cet abattement
   - Modification des labels et end_date de variables de revenus non salariaux dans non_salarie.py
 
-### 21.5.0 [#916](https://github.com/openfisca/openfisca-france/pull/916)
+## 21.5.0 [#916](https://github.com/openfisca/openfisca-france/pull/916)
 
 * Évolution du système socio-fiscal.
 * Zones impactées :
@@ -58,8 +67,7 @@
   - Correction de la formule du crédit d'impôt en 2012 et 2013
   - Ajout d'un nouveau paramètre associé
 
-
-### 21.4.0 [#915](https://github.com/openfisca/openfisca-france/pull/915)
+## 21.4.0 [#915](https://github.com/openfisca/openfisca-france/pull/915)
 
 * Évolution du système socio-fiscal.
 * Zones impactées :
@@ -71,7 +79,7 @@
   - Mise à jour des formules (2014-2016) de la réduction 'cappme' (réduction pour souscription au capital de PME non cotées)
   - Ajout des inputs variables associées
 
-### 21.3.0 [#914](https://github.com/openfisca/openfisca-france/pull/914)
+## 21.3.0 [#914](https://github.com/openfisca/openfisca-france/pull/914)
 
 * Évolution du système socio-fiscal.
 * Zones impactées :
@@ -83,7 +91,6 @@
 - Mise à jour des formules (2014-2016) du crédit d'impôt 'saldom2' et de la réduction d'impôt 'saldom'
 - Correction de la formule du crédit d'IR (sur la majoration pour nombre d'ascendants sd eplus de 65 bénéficiaires de l'APA et pour lesquels des dépenses d'emploi à domicile ont été engagées - case 7DL)
 - Ajout de la case 7DD dans les inputs variables
-
 
 ### 21.2.1 [#956](https://github.com/openfisca/openfisca-france/pull/956)
 
@@ -128,7 +135,7 @@
     + Création de `valeur_patrimoine_loue`, `valeur_immo_non_loue`, `valeur_terrains_non_loues` et `epargne_revenus_imposables`
     + Renommage de `valeur_terrains_non_loue` en `valeur_terrains_non_loues`
 
-## 20.9.1 [#954](https://github.com/openfisca/openfisca-france/pull/954)
+### 20.9.1 [#954](https://github.com/openfisca/openfisca-france/pull/954)
 
 * Évolution du système socio-fiscal.
 * Zones impactées : `mesures`

--- a/openfisca_france/model/prestations/cheque_energie.py
+++ b/openfisca_france/model/prestations/cheque_energie.py
@@ -24,7 +24,11 @@ class cheque_energie_unites_consommation(Variable):
         gardes_alternees = menage.sum(menage.members('garde_alternee', period.first_month))
 
         nb_personnes_ajuste = nb_personnes - 0.5 * gardes_alternees
-        return uc.premiere_personne + uc.deuxieme_personne * (nb_personnes_ajuste > 1) * (nb_personnes_ajuste - 1) + uc.autres_personnes * (nb_personnes_ajuste > 2) * (nb_personnes_ajuste - 2)
+        return (
+            + uc.premiere_personne
+            + uc.deuxieme_personne * (nb_personnes_ajuste > 1) * (min_(nb_personnes_ajuste, 2) - 1)
+            + uc.autres_personnes * (nb_personnes_ajuste > 2) * (nb_personnes_ajuste - 2)
+        )
 
 
 class cheque_energie_eligibilite_logement(Variable):

--- a/openfisca_france/model/prestations/cheque_energie.py
+++ b/openfisca_france/model/prestations/cheque_energie.py
@@ -18,7 +18,7 @@ class cheque_energie_unites_consommation(Variable):
     label = u"Unités de consommation du ménage pour le calcul du chèque Énergie"
     definition_period = YEAR
 
-    def formula_2017(menage, period, parameters):
+    def formula_2018(menage, period, parameters):
         uc = parameters(period).cheque_energie.unites_consommation
         nb_personnes = menage.nb_persons()
         gardes_alternees = menage.sum(menage.members('garde_alternee', period.first_month))
@@ -43,7 +43,7 @@ class cheque_energie_eligibilite_logement(Variable):
     label = u"Éligibilité du logement occupé au chèque énergie"
     definition_period = MONTH
 
-    def formula_2017(menage, period, parameters):
+    def formula_2018(menage, period, parameters):
         statut_occupation_logement = menage('statut_occupation_logement', period)
         residence_saint_martin = menage('residence_saint_martin', period)
 
@@ -65,7 +65,7 @@ class cheque_energie_montant(Variable):
     label = u"Montant du chèque énergie"
     definition_period = YEAR
 
-    def formula_2017(menage, period, parameters):
+    def formula_2018(menage, period, parameters):
         baremes = parameters(period).cheque_energie.baremes
         seuils = baremes.thresholds
         montants = baremes.montants
@@ -94,5 +94,5 @@ class cheque_energie(Variable):
     label = u"Montant auquel le ménage peut prétendre au titre du chèque energie"
     definition_period = MONTH
 
-    def formula_2017(menage, period, parameters):
+    def formula_2018(menage, period, parameters):
         return menage('cheque_energie_montant', period.this_year) * menage('cheque_energie_eligibilite_logement', period)

--- a/openfisca_france/model/prestations/cheque_energie.py
+++ b/openfisca_france/model/prestations/cheque_energie.py
@@ -25,7 +25,7 @@ class cheque_energie_unites_consommation(Variable):
 
         nb_personnes_ajuste = nb_personnes - 0.5 * gardes_alternees
         return (
-            + uc.premiere_personne
+            uc.premiere_personne
             + uc.deuxieme_personne * (nb_personnes_ajuste > 1) * (min_(nb_personnes_ajuste, 2) - 1)
             + uc.autres_personnes * (nb_personnes_ajuste > 2) * (nb_personnes_ajuste - 2)
         )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '21.8.0',
+    version = '21.8.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/cheque_energie/montant.yaml
+++ b/tests/formulas/cheque_energie/montant.yaml
@@ -117,3 +117,13 @@
   output_variables:
     cheque_energie_montant:
       2018: 0
+
+- name: 1 UC - RFR < 5600 en 2017
+  period: 2017
+  input_variables:
+    cheque_energie_unites_consommation: 1
+    rfr:
+     2016: 5599
+  output_variables:
+    cheque_energie:
+      2017-01: 0

--- a/tests/formulas/cheque_energie/unites_consommation.yaml
+++ b/tests/formulas/cheque_energie/unites_consommation.yaml
@@ -67,3 +67,36 @@
   output_variables:
     cheque_energie_unites_consommation:
       2018: 1.25
+
+- name: UC union libre, avec deux enfants
+  period: 2018
+  menages:
+    - personne_de_reference: parent
+      conjoint: conjoint
+      enfants:
+      - Mila
+      - Luca
+  foyers_fiscaux:
+    - declarants:
+      - parent
+      personnes_a_charge:
+      - Mila
+    - declarants:
+      - conjoint
+      personnes_a_charge:
+      - Luca
+  familles:
+    - parents:
+      - parent
+      - conjoint
+      enfants:
+      - Mila
+      - Luca
+  individus:
+    - id: parent
+    - id: conjoint
+    - id: Mila
+    - id: Luca
+  output_variables:
+    cheque_energie_unites_consommation:
+      2018: 2.1


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Zones impactées : `prestations/cheque_energie`
* Périodes concernées : À partir de 2017
* Détails :
  - Corrige le calcul des unités de consommation pour le chèque énergie
  - Corrige la période de validité des variables relatives au chèque énergie (valide à partir de 2018 et non 2017)

Superseeds #960.