### PR TITLE
Corrige le calcul de l'ASF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Changelog
 
+### 24.12.1 [#1132](https://github.com/openfisca/openfisca-france/pull/1043)
+
+* Changement mineur.
+* Zones impactées : `openfisca_france/parameters/prestations/prestations_familiales/af/bmaf.yaml`
+* Détails :
+  - Correction du calcul de l'ASF, en cas de pension alimentaire.
+  - Prise en compte de la revalorisation 2018.
+
 ### 24.12.0 [#1047](https://github.com/openfisca/openfisca-france/pull/1047)
- * Évolution du système socio-fiscal.
+
+* Évolution du système socio-fiscal.
 * Périodes concernées : toutes.
 * Zones impactées :
   - `model\prestations\minima_sociaux\ppa`

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '24.12.0',
+    version = '24.12.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/asf.yaml
+++ b/tests/formulas/asf.yaml
@@ -1,4 +1,4 @@
-- name: "Famille ayant droit à l'ASF"
+- name: "Famille ayant droit à l'ASF - 2015"
   period: 2015-01
   relative_error_margin: 0.01
   familles:
@@ -9,8 +9,40 @@
       age: 40
     - id: "enfant1"
       age: 9
+      garde_alternee: false
   output_variables:
     asf: 96
+
+- name: "Famille ayant droit à l'ASF - 2018"
+  period: 2018-05
+  relative_error_margin: 0.01
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1"]
+  individus:
+    - id: "parent1"
+      age: 40
+    - id: "enfant1"
+      age: 9
+      garde_alternee: false
+  output_variables:
+    asf: 115.87
+
+- name: "Famille ayant droit à l'ASF - avec pension alimentaire - 2018"
+  period: 2018-05
+  relative_error_margin: 0.01
+  familles:
+    parents: ["parent1"]
+    enfants: ["enfant1"]
+  individus:
+    - id: "parent1"
+      age: 40
+      pensions_alimentaires_percues: 50
+    - id: "enfant1"
+      age: 9
+      garde_alternee: true
+  output_variables:
+    asf: 65.87
 
 - name: "Limite d'âge : 20 ans"
   period: 2015-01

--- a/tests/mes-aides.gouv.fr/test_mes_aides_559161a648433cfe2f4370f0.yaml
+++ b/tests/mes-aides.gouv.fr/test_mes_aides_559161a648433cfe2f4370f0.yaml
@@ -323,4 +323,4 @@ menages:
   statut_occupation_logement: locataire_vide
 output_variables:
   acs: 400
-  asf: 0
+  asf: 98.15


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/04/2018.
* Zones impactées : `openfisca_france/parameters/prestations/prestations_familiales/af/bmaf.yaml`.
* Détails :
  - Correction du calcul de l'ASF, en cas de pension alimentaire.
  - Prise en compte de la revalorisation 2018.
  - Nécessite #994, lié à betagouv/mes-aides-ui#602

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.
