### PR TITLE
Linte model/prestations (W504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 24.14.6 [#1146](https://github.com/openfisca/openfisca-france/pull/1146)
+
+* Amélioration technique
+* Zones impactées : `openfisca_france/model/prestations/**/*`.
+* Détails :
+  - Corrige et uniformise le style des fichiers
+  - Règle W504 : saut de ligne avant opérateur binaire
+
 ### 24.14.5 [#1145](https://github.com/openfisca/openfisca-france/pull/1145)
 
 * Amélioration technique

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -130,9 +130,9 @@ class al_nb_personnes_a_charge(Variable):
             taux_incapacite_minimum = 0.8
 
             adulte_handicape = (
-                ((taux_incapacite > taux_incapacite_minimum) + inapte_travail) *
-                (age >= age_max_enfant) *
-                (base_ressources_i <= plafond_ressource)
+                ((taux_incapacite > taux_incapacite_minimum) + inapte_travail)
+                * (age >= age_max_enfant)
+                * (base_ressources_i <= plafond_ressource)
                 )
 
             # Par convention les adultes handicapé à charge de la famille ont le role ENFANT dans la famille
@@ -362,13 +362,16 @@ class aide_logement_base_ressources_defaut(Variable):
 
         # Revenus du foyer fiscal
         aide_logement_base_revenus_fiscaux = (
-            famille.demandeur.foyer_fiscal('aide_logement_base_revenus_fiscaux', period.n_2) * demandeur_declarant_principal +
-            famille.conjoint.foyer_fiscal('aide_logement_base_revenus_fiscaux', period.n_2) * conjoint_declarant_principal
+            famille.demandeur.foyer_fiscal('aide_logement_base_revenus_fiscaux', period.n_2) * demandeur_declarant_principal
+            + famille.conjoint.foyer_fiscal('aide_logement_base_revenus_fiscaux', period.n_2) * conjoint_declarant_principal
             )
 
         ressources = (
-            base_ressources_parents + base_ressources_enfants + ressources_patrimoine + aide_logement_base_revenus_fiscaux -
-            (abattement_chomage_indemnise + abattement_depart_retraite + neutralisation_rsa)
+            base_ressources_parents
+            + base_ressources_enfants
+            + ressources_patrimoine
+            + aide_logement_base_revenus_fiscaux
+            - (abattement_chomage_indemnise + abattement_depart_retraite + neutralisation_rsa)
             )
 
         # Abattement forfaitaire pour double activité
@@ -637,17 +640,17 @@ class aide_logement_R0(Variable):
             montant_de_base = minim_n_2.rmi.montant_de_base_du_rmi
 
         R1 = montant_de_base * (
-            al.r1.personne_isolee * not_(couple) * (al_nb_pac == 0) +
-            al.r1.couple_sans_enf * couple * (al_nb_pac == 0) +
-            al.r1.personne_isolee_ou_couple_avec_1_enf * (al_nb_pac == 1) +
-            al.r1.personne_isolee_ou_couple_avec_2_enf * (al_nb_pac >= 2) +
-            al.r1.majoration_enfant_a_charge_supp * (al_nb_pac > 2) * (al_nb_pac - 2)
+            al.r1.personne_isolee * not_(couple) * (al_nb_pac == 0)
+            + al.r1.couple_sans_enf * couple * (al_nb_pac == 0)
+            + al.r1.personne_isolee_ou_couple_avec_1_enf * (al_nb_pac == 1)
+            + al.r1.personne_isolee_ou_couple_avec_2_enf * (al_nb_pac >= 2)
+            + al.r1.majoration_enfant_a_charge_supp * (al_nb_pac > 2) * (al_nb_pac - 2)
             )
 
         R2 = pfam_n_2.af.bmaf * (
-            al.r2.taux3_dom * residence_dom * (al_nb_pac == 1) +
-            al.r2.personnes_isolees_ou_couples_avec_2_enf * (al_nb_pac >= 2) +
-            al.r2.majoration_par_enf_supp_a_charge * (al_nb_pac > 2) * (al_nb_pac - 2)
+            al.r2.taux3_dom * residence_dom * (al_nb_pac == 1)
+            + al.r2.personnes_isolees_ou_couples_avec_2_enf * (al_nb_pac >= 2)
+            + al.r2.majoration_par_enf_supp_a_charge * (al_nb_pac > 2) * (al_nb_pac - 2)
             )
 
         R0 = round_(12 * (R1 - R2) * (1 - al.autres.abat_sal))
@@ -661,15 +664,15 @@ class aide_logement_R0(Variable):
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
 
         R0 = (
-            al.R0.taux_seul * not_(couple) * (al_nb_pac == 0) +
-            al.R0.taux_couple * couple * (al_nb_pac == 0) +
-            al.R0.taux1pac * (al_nb_pac == 1) +
-            al.R0.taux2pac * (al_nb_pac == 2) +
-            al.R0.taux3pac * (al_nb_pac == 3) +
-            al.R0.taux4pac * (al_nb_pac == 4) +
-            al.R0.taux5pac * (al_nb_pac == 5) +
-            al.R0.taux6pac * (al_nb_pac == 6) +
-            al.R0.taux_pac_supp * (al_nb_pac > 6) * (al_nb_pac - 6)
+            al.R0.taux_seul * not_(couple) * (al_nb_pac == 0)
+            + al.R0.taux_couple * couple * (al_nb_pac == 0)
+            + al.R0.taux1pac * (al_nb_pac == 1)
+            + al.R0.taux2pac * (al_nb_pac == 2)
+            + al.R0.taux3pac * (al_nb_pac == 3)
+            + al.R0.taux4pac * (al_nb_pac == 4)
+            + al.R0.taux5pac * (al_nb_pac == 5)
+            + al.R0.taux6pac * (al_nb_pac == 6)
+            + al.R0.taux_pac_supp * (al_nb_pac > 6) * (al_nb_pac - 6)
             )
 
         return R0
@@ -688,24 +691,24 @@ class aide_logement_taux_famille(Variable):
         residence_dom = famille.demandeur.menage('residence_dom', period)
 
         TF_metropole = (
-            al.taux_participation_fam.taux_1_adulte * (not_(couple)) * (al_nb_pac == 0) +
-            al.taux_participation_fam.taux_2_adulte * (couple) * (al_nb_pac == 0) +
-            al.taux_participation_fam.taux_1_enf * (al_nb_pac == 1) +
-            al.taux_participation_fam.taux_2_enf * (al_nb_pac == 2) +
-            al.taux_participation_fam.taux_3_enf * (al_nb_pac == 3) +
-            al.taux_participation_fam.taux_4_enf * (al_nb_pac >= 4) +
-            al.taux_participation_fam.taux_enf_supp * (al_nb_pac > 4) * (al_nb_pac - 4)
+            al.taux_participation_fam.taux_1_adulte * (not_(couple)) * (al_nb_pac == 0)
+            + al.taux_participation_fam.taux_2_adulte * (couple) * (al_nb_pac == 0)
+            + al.taux_participation_fam.taux_1_enf * (al_nb_pac == 1)
+            + al.taux_participation_fam.taux_2_enf * (al_nb_pac == 2)
+            + al.taux_participation_fam.taux_3_enf * (al_nb_pac == 3)
+            + al.taux_participation_fam.taux_4_enf * (al_nb_pac >= 4)
+            + al.taux_participation_fam.taux_enf_supp * (al_nb_pac > 4) * (al_nb_pac - 4)
             )
 
         TF_dom = (
-            al.taux_participation_fam.dom.taux1 * (not_(couple)) * (al_nb_pac == 0) +
-            al.taux_participation_fam.dom.taux2 * (couple) * (al_nb_pac == 0) +
-            al.taux_participation_fam.dom.taux3 * (al_nb_pac == 1) +
-            al.taux_participation_fam.dom.taux4 * (al_nb_pac == 2) +
-            al.taux_participation_fam.dom.taux5 * (al_nb_pac == 3) +
-            al.taux_participation_fam.dom.taux6 * (al_nb_pac == 4) +
-            al.taux_participation_fam.dom.taux7 * (al_nb_pac == 5) +
-            al.taux_participation_fam.dom.taux8 * (al_nb_pac >= 6)
+            al.taux_participation_fam.dom.taux1 * (not_(couple)) * (al_nb_pac == 0)
+            + al.taux_participation_fam.dom.taux2 * (couple) * (al_nb_pac == 0)
+            + al.taux_participation_fam.dom.taux3 * (al_nb_pac == 1)
+            + al.taux_participation_fam.dom.taux4 * (al_nb_pac == 2)
+            + al.taux_participation_fam.dom.taux5 * (al_nb_pac == 3)
+            + al.taux_participation_fam.dom.taux6 * (al_nb_pac == 4)
+            + al.taux_participation_fam.dom.taux7 * (al_nb_pac == 5)
+            + al.taux_participation_fam.dom.taux8 * (al_nb_pac >= 6)
             )
 
         return where(residence_dom, TF_dom, TF_metropole)
@@ -726,10 +729,10 @@ class aide_logement_taux_loyer(Variable):
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
 
         loyer_reference = (
-            z2.personnes_seules * (not_(couple)) * (al_nb_pac == 0) +
-            z2.couples * (couple) * (al_nb_pac == 0) +
-            z2.un_enfant * (al_nb_pac >= 1) +
-            z2.majoration_par_enf_supp * (al_nb_pac > 1) * (al_nb_pac - 1)
+            z2.personnes_seules * (not_(couple)) * (al_nb_pac == 0)
+            + z2.couples * (couple) * (al_nb_pac == 0)
+            + z2.un_enfant * (al_nb_pac >= 1)
+            + z2.majoration_par_enf_supp * (al_nb_pac > 1) * (al_nb_pac - 1)
             )
 
         RL = L / loyer_reference
@@ -960,8 +963,11 @@ class als_non_etudiant(Variable):
         no_parent_etudiant = not_(famille.any(etudiant, role = Famille.PARENT))
 
         return (
-            (al_nb_pac == 0) * (statut_occupation_logement != 3) * not_(proprietaire_proche_famille) *
-            no_parent_etudiant * aide_logement_montant
+            (al_nb_pac == 0)
+            * (statut_occupation_logement != 3)
+            * not_(proprietaire_proche_famille)
+            * no_parent_etudiant
+            * aide_logement_montant
             )
 
 
@@ -983,8 +989,11 @@ class als_etudiant(Variable):
         parent_etudiant = famille.any(etudiant, role = Famille.PARENT)
 
         return (
-            (al_nb_pac == 0) * (statut_occupation_logement != 3) * not_(proprietaire_proche_famille) *
-            parent_etudiant * aide_logement_montant
+            (al_nb_pac == 0)
+            * (statut_occupation_logement != 3)
+            * not_(proprietaire_proche_famille)
+            * parent_etudiant
+            * aide_logement_montant
             )
 
 
@@ -1190,13 +1199,13 @@ class aides_logement_primo_accedant_nb_part(Variable):
         couple = famille('al_couple', period)
 
         return (
-            prestations.al_param_accal.n_0_personnes_a_charge.isole * not_(couple) * (al_nb_pac == 0) +
-            prestations.al_param_accal.n_0_personnes_a_charge.menage * couple * (al_nb_pac == 0) +
-            prestations.al_param.parametre_n['1_personne_a_charge'] * (al_nb_pac == 1) +
-            prestations.al_param.parametre_n['2_personnes_a_charge'] * (al_nb_pac == 2) +
-            prestations.al_param.parametre_n['3_personnes_a_charge'] * (al_nb_pac == 3) +
-            prestations.al_param.parametre_n['4_personnes_a_charge'] * (al_nb_pac >= 4) +
-            prestations.al_param.majoration_n_par_personne_a_charge_supplementaire * (al_nb_pac > 4) * (al_nb_pac - 4)
+            prestations.al_param_accal.n_0_personnes_a_charge.isole * not_(couple) * (al_nb_pac == 0)
+            + prestations.al_param_accal.n_0_personnes_a_charge.menage * couple * (al_nb_pac == 0)
+            + prestations.al_param.parametre_n['1_personne_a_charge'] * (al_nb_pac == 1)
+            + prestations.al_param.parametre_n['2_personnes_a_charge'] * (al_nb_pac == 2)
+            + prestations.al_param.parametre_n['3_personnes_a_charge'] * (al_nb_pac == 3)
+            + prestations.al_param.parametre_n['4_personnes_a_charge'] * (al_nb_pac >= 4)
+            + prestations.al_param.majoration_n_par_personne_a_charge_supplementaire * (al_nb_pac > 4) * (al_nb_pac - 4)
             )
 
 
@@ -1234,14 +1243,14 @@ class aides_logement_primo_accedant_plafond_mensualite(Variable):
         couple = famille('al_couple', period)
 
         return (
-            plafonds.personne_isolee_sans_enfant * not_(couple) * (al_nb_pac == 0) +
-            plafonds.menage_seul * couple * (al_nb_pac == 0) +
-            plafonds.menage_ou_isole_avec_1_enfant * (al_nb_pac == 1) +
-            plafonds.menage_ou_isole_avec_2_enfants * (al_nb_pac == 2) +
-            plafonds.menage_ou_isole_avec_3_enfants * (al_nb_pac == 3) +
-            plafonds.menage_ou_isole_avec_4_enfants * (al_nb_pac == 4) +
-            plafonds.menage_ou_isole_avec_5_enfants * (al_nb_pac >= 5) +
-            plafonds.menage_ou_isole_par_enfant_en_plus * (al_nb_pac > 5) * (al_nb_pac - 5)
+            plafonds.personne_isolee_sans_enfant * not_(couple) * (al_nb_pac == 0)
+            + plafonds.menage_seul * couple * (al_nb_pac == 0)
+            + plafonds.menage_ou_isole_avec_1_enfant * (al_nb_pac == 1)
+            + plafonds.menage_ou_isole_avec_2_enfants * (al_nb_pac == 2)
+            + plafonds.menage_ou_isole_avec_3_enfants * (al_nb_pac == 3)
+            + plafonds.menage_ou_isole_avec_4_enfants * (al_nb_pac == 4)
+            + plafonds.menage_ou_isole_avec_5_enfants * (al_nb_pac >= 5)
+            + plafonds.menage_ou_isole_par_enfant_en_plus * (al_nb_pac > 5) * (al_nb_pac - 5)
             )
 
 

--- a/openfisca_france/model/prestations/autonomie.py
+++ b/openfisca_france/model/prestations/autonomie.py
@@ -40,10 +40,13 @@ class apa_domicile_participation(Variable):
         majoration_tierce_personne = parameters.mtp.mtp
         taux_min_participation = parameters.apa_domicile.taux_de_participation_minimum
         taux_max_participation = parameters.apa_domicile.taux_de_participation_maximum
+
         proratisation_couple = (
-            1 +
-            en_couple * (parameters.apa_domicile.divison_des_ressources_du_menage_pour_les_couples - 1)
+            1
+            + en_couple
+            * (parameters.apa_domicile.divison_des_ressources_du_menage_pour_les_couples - 1)
             )
+
         dependance_plan_aide_domicile_accepte = individu('dependance_plan_aide_domicile_accepte', period)
         base_ressources_apa_domicile = base_ressources_apa / proratisation_couple
 
@@ -52,11 +55,13 @@ class apa_domicile_participation(Variable):
             (seuil_inf * majoration_tierce_personne) < base_ressources_apa_domicile <= (seuil_sup * majoration_tierce_personne),
             base_ressources_apa_domicile > (seuil_sup * majoration_tierce_personne),
             ]
+
         taux_participation = [
             taux_min_participation,
             (base_ressources_apa_domicile - seuil_inf * majoration_tierce_personne) / ((seuil_sup - seuil_inf) * majoration_tierce_personne) * taux_max_participation,
             taux_max_participation,
             ]
+
         return select(condition_ressources_domicile, taux_participation) * dependance_plan_aide_domicile_accepte
 
     def formula_2016_03_01(individu, period, parameters):
@@ -67,10 +72,13 @@ class apa_domicile_participation(Variable):
         dependance_plan_aide_domicile_accepte = individu('dependance_plan_aide_domicile_accepte', period)
         parameters = parameters(period.start).autonomie
         majoration_tierce_personne = parameters.mtp.mtp
+
         proratisation_couple = (
-            1 +
-            en_couple * (parameters.apa_domicile.divison_des_ressources_du_menage_pour_les_couples - 1)
+            1
+            + en_couple
+            * (parameters.apa_domicile.divison_des_ressources_du_menage_pour_les_couples - 1)
             )
+
         base_ressources_apa_domicile = base_ressources_apa / proratisation_couple
 
         premier_seuil = 0.317 * majoration_tierce_personne
@@ -99,18 +107,20 @@ class apa_domicile_participation(Variable):
         A_2 = select(condlist, choicelist_2)
         A_3 = select(condlist, choicelist_3)
 
-        apa_domicile_participation = min_(0.9 * dependance_plan_aide_domicile_accepte,
-            0.9 *
-            max_(0, base_ressources_apa_domicile - 0.725 * majoration_tierce_personne) / (1.945 * majoration_tierce_personne) *
-            (
-                A_1 +
-                A_2 * (
-                    (1 - 0.4) * base_ressources_apa_domicile / (1.945 * majoration_tierce_personne) +
-                    (0.4 * 2.67 * majoration_tierce_personne - 0.725 * majoration_tierce_personne) / (1.945 * majoration_tierce_personne)
-                    ) +
-                A_3 * (
-                    (1 - 0.2) * base_ressources_apa_domicile / (1.945 * majoration_tierce_personne) +
-                    (0.2 * 2.67 * majoration_tierce_personne - 0.725 * majoration_tierce_personne) / (1.945 * majoration_tierce_personne)
+        apa_domicile_participation = min_(
+            0.9 * dependance_plan_aide_domicile_accepte,
+            0.9
+            * max_(0, base_ressources_apa_domicile - 0.725 * majoration_tierce_personne)
+            / (1.945 * majoration_tierce_personne)
+            * (
+                A_1
+                + A_2 * (
+                    (1 - 0.4) * base_ressources_apa_domicile / (1.945 * majoration_tierce_personne)
+                    + (0.4 * 2.67 * majoration_tierce_personne - 0.725 * majoration_tierce_personne) / (1.945 * majoration_tierce_personne)
+                    )
+                + A_3 * (
+                    (1 - 0.2) * base_ressources_apa_domicile / (1.945 * majoration_tierce_personne)
+                    + (0.2 * 2.67 * majoration_tierce_personne - 0.725 * majoration_tierce_personne) / (1.945 * majoration_tierce_personne)
                     )
                 )
             )
@@ -132,10 +142,10 @@ class apa_eligibilite(Variable):
 
         gir = individu('gir', period)
         eligibilite_gir = (
-            (gir == TypesGir.gir_1) +
-            (gir == TypesGir.gir_2) +
-            (gir == TypesGir.gir_3) +
-            (gir == TypesGir.gir_4)
+            (gir == TypesGir.gir_1)
+            + (gir == TypesGir.gir_2)
+            + (gir == TypesGir.gir_3)
+            + (gir == TypesGir.gir_4)
             )
 
         return (age >= apa_age_min) * eligibilite_gir
@@ -189,10 +199,13 @@ class apa_etablissement(Variable):
         apa_eligibilite = individu('apa_eligibilite', period)
         gir = individu('gir', period)  # noqa F841
         base_ressources_apa = individu('base_ressources_apa', period)
+
         proratisation_couple_etablissement = (
-            1 +
-            en_couple * (parameters.apa_institution.divison_des_ressources_du_menage_pour_les_couples - 1)
+            1
+            + en_couple
+            * (parameters.apa_institution.divison_des_ressources_du_menage_pour_les_couples - 1)
             )
+
         base_ressources_apa_etablissement = base_ressources_apa / proratisation_couple_etablissement
         dependance_tarif_etablissement_gir_5_6 = individu('dependance_tarif_etablissement_gir_5_6', period)
         dependance_tarif_etablissement_gir_dependant = individu('dependance_tarif_etablissement_gir_dependant', period)
@@ -205,18 +218,23 @@ class apa_etablissement(Variable):
             seuil_inf_inst * majoration_tierce_personne < base_ressources_apa_etablissement <= seuil_sup_inst * majoration_tierce_personne,
             base_ressources_apa > seuil_sup_inst * majoration_tierce_personne
             ]
+
         participations = [
             dependance_tarif_etablissement_gir_5_6,
             (
-                dependance_tarif_etablissement_gir_5_6 +
-                (dependance_tarif_etablissement_gir_dependant - dependance_tarif_etablissement_gir_5_6) * (
-                    (base_ressources_apa - seuil_inf_inst * majoration_tierce_personne) /
-                    ((seuil_sup_inst - seuil_inf_inst) * majoration_tierce_personne) * 0.80
+                dependance_tarif_etablissement_gir_5_6
+                + (dependance_tarif_etablissement_gir_dependant - dependance_tarif_etablissement_gir_5_6)
+                * (
+                    (base_ressources_apa - seuil_inf_inst * majoration_tierce_personne)
+                    / ((seuil_sup_inst - seuil_inf_inst) * majoration_tierce_personne)
+                    * 0.80
                     )
                 ),
-            dependance_tarif_etablissement_gir_5_6 + (
-                dependance_tarif_etablissement_gir_dependant - dependance_tarif_etablissement_gir_5_6) * 0.80
+            dependance_tarif_etablissement_gir_5_6
+            + (dependance_tarif_etablissement_gir_dependant - dependance_tarif_etablissement_gir_5_6)
+            * 0.80
             ]
+
         participation_beneficiaire = select(conditions_ressources, participations)
         taux_reste_a_vivre = parameters.apa_institution.taux_reste_a_vivre
         participation_beneficiaire = min_(

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -156,8 +156,8 @@ class bourse_lycee_nombre_parts(Variable):
             rfr,
             thresholds = [
                 round_(
-                    plafonds_reference['{}_parts'.format(index)] +
-                    ((points_de_charge - 9) * increments_par_point_de_charge['{}_parts'.format(index)])
+                    plafonds_reference['{}_parts'.format(index)]
+                    + ((points_de_charge - 9) * increments_par_point_de_charge['{}_parts'.format(index)])
                     )
                 for index in choices
                 ],

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -98,12 +98,22 @@ class aah_base_ressources_eval_trimestrielle(Variable):
             return revenus_auto_entrepreneur + tns_micro_entreprise_benefice + tns_benefice_exploitant_agricole + tns_autres_revenus
 
         result = (
-            salaire_net + indemnites_chomage_partiel + indemnites_stage + chomage_net + retraite_nette +
-            pensions_alimentaires_percues - abs_(pensions_alimentaires_versees_individu) +
-            rsa_base_ressources_patrimoine_i + allocation_securisation_professionnelle +
-            indemnites_journalieres_imposables + prestation_compensatoire +
-            pensions_invalidite + bourse_recherche + gains_exceptionnels + revenus_tns() +
-            revenus_stage_formation_pro
+            salaire_net
+            + indemnites_chomage_partiel
+            + indemnites_stage
+            + chomage_net
+            + retraite_nette
+            + pensions_alimentaires_percues
+            - abs_(pensions_alimentaires_versees_individu)
+            + rsa_base_ressources_patrimoine_i
+            + allocation_securisation_professionnelle
+            + indemnites_journalieres_imposables
+            + prestation_compensatoire
+            + pensions_invalidite
+            + bourse_recherche
+            + gains_exceptionnels
+            + revenus_tns()
+            + revenus_stage_formation_pro
             )
 
         return result * 4
@@ -160,9 +170,9 @@ class aah_eligible(Variable):
         age = individu('age', period)
         autonomie_financiere = individu('autonomie_financiere', period)
         eligible_aah = (
-            (taux_incapacite >= 0.5) *
-            (age <= law.minima_sociaux.aah.age_legal_retraite) *
-            ((age >= law.minima_sociaux.aah.age_minimal) + ((age >= 16) * (autonomie_financiere)))
+            (taux_incapacite >= 0.5)
+            * (age <= law.minima_sociaux.aah.age_legal_retraite)
+            * ((age >= law.minima_sociaux.aah.age_minimal) + ((age >= 16) * (autonomie_financiere)))
             )
 
         return eligible_aah

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -52,14 +52,18 @@ class aefa(Variable):
             nbPAC = nb_enf(famille, janvier, af.age1, af.age3)
         else:
             nbPAC = af_nbenf
+
         # TODO check nombre de PAC pour une famille
         aefa = condition * P.mon_seul * (
-            1 + (nb_parents == 2) * P.tx_2p +
-            nbPAC * P.tx_supp * (nb_parents <= 2) +
-            nbPAC * P.tx_3pac * max_(nbPAC - 2, 0)
+            1
+            + (nb_parents == 2) * P.tx_2p
+            + nbPAC * P.tx_supp * (nb_parents <= 2)
+            + nbPAC * P.tx_3pac * max_(nbPAC - 2, 0)
             )
+
         aefa_maj = P.mon_seul * maj
         aefa = max_(aefa_maj, aefa)
+
         return aefa
 
     def formula_2008_01_01(famille, period, parameters):
@@ -85,12 +89,15 @@ class aefa(Variable):
             nbPAC = nb_enf(famille, janvier, af.age1, af.age3)
         else:
             nbPAC = af_nbenf
+
         # TODO check nombre de PAC pour une famille
         aefa = condition * P.mon_seul * (
-            1 + (nb_parents == 2) * P.tx_2p +
-            nbPAC * P.tx_supp * (nb_parents <= 2) +
-            nbPAC * P.tx_3pac * max_(nbPAC - 2, 0)
+            1
+            + (nb_parents == 2) * P.tx_2p
+            + nbPAC * P.tx_supp * (nb_parents <= 2)
+            + nbPAC * P.tx_3pac * max_(nbPAC - 2, 0)
             )
+
         aefa += condition * P.forf2008
         aefa_maj = P.mon_seul * maj
         aefa = max_(aefa_maj, aefa)
@@ -121,9 +128,10 @@ class aefa(Variable):
             nbPAC = af_nbenf
         # TODO check nombre de PAC pour une famille
         aefa = condition * P.mon_seul * (
-            1 + (nb_parents == 2) * P.tx_2p +
-            nbPAC * P.tx_supp * (nb_parents <= 2) +
-            nbPAC * P.tx_3pac * max_(nbPAC - 2, 0)
+            1
+            + (nb_parents == 2) * P.tx_2p
+            + nbPAC * P.tx_supp * (nb_parents <= 2)
+            + nbPAC * P.tx_3pac * max_(nbPAC - 2, 0)
             )
         aefa_maj = P.mon_seul * maj
         aefa = max_(aefa_maj, aefa)

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -65,8 +65,10 @@ class asi_aspa_base_ressources_individu(Variable):
             tns_autres_revenus = individu('tns_autres_revenus', last_year) * (3 / 12)
 
             return (
-                revenus_auto_entrepreneur + tns_micro_entreprise_benefice + tns_benefice_exploitant_agricole +
-                tns_autres_revenus
+                revenus_auto_entrepreneur
+                + tns_micro_entreprise_benefice
+                + tns_benefice_exploitant_agricole
+                + tns_autres_revenus
                 )
 
         pension_invalidite = (individu('pensions_invalidite', period) > 0)
@@ -157,9 +159,9 @@ class asi_eligibilite(Variable):
         condition_nationalite = individu('asi_aspa_condition_nationalite', period)
 
         eligible = (
-            non_eligible_aspa *
-            condition_nationalite *
-            (handicap * touche_retraite + touche_pension_invalidite)
+            non_eligible_aspa
+            * condition_nationalite
+            * (handicap * touche_retraite + touche_pension_invalidite)
             )
 
         return eligible

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -77,12 +77,12 @@ class ppa_montant_forfaitaire_familial_non_majore(Variable):
 
         # Dans la formule "ppa_forfait_logement", le montant forfaitaire se calcule pour trois personnes dans le cas où le foyer se compose de trois personnes ou plus.
         taux_non_majore = (
-            1 +
-            (nb_personnes >= 2) * ppa.taux_deuxieme_personne +
-            (nb_personnes >= 3) * ppa.taux_troisieme_personne +
-            (nb_personnes >= 4) * where(nb_parents == 1, ppa.taux_personne_supp, ppa.taux_troisieme_personne) +
+            1
+            + (nb_personnes >= 2) * ppa.taux_deuxieme_personne
+            + (nb_personnes >= 3) * ppa.taux_troisieme_personne
+            + (nb_personnes >= 4) * where(nb_parents == 1, ppa.taux_personne_supp, ppa.taux_troisieme_personne)
             # Si nb_parents == 1, pas de conjoint, la 4e personne est un enfant, donc le taux est de 40%.
-            max_(nb_personnes - 4, 0) * ppa.taux_personne_supp
+            + max_(nb_personnes - 4, 0) * ppa.taux_personne_supp
             )
 
         return ppa.montant_de_base * taux_non_majore
@@ -171,9 +171,9 @@ class ppa_rsa_derniers_revenus_tns_annuels_connus(Variable):
                 ) / 12.
 
         return (
-            get_last_known('tns_benefice_exploitant_agricole') +
-            get_last_known('tns_autres_revenus') +
-            get_last_known('tns_micro_entreprise_benefice')
+            get_last_known('tns_benefice_exploitant_agricole')
+            + get_last_known('tns_autres_revenus')
+            + get_last_known('tns_micro_entreprise_benefice')
             )
 
 

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -225,13 +225,19 @@ class af_majoration_enfant(Variable):
         pfam = parameters(period).prestations.prestations_familiales
 
         montant_enfant_seul = pfam.af.bmaf * (
-            (pfam.af.af_dom.age_1er_enf_tranche_1_dom <= age) * (age < pfam.af.af_dom.age_1er_enf_tranche_2_dom) * pfam.af.af_dom.taux_1er_enf_tranche_1_dom +
-            (pfam.af.af_dom.age_1er_enf_tranche_2_dom <= age) * pfam.af.af_dom.taux_1er_enf_tranche_2_dom
+            (pfam.af.af_dom.age_1er_enf_tranche_1_dom <= age)
+            * (age < pfam.af.af_dom.age_1er_enf_tranche_2_dom)
+            * pfam.af.af_dom.taux_1er_enf_tranche_1_dom
+            + (pfam.af.af_dom.age_1er_enf_tranche_2_dom <= age)
+            * pfam.af.af_dom.taux_1er_enf_tranche_2_dom
             )
 
         montant_plusieurs_enfants = pfam.af.bmaf * (
-            (pfam.af.maj_age_deux_enfants.age1 <= age) * (age < pfam.af.maj_age_deux_enfants.age2) * pfam.af.maj_age_deux_enfants.taux1 +
-            (pfam.af.maj_age_deux_enfants.age2 <= age) * pfam.af.maj_age_deux_enfants.taux2
+            (pfam.af.maj_age_deux_enfants.age1 <= age)
+            * (age < pfam.af.maj_age_deux_enfants.age2)
+            * pfam.af.maj_age_deux_enfants.taux1
+            + (pfam.af.maj_age_deux_enfants.age2 <= age)
+            * pfam.af.maj_age_deux_enfants.taux2
             )
 
         montant = (af_nbenf == 1) * montant_enfant_seul + (af_nbenf > 1) * montant_plusieurs_enfants

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '24.14.5',
+    version = '24.14.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Child of #372 

---

* Amélioration technique
* Zones impactées : `openfisca_france/model/prestations/**/*`.
* Détails :
  - Corrige et uniformise le style des fichiers
  - Règle W504 : saut de ligne avant opérateur binaire

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus