### PR TITLE
Ajoute l'abattement d'IR de 30 ou 40% pour les résidents des DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2013.
 * Zones impactées :
-  - `model\prelevements_obligatoires\impot_revenu\ir`
+  - `model/prelevements_obligatoires/impot_revenu/ir`
 * Détails :
   - Ajoute une variable "depcom_foyer" donnant le lieu de résidence fiscale du foyer.
   - Utilise cette variable pour calculer l'abattement d'impôt spécial DOM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 22.5.0 [#1040](https://github.com/openfisca/openfisca-france/pull/1040)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2013.
+* Zones impactées :
+  - `model\prelevements_obligatoires\impot_revenu\ir`
+* Détails :
+  - Ajoute une variable "depcom_foyer" donnant le lieu de résidence fiscale du foyer.
+  - Utilise cette variable pour calculer l'abattement d'impôt spécial DOM
+  - Ajoute des tests correspondants
+
 ### 22.4.0 [#1059](https://github.com/openfisca/openfisca-france/pull/1059)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1149,6 +1149,7 @@ class ir_plaf_qf(Variable):
         Impôt après plafonnement du quotient familial et réduction complémentaire (cf. fiche calcul IR)
         '''
         celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        depcom_foyer = foyer_fiscal('depcom_foyer', period)
         ir_brut = foyer_fiscal('ir_brut', period)
         ir_ss_qf = foyer_fiscal('ir_ss_qf', period)
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
@@ -1219,10 +1220,12 @@ class ir_plaf_qf(Variable):
         H = F * (F <= G) + G * (G < F)
         IP1 = IP0 - H
 
-         # PART3 - ABATTEMENT PARTICULIE DOM
+        # PART3 - ABATTEMENT PARTICULIE DOM
+        
+        departement_domicile = depcom_foyer[:3]
 
-        conditionGuadMarReu = 0 # faire une condition avec département + code commune (Depcom qui est pour l'instant une variable ménage)
-        conditionGuyMay = 0 # provisoire
+        conditionGuadMarReu = (departement_domicile == "971" | departement_domicile == "972" | departement_domicile == "974") 
+        conditionGuyMay = (departement_domicile == "973" | departement_domicile == "976")
         conditionDOM = conditionGuadMarReu | conditionGuyMay
 
         abat_dom = (conditionGuadMarReu * min_(plafond_qf.abat_dom.plaf_GuadMarReu, plafond_qf.abat_dom.taux_GuadMarReu * IP1) +

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -121,6 +121,13 @@ class age_en_mois(Variable):
         return (datetime64(period.start) - date_naissance).astype('timedelta64[M]')
 
 
+class depcom_foyer(Variable):
+    value_type = str
+    entity = FoyerFiscal
+    label = u"Code AFT du lieu de domicile fiscal"
+    definition_period = YEAR
+
+
 class nb_adult(Variable):
     value_type = float
     entity = FoyerFiscal

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1227,12 +1227,12 @@ class ir_plaf_qf(Variable):
         conditionGuadMarReu = (departement_domicile == "971" | departement_domicile == "972" | departement_domicile == "974") 
         conditionGuyMay = (departement_domicile == "973" | departement_domicile == "976")
         conditionDOM = conditionGuadMarReu | conditionGuyMay
-        abat_dom = (
+        abattement_dom = (
             conditionGuadMarReu * min_(plafond_qf.abat_dom.plaf_GuadMarReu, plafond_qf.abat_dom.taux_GuadMarReu * IP1)
             + conditionGuyMay * min_(plafond_qf.abat_dom.plaf_GuyMay, plafond_qf.abat_dom.taux_GuyMay * IP1)
             )
 
-        IP2 = max_(0, IP1 - abat_dom)
+        IP2 = max_(0, IP1 - abattement_dom)
 
         return (not_(conditionDOM) * (condition62a * IP0 + condition62b * IP1) + conditionDOM * IP2)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -123,6 +123,7 @@ class age_en_mois(Variable):
 
 class depcom_foyer(Variable):
     value_type = str
+    default_value = "00000"
     entity = FoyerFiscal
     label = u"Code AFT du lieu de domicile fiscal"
     definition_period = YEAR

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -124,10 +124,13 @@ class age_en_mois(Variable):
 
 class depcom_foyer(Variable):
     value_type = str
-    default_value = "00000"
+    max_length = 5
     entity = FoyerFiscal
+    default_value = "00000"
     label = u"Code AFT du lieu de domicile fiscal"
     definition_period = YEAR
+    set_input = set_input_dispatch_by_period
+    # Cette variable est similaire à la variable "depcom" qui est le lieu de domicile du ménage tandis que "depcom_foyer" est le lieu de résidence fiscale du foyer fiscal.
 
 
 class residence_fiscale_guadeloupe(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1286,8 +1286,8 @@ class ir_plaf_qf(Variable):
         residence_dom = (residence_guadeloupe_martinique_reunion | residence_guyane_mayotte)
         
         abattement_dom = (
-            residence_guadeloupe_martinique_reunion * min_(plafond_qf.abat_dom.plaf_GuadMarReu, plafond_qf.abat_dom.taux_GuadMarReu * IP1)
-            + residence_guyane_mayotte * min_(plafond_qf.abat_dom.plaf_GuyMay, plafond_qf.abat_dom.taux_GuyMay * IP1)
+            residence_guadeloupe_martinique_reunion * min_(plafond_qf.abat_dom.plaf_GuadMarReu, plafond_qf.abat_dom.taux_GuadMarReu * impot_apres_reduction_complementaire)
+            + residence_guyane_mayotte * min_(plafond_qf.abat_dom.plaf_GuyMay, plafond_qf.abat_dom.taux_GuyMay * impot_apres_reduction_complementaire)
             )
 
         impot_apres_abattement_dom = max_(0, impot_apres_reduction_complementaire - abattement_dom)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1289,7 +1289,10 @@ class ir_plaf_qf(Variable):
 
         IP2 = max_(0, IP1 - abattement_dom)
 
-        return (not_(residence_dom) * (condition62a * IP0 + condition62b * IP1) + residence_dom * IP2)
+        return (
+            not_(residence_dom) * (condition62a * IP0 + condition62b * IP1)
+            + residence_dom * IP2
+            )
 
 
 class avantage_qf(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1227,13 +1227,14 @@ class ir_plaf_qf(Variable):
         conditionGuadMarReu = (departement_domicile == "971" | departement_domicile == "972" | departement_domicile == "974") 
         conditionGuyMay = (departement_domicile == "973" | departement_domicile == "976")
         conditionDOM = conditionGuadMarReu | conditionGuyMay
+        abat_dom = (
+            conditionGuadMarReu * min_(plafond_qf.abat_dom.plaf_GuadMarReu, plafond_qf.abat_dom.taux_GuadMarReu * IP1)
+            + conditionGuyMay * min_(plafond_qf.abat_dom.plaf_GuyMay, plafond_qf.abat_dom.taux_GuyMay * IP1)
+            )
 
-        abat_dom = (conditionGuadMarReu * min_(plafond_qf.abat_dom.plaf_GuadMarReu, plafond_qf.abat_dom.taux_GuadMarReu * IP1) +
-                   conditionGuyMay * min_(plafond_qf.abat_dom.plaf_GuyMay, plafond_qf.abat_dom.taux_GuyMay * IP1))
         IP2 = IP1 - abat_dom
 
-        return (not_(conditionDOM) * (condition62a * IP0 + condition62b * IP1) +
-                conditionDOM * IP2)
+        return (not_(conditionDOM) * (condition62a * IP0 + condition62b * IP1) + conditionDOM * IP2)
 
 
 class avantage_qf(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1232,7 +1232,7 @@ class ir_plaf_qf(Variable):
             + conditionGuyMay * min_(plafond_qf.abat_dom.plaf_GuyMay, plafond_qf.abat_dom.taux_GuyMay * IP1)
             )
 
-        IP2 = IP1 - abat_dom
+        IP2 = max_(0, IP1 - abat_dom)
 
         return (not_(conditionDOM) * (condition62a * IP0 + condition62b * IP1) + conditionDOM * IP2)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1278,18 +1278,18 @@ class ir_plaf_qf(Variable):
 
         # PART3 - ABATTEMENT PARTICULIE DOM
 
-        conditionGuadMarReu = (residence_fiscale_guadeloupe | residence_fiscale_martinique | residence_fiscale_reunion)
-        conditionGuyMay = (residence_fiscale_guyane | residence_fiscale_mayotte)
-        conditionDOM = (conditionGuadMarReu | conditionGuyMay)
+        residence_guadeloupe_martinique_reunion = (residence_fiscale_guadeloupe | residence_fiscale_martinique | residence_fiscale_reunion)
+        residence_guyane_mayotte = (residence_fiscale_guyane | residence_fiscale_mayotte)
+        residence_dom = (residence_guadeloupe_martinique_reunion | residence_guyane_mayotte)
         
         abattement_dom = (
-            conditionGuadMarReu * min_(plafond_qf.abat_dom.plaf_GuadMarReu, plafond_qf.abat_dom.taux_GuadMarReu * IP1)
-            + conditionGuyMay * min_(plafond_qf.abat_dom.plaf_GuyMay, plafond_qf.abat_dom.taux_GuyMay * IP1)
+            residence_guadeloupe_martinique_reunion * min_(plafond_qf.abat_dom.plaf_GuadMarReu, plafond_qf.abat_dom.taux_GuadMarReu * IP1)
+            + residence_guyane_mayotte * min_(plafond_qf.abat_dom.plaf_GuyMay, plafond_qf.abat_dom.taux_GuyMay * IP1)
             )
 
         IP2 = max_(0, IP1 - abattement_dom)
 
-        return (not_(conditionDOM) * (condition62a * IP0 + condition62b * IP1) + conditionDOM * IP2)
+        return (not_(residence_dom) * (condition62a * IP0 + condition62b * IP1) + residence_dom * IP2)
 
 
 class avantage_qf(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1251,7 +1251,7 @@ class ir_plaf_qf(Variable):
 
         C = max_(0, A - B)
 
-        IP0 = max_(I, C)
+        impot_apres_plaf_qf = max_(I, C)
 
         # PART2 - REDUCTION IR APRES PLAFONNEMENT
 
@@ -1274,7 +1274,7 @@ class ir_plaf_qf(Variable):
         F = D + E
         G = max_(0, A - I - B)
         H = F * (F <= G) + G * (G < F)
-        IP1 = IP0 - H
+        impot_apres_reduction_complementaire = impot_apres_plaf_qf - H
 
         # PART3 - ABATTEMENT PARTICULIE DOM
 
@@ -1287,11 +1287,11 @@ class ir_plaf_qf(Variable):
             + residence_guyane_mayotte * min_(plafond_qf.abat_dom.plaf_GuyMay, plafond_qf.abat_dom.taux_GuyMay * IP1)
             )
 
-        IP2 = max_(0, IP1 - abattement_dom)
+        impot_apres_abattement_dom = max_(0, impot_apres_reduction_complementaire - abattement_dom)
 
         return (
-            not_(residence_dom) * (condition62a * IP0 + condition62b * IP1)
-            + residence_dom * IP2
+            not_(residence_dom) * (condition62a * impot_apres_plaf_qf + condition62b * impot_apres_reduction_complementaire)
+            + residence_dom * impot_apres_abattement_dom
             )
 
 

--- a/openfisca_france/parameters/impot_revenu/plafond_qf/abat_dom/taux_GuadMarReu.yaml
+++ b/openfisca_france/parameters/impot_revenu/plafond_qf/abat_dom/taux_GuadMarReu.yaml
@@ -3,4 +3,4 @@ reference: ipp
 unit: currency
 values:
   2001-01-01:
-    value: 30.0
+    value: 0.30

--- a/openfisca_france/parameters/impot_revenu/plafond_qf/abat_dom/taux_GuyMay.yaml
+++ b/openfisca_france/parameters/impot_revenu/plafond_qf/abat_dom/taux_GuyMay.yaml
@@ -3,4 +3,4 @@ reference: ipp
 unit: currency
 values:
   2001-01-01:
-    value: 40.0
+    value: 0.40

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '22.4.0',
+    version = '22.5.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/impot_revenu/abattement_dom.yaml
+++ b/tests/impot_revenu/abattement_dom.yaml
@@ -1,0 +1,70 @@
+
+- name: Résidence fiscale Guadeloupe
+  period: "year:2018"
+  individus:
+    id: "parent"
+  foyers_fiscaux:
+    depcom_foyer: 97105
+    declarants: "parent"
+  output_variables:
+    residence_fiscale_guadeloupe: true
+    residence_fiscale_guyane: false
+    residence_fiscale_martinique: false
+    residence_fiscale_mayotte: false
+    residence_fiscale_reunion: false
+
+- name: Résidence fiscale Guyane
+  period: "year:2018"
+  individus:
+    id: "parent"
+  foyers_fiscaux:
+    depcom_foyer: 97302
+    declarants: "parent"
+  output_variables:
+    residence_fiscale_guadeloupe: false
+    residence_fiscale_guyane: true
+    residence_fiscale_martinique: false
+    residence_fiscale_mayotte: false
+    residence_fiscale_reunion: false
+
+- name: Résidence fiscale Martinique
+  period: "year:2018"
+  individus:
+    id: "parent"
+  foyers_fiscaux:
+    depcom_foyer: 97209
+    declarants: "parent"
+  output_variables:
+    residence_fiscale_guadeloupe: false
+    residence_fiscale_guyane: false
+    residence_fiscale_martinique: true
+    residence_fiscale_mayotte: false
+    residence_fiscale_reunion: false
+
+- name: Résidence fiscale Mayotte
+  period: "year:2018"
+  individus:
+    id: "parent"
+  foyers_fiscaux:
+    depcom_foyer: 97611
+    declarants: "parent"
+  output_variables:
+    residence_fiscale_guadeloupe: false
+    residence_fiscale_guyane: false
+    residence_fiscale_martinique: false
+    residence_fiscale_mayotte: true
+    residence_fiscale_reunion: false
+
+- name: Résidence fiscale Réunion
+  period: "year:2018"
+  individus:
+    id: "parent"
+  foyers_fiscaux:
+    depcom_foyer: 97411
+    declarants: "parent"
+  output_variables:
+    residence_fiscale_guadeloupe: false
+    residence_fiscale_guyane: false
+    residence_fiscale_martinique: false
+    residence_fiscale_mayotte: false
+    residence_fiscale_reunion: true

--- a/tests/impot_revenu/abattement_dom.yaml
+++ b/tests/impot_revenu/abattement_dom.yaml
@@ -68,3 +68,54 @@
     residence_fiscale_martinique: false
     residence_fiscale_mayotte: false
     residence_fiscale_reunion: true
+
+- name: Pas d'abattement DOM
+  period: "year:2017"
+  absolute_error_margin: 1
+  individus:
+    id: "parent"
+    salaire_imposable: 50000
+  foyers_fiscaux:
+    depcom_foyer: 75101
+    declarants: "parent"
+  output_variables:
+    residence_fiscale_guadeloupe: false
+    residence_fiscale_guyane: false
+    residence_fiscale_martinique: false
+    residence_fiscale_mayotte: false
+    residence_fiscale_reunion: false
+    ir_plaf_qf: 7793.0
+
+- name: Abattement 30% DOM
+  period: "year:2017"
+  absolute_error_margin: 1
+  individus:
+    id: "parent"
+    salaire_imposable: 50000
+  foyers_fiscaux:
+    depcom_foyer: 97105
+    declarants: "parent"
+  output_variables:
+    residence_fiscale_guadeloupe: true
+    residence_fiscale_guyane: false
+    residence_fiscale_martinique: false
+    residence_fiscale_mayotte: false
+    residence_fiscale_reunion: false
+    ir_plaf_qf: 5455.0
+
+- name: Abattement 40% DOM
+  period: "year:2017"
+  absolute_error_margin: 1
+  individus:
+    id: "parent"
+    salaire_imposable: 50000
+  foyers_fiscaux:
+    depcom_foyer: 97302
+    declarants: "parent"
+  output_variables:
+    residence_fiscale_guadeloupe: false
+    residence_fiscale_guyane: true
+    residence_fiscale_martinique: false
+    residence_fiscale_mayotte: false
+    residence_fiscale_reunion: false
+    ir_plaf_qf: 4676.0


### PR DESCRIPTION


* Évolution du système socio-fiscal.
* Périodes concernées :à partir du 01/01/2013.
* Zones impactées : `model\prelevements_obligatoires\impot_revenu\ir`.
* Détails :
  - Ajoute une variable "depcom_foyer" donnant le lieu de résidence fiscale du foyer.
  - Utilise cette variable pour calculer l'abattement d'impôt spécial DOM 
- - - -

Ces changements :
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.
