### PR TITLE
Ajoute au Makefile une cible d'analyse de performances par profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 /openfisca_france/assets/apl/france2014.zip
 /tags
 .spyproject
+*.prof

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+TO_PROFILE=openfisca_france/scripts/performance_tests/test_tests.py
+
 all: test
 
 check-no-prints:
@@ -23,3 +27,8 @@ test: check-syntax-errors check-no-prints
 
 performance:
 	python openfisca_france/scripts/performance_tests/test_tests.py
+
+profile:
+	@echo "> Profiling $(TO_PROFILE)..."
+	python -m cProfile -o results.prof $(TO_PROFILE)
+	snakeviz results.prof

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ setup(
             'flake8 == 3.4.1',
             'scipy >= 0.17', # Only used to test de_net_a_brut reform
             ],
+        'profile': [
+            'snakeviz', # For make profile
+            ],
         },
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [


### PR DESCRIPTION
Fixes #1014 

* Changement mineur.
* Détails :
  - Ajout d'une cible `profile` au Makefile pour faciliter l'analyse visuelle des performances (en temps) 
    
    Dans openfisca-france :
    * Installer via `pip install -e .[profile]`
    * Exécuter via `make profile`
    * Ou, paramétrer le code python à profiler via 
      `make profile TO_PROFILE=mon_fichier_a_analyser.py`

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).
