### PR TITLE
Check version and changelog separately

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,12 +49,6 @@ jobs:
             make check-syntax-errors
             # make flake8
 
-      - run:
-          name: Check version number has been properly updated
-          command: |
-            git fetch
-            .circleci/is-version-number-acceptable.sh
-
   deploy_python2:
     docker:
       - image: python:2.7.14
@@ -134,12 +128,6 @@ jobs:
             make check-syntax-errors
             # make flake8
 
-      - run:
-          name: Check version number has been properly updated
-          command: |
-            git fetch
-            .circleci/is-version-number-acceptable.sh
-
   deploy_python3:
     docker:
       - image: python:3.6
@@ -163,16 +151,30 @@ jobs:
             source /tmp/venv/openfisca_france/bin/activate
             .circleci/publish-python-package.sh
 
+  check_version_and_changelog:
+    docker:
+      - image: python:3.6
+    steps:
+      - checkout
+
+      - run:
+          name: Check version number has been properly updated
+          command: |
+            git fetch
+            .circleci/is-version-number-acceptable.sh
+
 workflows:
   version: 2
   build_and_deploy:
     jobs:
       - build_python2
       - build_python3
+      - check_version_and_changelog
       - deploy_python2:
           requires:
             - build_python2
             - build_python3
+            - check_version_and_changelog
           filters:
             branches:
               only: master
@@ -180,6 +182,7 @@ workflows:
           requires:
             - build_python2
             - build_python3
+            - check_version_and_changelog
           filters:
             branches:
               only: master


### PR DESCRIPTION
Same deal as openfisca/openfisca-core#722

This adds a separate CircleCI job common to Python2 and Python3 for checking whether the version number has been bumped in `setup.py` and Changelog was updated.

Rationale:
- we get faster and more relevant feedback on our work while a PR is in progress
- we get highly relevant feedback when Python2 and Python3 tests behave differently
- the version check provides information of a different nature than functional tests

(It might also make sense to run the linting checks separately, as they rely purely on static properties of the code, just as the version and changelog checks.)