### PR TITLE
Fix logement social in Corse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 21.12.1 [#1030](https://github.com/openfisca/openfisca-france/pull/1030)
+
+* Correction d'un bug
+* Périodes concernées : à partir du 01/01/2017.
+* Zones impactées :
+  - `prestations/logement_social`
+* Détails :
+  - Corrige le calcul du logement social pour la Corse dont le code INSEE n'est pas un nombre
+
 ## 21.12.0 [#1018](https://github.com/openfisca/openfisca-france/pull/1018)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/logement_social.py
+++ b/openfisca_france/model/prestations/logement_social.py
@@ -1,48 +1,49 @@
 # -*- coding: utf-8 -*-
 
+from numpy.core.defchararray import startswith
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 paris_communes_limitrophes = [
-    75056, # Paris
-    93001, # Bagnolet
-    93006, # Boulogne-Billancourt
-    94018, # Charenton-le-Pont
-    92024, # Clichy-la-Garenne
-    94033, # Fontenay-sous-Bois
-    94037, # Gentilly
-    92040, # Issy-les-Moulineaux
-    94041, # Ivry-sur-Seine
-    94042, # Joinville-le-Pont
-    94043, # Le Kremlin-Bicêtre
-    93045, # Les Lilas
-    93061, # Le Pré-Saint-Gervais
-    92044, # Levallois-Perret
-    92046, # Malakoff
-    93048, # Montreuil
-    92049, # Montrouge
-    92051, # Neuilly-sur-Seine
-    94052, # Nogent-sur-Marne
-    93055, # Pantin
-    92062, # Puteaux
-    92064, # Saint-Cloud
-    93066, # Saint-Denis
-    94067, # Saint-Mandé
-    94069, # Saint-Maurice
-    93070, # Saint-Ouen
-    92073, # Suresnes
-    92075, # Vanves
-    94080, # Vincennes
+    b'75056', # Paris
+    b'93001', # Bagnolet
+    b'93006', # Boulogne-Billancourt
+    b'94018', # Charenton-le-Pont
+    b'92024', # Clichy-la-Garenne
+    b'94033', # Fontenay-sous-Bois
+    b'94037', # Gentilly
+    b'92040', # Issy-les-Moulineaux
+    b'94041', # Ivry-sur-Seine
+    b'94042', # Joinville-le-Pont
+    b'94043', # Le Kremlin-Bicêtre
+    b'93045', # Les Lilas
+    b'93061', # Le Pré-Saint-Gervais
+    b'92044', # Levallois-Perret
+    b'92046', # Malakoff
+    b'93048', # Montreuil
+    b'92049', # Montrouge
+    b'92051', # Neuilly-sur-Seine
+    b'94052', # Nogent-sur-Marne
+    b'93055', # Pantin
+    b'92062', # Puteaux
+    b'92064', # Saint-Cloud
+    b'93066', # Saint-Denis
+    b'94067', # Saint-Mandé
+    b'94069', # Saint-Maurice
+    b'93070', # Saint-Ouen
+    b'92073', # Suresnes
+    b'92075', # Vanves
+    b'94080', # Vincennes
 ]
 
 departements_idf = [
-    75,
-    77,
-    78,
-    91,
-    92,
-    93,
-    94,
-    95,
+    b'75',
+    b'77',
+    b'78',
+    b'91',
+    b'92',
+    b'93',
+    b'94',
+    b'95',
 ]
 
 class ZoneLogementSocial(Enum):
@@ -60,15 +61,10 @@ class zone_logement_social(Variable):
     definition_period = MONTH
     label = u"Zone logement social"
     def formula(menage, period):
+        depcom = menage('depcom', period)
 
-        depcom = menage('depcom', period).astype(int)
-
-        # Extraction du département
-        # Exemple : 75056 → 75
-        departement = (depcom.astype(int) / 1000).astype(int)
-
-        in_paris_communes_limitrophes = sum([depcom == dep for dep in paris_communes_limitrophes])
-        in_idf = sum([departement == dep for dep in departements_idf])
+        in_paris_communes_limitrophes = sum([depcom == commune_proche_paris for commune_proche_paris in paris_communes_limitrophes])
+        in_idf = sum([startswith(depcom, departement) for departement in departements_idf])
 
         return select(
             [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '21.12.0',
+    version = '21.12.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/logement_social_zone.yaml
+++ b/tests/formulas/logement_social_zone.yaml
@@ -25,3 +25,10 @@
     depcom: 13055
   output_variables:
     zone_logement_social: autres_regions
+
+- name: Logement social - Corse
+  period: 2018-01
+  input_variables:
+    depcom: 2A004
+  output_variables:
+    zone_logement_social: autres_regions


### PR DESCRIPTION
* Correction d'un bug
* Périodes concernées : à partir du 01/01/2017.
* Zones impactées :
  - `prestations/logement_social`
* Détails :
  - Corrige le calcul du logement social pour la Corse dont le code INSEE n'est pas un nombre