### PR TITLE
Introduit Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ nosetests tests/test_basics.py # Ces test peuvent prendre jusqu'à 60 secondes.
 ```
 :tada: OpenFisca-France est prêt à être utilisé !
 
+### C. Installation avancée avec Docker
+
+Si vous ne souhaitez pas avoir à gérer Python directement sur votre machine, vous pouvez utiliser Docker.
+
+Installez [Docker](https://docs.docker.com/install/) et [Docker Compose](https://docs.docker.com/compose/install/).
+
+[Clonez OpenFisca avec Git](#cloner-openfisca-france-avec-git), puis lancez simplement :
+
+```
+docker-compose up
+```
+
+Hop :space_invader: L'API Web OpenFisca est disponible sur le port 6000 de l'hôte Docker.
+
 #### Prochaines étapes
 
 - Pour enrichir ou faire évoluer la législation d'OpenFisca-France, lisez _[Coding the Legislation](http://openfisca.org/doc/coding-the-legislation/index.html)_ (en anglais).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+
+  python:
+    build:
+      dockerfile: './docker/python/Dockerfile'
+      context: '.'
+    volumes:
+      - './:/usr/src/app'
+    ports:
+      - '6000:6000'
+    # http://docs.gunicorn.org/en/stable/faq.html#how-do-i-avoid-gunicorn-excessively-blocking-in-os-fchmod
+    tmpfs:
+      - /mem:defaults,size=64m,mode=1777,noatime

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:2.7
+
+RUN mkdir /usr/src/app
+WORKDIR /usr/src/app
+
+COPY ./setup.py ./
+
+RUN pip install -e .
+RUN pip install -e ".[test]"
+
+COPY docker/python/start.sh /usr/local/bin/openfisca-start
+RUN chmod +x /usr/local/bin/openfisca-start
+
+CMD ["openfisca-start"]

--- a/docker/python/start.sh
+++ b/docker/python/start.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+openfisca serve \
+--log-level debug \
+--bind '0.0.0.0:6000' \
+--workers 4 \
+--timeout 6000 \
+--log-file=- \
+--worker-tmp-dir /mem \
+--preload \
+--country-package openfisca_france


### PR DESCRIPTION
⚠️ Ne pas merger pour l'instant. 

* Amélioration technique. 
* Détails :

Cette Pull Request permet de faire tourner OpenFisca dans un container Docker, orchestré avec Docker Compose. Il n'y a rien de bien compliqué, ça créé juste un container avec Python 2.7, ça installe tout, et ça sert l'API sur le port 6000 de l'hôte Docker. 

Je rencontre toutefois un problème : **l'API met près de 2 minutes à démarrer**. 

J'ai utilisé [l'option `--preload`](http://docs.gunicorn.org/en/stable/settings.html#preload-app) de Gunicorn pour être certain que l'API a bien démarré avant d'envoyer la première requête. 

Je me suis aussi assuré que [`worker_tmp_dir`](http://docs.gunicorn.org/en/stable/settings.html#worker-tmp-dir) est bien [monté en `tmpfs`](http://docs.gunicorn.org/en/stable/faq.html#how-do-i-avoid-gunicorn-excessively-blocking-in-os-fchmod), mais ça ne change rien au temps de démarrage. 

Est-ce normal ? Pourtant `libyaml` est bien installé dans le container Docker. 

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

