### PR TITLE
Amélioration de la lisibilité de variables de la fiscalité

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@
     - Renomme la variable `supp_familial_traitement` en `supplement_familial_traitement`
     - Renomme le noeud de l'arbre des paramètres `fonc.supp_fam` en `fonc.supplement_familial`
   - [Amélioration de la lisibilité de variables de la fiscalité du capital]()
-    - Renomme la variable `rev_cap_lib` en `revenus_capitaux_prelevement_liberatoire`
+    - Renomme les variables
+      - `rev_cap_lib` en `revenus_capitaux_prelevement_liberatoire`
+      - `rev_cap_bar` en `revenus_capitaux_prelevement_bareme`
 
 ### 21.10.11 [#1020](https://github.com/openfisca/openfisca-france/pull/1020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   - [Amélioration de la lisibilité du supplément familial de traitement](https://github.com/openfisca/openfisca-france/pull/1025)
     - Renomme la variable `supp_familial_traitement` en `supplement_familial_traitement`
     - Renomme le noeud de l'arbre des paramètres `fonc.supp_fam` en `fonc.supplement_familial`
+  - [Amélioration de la lisibilité de variables de la fiscalité du capital]()
+    - Renomme la variable `rev_cap_lib` en `revenus_capitaux_prelevement_liberatoire`
 
 ### 21.10.11 [#1020](https://github.com/openfisca/openfisca-france/pull/1020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@
   - [Amélioration de la lisibilité du supplément familial de traitement](https://github.com/openfisca/openfisca-france/pull/1025)
     - Renomme la variable `supp_familial_traitement` en `supplement_familial_traitement`
     - Renomme le noeud de l'arbre des paramètres `fonc.supp_fam` en `fonc.supplement_familial`
-  - [Amélioration de la lisibilité de variables de la fiscalité du capital]()
+  - [Amélioration de la lisibilité de variables de la fiscalité](https://github.com/openfisca/openfisca-france/pull/1027)
     - Renomme les variables
       - `rev_cap_lib` en `revenus_capitaux_prelevement_liberatoire`
       - `rev_cap_bar` en `revenus_capitaux_prelevement_bareme`
+      - `rev_cap_bar` en `revenus_capitaux_prelevement_bareme`
+      - `retraite_titre_onereux` en `rente_viagere_titre_onereux`
 
 ### 21.10.11 [#1020](https://github.com/openfisca/openfisca-france/pull/1020)
 
@@ -1478,8 +1480,8 @@ These changes are low impact since the two deprecated variables were not used.
 	* `pensions_alimentaires_versees_declarant1`
 	* `prelsoc_cap_bar_declarant1`
 	* `prelsoc_cap_lib_declarant1`
-	* `retraite_titre_onereux_declarant1`
-	* `retraite_titre_onereux_net_declarant1`
+	* `rente_viagere_titre_onereux_declarant1`
+	* `rente_viagere_titre_onereux_net_declarant1`
 	* `rev_microsocial_declarant1`
 	* `statut_occupation_famille`
 	* `statut_occupation_logement_individu`
@@ -1814,9 +1816,9 @@ It is included in the bases of the following variables.
 	* `rsa_forfait_asf_i` -> `rsa_forfait_asf_individu`
 	* `rsa_non_calculable_tns_i` -> `rsa_non_calculable_tns_individu`
 	* `rsa_revenu_activite_i` -> `rsa_revenu_activite_individu`
-	* `rto_declarant1` -> `retraite_titre_onereux_declarant1`
-	* `rto_net_declarant1` -> `retraite_titre_onereux_net_declarant1`
-	* `rto_net` -> `retraite_titre_onereux_net`
+	* `rto_declarant1` -> `rente_viagere_titre_onereux_declarant1`
+	* `rto_net_declarant1` -> `rente_viagere_titre_onereux_net_declarant1`
+	* `rto_net` -> `rente_viagere_titre_onereux_net`
 	* `salcho_imp` -> `revenu_assimile_salaire_apres_abattements`
 	* `smic55` -> `autonomie_financiere`
 	* `statut_occupation_famille` -> `statut_occupation_logement_famille`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - `prestations/minima_sociaux/aah`
   - `revenus/activite/salarie`
   - `fonc.supp_fam`
+  - `prelevements_obligatoires/impot_revenu/ir`
 * Détails :
   - [Prise en compte du taux d'incapacité dans l'éligibilité au CAAH #1021](https://github.com/openfisca/openfisca-france/pull/1021)
     - Renomme le paramètre `prestations.minima_sociaux.aah.taux_d_incapcite` en `prestations.minima_sociaux.aah.taux_incapacite`

--- a/openfisca_france/decompositions/decomp.xml
+++ b/openfisca_france/decompositions/decomp.xml
@@ -57,7 +57,7 @@
         <NODE code="fon" color="255,245,155" desc="Revenus fonciers" shortname="Rev. fonciers" />
         <NODE code="f3vg" color="255,245,155" desc="Plus-values de cessions de valeurs mobilières" shortname="Plus.-values mo." />
         <NODE code="f3vz" color="255,245,155" desc="Plus-values immobilières" shortname="Plus.-values immo." />
-        <NODE code="rev_cap_bar" color="255,239,103" desc="Revenus du capital soumis au barème" shortname="Rev cap bar" />
+        <NODE code="revenus_capitaux_prelevement_bareme" color="255,239,103" desc="Revenus du capital soumis au barème" shortname="Rev cap bar" />
         <NODE code="revenus_capitaux_prelevement_liberatoire" color="255,233,28" desc="Revenus du capital soumis au prélèvement libératoire" shortname="Rev cap lib" />
         <NODE code="rac" color="247,221,0" desc="Revenus accessoires" shortname="Rev. accesoires" />
       </NODE>

--- a/openfisca_france/decompositions/decomp.xml
+++ b/openfisca_france/decompositions/decomp.xml
@@ -50,7 +50,7 @@
       </NODE>
       <NODE code="pensions_alimentaires_percues" color="136,120,178" desc="Pensions alimentaires reçues" shortname="P. alim. reç." />
       <NODE code="pensions_alimentaires_versees" color="136,120,178" desc="Pensions alimentaires versée" shortname="P. alim. vers." />
-      <NODE code="retraite_titre_onereux" color="125,185,86" desc="Rentes viagères" shortname="Rentes viag." />
+      <NODE code="rente_viagere_titre_onereux" color="125,185,86" desc="Rentes viagères" shortname="Rentes viag." />
     </NODE>
     <NODE code="rev_cap_net" color="255,222,48" desc="Revenus du capital net" shortname="Rev. cap. net">
       <NODE code="rev_cap_brut" color="255,222,48" desc="Revenus du capital brut" shortname="Rev. cap. brut">

--- a/openfisca_france/decompositions/decomp.xml
+++ b/openfisca_france/decompositions/decomp.xml
@@ -58,7 +58,7 @@
         <NODE code="f3vg" color="255,245,155" desc="Plus-values de cessions de valeurs mobilières" shortname="Plus.-values mo." />
         <NODE code="f3vz" color="255,245,155" desc="Plus-values immobilières" shortname="Plus.-values immo." />
         <NODE code="rev_cap_bar" color="255,239,103" desc="Revenus du capital soumis au barème" shortname="Rev cap bar" />
-        <NODE code="rev_cap_lib" color="255,233,28" desc="Revenus du capital soumis au prélèvement libératoire" shortname="Rev cap lib" />
+        <NODE code="revenus_capitaux_prelevement_liberatoire" color="255,233,28" desc="Revenus du capital soumis au prélèvement libératoire" shortname="Rev cap lib" />
         <NODE code="rac" color="247,221,0" desc="Revenus accessoires" shortname="Rev. accesoires" />
       </NODE>
       <NODE code="cotsoc_cap" color="243,166,171" desc="Cotisations sociales sur les revenus du capital" shortname="Cotsoc. capital">

--- a/openfisca_france/decompositions/decomp_contrib.xml
+++ b/openfisca_france/decompositions/decomp_contrib.xml
@@ -52,7 +52,7 @@
       </NODE>
       <NODE code="pensions_alimentaires_percues" color="136,120,178" desc="Pensions alimentaires reçues" shortname="P. alim. reç." />
       <NODE code="pensions_alimentaires_versees" color="136,120,178" desc="Pensions alimentaires versée" shortname="P. alim. vers." />
-      <NODE code="retraite_titre_onereux" color="125,185,86" desc="Rentes viagères" shortname="Rentes viag." />
+      <NODE code="rente_viagere_titre_onereux" color="125,185,86" desc="Rentes viagères" shortname="Rentes viag." />
     </NODE>
     <NODE code="rev_cap_net" color="255,222,48" desc="Revenus du capital net" shortname="Rev. cap. net">
       <NODE code="rev_cap_brut" color="255,222,48" desc="Revenus du capital brut" shortname="Rev. cap. brut">

--- a/openfisca_france/decompositions/decomp_contrib.xml
+++ b/openfisca_france/decompositions/decomp_contrib.xml
@@ -60,7 +60,7 @@
         <NODE code="f3vg" color="255,245,155" desc="Plus-values de cessions de valeurs mobilières" shortname="Plus.-values mo." />
         <NODE code="f3vz" color="255,245,155" desc="Plus-values immobilières" shortname="Plus.-values immo." />
         <NODE code="rev_cap_bar" color="255,239,103" desc="Revenus du capital soumis au barème" shortname="Rev cap bar" />
-        <NODE code="rev_cap_lib" color="255,233,28" desc="Revenus du capital soumis au prélèvement libératoire" shortname="Rev cap lib" />
+        <NODE code="revenus_capitaux_prelevement_liberatoire" color="255,233,28" desc="Revenus du capital soumis au prélèvement libératoire" shortname="Rev cap lib" />
         <NODE code="rac" color="247,221,0" desc="Revenus accessoires" shortname="Rev. accesoires" />
       </NODE>
       <NODE code="cotsoc_cap" color="243,166,171" desc="Cotisations sociales sur les revenus du capital" shortname="Cotsoc. capital">

--- a/openfisca_france/decompositions/decomp_contrib.xml
+++ b/openfisca_france/decompositions/decomp_contrib.xml
@@ -59,7 +59,7 @@
         <NODE code="fon" color="255,245,155" desc="Revenus fonciers" shortname="Rev. fonciers" />
         <NODE code="f3vg" color="255,245,155" desc="Plus-values de cessions de valeurs mobilières" shortname="Plus.-values mo." />
         <NODE code="f3vz" color="255,245,155" desc="Plus-values immobilières" shortname="Plus.-values immo." />
-        <NODE code="rev_cap_bar" color="255,239,103" desc="Revenus du capital soumis au barème" shortname="Rev cap bar" />
+        <NODE code="revenus_capitaux_prelevement_bareme" color="255,239,103" desc="Revenus du capital soumis au barème" shortname="Rev cap bar" />
         <NODE code="revenus_capitaux_prelevement_liberatoire" color="255,233,28" desc="Revenus du capital soumis au prélèvement libératoire" shortname="Rev cap lib" />
         <NODE code="rac" color="247,221,0" desc="Revenus accessoires" shortname="Rev. accesoires" />
       </NODE>

--- a/openfisca_france/decompositions/decompositions-multiples.xml
+++ b/openfisca_france/decompositions/decompositions-multiples.xml
@@ -45,7 +45,7 @@
         </NODE>
         <NODE code="pensions_alimentaires_percues" color="136,120,178" desc="Pensions alimentaires reçues" shortname="P. alim. reç." />
         <NODE code="pensions_alimentaires_versees" color="136,120,178" desc="Pensions alimentaires versée" shortname="P. alim. vers." />
-        <NODE code="retraite_titre_onereux" color="125,185,86" desc="Rentes viagères" shortname="Rentes viag." />
+        <NODE code="rente_viagere_titre_onereux" color="125,185,86" desc="Rentes viagères" shortname="Rentes viag." />
       </NODE>
       <NODE code="rev_cap_net" color="255,222,48" desc="Revenus du capital net" shortname="Rev. cap. net">
         <NODE code="rev_cap_brut" color="255,222,48" desc="Revenus du capital brut" shortname="Rev. cap. brut">
@@ -206,7 +206,7 @@
       </NODE>
       <NODE code="pensions_alimentaires_percues" color="136,120,178" desc="Pensions alimentaires reçues" shortname="P. alim. reç." />
       <NODE code="pensions_alimentaires_versees" color="136,120,178" desc="Pensions alimentaires versée" shortname="P. alim. vers." />
-      <NODE code="retraite_titre_onereux" color="125,185,86" desc="Rentes viagères" shortname="Rentes viag." />
+      <NODE code="rente_viagere_titre_onereux" color="125,185,86" desc="Rentes viagères" shortname="Rentes viag." />
     </NODE>
     <NODE code="rev_cap_net" color="255,222,48" desc="Revenus du capital net" shortname="Rev. cap. net">
       <NODE code="rev_cap_brut" color="255,222,48" desc="Revenus du capital brut" shortname="Rev. cap. brut">

--- a/openfisca_france/decompositions/decompositions-multiples.xml
+++ b/openfisca_france/decompositions/decompositions-multiples.xml
@@ -52,7 +52,7 @@
           <NODE code="fon" color="255,245,155" desc="Revenus fonciers" shortname="Rev. fonciers" />
           <NODE code="f3vg" color="255,245,155" desc="Plus-values de cessions de valeurs mobilières" shortname="Plus.-values mo." />
           <NODE code="f3vz" color="255,245,155" desc="Plus-values immobilières" shortname="Plus.-values immo." />
-          <NODE code="rev_cap_bar" color="255,239,103" desc="Revenus du capital soumis au barème" shortname="Rev cap bar" />
+          <NODE code="revenus_capitaux_prelevement_bareme" color="255,239,103" desc="Revenus du capital soumis au barème" shortname="Rev cap bar" />
           <NODE code="revenus_capitaux_prelevement_liberatoire" color="255,233,28" desc="Revenus du capital soumis au prélèvement libératoire" shortname="Rev cap lib" />
           <NODE code="rac" color="247,221,0" desc="Revenus accessoires" shortname="Rev. accesoires" />
         </NODE>
@@ -213,7 +213,7 @@
         <NODE code="fon" color="255,245,155" desc="Revenus fonciers" shortname="Rev. fonciers" />
         <NODE code="f3vg" color="255,245,155" desc="Plus-values de cessions de valeurs mobilières" shortname="Plus.-values mo." />
         <NODE code="f3vz" color="255,245,155" desc="Plus-values immobilières" shortname="Plus.-values immo." />
-        <NODE code="rev_cap_bar" color="255,239,103" desc="Revenus du capital soumis au barème" shortname="Rev cap bar" />
+        <NODE code="revenus_capitaux_prelevement_bareme" color="255,239,103" desc="Revenus du capital soumis au barème" shortname="Rev cap bar" />
         <NODE code="revenus_capitaux_prelevement_liberatoire" color="255,233,28" desc="Revenus du capital soumis au prélèvement libératoire" shortname="Rev cap lib" />
         <NODE code="rac" color="247,221,0" desc="Revenus accessoires" shortname="Rev. accesoires" />
       </NODE>

--- a/openfisca_france/decompositions/decompositions-multiples.xml
+++ b/openfisca_france/decompositions/decompositions-multiples.xml
@@ -53,7 +53,7 @@
           <NODE code="f3vg" color="255,245,155" desc="Plus-values de cessions de valeurs mobilières" shortname="Plus.-values mo." />
           <NODE code="f3vz" color="255,245,155" desc="Plus-values immobilières" shortname="Plus.-values immo." />
           <NODE code="rev_cap_bar" color="255,239,103" desc="Revenus du capital soumis au barème" shortname="Rev cap bar" />
-          <NODE code="rev_cap_lib" color="255,233,28" desc="Revenus du capital soumis au prélèvement libératoire" shortname="Rev cap lib" />
+          <NODE code="revenus_capitaux_prelevement_liberatoire" color="255,233,28" desc="Revenus du capital soumis au prélèvement libératoire" shortname="Rev cap lib" />
           <NODE code="rac" color="247,221,0" desc="Revenus accessoires" shortname="Rev. accesoires" />
         </NODE>
         <NODE code="cotsoc_cap" color="243,166,171" desc="Cotisations sociales sur les revenus du capital" shortname="Cotsoc. capital">
@@ -214,7 +214,7 @@
         <NODE code="f3vg" color="255,245,155" desc="Plus-values de cessions de valeurs mobilières" shortname="Plus.-values mo." />
         <NODE code="f3vz" color="255,245,155" desc="Plus-values immobilières" shortname="Plus.-values immo." />
         <NODE code="rev_cap_bar" color="255,239,103" desc="Revenus du capital soumis au barème" shortname="Rev cap bar" />
-        <NODE code="rev_cap_lib" color="255,233,28" desc="Revenus du capital soumis au prélèvement libératoire" shortname="Rev cap lib" />
+        <NODE code="revenus_capitaux_prelevement_liberatoire" color="255,233,28" desc="Revenus du capital soumis au prélèvement libératoire" shortname="Rev cap lib" />
         <NODE code="rac" color="247,221,0" desc="Revenus accessoires" shortname="Rev. accesoires" />
       </NODE>
       <NODE code="cotsoc_cap" color="243,166,171" desc="Cotisations sociales sur les revenus du capital" shortname="Cotsoc. capital">

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -226,8 +226,8 @@ class pensions(Variable):
         # Revenus du foyer fiscal, que l'on projette uniquement sur le 1er déclarant
         foyer_fiscal = individu.foyer_fiscal
         pensions_alimentaires_versees = foyer_fiscal('pensions_alimentaires_versees', period)
-        retraite_titre_onereux = foyer_fiscal('retraite_titre_onereux', period, options = [ADD])
-        pen_foyer_fiscal = pensions_alimentaires_versees + retraite_titre_onereux
+        rente_viagere_titre_onereux = foyer_fiscal('rente_viagere_titre_onereux', period, options = [ADD])
+        pen_foyer_fiscal = pensions_alimentaires_versees + rente_viagere_titre_onereux
         pen_foyer_fiscal_projetees = pen_foyer_fiscal * (individu.has_role(foyer_fiscal.DECLARANT_PRINCIPAL))
 
         return (

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -281,11 +281,11 @@ class revenus_du_capital(Variable):
         fon = foyer_fiscal('fon', period)
         rev_cap_bar = foyer_fiscal('rev_cap_bar', period, options = [ADD])
         cotsoc_lib = foyer_fiscal('cotsoc_lib', period)
-        rev_cap_lib = foyer_fiscal('rev_cap_lib', period, options = [ADD])
+        revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
         imp_lib = foyer_fiscal('imp_lib', period)
         cotsoc_bar = foyer_fiscal('cotsoc_bar', period)
 
-        revenus_foyer_fiscal = fon + rev_cap_bar + cotsoc_lib + rev_cap_lib + imp_lib + cotsoc_bar
+        revenus_foyer_fiscal = fon + rev_cap_bar + cotsoc_lib + revenus_capitaux_prelevement_liberatoire + imp_lib + cotsoc_bar
         revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(foyer_fiscal.DECLARANT_PRINCIPAL)
 
         rac = individu('rac', period)

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -279,13 +279,13 @@ class revenus_du_capital(Variable):
         # Revenus du foyer fiscal, que l'on projette uniquement sur le 1er déclarant
         foyer_fiscal = individu.foyer_fiscal
         fon = foyer_fiscal('fon', period)
-        rev_cap_bar = foyer_fiscal('rev_cap_bar', period, options = [ADD])
+        revenus_capitaux_prelevement_bareme = foyer_fiscal('revenus_capitaux_prelevement_bareme', period, options = [ADD])
         cotsoc_lib = foyer_fiscal('cotsoc_lib', period)
         revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
         imp_lib = foyer_fiscal('imp_lib', period)
         cotsoc_bar = foyer_fiscal('cotsoc_bar', period)
 
-        revenus_foyer_fiscal = fon + rev_cap_bar + cotsoc_lib + revenus_capitaux_prelevement_liberatoire + imp_lib + cotsoc_bar
+        revenus_foyer_fiscal = fon + revenus_capitaux_prelevement_bareme + cotsoc_lib + revenus_capitaux_prelevement_liberatoire + imp_lib + cotsoc_bar
         revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(foyer_fiscal.DECLARANT_PRINCIPAL)
 
         rac = individu('rac', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1801,7 +1801,7 @@ class rfr(Variable):
         abattement_net_duree_detention = foyer_fiscal('abattement_net_duree_detention', period)
         f2dm = foyer_fiscal('f2dm', period)
         microentreprise = foyer_fiscal('microentreprise', period)
-        rev_cap_lib = foyer_fiscal('rev_cap_lib', period, options = [ADD])
+        revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
         rfr_charges_deductibles = foyer_fiscal('rfr_cd', period)
         rfr_plus_values = foyer_fiscal('rfr_plus_values', period)
         rfr_rev_capitaux_mobiliers = foyer_fiscal('rfr_rvcm', period)
@@ -1814,7 +1814,7 @@ class rfr(Variable):
 
         return (
             max_(0, rni)
-            + rfr_charges_deductibles + rfr_plus_values + rfr_rev_capitaux_mobiliers + rev_cap_lib
+            + rfr_charges_deductibles + rfr_plus_values + rfr_rev_capitaux_mobiliers + revenus_capitaux_prelevement_liberatoire
             + rpns_exon + rpns_pvce
             + abattement_net_retraite_dirigeant_pme
             + abattement_net_duree_detention
@@ -1881,7 +1881,7 @@ class rev_cap_bar(Variable):
         # We add f2da an f2ee to allow for comparaison between years
 
 
-class rev_cap_lib(Variable):
+class revenus_capitaux_prelevement_liberatoire(Variable):
     '''Revenu du capital imposé au prélèvement libératoire
 
     Annuel pour les impôts mais mensuel pour la base ressource des minimas sociaux donc mensuel.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -465,7 +465,7 @@ class abattement_salaires_pensions(Variable):
         return min_(abatsalpen.taux * max_(revenu_assimile_salaire_apres_abattements + revenu_assimile_pension_apres_abattements, 0), abatsalpen.max)
 
 
-class retraite_titre_onereux(Variable):
+class rente_viagere_titre_onereux(Variable):
     """Rentes viagères à titre onéreux (avant abattements)
 
     Annuel pour les impôts mais mensuel pour la base ressource des minimas sociaux donc mensuel.
@@ -488,7 +488,7 @@ class retraite_titre_onereux(Variable):
         return (f1aw + f1bw + f1cw + f1dw) / 12
 
 
-class retraite_titre_onereux_net(Variable):
+class rente_viagere_titre_onereux_net(Variable):
     value_type = float
     entity = FoyerFiscal
     label = u"Rentes viagères après abattements"
@@ -521,15 +521,15 @@ class traitements_salaires_pensions_rentes(Variable):
         revenu_assimile_pension_apres_abattements = individu('revenu_assimile_pension_apres_abattements', period)
         abattement_salaires_pensions = individu('abattement_salaires_pensions', period)
 
-        # Quand tspr est calculé sur une année glissante, retraite_titre_onereux_net est calculé sur l'année légale
+        # Quand tspr est calculé sur une année glissante, rente_viagere_titre_onereux_net est calculé sur l'année légale
         # correspondante.
-        retraite_titre_onereux_net = individu.foyer_fiscal('retraite_titre_onereux_net', period.offset('first-of'))
-        retraite_titre_onereux_net_declarant1 = retraite_titre_onereux_net * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
+        rente_viagere_titre_onereux_net = individu.foyer_fiscal('rente_viagere_titre_onereux_net', period.offset('first-of'))
+        rente_viagere_titre_onereux_net_declarant1 = rente_viagere_titre_onereux_net * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         return (
             + revenu_assimile_salaire_apres_abattements
             + revenu_assimile_pension_apres_abattements
-            + retraite_titre_onereux_net_declarant1
+            + rente_viagere_titre_onereux_net_declarant1
             - abattement_salaires_pensions
             )
 
@@ -940,10 +940,10 @@ class csg_deduc_patrimoine_simulated(Variable):
         '''
         rev_cat_rfon = foyer_fiscal('rev_cat_rfon', period)
         revenus_capitaux_prelevement_bareme = foyer_fiscal('revenus_capitaux_prelevement_bareme', period)
-        retraite_titre_onereux = foyer_fiscal('retraite_titre_onereux', period)
+        rente_viagere_titre_onereux = foyer_fiscal('rente_viagere_titre_onereux', period)
         taux = parameters(period).csg.capital.deduc
 
-        patrimoine_deduc = rev_cat_rfon + revenus_capitaux_prelevement_bareme + retraite_titre_onereux
+        patrimoine_deduc = rev_cat_rfon + revenus_capitaux_prelevement_bareme + rente_viagere_titre_onereux
         return taux * patrimoine_deduc
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -939,11 +939,11 @@ class csg_deduc_patrimoine_simulated(Variable):
         http://bofip.impots.gouv.fr/bofip/887-PGP
         '''
         rev_cat_rfon = foyer_fiscal('rev_cat_rfon', period)
-        rev_cap_bar = foyer_fiscal('rev_cap_bar', period)
+        revenus_capitaux_prelevement_bareme = foyer_fiscal('revenus_capitaux_prelevement_bareme', period)
         retraite_titre_onereux = foyer_fiscal('retraite_titre_onereux', period)
         taux = parameters(period).csg.capital.deduc
 
-        patrimoine_deduc = rev_cat_rfon + rev_cap_bar + retraite_titre_onereux
+        patrimoine_deduc = rev_cat_rfon + revenus_capitaux_prelevement_bareme + retraite_titre_onereux
         return taux * patrimoine_deduc
 
 
@@ -1844,7 +1844,7 @@ class glo(Variable):
         return f1tv + f1tw + f1tx + f3vf + f3vi + f3vj
 
 
-class rev_cap_bar(Variable):
+class revenus_capitaux_prelevement_bareme(Variable):
     """Revenus du capital imposés au barème
 
     Annuel pour les impôts mais mensuel pour la base ressource des minimas sociaux donc mensuel.

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -508,7 +508,7 @@ class revetproduits(Variable):
         '''
         salcho_imp_i = foyer_fiscal.members('revenu_assimile_salaire_apres_abattements', period)
         pen_net_i = foyer_fiscal.members('revenu_assimile_pension_apres_abattements', period)
-        retraite_titre_onereux_net = foyer_fiscal('retraite_titre_onereux_net', period)
+        rente_viagere_titre_onereux_net = foyer_fiscal('rente_viagere_titre_onereux_net', period)
         revenus_capitaux_prelevement_bareme = foyer_fiscal('revenus_capitaux_prelevement_bareme', period, options = [ADD])
         fon = foyer_fiscal('fon', period)
         ric_i = foyer_fiscal.members('ric', period)
@@ -530,7 +530,7 @@ class revetproduits(Variable):
         # # def rev_exon et rev_etranger dans data? ##
         pt = max_(
             0,
-            revenu_assimile_salaire_apres_abattements + revenu_assimile_pension_apres_abattements + retraite_titre_onereux_net + revenus_capitaux_prelevement_bareme + revenus_capitaux_prelevement_liberatoire + ric + rag + rpns_exon +
+            revenu_assimile_salaire_apres_abattements + revenu_assimile_pension_apres_abattements + rente_viagere_titre_onereux_net + revenus_capitaux_prelevement_bareme + revenus_capitaux_prelevement_liberatoire + ric + rag + rpns_exon +
             rpns_pvct + imp_lib + fon
             )
         return pt * P.plafonnement_taux_d_imposition_isf

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -515,7 +515,7 @@ class revetproduits(Variable):
         rag_i = foyer_fiscal.members('rag', period)
         rpns_exon_i = foyer_fiscal.members('rpns_exon', period)
         rpns_pvct_i = foyer_fiscal.members('rpns_pvct', period)
-        rev_cap_lib = foyer_fiscal('rev_cap_lib', period, options = [ADD])
+        revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
         imp_lib = foyer_fiscal('imp_lib', period)
         P = parameters(period).taxation_capital.isf.plafonnement
 
@@ -530,7 +530,7 @@ class revetproduits(Variable):
         # # def rev_exon et rev_etranger dans data? ##
         pt = max_(
             0,
-            revenu_assimile_salaire_apres_abattements + revenu_assimile_pension_apres_abattements + retraite_titre_onereux_net + rev_cap_bar + rev_cap_lib + ric + rag + rpns_exon +
+            revenu_assimile_salaire_apres_abattements + revenu_assimile_pension_apres_abattements + retraite_titre_onereux_net + rev_cap_bar + revenus_capitaux_prelevement_liberatoire + ric + rag + rpns_exon +
             rpns_pvct + imp_lib + fon
             )
         return pt * P.plafonnement_taux_d_imposition_isf
@@ -687,7 +687,7 @@ class bouclier_rev(Variable):
         rbg = foyer_fiscal('rbg', period)
         csg_deduc = foyer_fiscal('csg_deduc', period)
         rvcm_plus_abat = foyer_fiscal('rvcm_plus_abat', period)
-        rev_cap_lib = foyer_fiscal('rev_cap_lib', period)
+        revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period)
         rev_exo = foyer_fiscal('rev_exo', period)
         rev_or = foyer_fiscal('rev_or', period)
         pensions_alimentaires_deduites = foyer_fiscal('pensions_alimentaires_deduites', period)
@@ -711,7 +711,7 @@ class bouclier_rev(Variable):
     # # TODO: AJOUTER : indemnités de fonction percus par les élus- revenus soumis à régimes spéciaux
 
         # Revenu soumis à l'impôt sur le revenu forfaitaire
-        rev_lib = rev_cap_lib
+        rev_lib = revenus_capitaux_prelevement_liberatoire
         # # AJOUTER plus-values immo et moins values?
 
         # #Revenus exonérés d'IR réalisés en France et à l'étranger##

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -509,7 +509,7 @@ class revetproduits(Variable):
         salcho_imp_i = foyer_fiscal.members('revenu_assimile_salaire_apres_abattements', period)
         pen_net_i = foyer_fiscal.members('revenu_assimile_pension_apres_abattements', period)
         retraite_titre_onereux_net = foyer_fiscal('retraite_titre_onereux_net', period)
-        rev_cap_bar = foyer_fiscal('rev_cap_bar', period, options = [ADD])
+        revenus_capitaux_prelevement_bareme = foyer_fiscal('revenus_capitaux_prelevement_bareme', period, options = [ADD])
         fon = foyer_fiscal('fon', period)
         ric_i = foyer_fiscal.members('ric', period)
         rag_i = foyer_fiscal.members('rag', period)
@@ -530,7 +530,7 @@ class revetproduits(Variable):
         # # def rev_exon et rev_etranger dans data? ##
         pt = max_(
             0,
-            revenu_assimile_salaire_apres_abattements + revenu_assimile_pension_apres_abattements + retraite_titre_onereux_net + rev_cap_bar + revenus_capitaux_prelevement_liberatoire + ric + rag + rpns_exon +
+            revenu_assimile_salaire_apres_abattements + revenu_assimile_pension_apres_abattements + retraite_titre_onereux_net + revenus_capitaux_prelevement_bareme + revenus_capitaux_prelevement_liberatoire + ric + rag + rpns_exon +
             rpns_pvct + imp_lib + fon
             )
         return pt * P.plafonnement_taux_d_imposition_isf

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -395,10 +395,10 @@ class csg_cap_lib(Variable):
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
-        rev_cap_lib = foyer_fiscal('rev_cap_lib', period, options = [ADD])
+        revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
         _P = parameters(period)
 
-        return -rev_cap_lib * _P.prelevements_sociaux.contributions.csg.capital.glob
+        return -revenus_capitaux_prelevement_liberatoire * _P.prelevements_sociaux.contributions.csg.capital.glob
 
 
 class crds_cap_lib(Variable):
@@ -410,10 +410,10 @@ class crds_cap_lib(Variable):
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
-        rev_cap_lib = foyer_fiscal('rev_cap_lib', period, options = [ADD])
+        revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
         _P = parameters(period).taxation_capital.prelevements_sociaux
 
-        return -rev_cap_lib * _P.crds.revenus_du_patrimoine
+        return -revenus_capitaux_prelevement_liberatoire * _P.crds.revenus_du_patrimoine
 
 
 class prelsoc_cap_lib(Variable):
@@ -425,7 +425,7 @@ class prelsoc_cap_lib(Variable):
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
-        rev_cap_lib = foyer_fiscal('rev_cap_lib', period, options = [ADD])
+        revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
         prelsoc = parameters(period).taxation_capital.prelevements_sociaux
 
         start_year = period.start.year
@@ -447,7 +447,7 @@ class prelsoc_cap_lib(Variable):
                 prelsoc.prelevement_social.revenus_du_patrimoine + prelsoc.caps.revenus_du_patrimoine +
                 prelsoc.prelevements_solidarite.revenus_du_patrimoine
                 )
-        return -rev_cap_lib * total
+        return -revenus_capitaux_prelevement_liberatoire * total
 
 # TODO: non_imposabilité pour les revenus au barème
 #        verse = (-csgcap_bar - crdscap_bar - prelsoccap_bar) > bareme.prelevements_sociaux.contributions.csg.capital.nonimp

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -38,10 +38,10 @@ class csg_cap_bar(Variable):
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
-        rev_cap_bar = foyer_fiscal('rev_cap_bar', period, options = [ADD])
+        revenus_capitaux_prelevement_bareme = foyer_fiscal('revenus_capitaux_prelevement_bareme', period, options = [ADD])
         _P = parameters(period)
 
-        return -rev_cap_bar * _P.prelevements_sociaux.contributions.csg.capital.glob
+        return -revenus_capitaux_prelevement_bareme * _P.prelevements_sociaux.contributions.csg.capital.glob
 
 
 class crds_cap_bar(Variable):
@@ -53,10 +53,10 @@ class crds_cap_bar(Variable):
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
-        rev_cap_bar = foyer_fiscal('rev_cap_bar', period, options = [ADD])
+        revenus_capitaux_prelevement_bareme = foyer_fiscal('revenus_capitaux_prelevement_bareme', period, options = [ADD])
         _P = parameters(period).taxation_capital.prelevements_sociaux
 
-        return -rev_cap_bar * _P.crds.revenus_du_patrimoine
+        return -revenus_capitaux_prelevement_bareme * _P.crds.revenus_du_patrimoine
 
 
 class prelsoc_cap_bar(Variable):
@@ -68,45 +68,45 @@ class prelsoc_cap_bar(Variable):
     definition_period = YEAR
 
     def formula_2002_01_01(foyer_fiscal, period, parameters):
-        rev_cap_bar = foyer_fiscal('rev_cap_bar', period, options = [ADD])
+        revenus_capitaux_prelevement_bareme = foyer_fiscal('revenus_capitaux_prelevement_bareme', period, options = [ADD])
         P = parameters(period).taxation_capital.prelevements_sociaux
 
         total = P.prelevement_social.revenus_du_patrimoine
-        return -rev_cap_bar * total
+        return -revenus_capitaux_prelevement_bareme * total
 
     def formula_2006_01_01(foyer_fiscal, period, parameters):
-        rev_cap_bar = foyer_fiscal('rev_cap_bar', period, options = [ADD])
+        revenus_capitaux_prelevement_bareme = foyer_fiscal('revenus_capitaux_prelevement_bareme', period, options = [ADD])
         P = parameters(period).taxation_capital.prelevements_sociaux
 
         total = P.prelevement_social.revenus_du_patrimoine + P.caps.revenus_du_patrimoine
-        return -rev_cap_bar * total
+        return -revenus_capitaux_prelevement_bareme * total
 
     def formula_2009_01_01(foyer_fiscal, period, parameters):
-        rev_cap_bar = foyer_fiscal('rev_cap_bar', period, options = [ADD])
+        revenus_capitaux_prelevement_bareme = foyer_fiscal('revenus_capitaux_prelevement_bareme', period, options = [ADD])
         P = parameters(period).taxation_capital.prelevements_sociaux
 
         total = P.prelevement_social.revenus_du_patrimoine + P.caps.revenus_du_patrimoine + P.caps.rsa
-        return -rev_cap_bar * total
+        return -revenus_capitaux_prelevement_bareme * total
 
     def formula_2012_01_01(foyer_fiscal, period, parameters):
-        rev_cap_bar = foyer_fiscal('rev_cap_bar', period, options = [ADD])
+        revenus_capitaux_prelevement_bareme = foyer_fiscal('revenus_capitaux_prelevement_bareme', period, options = [ADD])
         P = parameters(period).taxation_capital.prelevements_sociaux
 
         total = (
             P.prelevement_social.revenus_du_patrimoine + P.caps.revenus_du_patrimoine + P.caps.rsa +
             P.prelevements_solidarite.revenus_du_patrimoine
             )
-        return -rev_cap_bar * total
+        return -revenus_capitaux_prelevement_bareme * total
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
-        rev_cap_bar = foyer_fiscal('rev_cap_bar', period, options = [ADD])
+        revenus_capitaux_prelevement_bareme = foyer_fiscal('revenus_capitaux_prelevement_bareme', period, options = [ADD])
         P = parameters(period).taxation_capital.prelevements_sociaux
 
         total = (
             P.prelevement_social.revenus_du_patrimoine + P.caps.revenus_du_patrimoine +
             P.prelevements_solidarite.revenus_du_patrimoine
             )
-        return -rev_cap_bar * total
+        return -revenus_capitaux_prelevement_bareme * total
 
 
 class csg_pv_mo(Variable):

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -336,7 +336,7 @@ class aide_logement_base_revenus_fiscaux(Variable):
     definition_period = YEAR
 
     def formula(foyer_fiscal, period):
-        retraite_titre_onereux_net = foyer_fiscal('retraite_titre_onereux_net', period)
+        rente_viagere_titre_onereux_net = foyer_fiscal('rente_viagere_titre_onereux_net', period)
         pensions_alimentaires_versees = foyer_fiscal('pensions_alimentaires_versees', period)
         revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
         rev_cat_rvcm = foyer_fiscal('rev_cat_rvcm', period)
@@ -358,7 +358,7 @@ class aide_logement_base_revenus_fiscaux(Variable):
         return (
             + fon
             + pensions_alimentaires_versees
-            + retraite_titre_onereux_net
+            + rente_viagere_titre_onereux_net
             + revenus_capitaux_prelevement_liberatoire
             + rev_cat_pv
             + rev_cat_rvcm

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -338,7 +338,7 @@ class aide_logement_base_revenus_fiscaux(Variable):
     def formula(foyer_fiscal, period):
         retraite_titre_onereux_net = foyer_fiscal('retraite_titre_onereux_net', period)
         pensions_alimentaires_versees = foyer_fiscal('pensions_alimentaires_versees', period)
-        rev_cap_lib = foyer_fiscal('rev_cap_lib', period, options = [ADD])
+        revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
         rev_cat_rvcm = foyer_fiscal('rev_cat_rvcm', period)
         fon = foyer_fiscal('fon', period)
         f7ga = foyer_fiscal('f7ga', period)
@@ -359,7 +359,7 @@ class aide_logement_base_revenus_fiscaux(Variable):
             + fon
             + pensions_alimentaires_versees
             + retraite_titre_onereux_net
-            + rev_cap_lib
+            + revenus_capitaux_prelevement_liberatoire
             + rev_cat_pv
             + rev_cat_rvcm
             - abat_spe * apply_abat_spe

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -71,8 +71,8 @@ class asi_aspa_base_ressources_individu(Variable):
         # Revenus du foyer fiscal que l'on projette sur le premier invidividus
         revenus_capitaux_prelevement_bareme_foyer_fiscal = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_bareme', three_previous_months, options = [ADD]))
         revenus_capitaux_prelevement_liberatoire_foyer_fiscal = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', three_previous_months, options = [ADD]))
-        retraite_titre_onereux_foyer_fiscal = individu.foyer_fiscal('retraite_titre_onereux', three_previous_months, options = [ADD])
-        revenus_foyer_fiscal = revenus_capitaux_prelevement_bareme_foyer_fiscal + revenus_capitaux_prelevement_liberatoire_foyer_fiscal + retraite_titre_onereux_foyer_fiscal
+        rente_viagere_titre_onereux_foyer_fiscal = individu.foyer_fiscal('rente_viagere_titre_onereux', three_previous_months, options = [ADD])
+        revenus_foyer_fiscal = revenus_capitaux_prelevement_bareme_foyer_fiscal + revenus_capitaux_prelevement_liberatoire_foyer_fiscal + rente_viagere_titre_onereux_foyer_fiscal
         revenus_foyer_fiscal_individu = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         def revenus_tns():

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -69,10 +69,10 @@ class asi_aspa_base_ressources_individu(Variable):
             ]
 
         # Revenus du foyer fiscal que l'on projette sur le premier invidividus
-        rev_cap_bar_foyer_fiscal = max_(0, individu.foyer_fiscal('rev_cap_bar', three_previous_months, options = [ADD]))
+        revenus_capitaux_prelevement_bareme_foyer_fiscal = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_bareme', three_previous_months, options = [ADD]))
         revenus_capitaux_prelevement_liberatoire_foyer_fiscal = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', three_previous_months, options = [ADD]))
         retraite_titre_onereux_foyer_fiscal = individu.foyer_fiscal('retraite_titre_onereux', three_previous_months, options = [ADD])
-        revenus_foyer_fiscal = rev_cap_bar_foyer_fiscal + revenus_capitaux_prelevement_liberatoire_foyer_fiscal + retraite_titre_onereux_foyer_fiscal
+        revenus_foyer_fiscal = revenus_capitaux_prelevement_bareme_foyer_fiscal + revenus_capitaux_prelevement_liberatoire_foyer_fiscal + retraite_titre_onereux_foyer_fiscal
         revenus_foyer_fiscal_individu = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         def revenus_tns():

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -70,9 +70,9 @@ class asi_aspa_base_ressources_individu(Variable):
 
         # Revenus du foyer fiscal que l'on projette sur le premier invidividus
         rev_cap_bar_foyer_fiscal = max_(0, individu.foyer_fiscal('rev_cap_bar', three_previous_months, options = [ADD]))
-        rev_cap_lib_foyer_fiscal = max_(0, individu.foyer_fiscal('rev_cap_lib', three_previous_months, options = [ADD]))
+        revenus_capitaux_prelevement_liberatoire_foyer_fiscal = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', three_previous_months, options = [ADD]))
         retraite_titre_onereux_foyer_fiscal = individu.foyer_fiscal('retraite_titre_onereux', three_previous_months, options = [ADD])
-        revenus_foyer_fiscal = rev_cap_bar_foyer_fiscal + rev_cap_lib_foyer_fiscal + retraite_titre_onereux_foyer_fiscal
+        revenus_foyer_fiscal = rev_cap_bar_foyer_fiscal + revenus_capitaux_prelevement_liberatoire_foyer_fiscal + retraite_titre_onereux_foyer_fiscal
         revenus_foyer_fiscal_individu = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         def revenus_tns():

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -136,10 +136,10 @@ class rsa_base_ressources_individu(Variable):
             )
 
         # Revenus du foyer fiscal que l'on projette sur le premier invidividus
-        rev_cap_bar = max_(0, individu.foyer_fiscal('rev_cap_bar', period.last_3_months, options = [ADD]))
+        revenus_capitaux_prelevement_bareme = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_bareme', period.last_3_months, options = [ADD]))
         revenus_capitaux_prelevement_liberatoire = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period.last_3_months, options = [ADD]))
         retraite_titre_onereux = individu.foyer_fiscal('retraite_titre_onereux', period.last_3_months, options = [ADD])
-        revenus_foyer_fiscal = rev_cap_bar + revenus_capitaux_prelevement_liberatoire + retraite_titre_onereux
+        revenus_foyer_fiscal = revenus_capitaux_prelevement_bareme + revenus_capitaux_prelevement_liberatoire + retraite_titre_onereux
         revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         return (revenus_pro + revenus_non_pros + revenus_foyer_fiscal_projetes) / 3

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -137,9 +137,9 @@ class rsa_base_ressources_individu(Variable):
 
         # Revenus du foyer fiscal que l'on projette sur le premier invidividus
         rev_cap_bar = max_(0, individu.foyer_fiscal('rev_cap_bar', period.last_3_months, options = [ADD]))
-        rev_cap_lib = max_(0, individu.foyer_fiscal('rev_cap_lib', period.last_3_months, options = [ADD]))
+        revenus_capitaux_prelevement_liberatoire = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period.last_3_months, options = [ADD]))
         retraite_titre_onereux = individu.foyer_fiscal('retraite_titre_onereux', period.last_3_months, options = [ADD])
-        revenus_foyer_fiscal = rev_cap_bar + rev_cap_lib + retraite_titre_onereux
+        revenus_foyer_fiscal = rev_cap_bar + revenus_capitaux_prelevement_liberatoire + retraite_titre_onereux
         revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         return (revenus_pro + revenus_non_pros + revenus_foyer_fiscal_projetes) / 3

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -138,8 +138,8 @@ class rsa_base_ressources_individu(Variable):
         # Revenus du foyer fiscal que l'on projette sur le premier invidividus
         revenus_capitaux_prelevement_bareme = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_bareme', period.last_3_months, options = [ADD]))
         revenus_capitaux_prelevement_liberatoire = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period.last_3_months, options = [ADD]))
-        retraite_titre_onereux = individu.foyer_fiscal('retraite_titre_onereux', period.last_3_months, options = [ADD])
-        revenus_foyer_fiscal = revenus_capitaux_prelevement_bareme + revenus_capitaux_prelevement_liberatoire + retraite_titre_onereux
+        rente_viagere_titre_onereux = individu.foyer_fiscal('rente_viagere_titre_onereux', period.last_3_months, options = [ADD])
+        revenus_foyer_fiscal = revenus_capitaux_prelevement_bareme + revenus_capitaux_prelevement_liberatoire + rente_viagere_titre_onereux
         revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         return (revenus_pro + revenus_non_pros + revenus_foyer_fiscal_projetes) / 3

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -125,7 +125,7 @@ class rev_coll(Variable):
         # Quand rev_coll est calculé sur une année glissante, retraite_titre_onereux_net et pensions_alimentaires_versees sont calculés sur l'année légale correspondante.
         retraite_titre_onereux_net = foyer_fiscal('retraite_titre_onereux_net', period)
         pensions_alimentaires_versees = foyer_fiscal('pensions_alimentaires_versees', period)
-        rev_cap_lib = foyer_fiscal('rev_cap_lib', period, options = [ADD])
+        revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
         rev_cat_rvcm = foyer_fiscal('rev_cat_rvcm', period)
         abat_spe = foyer_fiscal('abat_spe', period)
         fon = foyer_fiscal('fon', period)
@@ -139,7 +139,7 @@ class rev_coll(Variable):
             + fon
             + pensions_alimentaires_versees  # négatif
             + retraite_titre_onereux_net
-            + rev_cap_lib
+            + revenus_capitaux_prelevement_liberatoire
             + rev_cat_pv
             + rev_cat_rvcm
             - abat_spe

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -122,8 +122,8 @@ class rev_coll(Variable):
     definition_period = YEAR
 
     def formula(foyer_fiscal, period):
-        # Quand rev_coll est calculé sur une année glissante, retraite_titre_onereux_net et pensions_alimentaires_versees sont calculés sur l'année légale correspondante.
-        retraite_titre_onereux_net = foyer_fiscal('retraite_titre_onereux_net', period)
+        # Quand rev_coll est calculé sur une année glissante, rente_viagere_titre_onereux_net et pensions_alimentaires_versees sont calculés sur l'année légale correspondante.
+        rente_viagere_titre_onereux_net = foyer_fiscal('rente_viagere_titre_onereux_net', period)
         pensions_alimentaires_versees = foyer_fiscal('pensions_alimentaires_versees', period)
         revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
         rev_cat_rvcm = foyer_fiscal('rev_cat_rvcm', period)
@@ -138,7 +138,7 @@ class rev_coll(Variable):
         return (
             + fon
             + pensions_alimentaires_versees  # négatif
-            + retraite_titre_onereux_net
+            + rente_viagere_titre_onereux_net
             + revenus_capitaux_prelevement_liberatoire
             + rev_cat_pv
             + rev_cat_rvcm

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -56,7 +56,7 @@ class allocations_familiales_imposables(Reform):
             rni = foyer_fiscal('rni')
             rpns_exon_holder = foyer_fiscal.members('rpns_exon')
             rpns_pvce_holder = foyer_fiscal.members('rpns_pvce')
-            rev_cap_lib = simulation.calculate_add('rev_cap_lib')
+            revenus_capitaux_prelevement_liberatoire = simulation.calculate_add('revenus_capitaux_prelevement_liberatoire')
             microentreprise = foyer_fiscal('microentreprise')
 
             f3vi = foyer_fiscal.sum(f3vi_holder)
@@ -65,7 +65,7 @@ class allocations_familiales_imposables(Reform):
 
             return (
                 max_(0, rni - allocations_familiales_imposables) +
-                rfr_cd + rfr_rvcm + rev_cap_lib + f3vi + rpns_exon + rpns_pvce + abattement_net_retraite_dirigeant_pme + f3vz + microentreprise
+                rfr_cd + rfr_rvcm + revenus_capitaux_prelevement_liberatoire + f3vi + rpns_exon + rpns_pvce + abattement_net_retraite_dirigeant_pme + f3vz + microentreprise
                 )
 
             # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)

--- a/openfisca_france/reforms/landais_piketty_saez.py
+++ b/openfisca_france/reforms/landais_piketty_saez.py
@@ -26,9 +26,9 @@ class assiette_csg(Variable):
         salaire_de_base = individu('salaire_de_base', period, options = [ADD])
         chomage_brut = individu('chomage_brut', period, options = [ADD])
         retraite_brute = individu('retraite_brute', period, options = [ADD])
-        rev_cap_bar = individu.foyer_fiscal('rev_cap_bar', period, options = [ADD]) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
+        revenus_capitaux_prelevement_bareme = individu.foyer_fiscal('revenus_capitaux_prelevement_bareme', period, options = [ADD]) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
         revenus_capitaux_prelevement_liberatoire = individu.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD]) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
-        return salaire_de_base + chomage_brut + retraite_brute + rev_cap_bar + revenus_capitaux_prelevement_liberatoire
+        return salaire_de_base + chomage_brut + retraite_brute + revenus_capitaux_prelevement_bareme + revenus_capitaux_prelevement_liberatoire
 
 
 class impot_revenu_lps(Variable):

--- a/openfisca_france/reforms/landais_piketty_saez.py
+++ b/openfisca_france/reforms/landais_piketty_saez.py
@@ -27,8 +27,8 @@ class assiette_csg(Variable):
         chomage_brut = individu('chomage_brut', period, options = [ADD])
         retraite_brute = individu('retraite_brute', period, options = [ADD])
         rev_cap_bar = individu.foyer_fiscal('rev_cap_bar', period, options = [ADD]) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
-        rev_cap_lib = individu.foyer_fiscal('rev_cap_lib', period, options = [ADD]) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
-        return salaire_de_base + chomage_brut + retraite_brute + rev_cap_bar + rev_cap_lib
+        revenus_capitaux_prelevement_liberatoire = individu.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD]) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
+        return salaire_de_base + chomage_brut + retraite_brute + rev_cap_bar + revenus_capitaux_prelevement_liberatoire
 
 
 class impot_revenu_lps(Variable):

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -92,7 +92,7 @@
     # start revenus_du_capital
     rev_cap_bar:
       2012-01: 0
-    rev_cap_lib:
+    revenus_capitaux_prelevement_liberatoire:
       2012-01: 1500
     cotsoc_lib:
     # TODO si haut je pensais plutôt à 15.5 ?
@@ -143,7 +143,7 @@
     # start revenus_du_capital
     rev_cap_bar:
       2012-01: 2500
-    rev_cap_lib:
+    revenus_capitaux_prelevement_liberatoire:
       2012-01: 0
     cotsoc_lib:
       2012: 0

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -90,7 +90,7 @@
     pensions:
       2012: 0
     # start revenus_du_capital
-    rev_cap_bar:
+    revenus_capitaux_prelevement_bareme:
       2012-01: 0
     revenus_capitaux_prelevement_liberatoire:
       2012-01: 1500
@@ -141,7 +141,7 @@
     pensions:
       2012: 0
     # start revenus_du_capital
-    rev_cap_bar:
+    revenus_capitaux_prelevement_bareme:
       2012-01: 2500
     revenus_capitaux_prelevement_liberatoire:
       2012-01: 0


### PR DESCRIPTION
Depends on #1025 

* Changement de nommage.
* Périodes concernées : toutes.
* Zones impactées : `prelevements_obligatoires/impot_revenu/ir`.
* Détails :
  - Renomme les variables
    - `rev_cap_lib` en `revenus_capitaux_prelevement_liberatoire`
    - `rev_cap_bar` en `revenus_capitaux_prelevement_bareme`

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Modifient l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).
