### PR TITLE
Rend l'installation de la Web API optionnelle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             pip install --upgrade pip twine wheel
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
-            pip install --editable ".[api, dev]" --upgrade
+            pip install --editable .[dev] --upgrade && pip install openfisca-core[web-api]
 
       - save_cache:
           key: v1-py2-{{ checksum "setup.py" }}
@@ -102,7 +102,7 @@ jobs:
           command: |
             pip install --upgrade pip twine wheel
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
-            pip install --editable ".[api, dev]" --upgrade
+            pip install --editable .[dev] --upgrade && pip install openfisca-core[web-api]
 
       - save_cache:
           key: v1-py3-{{ checksum "setup.py" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ jobs:
           name: Install dependencies
           command: |
             pip install --upgrade pip twine wheel
-            pip install --editable .[test] --upgrade
-          #  pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
+            # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
+            pip install --editable ".[api, dev]" --upgrade
 
       - save_cache:
           key: v1-py2-{{ checksum "setup.py" }}
@@ -101,8 +101,8 @@ jobs:
           name: Install dependencies
           command: |
             pip install --upgrade pip twine wheel
-            pip install --editable .[test] --upgrade
-          #  pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
+            # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
+            pip install --editable ".[api, dev]" --upgrade
 
       - save_cache:
           key: v1-py3-{{ checksum "setup.py" }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   - Aucun impact pour les **clients** de l'API.
   - Rend optionnelle l'installation de la Web API
     - `pip install OpenFisca-France` n'installera _plus_ l'API.
-    - `pip install OpenFisca-France[api]` permet d'inclure l'API.
+    - `pip install openfisca-france && pip install openfisca-core[web-api]` permet d'inclure l'API.
   - Sert l'API Web sur le port 5000 par défault (à la place de 6000, considéré non-sûr)
   - Renomme le groupe des dépendances optionnelles de développement:
     - `pip install --editable .[dev]` permet de les installer (à la place de of `pip install --editable .[test]`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+# 24.0.0 [#1062](https://github.com/openfisca/openfisca-france/pull/1062)
+
+* Amélioration technique **non rétro-compatibles**.
+* Détails :
+  - Aucun impact pour les **clients** de l'API.
+  - Rend optionnelle l'installation de la Web API
+    - `pip install OpenFisca-France` n'installera _plus_ l'API.
+    - `pip install OpenFisca-France[api]` permet d'inclure l'API.
+  - Sert l'API Web sur le port 5000 par défault (à la place de 6000, considéré non-sûr)
+  - Renomme le groupe des dépendances optionnelles de développement:
+    - `pip install --editable .[dev]` permet de les installer (à la place de of `pip install --editable .[test]`).
+
 ### 23.1.1 [#1077](https://github.com/openfisca/openfisca-france/pull/1077)
 
 * Correction d'un crash

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ pip --version  # Devrait afficher au moins 9.0.x
 Installez OpenFisca-France :
 
 ```sh
-pip install openfisca-france
+pip install 'openfisca-france[api]'
 ```
 Félicitations :tada: OpenFisca-France est prêt à être utilisé !
 
@@ -143,13 +143,12 @@ Clonez OpenFisca-France sur votre machine :
 ```sh
 git clone https://github.com/openfisca/openfisca-france.git
 cd openfisca-france
-pip install -e .
+pip install -e ".[api, dev]"
 ```
 
 Vous pouvez vous assurer que votre installation s'est bien passée en exécutant :
 
 ```sh
-pip install -e ".[test]"
 nosetests tests/test_basics.py # Ces test peuvent prendre jusqu'à 60 secondes.
 ```
 :tada: OpenFisca-France est prêt à être utilisé !
@@ -172,7 +171,7 @@ Pour en savoir plus sur la commande `openfisca serve` et ses options, consultez 
 Testez votre installation en requêtant la commande suivante :
 
 ```sh
-curl "http://localhost:6000/parameter/cotsoc.gen.smic_h_b"
+curl "http://localhost:5000/parameter/cotsoc.gen.smic_h_b"
 ```
 Vous devriez avoir le resultat suivant :
 ```JSON

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ pip --version  # Devrait afficher au moins 9.0.x
 Installez OpenFisca-France :
 
 ```sh
-pip install 'openfisca-france[api]'
+pip install openfisca-france && pip install openfisca-core[web-api]
 ```
+> _Note: La deuxième partie de la commande, à partir du `&&`, est optionnelle. Elle vous permet d'installer l'API Web d'OpenFisca._
+
 Félicitations :tada: OpenFisca-France est prêt à être utilisé !
 
 #### Prochaines étapes
@@ -143,7 +145,7 @@ Clonez OpenFisca-France sur votre machine :
 ```sh
 git clone https://github.com/openfisca/openfisca-france.git
 cd openfisca-france
-pip install -e ".[api, dev]"
+pip install --editable .[dev] && pip install openfisca-core[web-api]
 ```
 
 Vous pouvez vous assurer que votre installation s'est bien passée en exécutant :

--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,13 @@ setup(
             'nose',
             'flake8 == 3.4.1',
             'scipy >= 0.17',  # Only used to test de_net_a_brut reform
+            'requests >= 2.8',
             'yamllint >= 1.11.1, < 1.12',
             ],
         },
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
         'OpenFisca-Core >= 23.1.2, < 24',
-        'requests >= 2.8',
         ],
     message_extractors = {'openfisca_france': [
         ('**.py', 'python', None),

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ setup(
         ('share/openfisca/openfisca-france', ['CHANGELOG.md', 'LICENSE.AGPL.txt', 'README.md']),
         ],
     extras_require = {
+        'api': [
+            'OpenFisca-Core[api]'
+        ],
         'baremes_ipp': [
             'xlrd >= 1.0.0',
             'lxml >= 3.8.0, < 4.0',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'taxipp': [
             'pandas >= 0.13',
             ],
-        'test': [
+        'dev': [
             'nose',
             'flake8 == 3.4.1',
             'scipy >= 0.17',  # Only used to test de_net_a_brut reform

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         },
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
-        'OpenFisca-Core >= 23.1.2, < 24',
+        'OpenFisca-Core >= 24.0.0, < 25',
         ],
     message_extractors = {'openfisca_france': [
         ('**.py', 'python', None),

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,6 @@ setup(
         ('share/openfisca/openfisca-france', ['CHANGELOG.md', 'LICENSE.AGPL.txt', 'README.md']),
         ],
     extras_require = {
-        'api': [
-            'OpenFisca-Core[api]'
-        ],
         'baremes_ipp': [
             'xlrd >= 1.0.0',
             'lxml >= 3.8.0, < 4.0',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '23.1.1',
+    version = '24.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,9 +16,9 @@ class TestNewApi(TestCase):
 
     def test_response(self):
         try:
-            subprocess.check_call(['wget', '--quiet',  '--retry-connrefused', '--waitretry=1', '--tries=10', 'http://localhost:6000/parameters', '--output-document=/dev/null'])
+            subprocess.check_call(['wget', '--quiet',  '--retry-connrefused', '--waitretry=1', '--tries=10', 'http://localhost:5000/parameters', '--output-document=/dev/null'])
         except subprocess.CalledProcessError:
-            raise subprocess.CalledProcessError("Could not reach OpenFisca Web API at localhost:6000 after 10s")
+            raise subprocess.CalledProcessError("Could not reach OpenFisca Web API at localhost:5000 after 10s")
         except OSError:
             try:
                 subprocess.check_call(['wget', '--version'])


### PR DESCRIPTION
Connected to openfisca/openfisca-core#641
Depends on openfisca/openfisca-core#703

* Amélioration technique **non rétro-compatibles**.
* Détails :
  - Aucun impact pour les **clients** de l'API.
  - Rend optionnelle l'installation de la Web API
    - `pip install OpenFisca-France` n'installera _plus_ l'API.
    - ~`pip install OpenFisca-France[api]` permet d'inclure l'API.~
    - `pip install openfisca-france && pip install openfisca-core[web-api]` permet d'inclure l'API.
  - Sert l'API Web sur le port 5000 par défault (à la place de 6000, considéré non-sûr)
  - Renomme le groupe des dépendances optionnelles de développement:
    - `pip install --editable .[dev]` permet de les installer (à la place de of `pip install --editable .[test]`).