### PR TITLE
Tests de la revalorisation de l'ASPA de 2018-04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+###  24.5.4 [#1103](https://github.com/openfisca/openfisca-france/pull/1103)
+
+* Changement mineur.
+* Périodes concernées : à partir du 01/04/2018.
+* Zones impactées : `tests/formulas/aspa`.
+* Détails :
+  - Ajoute des tests pour la revalorisation de l'ASPA (voir [#1066](https://github.com/openfisca/openfisca-france/pull/1066))
+
 ###  24.5.3 [#1097](https://github.com/openfisca/openfisca-france/pull/1097)
 
 * Évolution du système socio-fiscal.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '24.5.3',
+    version = '24.5.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/aspa.yaml
+++ b/tests/formulas/aspa.yaml
@@ -1,0 +1,155 @@
+- name: "ASPA - Cas N°1"
+  period: 2018-04
+  absolute_error_margin: 0.02
+  familles:
+    parents: ["parent1", "parent2"]
+  foyers_fiscaux:
+    declarants: ["parent1", "parent2"]
+  menages:
+    personne_de_reference: "parent1"
+    conjoint: "parent2"
+  individus:
+    - id: "parent1"
+      date_naissance: 1953-03-15
+      #ressources du dernier trimestre / 3
+      asi_aspa_base_ressources_individu: 1173 / 3
+    - id: "parent2"
+      asi_aspa_base_ressources_individu: 0
+  output_variables:
+    aspa: 833.20
+
+- name: "ASPA - Cas N°2"
+  period: 2018-04
+  absolute_error_margin: 0.02
+  familles:
+    parents: ["parent1"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+  menages:
+    personne_de_reference: "parent1"
+  individus:
+    - id: "parent1"
+      date_naissance: 1953-04-01
+      duree_possession_titre_sejour: 12
+      #ressources du dernier trimestre / 3
+      asi_aspa_base_ressources_individu: 1590 / 3
+  output_variables:
+    aspa: 303.20
+
+- name: "ASPA - Cas N°3"
+  period: 2018-04
+  absolute_error_margin: 0.02
+  familles:
+    parents: ["parent1", "parent2"]
+  foyers_fiscaux:
+    declarants: ["parent1", "parent2"]
+  menages:
+    personne_de_reference: "parent1"
+    conjoint: "parent2"
+  individus:
+    - id: "parent1"
+      date_naissance: 1958-04-12
+    - id: "parent2"
+  output_variables:
+    aspa: 0
+
+- name: "ASPA - Cas N°4"
+  period: 2018-04
+  absolute_error_margin: 0.02
+  familles:
+    parents: ["parent1", "parent2"]
+  foyers_fiscaux:
+    declarants: ["parent1", "parent2"]
+  menages:
+    personne_de_reference: "parent1"
+    conjoint: "parent2"
+  individus:
+    - id: "parent1"
+      date_naissance: 1950-05-12
+      #ressources du dernier trimestre / 3
+      asi_aspa_base_ressources_individu: 1800 / 3
+    - id: "parent2"
+      asi_aspa_base_ressources_individu: 3000 / 3
+  output_variables:
+    aspa: 0
+
+- name: "ASPA - Cas N°5"
+  period: 2018-04
+  absolute_error_margin: 0.02
+  familles:
+    parents: ["parent1"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+  menages:
+    personne_de_reference: "parent1"
+  individus:
+    - id: "parent1"
+      date_naissance: 1956-03-12
+      duree_possession_titre_sejour: 12
+      inapte_travail: true
+      #ressources du dernier trimestre / 3
+      asi_aspa_base_ressources_individu: 2250 / 3
+  output_variables:
+    aspa: 83.20
+
+- name: "ASPA - Cas N°6"
+  period: 2018-04
+  absolute_error_margin: 0.02
+  familles:
+    parents: ["parent1", "parent2"]
+  foyers_fiscaux:
+    declarants: ["parent1", "parent2"]
+  menages:
+    personne_de_reference: "parent1"
+    conjoint: "parent2"
+  individus:
+    - id: "parent1"
+      date_naissance: 1953-03-12
+      #ressources du dernier trimestre / 3
+      asi_aspa_base_ressources_individu: 2175 / 3
+    - id: "parent2"
+      date_naissance: 1956-01-15
+      inapte_travail: true
+      asi_aspa_base_ressources_individu: 1050 / 3
+  output_variables:
+    #touchée par les deux membres du couple
+    aspa: 109.27 * 2
+
+- name: "ASPA - Cas N°7"
+  period: 2018-04
+  absolute_error_margin: 0.02
+  familles:
+    parents: ["parent1", "parent2"]
+  foyers_fiscaux:
+    declarants: ["parent1", "parent2"]
+  menages:
+    personne_de_reference: "parent1"
+    conjoint: "parent2"
+  individus:
+    - id: "parent1"
+      date_naissance: 1953-03-12
+      #ressources du dernier trimestre / 3
+      asi_aspa_base_ressources_individu: 60 / 3
+    - id: "parent2"
+      date_naissance: 1953-01-15
+      asi_aspa_base_ressources_individu: 60 / 3
+  output_variables:
+    #touchée par les deux membres du couple
+    aspa: 626.77 * 2
+
+- name: "ASPA - Cas N°2"
+  period: 2018-04
+  absolute_error_margin: 0.02
+  familles:
+    parents: ["parent1"]
+  foyers_fiscaux:
+    declarants: ["parent1"]
+  menages:
+    personne_de_reference: "parent1"
+  individus:
+    - id: "parent1"
+      date_naissance: 1953-05-12
+      ressortissant_eee: false
+      duree_possession_titre_sejour: 0
+  output_variables:
+    aspa: 0


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/04/2018.
* Zones impactées : `tests/formulas/aspa`.
* Détails :
  - Ajoute des tests pour la revalorisation de l'ASPA (voir PR #1066)

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).