### PR TITLE
Update csg déductible retraite for 2018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+###  24.5.1 [#1093](https://github.com/openfisca/openfisca-france/pull/1093)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2018.
+* Zones impactées : `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement`.
+* Détails :
+  - Mise à jour du taux de CSG déductible sur les retraites
+
 ## 24.5.0 [#1075](https://github.com/openfisca/openfisca-france/pull/1075)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/prelevements_sociaux/contributions/csg/retraite/deductible/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions/csg/retraite/deductible/taux_plein.yaml
@@ -8,3 +8,6 @@ values:
     value: 0.038
   2005-01-01:
     value: 0.042
+  2018-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1725580L/jo/article_8
+    value: 0.059

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '24.5.0',
+    version = '24.5.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal. 
* Périodes concernées : à partir du 01/01/2018.
* Zones impactées : `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement`.
* Détails :
  - Mise à jour du taux de CSG déductible sur les retraites

- - - -

- Corrigent ou améliorent un calcul déjà existant.

- - - -

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
