### PR TITLE
Corrige cotisation chomage apres 2018-10-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ##  24.3.0 [#1092](https://github.com/openfisca/openfisca-france/pull/1092)
 
 * Évolution du système socio-fiscal
-* Périodes concernées : à partir du 01/10/2018
+* Périodes concernées : à partir du 01-10-2018
 * Zones impactées : prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive
 * Détails :
-  - Annule la cotisation chomage à partir du 01/10/2018
+  - Annule la cotisation chomage à partir du 01-10-2018
 
 ## 24.2.1 [#1090](https://github.com/openfisca/openfisca-france/pull/1090)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ##  24.3.0 [#1092](https://github.com/openfisca/openfisca-france/pull/1092)
 
 * Évolution du système socio-fiscal
-* Périodes concernées : à partir du 01-10-2018
+* Périodes concernées : à partir du 01/10/2018
 * Zones impactées : prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive
 * Détails :
-  - Annule la cotisation chomage à partir du 01-10-2018
+  - Annule la cotisation chomage à partir du 01/10/2018
 
 ## 24.2.1 [#1090](https://github.com/openfisca/openfisca-france/pull/1090)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+##  24.3.0 [#1092](https://github.com/openfisca/openfisca-france/pull/1092)
+
+* Évolution du système socio-fiscal
+* Périodes concernées : à partir du 01/10/2018
+* Zones impactées : prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive
+* Détails :
+  - Annule la cotisation chomage à partir du 01/10/2018
+
 ## 24.2.1 [#1090](https://github.com/openfisca/openfisca-france/pull/1090)
 
 * Évolution du système socio-fiscal.
@@ -8,6 +16,10 @@
 * Détails :
   - Corrige la cotisation patronale maladie (mmida) à partir de 2018.
   - Annule la cotisation salariale maladie (mmid) à partir de 2018.
+
+## 24.2.0
+
+ * Il n'y a pas de version 24.2.0
 
 ### 24.1.1 [#1085](https://github.com/openfisca/openfisca-france/pull/1085)
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -503,6 +503,7 @@ class chomage_salarie(Variable):
     entity = Individu
     label = u"Cotisation chômage tranche A (salarié)"
     definition_period = MONTH
+    end = '2018-09-30'
 
     def formula(individu, period, parameters):
         cotisation = apply_bareme(

--- a/openfisca_france/parameters/cotsoc/sal/commun/assedic.yaml
+++ b/openfisca_france/parameters/cotsoc/sal/commun/assedic.yaml
@@ -23,23 +23,28 @@ brackets:
     2007-01-01:
       value: 0.024
     2018-01-01:
+      reference: https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1725580L/jo/article_8
       value: 0.0095
     2018-10-01:
+      reference: https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1725580L/jo/article_8
       value: null
   threshold:
     1993-07-01:
       value: 0.0
     2018-10-01:
+      reference: https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1725580L/jo/article_8
       value: null
 - rate:
     2003-01-01:
       value: 0.0
     2018-10-01:
+      reference: https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1725580L/jo/article_8
       value: null
   threshold:
     2003-01-01:
       value: 4.0
     2018-10-01:
+      reference: https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1725580L/jo/article_8
       value: null
 description: Chômage-emploi ASSEDIC
 reference: openfisca

--- a/openfisca_france/parameters/cotsoc/sal/commun/assedic.yaml
+++ b/openfisca_france/parameters/cotsoc/sal/commun/assedic.yaml
@@ -24,14 +24,22 @@ brackets:
       value: 0.024
     2018-01-01:
       value: 0.0095
-  threshold:
+    2018-10-01:
+      value: null
+    threshold:
     1993-07-01:
       value: 0.0
-- rate:
+    2018-10-01:
+      value: null
+  - rate:
     2003-01-01:
       value: 0.0
+    2018-10-01:
+      value: null
   threshold:
     2003-01-01:
       value: 4.0
+    2018-10-01:
+      value: null
 description: Chômage-emploi ASSEDIC
 reference: openfisca

--- a/openfisca_france/parameters/cotsoc/sal/commun/assedic.yaml
+++ b/openfisca_france/parameters/cotsoc/sal/commun/assedic.yaml
@@ -26,12 +26,12 @@ brackets:
       value: 0.0095
     2018-10-01:
       value: null
-    threshold:
+  threshold:
     1993-07-01:
       value: 0.0
     2018-10-01:
       value: null
-  - rate:
+- rate:
     2003-01-01:
       value: 0.0
     2018-10-01:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '24.2.1',
+    version = '24.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '24.2.0',
+    version = '24.3.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal
* Périodes concernées : à partir du 01-10-2018
* Zones impactées : prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive
* Détails :
  - Annule la cotisation chômage à partir du 01-10-2018

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

