### PR TITLE
Correction du calcul du revenu fiscal de référence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 22.6.0 [#1064](https://github.com/openfisca/openfisca-france/pull/1064)
+
+* Évolution du système socio-fiscal | Changements mineurs
+* Périodes concernées : toutes.
+* Zones impactées : openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.
+* Détails : 
+  - Corrige une erreur dans le calcul du revenu fiscal de référence à propos des charges déductibles
+
+
 ## 22.5.0 [#1040](https://github.com/openfisca/openfisca-france/pull/1040)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
@@ -353,16 +353,19 @@ class rfr_cd(Variable):
     value_type = float
     entity = FoyerFiscal
     label = u"Charges déductibles entrant dans le revenus fiscal de référence"
-    reference = "http://impotsurlerevenu.org/definitions/215-charge-deductible.php"
+    reference = "Article 1417 du Code Général des Impôts - IV-1°-a)"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
-        cd_acc75a = foyer_fiscal('cd_acc75a', period)
-        cd_doment = foyer_fiscal('cd_doment', period)
         cd_eparet = foyer_fiscal('cd_eparet', period)
         cd_sofipe = foyer_fiscal('cd_sofipe', period)
 
-        return cd_acc75a + cd_doment + cd_eparet + cd_sofipe
+        return cd_eparet + cd_sofipe
+
+    def formula_2007_01_01(foyer_fiscal, period, parameters):
+        cd_eparet = foyer_fiscal('cd_eparet', period)
+        
+        return cd_eparet
 
 
 class cd1(Variable):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '22.5.0',
+    version = '22.6.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Jusqu'ici, toutes les charges déductibles du revenu brut global (RBG) étaient réintégrées lors du calcul du revenu fiscal de référence (RFR). 
Or, la plupart des charges déductibles le sont bien à la fois du RBG et du RFR. Seules les charges d'épargne-retraite et de souscription au capital de SOFIPECHE ne sont pas déductibles du RFR.

Référence : [Article 1417 du Code Général des Impôts](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000027517723&cidTexte=LEGITEXT000006069577) - 1° a) du IV

* Évolution du système socio-fiscal | Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles`.

- - - -

Ces changements :
- Corrigent ou améliorent un calcul déjà existant.

- - --
