### PR TITLE
Linte model/revenus (W504)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 24.14.7 [#1147](https://github.com/openfisca/openfisca-france/pull/1147)
+
+* Amélioration technique
+* Zones impactées : `openfisca_france/model/revenus/**/*`.
+* Détails :
+  - Corrige et uniformise le style des fichiers
+  - Règle W504 : saut de ligne avant opérateur binaire
+
 ### 24.14.6 [#1146](https://github.com/openfisca/openfisca-france/pull/1146)
 
 * Amélioration technique

--- a/openfisca_france/model/revenus/activite/non_salarie.py
+++ b/openfisca_france/model/revenus/activite/non_salarie.py
@@ -1710,8 +1710,11 @@ class travailleur_non_salarie(Variable):
         tns_autres_revenus_chiffre_affaires = individu('tns_autres_revenus_chiffre_affaires', this_year_and_last_year, options = [ADD]) != 0
 
         result = (
-            tns_auto_entrepreneur_chiffre_affaires + tns_micro_entreprise_chiffre_affaires +
-            tns_autres_revenus + tns_benefice_exploitant_agricole + tns_autres_revenus_chiffre_affaires
+            tns_auto_entrepreneur_chiffre_affaires
+            + tns_micro_entreprise_chiffre_affaires
+            + tns_autres_revenus
+            + tns_benefice_exploitant_agricole
+            + tns_autres_revenus_chiffre_affaires
             )
 
         return result
@@ -1721,10 +1724,11 @@ class travailleur_non_salarie(Variable):
 def compute_benefice_auto_entrepreneur_micro_entreprise(bareme, type_activite, chiffre_affaire):
     abatt_fp_me = bareme.micro_entreprise.abattement_forfaitaire_fp
     benefice = chiffre_affaire * (
-        1 -
-        (type_activite == TypesTnsTypeActivite.achat_revente) * abatt_fp_me.achat_revente -
-        (type_activite == TypesTnsTypeActivite.bic) * abatt_fp_me.bic -
-        (type_activite == TypesTnsTypeActivite.bnc) * abatt_fp_me.bnc)
+        1
+        - (type_activite == TypesTnsTypeActivite.achat_revente) * abatt_fp_me.achat_revente
+        - (type_activite == TypesTnsTypeActivite.bic) * abatt_fp_me.bic
+        - (type_activite == TypesTnsTypeActivite.bnc) * abatt_fp_me.bnc
+        )
 
     return benefice
 
@@ -1779,9 +1783,10 @@ class tns_auto_entrepreneur_revenus_net(Variable):
         tns_auto_entrepreneur_chiffre_affaires = individu('tns_auto_entrepreneur_chiffre_affaires', period)
         bareme_cs_ae = parameters(period).tns.auto_entrepreneur
         taux_cotisations_sociales_sur_CA = (
-            (tns_auto_entrepreneur_type_activite == TypesTnsTypeActivite.achat_revente) * bareme_cs_ae.achat_revente +
-            (tns_auto_entrepreneur_type_activite == TypesTnsTypeActivite.bic) * bareme_cs_ae.bic +
-            (tns_auto_entrepreneur_type_activite == TypesTnsTypeActivite.bnc) * bareme_cs_ae.bnc)
+            (tns_auto_entrepreneur_type_activite == TypesTnsTypeActivite.achat_revente) * bareme_cs_ae.achat_revente
+            + (tns_auto_entrepreneur_type_activite == TypesTnsTypeActivite.bic) * bareme_cs_ae.bic
+            + (tns_auto_entrepreneur_type_activite == TypesTnsTypeActivite.bnc) * bareme_cs_ae.bnc
+            )
         tns_auto_entrepreneur_charges_sociales = taux_cotisations_sociales_sur_CA * tns_auto_entrepreneur_chiffre_affaires
         revenus = tns_auto_entrepreneur_benefice - tns_auto_entrepreneur_charges_sociales
 

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -780,10 +780,11 @@ class primes_fonction_publique(Variable):
         traitement_indiciaire_brut = individu('traitement_indiciaire_brut', period)
 
         public = (
-            (categorie_salarie == TypesCategorieSalarie.public_titulaire_etat) +
-            (categorie_salarie == TypesCategorieSalarie.public_titulaire_territoriale) +
-            (categorie_salarie == TypesCategorieSalarie.public_titulaire_hospitaliere)
+            (categorie_salarie == TypesCategorieSalarie.public_titulaire_etat)
+            + (categorie_salarie == TypesCategorieSalarie.public_titulaire_territoriale)
+            + (categorie_salarie == TypesCategorieSalarie.public_titulaire_hospitaliere)
             )
+
         return TAUX_DE_PRIME * traitement_indiciaire_brut * public
 
 
@@ -804,16 +805,20 @@ class af_nbenf_fonc(Variable):
         law = parameters(period)
         nbh_travaillees = 169
         smic_mensuel_brut = law.cotsoc.gen.smic_h_b * nbh_travaillees
-        autonomie_financiere = (
-            salaire_de_base_mensualise >=
-            (law.prestations.prestations_familiales.af.seuil_rev_taux * smic_mensuel_brut)
-            )
+
+        autonomie_financiere = (salaire_de_base_mensualise >= (
+            law.prestations.prestations_familiales.af.seuil_rev_taux
+            * smic_mensuel_brut
+            ))
+
         age = famille.members('age', period)
+
         condition_enfant = (
-            (age >= law.prestations.prestations_familiales.af.age1) *
-            (age <= law.prestations.prestations_familiales.af.age2) *
-            not_(autonomie_financiere)
+            (age >= law.prestations.prestations_familiales.af.age1)
+            * (age <= law.prestations.prestations_familiales.af.age2)
+            * not_(autonomie_financiere)
             )
+
         return famille.sum(condition_enfant, role = Famille.ENFANT)
 
 
@@ -837,17 +842,23 @@ class supplement_familial_traitement(Variable):
         part_fixe_1 = P.fixe.enf1
         part_fixe_2 = P.fixe.enf2
         part_fixe_supp = P.fixe.enfsupp
+
         part_fixe = (
-            part_fixe_1 * (fonc_nbenf == 1) + part_fixe_2 * (fonc_nbenf == 2) +
-            part_fixe_supp * max_(0, fonc_nbenf - 2)
+            part_fixe_1 * (fonc_nbenf == 1)
+            + part_fixe_2 * (fonc_nbenf == 2)
+            + part_fixe_supp * max_(0, fonc_nbenf - 2)
             )
+
         # pct_variable_1 = 0
         pct_variable_2 = P.prop.enf2
         pct_variable_3 = P.prop.enf3
         pct_variable_supp = P.prop.enfsupp
+
         pct_variable = (
-            pct_variable_2 * (fonc_nbenf == 2) + (pct_variable_3) * (fonc_nbenf == 3) +
-            pct_variable_supp * max_(0, fonc_nbenf - 3))
+            pct_variable_2 * (fonc_nbenf == 2)
+            + (pct_variable_3) * (fonc_nbenf == 3)
+            + pct_variable_supp * max_(0, fonc_nbenf - 3)
+            )
 
         indice_maj_min = P.IM_min
         indice_maj_max = P.IM_max
@@ -858,10 +869,12 @@ class supplement_familial_traitement(Variable):
         plancher_mensuel_3 = part_fixe + traitement_brut_mensuel_min * pct_variable_3
         plancher_mensuel_supp = traitement_brut_mensuel_min * pct_variable_supp
 
-        plancher = (plancher_mensuel_1 * (fonc_nbenf == 1) +
-                    plancher_mensuel_2 * (fonc_nbenf == 2) +
-                    plancher_mensuel_3 * (fonc_nbenf >= 3) +
-                    plancher_mensuel_supp * max_(0, fonc_nbenf - 3))
+        plancher = (
+            plancher_mensuel_1 * (fonc_nbenf == 1)
+            + plancher_mensuel_2 * (fonc_nbenf == 2)
+            + plancher_mensuel_3 * (fonc_nbenf >= 3)
+            + plancher_mensuel_supp * max_(0, fonc_nbenf - 3)
+            )
 
         traitement_brut_mensuel_max = _traitement_brut_mensuel(indice_maj_max, _P)
         plafond_mensuel_1 = part_fixe
@@ -869,9 +882,13 @@ class supplement_familial_traitement(Variable):
         plafond_mensuel_3 = part_fixe + traitement_brut_mensuel_max * pct_variable_3
         plafond_mensuel_supp = traitement_brut_mensuel_max * pct_variable_supp
 
-        plafond = (plafond_mensuel_1 * (fonc_nbenf == 1) + plafond_mensuel_2 * (fonc_nbenf == 2) +
-                   plafond_mensuel_3 * (fonc_nbenf == 3) +
-                   plafond_mensuel_supp * max_(0, fonc_nbenf - 3))
+        plafond = (
+            plafond_mensuel_1 * (fonc_nbenf == 1)
+            + plafond_mensuel_2 * (fonc_nbenf == 2)
+            + plafond_mensuel_3 * (fonc_nbenf == 3)
+            + plafond_mensuel_supp * max_(0, fonc_nbenf - 3)
+            )
+
         public = (
             (categorie_salarie == TypesCategorieSalarie.public_titulaire_etat)
             + (categorie_salarie == TypesCategorieSalarie.public_titulaire_militaire)
@@ -879,10 +896,12 @@ class supplement_familial_traitement(Variable):
             + (categorie_salarie == TypesCategorieSalarie.public_titulaire_hospitaliere)
             + (categorie_salarie == TypesCategorieSalarie.public_non_titulaire)
             )
+
         sft = public * min_(
             max_(part_fixe + pct_variable * traitement_indiciaire_brut, plancher),
             plafond
             )
+
         return sft
 
 
@@ -936,11 +955,11 @@ class salaire_net_a_payer(Variable):
         remuneration_apprenti = individu('remuneration_apprenti', period)
         stage_gratification = individu('stage_gratification', period)
         salaire_net_a_payer = (
-            salaire_net +
-            remuneration_apprenti +
-            stage_gratification +
-            depense_cantine_titre_restaurant_employe +
-            indemnites_forfaitaires
+            salaire_net
+            + remuneration_apprenti
+            + stage_gratification
+            + depense_cantine_titre_restaurant_employe
+            + indemnites_forfaitaires
             )
         return salaire_net_a_payer
 
@@ -1015,12 +1034,12 @@ class exonerations_et_allegements(Variable):
         allegement_cot_alloc_fam = individu('allegement_cotisation_allocations_familiales', period, options = [ADD])
 
         return (
-            allegement_fillon +
-            allegement_cot_alloc_fam +
-            exoneration_cotisations_employeur_geographiques +
-            exoneration_cotisations_employeur_jei +
-            exoneration_cotisations_employeur_apprenti +
-            exoneration_cotisations_employeur_stagiaire
+            allegement_fillon
+            + allegement_cot_alloc_fam
+            + exoneration_cotisations_employeur_geographiques
+            + exoneration_cotisations_employeur_jei
+            + exoneration_cotisations_employeur_apprenti
+            + exoneration_cotisations_employeur_stagiaire
             )
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '24.14.6',
+    version = '24.14.7',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Child of #372 

---

* Amélioration technique
* Zones impactées : `openfisca_france/model/revenus/**/*`.
* Détails :
  - Corrige et uniformise le style des fichiers
  - Règle W504 : saut de ligne avant opérateur binaire

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus