### PR TITLE
Fix du script qui détermine le besoin d'un bump de version

### DIFF
--- a/.circleci/is-version-number-acceptable.sh
+++ b/.circleci/is-version-number-acceptable.sh
@@ -6,7 +6,7 @@ then
     exit 0
 fi
 
-if ! $(dirname "$BASH_SOURCE")/detect-functional-changes.sh
+if ! $(dirname "$BASH_SOURCE")/has-functional-changes.sh
 then
     echo "No need for a version update."
     exit 0
@@ -24,7 +24,7 @@ then
     exit 1
 fi
 
-if ! $(dirname "$BASH_SOURCE")/detect-functional-changes.sh | grep --quiet CHANGELOG.md
+if ! $(dirname "$BASH_SOURCE")/has-functional-changes.sh | grep --quiet CHANGELOG.md
 then
     echo "CHANGELOG.md has not been modified, while functional changes were made."
     echo "Explain what you changed before merging this branch into master."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-### 21.12.2 [#1030](https://github.com/openfisca/openfisca-france/pull/1031)
+### 21.12.2 [#1032](https://github.com/openfisca/openfisca-france/pull/1032)
+
+* Correction d'un bug dans le script qui détermine le besoin d'un bump de version
+* Zones impactées : .circleci/is-version-number-acceptable.sh b/.circleci/is-version-number-acceptable.sh.
+* Détails :
+  - Le script faisait référence a un autre script qui a été renommé
+  - Changement du path du script pour qu'il soit bien exécuté
+
+### 21.12.2 [#1031](https://github.com/openfisca/openfisca-france/pull/1031)
 
 * Correction d'un bug
 * Périodes concernées : toutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 21.12.2 [#1030](https://github.com/openfisca/openfisca-france/pull/1031)
+
+* Correction d'un bug
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `prelevements_obligatoires/impot_revenu/reductions_impot`
+* Détails :
+  - Corrige une erreur dans le nom de variable utilisée
+
 ### 21.12.1 [#1030](https://github.com/openfisca/openfisca-france/pull/1030)
 
 * Correction d'un bug

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '21.12.1',
+    version = '21.12.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Fix du script qui détermine le besoin d'un bump de version
* Zones impactées : `.circleci/is-version-number-acceptable.sh b/.circleci/is-version-number-acceptable.sh`.
* Détails :
  - Le script faisait référence a un autre script qui a été renommé
  - Changement du path du script pour qu'il soit bien exécuté

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] ~Documentez votre contribution avec des références législatives.~
- [ ] ~Mettez à jour ou ajoutez des tests correspondant à votre contribution.~
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
