### PR TITLE
Revalorisation de la PPA au 1er avril 2018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 21.10.2 [#982](https://github.com/openfisca/openfisca-france/pull/984)
+
+* Évolution du système socio-fiscal.
+* Zones impactées : `prestations/minima_sociaux/ppa`
+* Périodes concernées : à partir du 01/04/2018.
+* Détails :
+  - Met à jour le montant forfaitaire de base du calcul de la PPA
+
 ### 21.10.1 [#977](https://github.com/openfisca/openfisca-france/pull/977)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/montant_de_base.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/montant_de_base.yaml
@@ -3,10 +3,13 @@ unit: currency
 values:
   2016-01-01:
     value: 524.16
-    reference: https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=F16D1893679E33D9ED714338F70661BC.tplgfr21s_3?idArticle=JORFARTI000031665102&cidTexte=JORFTEXT000031665094&dateTexte=29990101&categorieLien=id
+    reference: https://www.legifrance.gouv.fr/eli/decret/2015/12/21/AFSA1521306D/jo/article_1
   2016-04-01:
     value: 524.68
-    reference: https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=598BE225CBC742C019484C8F9C5D58A3.tplgfr21s_3?idArticle=JORFARTI000034580247&cidTexte=JORFTEXT000034580242&dateTexte=29990101&categorieLien=id
+    reference: https://www.legifrance.gouv.fr/eli/decret/2017/5/4/AFSA1710709D/jo/article_1
   2017-04-01:
     value: 526.25
     reference: https://www.legifrance.gouv.fr/affichTexte.do;jsessionid=F0C7F140213C6E7F350E4D08F8ABCC7E.tplgfr21s_3?cidTexte=LEGITEXT000034780395&dateTexte=20170505&categorieLien=cid#LEGITEXT000034780395
+  2018-04-01:
+    value: 531.51
+    reference: https://www.legifrance.gouv.fr/eli/decret/2018/5/3/SSAA1805962D/jo/texte

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '21.10.1',
+    version = '21.10.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/ppa_2018.yaml
+++ b/tests/formulas/ppa_2018.yaml
@@ -1,0 +1,363 @@
+- name: "PPA Cas N°1"
+  period: 2018-05
+  absolute_error_margin: 0.03
+  familles:
+    parents: ["personne1"]
+    aide_logement: 80
+  menages:
+    personne_de_reference: "personne1"
+    statut_occupation_logement: locataire_vide
+  individus:
+    - id: "personne1"
+      date_naissance: 1980-01-01
+      salaire_net:
+        2018-05: 134
+        2018-04: 134
+        2018-03: 134
+        2018-02: 134
+  output_variables:
+    ppa: 83.08
+
+- name: "PPA Cas N°2"
+  period: 2018-05
+  absolute_error_margin: 0.03
+  familles:
+    parents: ["personne1"]
+    enfants: ["enfant1"]
+    aide_logement: 150
+    asf:
+      2018-05: 115.30
+      2018-04: 115.30
+      2018-03: 109.65
+      2018-02: 109.65
+  foyers_fiscaux:
+    declarants: ["personne1"]
+    personnes_a_charge: ["enfant1"]
+  menages:
+    personne_de_reference: "personne1"
+    enfants: ["enfant1"]
+    statut_occupation_logement: locataire_vide
+  individus:
+    - id: "personne1"
+      date_naissance: 1980-01-01
+      salaire_net:
+        2018-05: 134
+        2018-04: 134
+        2018-03: 134
+        2018-02: 134
+    - id: "enfant1"
+      date_naissance: 2005-03-10
+  output_variables:
+    ppa: 83.08
+
+- name: "PPA Cas N°3"
+  period: 2018-05
+  absolute_error_margin: 0.03
+  familles:
+    parents: ["personne1"]
+    enfants: ["enfant1", "enfant2"]
+    aide_logement: 200
+    asf:
+      2018-05: 230.60
+      2018-04: 230.60
+      2018-03: 219.30
+      2018-02: 219.30
+    af:
+      2018-05: 131.16
+      2018-04: 131.16
+      2018-03: 129.86
+      2018-02: 129.86
+  foyers_fiscaux:
+    declarants: ["personne1"]
+    personnes_a_charge: ["enfant1", "enfant2"]
+  menages:
+    personne_de_reference: "personne1"
+    enfants: ["enfant1", "enfant2"]
+    statut_occupation_logement: locataire_vide
+  individus:
+    - id: "personne1"
+      date_naissance: 1980-01-01
+      salaire_net:
+        2018-05: 134
+        2018-04: 134
+        2018-03: 134
+        2018-02: 134
+    - id: "enfant1"
+      date_naissance: 2005-03-10
+    - id: "enfant2"
+      date_naissance: 2008-01-04
+  output_variables:
+    ppa: 83.08
+
+- name: "PPA Cas N°4"
+  period: 2018-05
+  absolute_error_margin: 0.03
+  familles:
+    parents: ["personne1", "personne2"]
+    aide_logement: 200
+  foyers_fiscaux:
+    declarants: ["personne1", "personne2"]
+  menages:
+    personne_de_reference: "personne1"
+    conjoint: "personne2"
+    statut_occupation_logement: locataire_vide
+  individus:
+    - id: "personne1"
+      date_naissance: 1980-01-01
+      salaire_net:
+        2018-05: 100
+        2018-04: 100
+        2018-03: 100
+        2018-02: 100
+    - id: "personne2"
+      date_naissance: 1982-02-02
+      salaire_net:
+        2018-05: 67
+        2018-04: 67
+        2018-03: 67
+        2018-02: 67
+  output_variables:
+    ppa: 103.54
+
+- name: "PPA Cas N°5"
+  period: 2018-05
+  absolute_error_margin: 0.03
+  familles:
+    parents: ["personne1", "personne2"]
+    enfants: ["enfant1"]
+    aide_logement: 200
+  foyers_fiscaux:
+    declarants: ["personne1", "personne2"]
+    personnes_a_charge: ["enfant1"]
+  menages:
+    personne_de_reference: "personne1"
+    conjoint: "personne2"
+    enfants: ["enfant1"]
+    statut_occupation_logement: locataire_vide
+  individus:
+    - id: "personne1"
+      date_naissance: 1980-01-01
+      salaire_net:
+        2018-05: 250
+        2018-04: 250
+        2018-03: 250
+        2018-02: 250
+    - id: "personne2"
+      date_naissance: 1982-02-02
+      salaire_net:
+        2018-05: 400
+        2018-04: 400
+        2018-03: 400
+        2018-02: 400
+    - id: "enfant1"
+      date_naissance: 2005-03-10
+  output_variables:
+    ppa: 403.00
+
+- name: "PPA Cas N°6"
+  period: 2018-05
+  absolute_error_margin: 0.03
+  familles:
+    parents: ["personne1", "personne2"]
+    enfants: ["enfant1", "enfant2"]
+    aide_logement: 250
+    af:
+      2018-05: 131.16
+      2018-04: 131.16
+      2018-03: 129.86
+      2018-02: 129.86
+  foyers_fiscaux:
+    declarants: ["personne1", "personne2"]
+    personnes_a_charge: ["enfant1", "enfant2"]
+  menages:
+    personne_de_reference: "personne1"
+    conjoint: "personne2"
+    enfants: ["enfant1", "enfant2"]
+    statut_occupation_logement: locataire_vide
+  individus:
+    - id: "personne1"
+      date_naissance: 1980-01-01
+      salaire_net:
+        2018-05: 250
+        2018-04: 250
+        2018-03: 250
+        2018-02: 250
+    - id: "personne2"
+      date_naissance: 1982-02-02
+      salaire_net:
+        2018-05: 400
+        2018-04: 400
+        2018-03: 400
+        2018-02: 400
+    - id: "enfant1"
+      date_naissance: 2005-03-10
+    - id: "enfant2"
+      date_naissance: 2008-01-04
+  output_variables:
+    ppa: 403.00
+
+- name: "PPA Cas Non Passant N°1"
+  period: 2018-05
+  absolute_error_margin: 0.03
+  familles:
+    parents: ["personne1", "personne2"]
+    aide_logement: 200
+  foyers_fiscaux:
+    declarants: ["personne1", "personne2"]
+  menages:
+    personne_de_reference: "personne1"
+    conjoint: "personne2"
+    statut_occupation_logement: locataire_vide
+  individus:
+    - id: "personne1"
+      date_naissance: 1980-01-01
+      salaire_net:
+        2018-05: 1200
+        2018-04: 1200
+        2018-03: 1200
+        2018-02: 1200
+    - id: "personne2"
+      date_naissance: 1982-02-02
+      salaire_net:
+        2018-05: 1000
+        2018-04: 1000
+        2018-03: 1000
+        2018-02: 1000
+  output_variables:
+    ppa: 0
+
+- name: "PPA Cas Non Passant N°2"
+  period: 2018-05
+  absolute_error_margin: 0.03
+  familles:
+    parents: ["personne1", "personne2"]
+    enfants: ["enfant1"]
+    aide_logement: 80
+  foyers_fiscaux:
+    declarants: ["personne1", "personne2"]
+    personnes_a_charge: ["enfant1"]
+  menages:
+    personne_de_reference: "personne1"
+    conjoint: "personne2"
+    enfants: ["enfant1"]
+    statut_occupation_logement: locataire_vide
+  individus:
+    - id: "personne1"
+      date_naissance: 1980-01-01
+      salaire_net:
+        2018-05: 1200
+        2018-04: 1200
+        2018-03: 1200
+        2018-02: 1200
+    - id: "personne2"
+      date_naissance: 1982-02-02
+      salaire_net:
+        2018-05: 1500
+        2018-04: 1500
+        2018-03: 1500
+        2018-02: 1500
+    - id: "enfant1"
+      date_naissance: 2005-03-10
+  output_variables:
+    ppa: 0
+
+- name: "PPA Cas Non Passant N°3"
+  period: 2018-05
+  absolute_error_margin: 0.03
+  familles:
+    parents: ["personne1", "personne2"]
+    enfants: ["enfant1", "enfant2"]
+    aide_logement: 100
+    af:
+      2018-05: 131.16
+      2018-04: 131.16
+      2018-03: 129.86
+      2018-02: 129.86
+  foyers_fiscaux:
+    declarants: ["personne1", "personne2"]
+    personnes_a_charge: ["enfant1", "enfant2"]
+  menages:
+    personne_de_reference: "personne1"
+    conjoint: "personne2"
+    enfants: ["enfant1", "enfant2"]
+    statut_occupation_logement: locataire_vide
+  individus:
+    - id: "personne1"
+      date_naissance: 1980-01-01
+      salaire_net:
+        2018-05: 1200
+        2018-04: 1200
+        2018-03: 1200
+        2018-02: 1200
+    - id: "personne2"
+      date_naissance: 1982-02-02
+      salaire_net:
+        2018-05: 1450
+        2018-04: 1450
+        2018-03: 1450
+        2018-02: 1450
+    - id: "enfant1"
+      date_naissance: 2000-01-10
+      salaire_net:
+        2018-05: 400
+        2018-04: 400
+        2018-03: 400
+        2018-02: 400
+    - id: "enfant2"
+      date_naissance: 2005-03-10
+  output_variables:
+    ppa: 0
+
+- name: "PPA Cas Non Passant N°4"
+  period: 2018-05
+  absolute_error_margin: 0.03
+  familles:
+    parents: ["personne1"]
+    aide_logement: 80
+  foyers_fiscaux:
+    declarants: ["personne1"]
+  menages:
+    personne_de_reference: "personne1"
+    statut_occupation_logement: locataire_vide
+  individus:
+    - id: "personne1"
+      date_naissance: 1980-01-01
+      salaire_net:
+        2018-05: 1450
+        2018-04: 1450
+        2018-03: 1450
+        2018-02: 1450
+  output_variables:
+    ppa: 0
+
+- name: "PPA Cas Non Passant N°5"
+  period: 2018-05
+  absolute_error_margin: 0.03
+  familles:
+    parents: ["personne1"]
+    enfants: ["enfant1"]
+    aide_logement: 150
+    asf:
+      2018-05: 115.30
+      2018-04: 115.30
+      2018-03: 109.65
+      2018-02: 109.65
+  foyers_fiscaux:
+    declarants: ["personne1"]
+    personnes_a_charge: ["enfant1"]
+  menages:
+    personne_de_reference: "personne1"
+    enfants: ["enfant1"]
+    statut_occupation_logement: locataire_vide
+  individus:
+    - id: "personne1"
+      date_naissance: 1980-01-01
+      salaire_net:
+        2018-05: 2000
+        2018-04: 2000
+        2018-03: 2000
+        2018-02: 2000
+    - id: "enfant1"
+      date_naissance: 2005-03-10
+  output_variables:
+    ppa: 0


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/04/2018.
* Zones impactées : `prestations\minima_sociaux\ppa`.
* Détails :
  - Met à jour le montant forfaitaire de base du calcul de la PPA

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.