### PR TITLE
Ajoute l'exclusion des cas particuliers dans le calcul de la base ressource patrimoine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 21.9.1 [#975](https://github.com/openfisca/openfisca-france/pull/975)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/10/2016.
+* Zones impactées :
+  - `prestations/aides_logement`
+* Détails :
+  - Ajoute l'exclusion des cas particuliers dans le calcul des ressources prises en compte pour l'aide logement (AAH, AEEH, logement foyer)
+
 ## 21.9.0 [#969](https://github.com/openfisca/openfisca-france/pull/969)
 
 * Amélioration technique

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -121,7 +121,7 @@ class aide_logement_base_ressources_patrimoine(Variable):
         patrimoine = epargne_revenus_imposables + capitaux_non_productifs + foncier
 
         statut_logement = famille.demandeur.menage("statut_occupation_logement", period)
-        est_locataire_foyer = statut_logement == TypesStatutOccupationLogement.locataire_foyer
+        est_locataire_foyer = (statut_logement == TypesStatutOccupationLogement.locataire_foyer)
         membres_famille_percoit_aah = famille.members('aah', period) > 0
         famille_percoit_aah = famille.any(membres_famille_percoit_aah)
         famille_percoit_aeeh = famille('aeeh', period) > 0

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -120,7 +120,14 @@ class aide_logement_base_ressources_patrimoine(Variable):
 
         patrimoine = epargne_revenus_imposables + capitaux_non_productifs + foncier
 
-        return (patrimoine > 30000) * (
+        statut_logement = famille.demandeur.menage("statut_occupation_logement", period)
+        est_locataire_foyer = statut_logement == TypesStatutOccupationLogement.locataire_foyer
+        membres_famille_percoit_aah = famille.members('aah', period) > 0
+        famille_percoit_aah = famille.any(membres_famille_percoit_aah)
+        famille_percoit_aeeh = famille('aeeh', period) > 0
+
+        return not_(est_locataire_foyer) * not_(famille_percoit_aah) * not_(famille_percoit_aeeh) *\
+            (patrimoine > 30000) * (
             + capitaux_non_productifs * abattements.taux_interet_forfaitaire_epargne_non_imposable
             + valeur_locative_immo_non_loue * abattements.abattement_valeur_locative_immo_non_loue
             + valeur_locative_terrains_non_loues * abattements.abattement_valeur_locative_terrains_non_loues

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -126,11 +126,12 @@ class aide_logement_base_ressources_patrimoine(Variable):
         famille_percoit_aah = famille.any(membres_famille_percoit_aah)
         famille_percoit_aeeh = famille('aeeh', period) > 0
 
-        return not_(est_locataire_foyer) * not_(famille_percoit_aah) * not_(famille_percoit_aeeh) *\
-            (patrimoine > 30000) * (
-            + capitaux_non_productifs * abattements.taux_interet_forfaitaire_epargne_non_imposable
-            + valeur_locative_immo_non_loue * abattements.abattement_valeur_locative_immo_non_loue
-            + valeur_locative_terrains_non_loues * abattements.abattement_valeur_locative_terrains_non_loues
+        return not_(est_locataire_foyer) * not_(famille_percoit_aah) * not_(famille_percoit_aeeh) * (
+                (patrimoine > 30000) * (
+                    + capitaux_non_productifs * abattements.taux_interet_forfaitaire_epargne_non_imposable
+                    + valeur_locative_immo_non_loue * abattements.abattement_valeur_locative_immo_non_loue
+                    + valeur_locative_terrains_non_loues * abattements.abattement_valeur_locative_terrains_non_loues
+                )
             )
 
 

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -126,8 +126,10 @@ class aide_logement_base_ressources_patrimoine(Variable):
         famille_percoit_aah = famille.any(membres_famille_percoit_aah)
         famille_percoit_aeeh = famille('aeeh', period) > 0
 
+        seuil_valorisation = parameters(period).prestations.aides_logement.patrimoine.seuil_valorisation
+
         return not_(est_locataire_foyer) * not_(famille_percoit_aah) * not_(famille_percoit_aeeh) * (
-                (patrimoine > 30000) * (
+                (patrimoine > seuil_valorisation) * (
                     + capitaux_non_productifs * abattements.taux_interet_forfaitaire_epargne_non_imposable
                     + valeur_locative_immo_non_loue * abattements.abattement_valeur_locative_immo_non_loue
                     + valeur_locative_terrains_non_loues * abattements.abattement_valeur_locative_terrains_non_loues

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -92,6 +92,12 @@ class aide_logement_base_ressources_patrimoine(Variable):
     definition_period = MONTH
 
     def formula_2016_10_01(famille, period, parameters):
+        '''
+        Exclusion des titulaires de l'AAH, AEEH et des personnes résidant en EHPAD :
+        'Les personnes titulaires de l’AAH ainsi que les personnes âgées dépendantes en EHPAD
+        ne sont pas concernées par la mesure.'
+        Lien: http://www.cohesion-territoires.gouv.fr/IMG/pdf/160923_edl_apl_detailles_patrimoine.pdf
+        '''
         livret_a_i = famille.members('livret_a', period)
         livret_a = famille.sum(livret_a_i)
         taux_livret_a = parameters(period).epargne.livret_a.taux

--- a/openfisca_france/parameters/prestations/aides_logement/patrimoine/seuil_valorisation.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/patrimoine/seuil_valorisation.yaml
@@ -1,5 +1,5 @@
 description: Seuil de l'estimation de la valeur du patrimoine au delà duquel le patrimoine est valorisé
-reference: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000033243725&categorieLien=id
+reference: https://www.legifrance.gouv.fr/eli/decret/2016/10/12/LHAL1606833D/jo/texte
 unit: currency
 values:
   2016-10-01:

--- a/openfisca_france/parameters/prestations/aides_logement/patrimoine/seuil_valorisation.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/patrimoine/seuil_valorisation.yaml
@@ -1,0 +1,6 @@
+description: Seuil de l'estimation de la valeur du patrimoine au delà duquel le patrimoine est valorisé
+reference: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000033243725&categorieLien=id
+unit: currency
+values:
+  2016-10-01:
+    value: 30000.00

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '21.9.0',
+    version = '21.9.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/patrimoine.yaml
+++ b/tests/formulas/patrimoine.yaml
@@ -129,3 +129,150 @@
     conjoint: "parent2"
   output_variables:
      aide_logement_base_ressources_patrimoine: 0 + 0 + 0
+
+- name: 5. Personne Résidant en EHPAD
+  keywords:
+    - patrimoine
+  description:
+  period: "2016-10"
+  relative_error_margin: 0.02
+  individus:
+    - id: "parent1"
+      date_naissance: 1948-03-15
+      epargne_revenus_non_imposables: 9800
+      valeur_immo_non_loue: 156000
+      valeur_locative_immo_non_loue: 450 * 2
+      valeur_terrains_non_loues: 0
+      valeur_locative_terrains_non_loues: 0 * 2
+  familles:
+    parents: ["parent1"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+  menages:
+    personne_de_reference: "parent1"
+    statut_occupation_logement: "locataire_foyer"
+  output_variables:
+     aide_logement_base_ressources_patrimoine: 0 + 0 + 0
+
+- name: 6. Personne residant en Logement-foyer
+  keywords:
+    - patrimoine
+  description:
+  period: "2016-10"
+  relative_error_margin: 0.02
+  individus:
+    - id: "parent1"
+      date_naissance: 1940-01-27
+      epargne_revenus_non_imposables: 7200
+      valeur_immo_non_loue: 120000
+      valeur_locative_immo_non_loue: 350 * 2
+      valeur_terrains_non_loues: 80000
+      valeur_locative_terrains_non_loues: 300 * 2
+  familles:
+    parents: ["parent1"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+  menages:
+    personne_de_reference: "parent1"
+    statut_occupation_logement: "locataire_foyer"
+  output_variables:
+     aide_logement_base_ressources_patrimoine: 0 + 0 + 0
+
+- name: 7. Personne résidant en Maison de retraite
+  keywords:
+    - patrimoine
+  description:
+  period: "2016-10"
+  relative_error_margin: 0.02
+  individus:
+    - id: "parent1"
+      date_naissance: 1946-07-20
+      epargne_revenus_non_imposables: 10200
+      valeur_immo_non_loue: 180000
+      valeur_locative_immo_non_loue: 450 * 2
+      valeur_terrains_non_loues: 40000
+      valeur_locative_terrains_non_loues: 150 * 2
+  familles:
+    parents: ["parent1"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+  menages:
+    personne_de_reference: "parent1"
+    statut_occupation_logement: "locataire_foyer"
+  output_variables:
+     aide_logement_base_ressources_patrimoine: 0 + 0 + 0
+
+- name: 8. Foyer avec un membre bénéficiaire d'AAH
+  keywords:
+    - patrimoine
+  description:
+  period: "2016-10"
+  relative_error_margin: 0.02
+  individus:
+    - id: "parent1"
+      date_naissance: 1968-01-10
+      epargne_revenus_non_imposables: 20768
+      valeur_immo_non_loue: 0
+      valeur_locative_immo_non_loue: 0 * 2
+      valeur_terrains_non_loues: 80000
+      valeur_locative_terrains_non_loues: 300 * 2
+    - id: "parent2"
+      date_naissance: 1971-01-20
+      epargne_revenus_non_imposables: 4812
+      valeur_immo_non_loue: 0
+      valeur_locative_immo_non_loue: 0 * 2
+      valeur_terrains_non_loues: 0
+      valeur_locative_terrains_non_loues: 0 * 2
+      aah: 1000
+    - id: "enfant1"
+      date_naissance: 2005-07-11
+  familles:
+    parents: ["parent1", "parent2"]
+    enfants: ["enfant1"]
+  foyers_fiscaux:
+    declarants: ["parent1", "parent2"]
+    personnes_a_charge: ["enfant1"]
+  menages:
+    personne_de_reference: "parent1"
+    conjoint: "parent2"
+    enfants: ["enfant1"]
+  output_variables:
+     aide_logement_base_ressources_patrimoine: 0 + 0 + 0
+
+- name: 9. Foyer avec un membre bénéficiaire d'AEEH
+  keywords:
+    - patrimoine
+  description:
+  period: "2016-10"
+  relative_error_margin: 0.02
+  individus:
+    - id: "parent1"
+      date_naissance: 1968-01-10
+      epargne_revenus_non_imposables: 0
+      valeur_immo_non_loue: 0
+      valeur_locative_immo_non_loue: 0 * 2
+      valeur_terrains_non_loues: 80000
+      valeur_locative_terrains_non_loues: 300 * 2
+    - id: "parent2"
+      date_naissance: 1971-01-20
+      epargne_revenus_non_imposables: 10000
+      valeur_immo_non_loue: 0
+      valeur_locative_immo_non_loue: 0 * 2
+      valeur_terrains_non_loues: 0
+      valeur_locative_terrains_non_loues: 0 * 2
+      aah: 1000
+    - id: "enfant1"
+      date_naissance: 2005-07-11
+  familles:
+    parents: ["parent1", "parent2"]
+    enfants: ["enfant1"]
+    aeeh: 1000
+  foyers_fiscaux:
+    declarants: ["parent1", "parent2"]
+    personnes_a_charge: ["enfant1"]
+  menages:
+    personne_de_reference: "parent1"
+    conjoint: "parent2"
+    enfants: ["enfant1"]
+  output_variables:
+     aide_logement_base_ressources_patrimoine: 0 + 0 + 0


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/10/2016.
* Zones impactées : `prestations/`
* Détails :
  - Ajoute l'exclusion des cas particuliers dans le calcul des ressources prises en compte pour l'aide logement (AAH, AEEH, logement foyer)

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.
