### PR TITLE
Factorise la duplication dans le calcul de la 'Prime de Noël'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-### 26.1.4 [#1151](https://github.com/openfisca/openfisca-france/pull/1159) [#1158](https://github.com/openfisca/openfisca-france/pull/1151)
+## 26.2.0 [#1149](https://github.com/openfisca/openfisca-france/pull/1149)
+
+* Évolution du système socio-fiscal
+* Périodes concernées : à partir du 01/01/2003.
+* Zones impactées : `openfisca_france/model/prestations/minima_sociaux/aefa.py`.
+* Détails :
+  - Fiabilise, unifie et simplifie le calcul de l'aide exceptionnelle de fin d'année.
+  - Corrige le montant de base de l'AEFA de 125,45€ à 152,45€
+  - Prolonge l'AEFA au-delà de 2015 car elle a été reconduite
+  - N'applique la majoration familiale que pour les bénéficiaires du RSA
+
+### 26.1.4 [#1151](https://github.com/openfisca/openfisca-france/pull/1151)
 
 * Changement mineur.
 * Périodes concernées : 2013
@@ -8,7 +19,7 @@
 * Détails :
   - Ajoute des tests couvrant le calcul de la décote de l'IR en 2013
 
-### 26.1.3 [#1155](https://github.com/openfisca/openfisca-france/pull/1159) [#1158](https://github.com/openfisca/openfisca-france/pull/1155)
+### 26.1.3 [#1155](https://github.com/openfisca/openfisca-france/pull/1155)
 
 * Amélioration technique.
 * Périodes concernées : NA
@@ -18,7 +29,7 @@
   - Documentation de scripts.
   - Suppression de scripts.
 
-### 26.1.2 [#1159](https://github.com/openfisca/openfisca-france/pull/1159) [#1159](https://github.com/openfisca/openfisca-france/pull/1158)
+### 26.1.2 [#1159](https://github.com/openfisca/openfisca-france/pull/1159) [#1158](https://github.com/openfisca/openfisca-france/pull/1158)
 
 * Évolution du système socio-fiscal
 * Périodes concernées : toutes

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -27,7 +27,6 @@ class aefa(Variable):
     label = u"Aide exceptionelle de fin d'année (prime de Noël)"
     reference = u"http://www.pole-emploi.fr/candidat/aide-exceptionnelle-de-fin-d-annee-dite-prime-de-noel--@/suarticle.jspz?id=70996"
     definition_period = YEAR
-    end = '2015-12-31'
 
     def formula_2002_01_01(famille, period, parameters):
         ass = famille('ass', period, options = [ADD])

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -47,17 +47,15 @@ class aefa(Variable):
             nbPAC = af_nbenf
 
         aefa = parameters(period).prestations.minima_sociaux.aefa
-        montant_seul = aefa.mon_seul
-        aide_exceptionnelle = aefa.forf2008
 
         # TODO check nombre de PAC pour une famille
-        montant_aefa = condition * montant_seul * (
+        montant_aefa = condition * aefa.mon_seul * (
             1
             + (nb_parents == 2) * aefa.tx_2p
             + nbPAC * aefa.tx_supp * (nb_parents <= 2)
             + nbPAC * aefa.tx_3pac * max_(nbPAC - 2, 0)
             )
 
-        montant_aefa += condition * aide_exceptionnelle
+        montant_aefa += condition * aefa.prime_exceptionnelle
 
         return montant_aefa

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -29,12 +29,13 @@ class aefa(Variable):
     definition_period = YEAR
 
     def formula_2002_01_01(famille, period, parameters):
+        rsa = famille('rsa', period, options = [ADD])
         ass = famille('ass', period, options = [ADD])
         api = famille('api', period, options = [ADD])
-        rsa = famille('rsa', period, options = [ADD])
         aer_i = famille.members('aer', period, options = [ADD])
         aer = famille.sum(aer_i)
         condition = (ass > 0) + (aer > 0) + (api > 0) + (rsa > 0)
+        condition_majoration = rsa > 0
 
         af = parameters(period).prestations.prestations_familiales.af
         janvier = period.first_month
@@ -48,13 +49,13 @@ class aefa(Variable):
         aefa = parameters(period).prestations.minima_sociaux.aefa
 
         # TODO check nombre de PAC pour une famille
-        montant_aefa = condition * aefa.mon_seul * (
-            1
-            + (nb_parents == 2) * aefa.tx_2p
+        majoration = 1 + (condition_majoration * (
+            (nb_parents == 2) * aefa.tx_2p
             + nbPAC * aefa.tx_supp * (nb_parents <= 2)
             + nbPAC * aefa.tx_3pac * max_(nbPAC - 2, 0)
-            )
+            ))
 
-        montant_aefa += condition * aefa.prime_exceptionnelle
+        montant_aefa = aefa.mon_seul * majoration
+        montant_aefa += aefa.prime_exceptionnelle
 
-        return montant_aefa
+        return condition * montant_aefa

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -29,44 +29,7 @@ class aefa(Variable):
     definition_period = YEAR
     end = '2015-12-31'
 
-    def formula_2009_01_01(famille, period, parameters):
-        janvier = period.first_month
-
-        af_nbenf = famille('af_nbenf', janvier)
-        nb_parents = famille('nb_parents', janvier)
-        ass = famille('ass', period, options = [ADD])
-        api = famille('api', period, options = [ADD])
-        rsa = famille('rsa', period, options = [ADD])
-        P = parameters(period).prestations.minima_sociaux.aefa
-        af = parameters(period).prestations.prestations_familiales.af
-
-        aer_i = famille.members('aer', period, options = [ADD])
-        aer = famille.sum(aer_i)
-        dummy_ass = ass > 0
-        dummy_aer = aer > 0
-        dummy_api = api > 0
-        dummy_rmi = rsa > 0
-        maj = 0  # TODO
-        condition = (dummy_ass + dummy_aer + dummy_api + dummy_rmi > 0)
-        if hasattr(af, "age3"):
-            nbPAC = nb_enf(famille, janvier, af.age1, af.age3)
-        else:
-            nbPAC = af_nbenf
-
-        # TODO check nombre de PAC pour une famille
-        aefa = condition * P.mon_seul * (
-            1
-            + (nb_parents == 2) * P.tx_2p
-            + nbPAC * P.tx_supp * (nb_parents <= 2)
-            + nbPAC * P.tx_3pac * max_(nbPAC - 2, 0)
-            )
-
-        aefa_maj = P.mon_seul * maj
-        aefa = max_(aefa_maj, aefa)
-
-        return aefa
-
-    def formula_2008_01_01(famille, period, parameters):
+    def formula_2002_01_01(famille, period, parameters):
         janvier = period.first_month
 
         af_nbenf = famille('af_nbenf', janvier)
@@ -101,38 +64,5 @@ class aefa(Variable):
         aefa += condition * P.forf2008
         aefa_maj = P.mon_seul * maj
         aefa = max_(aefa_maj, aefa)
-        return aefa
 
-    def formula_2002_01_01(famille, period, parameters):
-        janvier = period.first_month
-
-        af_nbenf = famille('af_nbenf', janvier)
-        nb_parents = famille('nb_parents', janvier)
-        ass = famille('ass', period, options = [ADD])
-        api = famille('api', period, options = [ADD])
-        rsa = famille('rsa', period, options = [ADD])
-        P = parameters(period).prestations.minima_sociaux.aefa
-        af = parameters(period).prestations.prestations_familiales.af
-
-        aer_i = famille.members('aer', period, options = [ADD])
-        aer = famille.sum(aer_i)
-        dummy_ass = ass > 0
-        dummy_aer = aer > 0
-        dummy_api = api > 0
-        dummy_rmi = rsa > 0
-        maj = 0  # TODO
-        condition = (dummy_ass + dummy_aer + dummy_api + dummy_rmi > 0)
-        if hasattr(af, "age3"):
-            nbPAC = nb_enf(famille, janvier, af.age1, af.age3)
-        else:
-            nbPAC = af_nbenf
-        # TODO check nombre de PAC pour une famille
-        aefa = condition * P.mon_seul * (
-            1
-            + (nb_parents == 2) * P.tx_2p
-            + nbPAC * P.tx_supp * (nb_parents <= 2)
-            + nbPAC * P.tx_3pac * max_(nbPAC - 2, 0)
-            )
-        aefa_maj = P.mon_seul * maj
-        aefa = max_(aefa_maj, aefa)
         return aefa

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -37,7 +37,6 @@ class aefa(Variable):
         ass = famille('ass', period, options = [ADD])
         api = famille('api', period, options = [ADD])
         rsa = famille('rsa', period, options = [ADD])
-        P = parameters(period).prestations.minima_sociaux.aefa
         af = parameters(period).prestations.prestations_familiales.af
 
         aer_i = famille.members('aer', period, options = [ADD])
@@ -46,23 +45,24 @@ class aefa(Variable):
         dummy_aer = aer > 0
         dummy_api = api > 0
         dummy_rmi = rsa > 0
-        maj = 0  # TODO
         condition = (dummy_ass + dummy_aer + dummy_api + dummy_rmi > 0)
         if hasattr(af, "age3"):
             nbPAC = nb_enf(famille, janvier, af.age1, af.age3)
         else:
             nbPAC = af_nbenf
 
+        aefa = parameters(period).prestations.minima_sociaux.aefa
+        montant_seul = aefa.mon_seul
+        aide_exceptionnelle = aefa.forf2008
+
         # TODO check nombre de PAC pour une famille
-        aefa = condition * P.mon_seul * (
+        montant_aefa = condition * montant_seul * (
             1
-            + (nb_parents == 2) * P.tx_2p
-            + nbPAC * P.tx_supp * (nb_parents <= 2)
-            + nbPAC * P.tx_3pac * max_(nbPAC - 2, 0)
+            + (nb_parents == 2) * aefa.tx_2p
+            + nbPAC * aefa.tx_supp * (nb_parents <= 2)
+            + nbPAC * aefa.tx_3pac * max_(nbPAC - 2, 0)
             )
 
-        aefa += condition * P.forf2008
-        aefa_maj = P.mon_seul * maj
-        aefa = max_(aefa_maj, aefa)
+        montant_aefa += condition * aide_exceptionnelle
 
-        return aefa
+        return montant_aefa

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -30,22 +30,17 @@ class aefa(Variable):
     end = '2015-12-31'
 
     def formula_2002_01_01(famille, period, parameters):
-        janvier = period.first_month
-
-        af_nbenf = famille('af_nbenf', janvier)
-        nb_parents = famille('nb_parents', janvier)
         ass = famille('ass', period, options = [ADD])
         api = famille('api', period, options = [ADD])
         rsa = famille('rsa', period, options = [ADD])
-        af = parameters(period).prestations.prestations_familiales.af
-
         aer_i = famille.members('aer', period, options = [ADD])
         aer = famille.sum(aer_i)
-        dummy_ass = ass > 0
-        dummy_aer = aer > 0
-        dummy_api = api > 0
-        dummy_rmi = rsa > 0
-        condition = (dummy_ass + dummy_aer + dummy_api + dummy_rmi > 0)
+        condition = (ass > 0) + (aer > 0) + (api > 0) + (rsa > 0)
+
+        af = parameters(period).prestations.prestations_familiales.af
+        janvier = period.first_month
+        af_nbenf = famille('af_nbenf', janvier)
+        nb_parents = famille('nb_parents', janvier)
         if hasattr(af, "age3"):
             nbPAC = nb_enf(famille, janvier, af.age1, af.age3)
         else:

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -25,7 +25,7 @@ class aefa(Variable):
     value_type = float
     entity = Famille
     label = u"Aide exceptionelle de fin d'année (prime de Noël)"
-    reference = u"http://www.pole-emploi.fr/candidat/aide-exceptionnelle-de-fin-d-annee-dite-prime-de-noel--@/suarticle.jspz?id=70996"
+    reference = u"https://www.service-public.fr/particuliers/vosdroits/F1325"
     definition_period = YEAR
 
     def formula_2002_01_01(famille, period, parameters):

--- a/openfisca_france/parameters/prestations/minima_sociaux/aefa/forf2008.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aefa/forf2008.yaml
@@ -3,8 +3,8 @@ reference: openfisca
 unit: currency
 values:
   2002-01-01:
-    value: null
+    value: 0
   2008-01-01:
     value: 67.55
   2009-01-01:
-    value: null
+    value: 0

--- a/openfisca_france/parameters/prestations/minima_sociaux/aefa/forf2008.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aefa/forf2008.yaml
@@ -2,7 +2,9 @@ description: Montant de l'aide forfaitaire exceptionnelle de 2008
 reference: openfisca
 unit: currency
 values:
+  2002-01-01:
+    value: 0
   2008-01-01:
     value: 67.55
   2009-01-01:
-    value: null
+    value: 0

--- a/openfisca_france/parameters/prestations/minima_sociaux/aefa/forf2008.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aefa/forf2008.yaml
@@ -3,8 +3,8 @@ reference: openfisca
 unit: currency
 values:
   2002-01-01:
-    value: 0
+    value: null
   2008-01-01:
     value: 67.55
   2009-01-01:
-    value: 0
+    value: null

--- a/openfisca_france/parameters/prestations/minima_sociaux/aefa/mon_seul.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aefa/mon_seul.yaml
@@ -1,6 +1,6 @@
 description: Montant de l'aide pour une personne seule
-reference: ipp
+reference: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=LEGITEXT000005745247
 unit: currency
 values:
   2003-01-01:
-    value: 125.45
+    value: 152.45

--- a/openfisca_france/parameters/prestations/minima_sociaux/aefa/prime_exceptionnelle.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aefa/prime_exceptionnelle.yaml
@@ -1,4 +1,4 @@
-description: Montant de l'aide forfaitaire exceptionnelle de 2008
+description: Montant de la prime forfaitaire exceptionnelle
 reference: openfisca
 unit: currency
 values:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '26.1.4',
+    version = '26.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Amélioration technique.
* Périodes concernées : à partir du 01/01/2002.
* Zones impactées : `openfisca_france/model/prestations/minima_sociaux/aefa.py`.
* Détails :
 - Factorise le code dupliqué (tripliqué d'ailleurs) du calcul de l'aide exceptionnelle de fin d'année.
 - Corrige le montant de base de l'AEFA
 - Prolonge l'AEFA au-delà de 2015 car elle a été reconduite
 - N'applique la majoration familiale que pour les bénéficiaires du RSA

Fixes #569

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
