### PR TITLE
Renseigne l'unité de certains barèmes libellés en monnaie nominale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 21.10.11 [#XXX](https://github.com/openfisca/openfisca-france/pull/XXX)
+
+* Changement mineur.
+* Détails :
+  - Ajoute l'unité manquante à certains barèmes libellés en euros ou francs.
+
 ### 21.10.10 [#1017](https://github.com/openfisca/openfisca-france/pull/1017)
 
 * Évolution du système socio-fiscal.
@@ -14,7 +20,7 @@
 * Changement mineur.
 * Détails :
   - Ajoute un test de performance sur les tests de CircleCI
-  - Ce test peut être lancé avec la commande: 
+  - Ce test peut être lancé avec la commande:
     `python openfisca_france/scripts/performance_tests/test_circleci_builds.py 1717 1716`
 
 ### 21.10.8 [#1010](https://github.com/openfisca/openfisca-france/pull/1010)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * Changement mineur.
 * Détails :
   - Ajoute un test de performance sur les tests de CircleCI
-  - Ce test peut être lancé avec la commande:
+  - Ce test peut être lancé avec la commande :
     `python openfisca_france/scripts/performance_tests/test_circleci_builds.py 1717 1716`
 
 ### 21.10.8 [#1010](https://github.com/openfisca/openfisca-france/pull/1010)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 21.10.11 [#XXX](https://github.com/openfisca/openfisca-france/pull/XXX)
+### 21.10.11 [#1020](https://github.com/openfisca/openfisca-france/pull/1020)
 
 * Changement mineur.
 * Détails :

--- a/openfisca_france/parameters/cotsoc/taxes_sal/taux_maj.yaml
+++ b/openfisca_france/parameters/cotsoc/taxes_sal/taux_maj.yaml
@@ -83,3 +83,4 @@ brackets:
       value: 152122.0
 description: 'Taxes sur les salaires : taux majorés (France métropolitaine seulement)'
 reference: openfisca
+unit: currency

--- a/openfisca_france/parameters/cotsoc/taxes_sal/taux_maj.yaml
+++ b/openfisca_france/parameters/cotsoc/taxes_sal/taux_maj.yaml
@@ -1,3 +1,6 @@
+description: 'Taxes sur les salaires : taux majorés (France métropolitaine seulement)'
+reference: openfisca
+unit: currency
 brackets:
 - rate:
     2001-01-01:
@@ -81,6 +84,3 @@ brackets:
       value: 151965.0
     2016-01-01:
       value: 152122.0
-description: 'Taxes sur les salaires : taux majorés (France métropolitaine seulement)'
-reference: openfisca
-unit: currency

--- a/openfisca_france/parameters/cotsoc/tehr.yaml
+++ b/openfisca_france/parameters/cotsoc/tehr.yaml
@@ -7,3 +7,4 @@ brackets:
       value: 1000000.0
 description: Taxes exceptionnelles sur les hauts revenus
 reference: openfisca
+unit: currency

--- a/openfisca_france/parameters/impot_revenu/bareme.yaml
+++ b/openfisca_france/parameters/impot_revenu/bareme.yaml
@@ -1165,3 +1165,4 @@ brackets:
       value: 241740.0
     1986-01-01:
       value: null
+unit: currency

--- a/openfisca_france/parameters/impot_revenu/cehr_ipp.yaml
+++ b/openfisca_france/parameters/impot_revenu/cehr_ipp.yaml
@@ -1,3 +1,6 @@
+description: "Contribution exceptionnelle sur les hauts revenus"
+reference: ipp -  http://bofip.impots.gouv.fr/bofip/7804-PGP.html?identifiant=BOI-IR-CHR-20170711
+unit: currency
 brackets:
 - rate:
     2011-01-01:
@@ -11,5 +14,3 @@ brackets:
   threshold:
     2011-01-01:
       value: 500000.0
-reference: ipp
-unit: currency

--- a/openfisca_france/parameters/impot_revenu/cehr_ipp.yaml
+++ b/openfisca_france/parameters/impot_revenu/cehr_ipp.yaml
@@ -12,3 +12,4 @@ brackets:
     2011-01-01:
       value: 500000.0
 reference: ipp
+unit: currency

--- a/openfisca_france/parameters/prestations/al_param_accal/bareme_loyer_minimun_lo.yaml
+++ b/openfisca_france/parameters/prestations/al_param_accal/bareme_loyer_minimun_lo.yaml
@@ -24,3 +24,4 @@ brackets:
     2007-07-01:
       value: 4095.05
 description: Loyer minimun lo
+unit: currency

--- a/openfisca_france/parameters/taxation_capital/isf/bareme.yaml
+++ b/openfisca_france/parameters/taxation_capital/isf/bareme.yaml
@@ -287,3 +287,4 @@ brackets:
       value: null
 description: Impôt de solidarité
 reference: ipp
+unit: currency

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '21.10.10',
+    version = '21.10.11',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Détails :
  - Ajoute l'unité manquante à certains barèmes libellés en euros ou francs.

