### PR TITLE
Make the scripts compatible with py3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 22.6.1 [#998](https://github.com/openfisca/openfisca-france/pull/1053)
+
+* Amélioration technique.
+* Détails :
+  - Compatibilité python2 et python3
+
 ## 22.6.0 [#1064](https://github.com/openfisca/openfisca-france/pull/1064)
 
 * Évolution du système socio-fiscal | Changements mineurs

--- a/openfisca_france/assets/apl/extract_subcommunes.py
+++ b/openfisca_france/assets/apl/extract_subcommunes.py
@@ -36,7 +36,7 @@ def main():
                 commune_depcom = row['POLE']
                 commune_depcom_by_subcommune_depcom[subcommune_depcom] = commune_depcom
 
-    print json.dumps(commune_depcom_by_subcommune_depcom, encoding = 'utf-8', ensure_ascii = False, indent = 2)
+    print(json.dumps(commune_depcom_by_subcommune_depcom, encoding = 'utf-8', ensure_ascii = False, indent = 2))
     return 0
 
 

--- a/openfisca_france/scripts/cnaf/exploitation_rsa.py
+++ b/openfisca_france/scripts/cnaf/exploitation_rsa.py
@@ -41,4 +41,4 @@ for revenu in range(10):
     exemple_rev[-4] = 100*revenu
     rsa.set_choice(exemple_rev)
     result_rev[100*revenu] = rsa.fill_in()
-    print result_rev[100*revenu]
+    print(result_rev[100*revenu])

--- a/openfisca_france/scripts/cnaf/formulaires_caf.py
+++ b/openfisca_france/scripts/cnaf/formulaires_caf.py
@@ -25,8 +25,8 @@ def go_to_next_page(parameters, response, form_element, form_to_take=1):
     try:
         response = url_opener.open(request, urllib.urlencode(parameters, doseq = True))
     except urllib2.HTTPError as response:
-        print "Erreur", response.code
-        print response.read()
+        print("Erreur", response.code)
+        print(response.read())
         raise
     html_page = response.read()
     tree = etree.parse(StringIO(html_page), parser)
@@ -101,7 +101,7 @@ def _get_a_page(form_element):
                 else:  # if 'RessFR' in name or 'RessIJ' in name:
                     values = ['0']
             if values == []:
-                print name
+                print(name)
                 pdb.set_trace()
             page_question += [Question(name, values, 'text')]
         elif input.attrib['type'] == 'checkbox':
@@ -109,8 +109,8 @@ def _get_a_page(form_element):
         elif input.attrib['type'] == 'submit':
             page_question += [Question(name, [name[2:]], 'submit')]
         else:
-            print 'type non rencontré encore'
-            print input.attrib['type']
+            print('type non rencontré encore')
+            print(input.attrib['type'])
             pdb.set_trace()
 
     return Page(page_question)
@@ -169,7 +169,7 @@ class Formulaire(object):
             # on cherche la page, ou bien on la crée
             name_page = _get_page_name(form_element)
             if 'otre conjoint'  in html.title():
-                print 'Votre conjoint'
+                print('Votre conjoint')
                 import pdb
                 pdb.set_trace()
             if name_page not in self.pages_collections:
@@ -179,7 +179,7 @@ class Formulaire(object):
 
             else:
                 page_question = self.pages_collections[name_page]
-                print name_page
+                print(name_page)
                 page_question.set_next_choices()
 
 
@@ -192,9 +192,9 @@ class Formulaire(object):
         montant = re.findall("\d+.\d+", look[-10:])[0]
         montant = montant.replace(',', '.')
         montant = float(montant)
-        print montant
+        print(montant)
 
-        print ('fin de boucle')
+        print('fin de boucle')
         import pdb
         pdb.set_trace()
 
@@ -207,7 +207,7 @@ class Formulaire(object):
         response, form_element = self.init()
         parameters_serie = self.get_parameters_serie()
         for parameters in parameters_serie:
-            print parameters
+            print(parameters)
             response, form_element, html = go_to_next_page(parameters, response, form_element)
 
         if '&euro' in html and "loyer" not in html:
@@ -218,7 +218,7 @@ class Formulaire(object):
             return montant
 
         for input_element in form_element.xpath('.//input'):
-            print etree.tostring(input_element)
+            print(etree.tostring(input_element))
 
 
 

--- a/openfisca_france/scripts/cnaf/get_tree.py
+++ b/openfisca_france/scripts/cnaf/get_tree.py
@@ -32,7 +32,7 @@ def _get_inputs(browser):
     inputs = [input for input in inputs
               if input.get_attribute('name') not in input_pas_interessant]
     for input in inputs:
-        print input.get_attribute('name'), input.get_attribute('type')
+        print(input.get_attribute('name'), input.get_attribute('type'))
     return inputs
 
 def continuer(browser):
@@ -83,27 +83,27 @@ def create_page_from_inputs(browser):
                 else:  # if 'RessFR' in name or 'RessIJ' in name:
                     values = ['0']
             if values == []:
-                print name
+                print(name)
                 pdb.set_trace()
             page_question += [Question(name, values, 'text')]
         elif input.get_attribute('type') == 'checkbox':
             page_question += [Question(name, ['false', 'true'], 'text')]
         else:
-            print 'type non rencontré encore'
-            print input.get_attribute('type')
+            print('type non rencontré encore')
+            print(input.get_attribute('type'))
             pdb.set_trace()
 
     if name_page not in page_collection.keys():
         page_collection[name_page] = page_question
 
-    print name_page
+    print(name_page)
     return name_page
 
 def fill_page(browser, name_page):
     questions = page_collection[name_page]
     for question in questions:
         try:
-            print 'question', question.name
+            print('question', question.name)
             champs = browser.find_elements_by_name(question.name)
             if question.type == 'text':
                 assert len(champs) == 1

--- a/openfisca_france/scripts/measure_performances.py
+++ b/openfisca_france/scripts/measure_performances.py
@@ -79,7 +79,7 @@ def timeit(method):
         start_time = time.time()
         result = method(*args, **kwargs)
         # print '%r (%r, %r) %2.9f s' % (method.__name__, args, kw, time.time() - start_time)
-        print '{:2.6f} s'.format(time.time() - start_time)
+        print('{:2.6f} s'.format(time.time() - start_time))
         return result
 
     return timed
@@ -118,7 +118,7 @@ def main():
     args = parser.parse_args()
     logging.basicConfig(level = logging.DEBUG if args.verbose else logging.WARNING, stream = sys.stdout)
 
-    print 'salaire_imposable'
+    print('salaire_imposable')
 
     test_irpp(2010, -1181, salaire_imposable =  20000)
     test_irpp(2010, -7934, salaire_imposable =  50000)
@@ -133,7 +133,7 @@ def main():
     test_irpp(2013, -7889, salaire_imposable =  50000)
     test_irpp(2013, -43076, salaire_imposable =  150000)
 
-    print 'retraite_imposable'
+    print('retraite_imposable')
 
     test_irpp(2010, -1181, retraite_imposable = 20000)
     test_irpp(2010, -8336, retraite_imposable = 50000)
@@ -148,7 +148,7 @@ def main():
     test_irpp(2013, -8283, retraite_imposable = 50000)
     test_irpp(2013, -46523, retraite_imposable = 150000)
 
-    print 'f2da'
+    print('f2da')
 
     test_irpp(2010, 0, f2da = 20000)
     test_irpp(2010, 0, f2da = 50000)
@@ -163,7 +163,7 @@ def main():
     # test_irpp(2013, 0, f2da = 50000)
     # test_irpp(2013, 0, f2da = 150000)
 
-    print 'f2dc'
+    print('f2dc')
 
     test_irpp(2010, 0, f2dc = 20000)
     test_irpp(2010, -2976, f2dc = 50000)
@@ -178,7 +178,7 @@ def main():
     # test_irpp(2013, 0, f2dc = 50000)
     # test_irpp(2013, 0, f2dc = 150000)
 
-    print 'f2dh'
+    print('f2dh')
 
     test_irpp(2010, 345, f2dh = 20000)
     test_irpp(2010, 345, f2dh = 50000)
@@ -193,7 +193,7 @@ def main():
     test_irpp(2013, 345, f2dh = 50000)
     test_irpp(2013, 345, f2dh = 150000)
 
-    print 'f2tr'
+    print('f2tr')
 
     test_irpp(2010, -1461, f2tr = 20000)
     test_irpp(2010, -9434, f2tr = 50000)
@@ -208,7 +208,7 @@ def main():
     test_irpp(2013, -9389, f2tr = 50000)
     test_irpp(2013, -48036, f2tr = 150000)
 
-    print 'f2ts'
+    print('f2ts')
 
     test_irpp(2010, -1461, f2ts = 20000)
     test_irpp(2010, -9434, f2ts = 50000)
@@ -223,7 +223,7 @@ def main():
     test_irpp(2013, -9389, f2ts = 50000)
     test_irpp(2013, -48036, f2ts = 150000)
 
-    print 'f3vg'
+    print('f3vg')
 
     test_irpp(2010, -3600, f3vg = 20000)
     test_irpp(2010, -9000, f3vg = 50000)
@@ -238,7 +238,7 @@ def main():
     test_irpp(2013, -9389, f3vg = 50000)
     test_irpp(2013, -48036, f3vg = 150000)
 
-    print 'f3vz'
+    print('f3vz')
 
     # test_irpp(2010, 0, f3vz = 20000)
     # test_irpp(2010, 0, f3vz = 50000)
@@ -253,7 +253,7 @@ def main():
     test_irpp(2013, 0, f3vz = 50000)
     test_irpp(2013, 0, f3vz = 150000)
 
-    print 'f4ba'
+    print('f4ba')
 
     test_irpp(2010, -1461, f4ba = 20000)
     test_irpp(2010, -9434, f4ba = 50000)

--- a/openfisca_france/scripts/parameters/baremes_ipp/xls_to_yaml_raw.py
+++ b/openfisca_france/scripts/parameters/baremes_ipp/xls_to_yaml_raw.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 
 """Convert IPP's tax and benefit tables from XLS format to YAML, trying to preserve its content as much as possible."""
 
@@ -19,14 +21,14 @@ import xlrd
 import yaml
 
 
-aad_re = re.compile(ur'AAD(\s+[-+]\s+\d+\s+ans?)?$')
+aad_re = re.compile(r'AAD(\s+[-+]\s+\d+\s+ans?)?$')
 app_name = os.path.splitext(os.path.basename(__file__))[0]
 conv = custom_conv(baseconv, datetimeconv, states)
-french_date_re = re.compile(ur'(?P<day>0?[1-9]|[12]\d|3[01])/(?P<month>0?[1-9]|1[0-2])/(?P<year>[12]\d{3})$')
+french_date_re = re.compile(r'(?P<day>0?[1-9]|[12]\d|3[01])/(?P<month>0?[1-9]|1[0-2])/(?P<year>[12]\d{3})$')
 log = logging.getLogger(app_name)
 number_re = re.compile(u'\d+\.?$')
 parameters = []
-year_re = re.compile(ur'[12]\d{3}$')
+year_re = re.compile(r'[12]\d{3}$')
 
 
 # YAML configuration
@@ -164,7 +166,7 @@ def transform_xls_cell_to_json(book, sheet, merged_cells_tree, row_index, column
             return value
         if u'€' in format_str:
             return (value, u'EUR')
-        if u'FRF' in format_str or ur'\F\R\F' in format_str or format_str.endswith(ur'\ "F"'):
+        if u'FRF' in format_str or u'\F\R\F' in format_str or format_str.endswith(u'\ "F"'):
             return (value, u'FRF')
         assert format_str.endswith(u'%'), 'Unexpected format "{}" for value: {}'.format(format_str, value)
         return (value, u'%')

--- a/openfisca_france/scripts/parameters/baremes_ipp/yaml_raw_to_yaml_clean.py
+++ b/openfisca_france/scripts/parameters/baremes_ipp/yaml_raw_to_yaml_clean.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 
 """Clean up YAML files extracted from IPP's tax and benefit tables."""
 
@@ -17,12 +19,12 @@ import yaml
 
 enable_warnings = True
 
-aad_re = re.compile(ur'AAD(\s+[-+]\s+\d+\s+ans?)?$')
-ans_et_mois_re = re.compile(ur"\d+ ans( \d+ mois)?$")
+aad_re = re.compile(r'AAD(\s+[-+]\s+\d+\s+ans?)?$')
+ans_et_mois_re = re.compile(r"\d+ ans( \d+ mois)?$")
 app_name = u"cleanup_yaml"
-apres_le_re = re.compile(ur'après le (?P<day>0?[1-9]|[12]\d|3[01])/(?P<month>0?[1-9]|1[0-2])/(?P<year>[12]\d{3})$')
+apres_le_re = re.compile(r'après le (?P<day>0?[1-9]|[12]\d|3[01])/(?P<month>0?[1-9]|1[0-2])/(?P<year>[12]\d{3})$')
 conv = custom_conv(baseconv, datetimeconv, states)
-french_date_re = re.compile(ur'(?P<day>0?[1-9]|[12]\d|3[01])/(?P<month>0?[1-9]|1[0-2])/(?P<year>[12]\d{3})$')
+french_date_re = re.compile(r'(?P<day>0?[1-9]|[12]\d|3[01])/(?P<month>0?[1-9]|1[0-2])/(?P<year>[12]\d{3})$')
 label_by_alias = {
     u"Commentaires": u"Notes",
     u"Date d'entrée en vigueur": u"Date d'effet",
@@ -46,10 +48,10 @@ label_by_alias = {
     u"Références législatives ou BOI": u"Références législatives",
     u"Remarques": u"Notes",
     }
-limite_age_re = re.compile(ur"limite d'âge( - \d+ trimestres?)?$")
+limite_age_re = re.compile(r"limite d'âge( - \d+ trimestres?)?$")
 log = logging.getLogger(app_name)
-trimestres_re = re.compile(ur"\d+ trimestres?$")
-year_re = re.compile(ur'[12]\d{3}$')
+trimestres_re = re.compile(r"\d+ trimestres?$")
+year_re = re.compile(r'[12]\d{3}$')
 
 
 def N_(message):

--- a/openfisca_france/scripts/parameters/reduce_parameters_paths.py
+++ b/openfisca_france/scripts/parameters/reduce_parameters_paths.py
@@ -100,13 +100,13 @@ def parse_and_clean(directory, paths_to_clean):
             if functional_path in paths_to_clean:
                 yaml_path = os.path.join(directory, item + ".yaml")
 
-                print os.linesep + "Cleaning long directory into: " + yaml_path
+                print(os.linesep + "Cleaning long directory into: " + yaml_path)
                 content = harvest(item_path)
                 with open(yaml_path, 'w') as yaml_file:
                     yaml_file.write(yaml.dump(content[item], default_flow_style=False, allow_unicode=True))
 
                 # Delete harvested directory
-                print "Deleting " + item_path
+                print("Deleting " + item_path)
                 shutil.rmtree(item_path)
 
             else:
@@ -114,7 +114,7 @@ def parse_and_clean(directory, paths_to_clean):
 
 
 long_parameters_paths = list_long_paths(PARAMETERS_DIRECTORY)
-print "{} directories have files with more than {} characters in their paths starting from this directory: {}".format(len(long_parameters_paths), PATH_MAX_LENGTH, PARENT_DIRECTORY).encode('utf-8')
+print("{} directories have files with more than {} characters in their paths starting from this directory: {}".format(len(long_parameters_paths), PATH_MAX_LENGTH, PARENT_DIRECTORY).encode('utf-8'))
 
 while len(long_parameters_paths) > 0:
     parse_and_clean(PARAMETERS_DIRECTORY, long_parameters_paths)

--- a/openfisca_france/scripts/rattachement.py
+++ b/openfisca_france/scripts/rattachement.py
@@ -69,7 +69,7 @@ def split(scenario):
             min_ = [i, irpp]
         impots.append(irpp)
 
-    print "Le plus avantageux pour votre famille est que les jeunes rattachés à votre foyer fiscal soient : {}. Vous paierez alors {}€ d'impôts. (Seuls les jeunes éligibles au rattachement sont indiqués (18 <= age < 21 si pas étudiant / 25 sinon. Le calculateur a émis l'hypothèse qu'il n'y avait qu'un seul foyer fiscal au départ, auquel tous les jeunes éligibles étaient rattachés.)".format(foyers_possibles[min_[0]],min_[1])
+    print("Le plus avantageux pour votre famille est que les jeunes rattachés à votre foyer fiscal soient : {}. Vous paierez alors {}€ d'impôts. (Seuls les jeunes éligibles au rattachement sont indiqués (18 <= age < 21 si pas étudiant / 25 sinon. Le calculateur a émis l'hypothèse qu'il n'y avait qu'un seul foyer fiscal au départ, auquel tous les jeunes éligibles étaient rattachés.)".format(foyers_possibles[min_[0]],min_[1]))
     return impots
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '22.6.0',
+    version = '22.6.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
This is a very straightforward change involving mainly adding parens to the print statements.

The non-trivial changes are in openfisca_france/scripts/parameters/baremes_ipp/xls_to_yaml_raw.py and openfisca_france/scripts/parameters/baremes_ipp/yaml_raw_to_yaml_clean.py:
changing `ur` to `r` in regexes.

I'm really baffled that those tests [would pass without failing in py3 on circleCI previously](https://circleci.com/gh/openfisca/openfisca-france/2338#config/containers/0) ...