### PR TITLE
Suppression du fichier 'openfisca-run-test'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 24.12.3 [#1137](https://github.com/openfisca/openfisca-france/pull/1137)
+
+* Changement mineur.
+* Périodes concernées : n/a
+* Zones impactées : n/a
+* Détails :
+  - Supprime le fichier `openfisca-run-test` à la racine
+
 ### 24.12.2 [#1135](https://github.com/openfisca/openfisca-france/pull/1135)
 
 * Changement mineur.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '24.12.2',
+    version = '24.12.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : n/a
* Zones impactées : n/a
* Détails :
  - Supprime le fichier `openfisca-run-test` à la racine