### PR TITLE
Extrait en paramètre un seuil en nombre de salariés

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 24.14.8 [#1148](https://github.com/openfisca/openfisca-france/pull/1148)
+
+* Changement mineur.
+* Périodes concernées : à partir du 01/01/1943
+* Zones impactées:
+- `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py`
+- `openfisca_france/parameters/cotsoc/pat/commun/construction_node/seuil.yaml`
+* Détails :
+  - Extrait vers un paramètre le nombre de salariés au-delà duquel le prélèvement s'applique.
+
 ### 24.14.7 [#1147](https://github.com/openfisca/openfisca-france/pull/1147)
 
 * Amélioration technique

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -302,11 +302,10 @@ class participation_effort_construction(Variable):
             variable_name = 'participation_effort_construction',
             )
 
-        # TODO : seuil passé de 10 à 20 avec l'Ordonnance n° 2005-895 du 2 août 2005
-
+        seuil = parameters(period).cotsoc.pat.commun.construction_node.seuil
         cotisation = (
-            bareme * (effectif_entreprise >= 20)
-            + individu.filled_array(0) * (effectif_entreprise < 20)
+            bareme * (effectif_entreprise >= seuil)
+            + individu.filled_array(0) * (effectif_entreprise < seuil)
             )
 
         return cotisation

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -303,10 +303,7 @@ class participation_effort_construction(Variable):
             )
 
         seuil = parameters(period).cotsoc.pat.commun.construction_node.seuil
-        cotisation = (
-            bareme * (effectif_entreprise >= seuil)
-            + individu.filled_array(0) * (effectif_entreprise < seuil)
-            )
+        cotisation = bareme * (effectif_entreprise >= seuil)
 
         return cotisation
 

--- a/openfisca_france/parameters/cotsoc/pat/commun/construction_node/seuil.yaml
+++ b/openfisca_france/parameters/cotsoc/pat/commun/construction_node/seuil.yaml
@@ -1,0 +1,8 @@
+description: Seuil en nombre de salariés
+reference: https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=9A0DD751081EBD0182A9DEFC36BF9E89.tplgfr41s_2?idArticle=JORFARTI000001679859&cidTexte=JORFTEXT000000632642&dateTexte=29990101&categorieLien=id
+unit: /1
+values:
+  1943-01-01:
+    value: 10
+  2005-02-08:
+    value: 20

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '24.14.7',
+    version = '24.14.8',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/1943
* Zones impactées:
- `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py`
- `openfisca_france/parameters/cotsoc/pat/commun/construction_node/seuil.yaml`
* Détails :
  - Extrait vers un paramètre le nombre de salariés au-delà duquel le prélèvement s'applique.

Fixes #432

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
