### PR TITLE
Corrige doubles comptes revenus capital dans rsa asi aspa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 23.1.1 [#1077](https://github.com/openfisca/openfisca-france/pull/1077)
+
+* Correction d'un crash
+* Périodes concernées : toutes
+* Zones impactées:
+   - `openfisca_france\model\prestations\minima_sociaux\rsa.py`
+   - `openfisca_france\model\prestations\minima_sociaux\asi_aspa.py`
+   - `openfisca_france\model\revenus\capital\financier.py`
+* Détails :
+  - Supprime les doubles comptes de certains revenus du capital dans les bases ressources du RSA et de l'ASI-ASPA
+  - Exemple : les revenus de `f2ee` étaient injectés deux fois via `rsa_base_ressources_patrimoine_individu` et via les variables `revenus_capitaux_prelevement_bareme` et `revenus_capitaux_prelevement_liberatoire`
+
 ## 23.1.0 [#1058](https://github.com/openfisca/openfisca-france/pull/1058)
 
 * Évolution du système socio-fiscal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 * Correction d'un crash
 * Périodes concernées : toutes
 * Zones impactées:
-   - `openfisca_france\model\prestations\minima_sociaux\rsa.py`
-   - `openfisca_france\model\prestations\minima_sociaux\asi_aspa.py`
-   - `openfisca_france\model\revenus\capital\financier.py`
+   - `prestations/minima_sociaux/rsa`
+   - `prestations/minima_sociaux/asi_aspa`
+   - `modelrevenus/capital/financier`
 * Détails :
   - Supprime les doubles comptes de certains revenus du capital dans les bases ressources du RSA et de l'ASI-ASPA
   - Exemple : les revenus de `f2ee` étaient injectés deux fois via `rsa_base_ressources_patrimoine_individu` et via les variables `revenus_capitaux_prelevement_bareme` et `revenus_capitaux_prelevement_liberatoire`

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -69,11 +69,8 @@ class asi_aspa_base_ressources_individu(Variable):
             ]
 
         # Revenus du foyer fiscal que l'on projette sur le premier invidividus
-        revenus_capitaux_prelevement_bareme_foyer_fiscal = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_bareme', three_previous_months, options = [ADD]))
-        revenus_capitaux_prelevement_liberatoire_foyer_fiscal = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', three_previous_months, options = [ADD]))
         rente_viagere_titre_onereux_foyer_fiscal = individu.foyer_fiscal('rente_viagere_titre_onereux', three_previous_months, options = [ADD])
-        revenus_foyer_fiscal = revenus_capitaux_prelevement_bareme_foyer_fiscal + revenus_capitaux_prelevement_liberatoire_foyer_fiscal + rente_viagere_titre_onereux_foyer_fiscal
-        revenus_foyer_fiscal_individu = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
+        revenus_foyer_fiscal_individu = rente_viagere_titre_onereux_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         def revenus_tns():
             revenus_auto_entrepreneur = individu('tns_auto_entrepreneur_benefice', three_previous_months, options = [ADD])

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -143,15 +143,8 @@ class rsa_base_ressources_individu(Variable):
             for type_revenu in types_revenus_non_pros
             )
 
-        # Revenus du foyer fiscal que l'on projette sur le premier invidividus
-        revenus_capitaux = (
-                max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_bareme', period.last_3_months, options = [ADD]))
-                + max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period.last_3_months, options = [ADD]))
-        )
-
         rentes_viageres = individu.foyer_fiscal('rente_viagere_titre_onereux', period.last_3_months, options = [ADD])
-        revenus_foyer_fiscal = revenus_capitaux + rentes_viageres
-        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
+        revenus_foyer_fiscal_projetes = rentes_viageres * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         return (revenus_pro + revenus_non_pros + revenus_foyer_fiscal_projetes) / 3
 
@@ -200,11 +193,8 @@ class rsa_base_ressources_individu(Variable):
             )
 
         # Revenus du foyer fiscal que l'on projette sur le premier invidividus
-        revenus_capitaux_prelevement_bareme = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_bareme', period.last_3_months, options = [ADD]))
-        revenus_capitaux_prelevement_liberatoire = max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period.last_3_months, options = [ADD]))
         rente_viagere_titre_onereux = individu.foyer_fiscal('rente_viagere_titre_onereux', period.last_3_months, options = [ADD])
-        revenus_foyer_fiscal = revenus_capitaux_prelevement_bareme + revenus_capitaux_prelevement_liberatoire + rente_viagere_titre_onereux
-        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
+        revenus_foyer_fiscal_projetes = rente_viagere_titre_onereux * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         return (revenus_pro + revenus_non_pros + revenus_foyer_fiscal_projetes) / 3
 

--- a/openfisca_france/model/revenus/capital/financier.py
+++ b/openfisca_france/model/revenus/capital/financier.py
@@ -399,9 +399,9 @@ class revenus_capital(Variable):
     set_input = set_input_divide_by_period
 
     def formula(individu, period):
-        types_revenus_capital = ['f2dc', 'f2ch', 'f2ts', 'f2tr', 'f2da', 'f2dh', 'f2ee']
-        return sum(
-            individu.foyer_fiscal(type_revenu, period, options = [DIVIDE]) *
-            individu.has_role(individu.foyer_fiscal.DECLARANT_PRINCIPAL)
-            for type_revenu in types_revenus_capital
+        revenus_capitaux = (
+            max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_bareme', period))
+            + max_(0, individu.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period))
             )
+
+        return revenus_capitaux

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '23.1.0',
+    version = '23.1.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/asi_aspa.yaml
+++ b/tests/formulas/asi_aspa.yaml
@@ -1,0 +1,11 @@
+- name: absence_double_compte_revcap_asi_aspa_base_ressource_2016
+  description: "Absence de double compte des revenus du capital des cases 2EE et 2DC dans la base ressource de l'ASI et de l'ASPA (2016)"
+  period: 2016-10
+  absolute_error_margin: 1
+  input_variables:
+    f2ee:
+      2016: 12000
+    f2dc:
+      2016: 12000
+  output_variables:
+    asi_aspa_base_ressources: 2000

--- a/tests/formulas/asi_aspa.yaml
+++ b/tests/formulas/asi_aspa.yaml
@@ -1,5 +1,4 @@
-- name: absence_double_compte_revcap_asi_aspa_base_ressource_2016
-  description: "Absence de double compte des revenus du capital des cases 2EE et 2DC dans la base ressource de l'ASI et de l'ASPA (2016)"
+- name: Absence de double compte des revenus du capital des cases 2EE et 2DC dans la base ressource de l'ASI et de l'ASPA (2016)
   period: 2016-10
   absolute_error_margin: 1
   input_variables:

--- a/tests/formulas/rsa/rsa_base_ressources.yaml
+++ b/tests/formulas/rsa/rsa_base_ressources.yaml
@@ -1,5 +1,4 @@
-- name: absence_double_compte_revcap_rsa_base_ressource_2016
-  description: "Absence de double compte des revenus du capital des cases 2EE et 2DC dans la base ressource du RSA (2016)"
+- name: Absence de double compte des revenus du capital des cases 2EE et 2DC dans la base ressource du RSA (2016)
   period: 2016-10
   absolute_error_margin: 1
   input_variables:

--- a/tests/formulas/rsa/rsa_base_ressources.yaml
+++ b/tests/formulas/rsa/rsa_base_ressources.yaml
@@ -1,0 +1,11 @@
+- name: absence_double_compte_revcap_rsa_base_ressource_2016
+  description: "Absence de double compte des revenus du capital des cases 2EE et 2DC dans la base ressource du RSA (2016)"
+  period: 2016-10
+  absolute_error_margin: 1
+  input_variables:
+    f2ee:
+      2016: 12000
+    f2dc:
+      2016: 12000
+  output_variables:
+    rsa_base_ressources: 2000


### PR DESCRIPTION
* Correction d'un crash
* Périodes concernées : toutes
* Zones impactées:
   - `openfisca_france\model\prestations\minima_sociaux\rsa.py`
   - `openfisca_france\model\prestations\minima_sociaux\asi_aspa.py`
   - `openfisca_france\model\revenus\capital\financier.py`
* Détails :
  - Supprime les doubles comptes de certains revenus du capital dans les bases ressources du RSA et de l'ASI-ASPA
  - Exemple : les revenus de `f2ee` étaient injectés deux fois via `rsa_base_ressources_patrimoine_individu` et via les variables `revenus_capitaux_prelevement_bareme` et `revenus_capitaux_prelevement_liberatoire`


Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.