### PR TITLE
Fait commencer la variable `logement_social_eligible` au 01/01/2017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 22.0.1 [#1036](https://github.com/openfisca/openfisca-france/pull/1036)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2017.
+* Zones impactées :
+  - `prestations/logement_social`
+* Détails :
+  - Fait commencer la variable `logement_social_eligible` au 01/01/2017
+
 ### 22.0.0 [#102](https://github.com/openfisca/openfisca-france/pull/1026)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/logement_social.py
+++ b/openfisca_france/model/prestations/logement_social.py
@@ -164,7 +164,7 @@ class logement_social_eligible(Variable):
     definition_period = MONTH
     label = u"Logement social - Éligibilité"
 
-    def formula(famille, period, parameters):
+    def formula_2017(famille, period, parameters):
 
         logement_social_plafond_ressources = famille('logement_social_plafond_ressources', period)
         revenu_fiscal_de_reference = famille.demandeur.foyer_fiscal('rfr', period.n_2)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '22.0.0',
+    version = '22.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2017.
* Zones impactées :
  - `prestations/logement_social`
* Détails :
  - Fait commencer la variable `logement_social_eligible` au 01/01/2017
