### PR TITLE
Efface __init.py__ de la racine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 24.11.2 [#1132](https://github.com/openfisca/openfisca-france/pull/1132)
+
+* Changement mineur.
+* Zones impactées : `__init__.py`.
+* Détails :
+  - Efface __init.py__ de la racine.
+
 ### 24.11.1 [#1110](https://github.com/openfisca/openfisca-france/pull/1110)
 
 * Correction d'un bug.
@@ -14,7 +21,7 @@
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2018.
-* Zones impactées : 
+* Zones impactées :
   - `prestations/minima_sociaux/rsa`
   - `parameters/prestations/prestations_familiales/af/bmaf`
   - `parameters/prestations/minima_sociaux/rsa/age_min_rsa_jeune`

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '24.11.1',
+    version = '24.11.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Fixes #1113

Normalement, le fichier `__init__.py` permet de rendre découvrables des
modules Python.

Dans le cas des packages, ce qui n'est pas toujours les cas avec des
applications, il n'y a pas des modules Python à la racine faisant partie
du package.

La présence de ce fichier est donc très probablement due à une faute de frappe involontaire.

---

* Changement mineur.
* Zones impactées : `__init__.py`.
* Détails :
  - Efface __init.py__ de la racine.

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] ~Documentez votre contribution avec des références législatives.~
- [ ] ~Mettez à jour ou ajoutez des tests correspondant à votre contribution.~
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

> Et surtout, n'hésitez pas à demander de l'aide ! :)

👍 
