### PR TITLE
Fix set_input attribute for supplement_familial_traitement et indemni…

### DIFF
--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -708,6 +708,7 @@ class indemnite_residence(Variable):
     entity = Individu
     label = u"Indemnité de résidence des fonctionnaires"
     definition_period = MONTH
+    set_input = set_input_divide_by_period
 
     def formula(individu, period, parameters):
         traitement_indiciaire_brut = individu('traitement_indiciaire_brut', period)
@@ -815,6 +816,7 @@ class supplement_familial_traitement(Variable):
     entity = Individu
     label = u"Supplément familial de traitement"
     definition_period = MONTH
+    set_input = set_input_divide_by_period
     # Attention : par hypothèse ne peut êre attribué qu'à la tête du ménage
     # TODO: gérer le cas encore problématique du conjoint fonctionnaire
 
@@ -875,17 +877,6 @@ class supplement_familial_traitement(Variable):
             max_(part_fixe + pct_variable * traitement_indiciaire_brut, plancher),
             plafond
             )
-        # Nota Bene:
-        # categorie_salarie is an enum :
-        # class TypesCategorieSalarie(Enum):
-        #   prive_non_cadre = u'prive_non_cadre'
-        #   prive_cadre = u'prive_cadre'
-        #   public_titulaire_etat = u'public_titulaire_etat'
-        #   public_titulaire_militaire = u'public_titulaire_militaire'
-        #   public_titulaire_territoriale = u'public_titulaire_territoriale'
-        #   public_titulaire_hospitaliere = u'public_titulaire_hospitaliere'
-        #   public_non_titulaire = u'public_non_titulaire'
-        #   non_pertinent = u'non_pertinent'
         return sft
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '24.7.0',
+    version = '24.7.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
…te_residence

* Amélioration technique. 
* Périodes concernées : toutes.
* Zones impactées : `revenus/activite/salarie.py`.
* Détails :
  - Fixe l'attribut set_input = set_input_divide_by_period pour les variables `supplement_familial_traitement` et `indemnite_residence`

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

