### PR TITLE
Supprime la variable allocation_aide_retour_emploi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# 27.0.0 [#1150](https://github.com/openfisca/openfisca-france/pull/1150)
+
+* Évolution du système socio-fiscal **non rétro-compatible**
+* Périodes concernées : toutes.
+* Zones impactées :
+- `openfisca_france/model/prestations/minima_sociaux/[cmu,rsa].py`.
+- `openfisca_france/model/revenus/autres.py`
+* Détails :
+  - Supprime la variable allocation_aide_retour_emploi, inutilisée
+
 ## 26.2.0 [#1149](https://github.com/openfisca/openfisca-france/pull/1149)
 
 * Évolution du système socio-fiscal

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -272,14 +272,13 @@ class cmu_base_ressources_individu(Variable):
             chomage = individu('activite', period) == TypesActivite.chomeur
             indemnites_chomage_partiel = individu('indemnites_chomage_partiel', period)
             chomage_net = individu('chomage_net', period)
-            allocation_aide_retour_emploi = individu('allocation_aide_retour_emploi', period)
 
             ass = individu.famille('ass', period)
 
             revenus_stage_formation_pro = individu('revenus_stage_formation_pro', period)
 
             condition_ij_maladie = indemnites_journalieres_maladie > 0
-            condition_chomage = chomage * ((indemnites_chomage_partiel + chomage_net + allocation_aide_retour_emploi) > 0)
+            condition_chomage = chomage * ((indemnites_chomage_partiel + chomage_net) > 0)
             condition_ass = ass > 0
             condition_revenus_formation_pro = revenus_stage_formation_pro > 0
 

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -120,7 +120,6 @@ class rsa_base_ressources_individu(Variable):
             )
 
         types_revenus_non_pros = [
-            'allocation_aide_retour_emploi',
             'allocation_securisation_professionnelle',
             'dedommagement_victime_amiante',
             'div_ms',
@@ -175,7 +174,6 @@ class rsa_base_ressources_individu(Variable):
             )
 
         types_revenus_non_pros = [
-            'allocation_aide_retour_emploi',
             'allocation_securisation_professionnelle',
             'dedommagement_victime_amiante',
             'div_ms',

--- a/openfisca_france/model/revenus/autres.py
+++ b/openfisca_france/model/revenus/autres.py
@@ -44,14 +44,6 @@ class gains_exceptionnels(Variable):
     set_input = set_input_divide_by_period
 
 
-class allocation_aide_retour_emploi(Variable):
-    value_type = float
-    entity = Individu
-    label = u"Allocation d'aide au retour à l'emploi"
-    definition_period = MONTH
-    set_input = set_input_divide_by_period
-
-
 class allocation_securisation_professionnelle(Variable):
     value_type = float
     entity = Individu

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '26.2.0',
+    version = '27.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées :
- `openfisca_france/model/prestations/minima_sociaux/[cmu,rsa].py`.
- `openfisca_france/model/revenus/autres.py`
* Détails :
  - Supprime la variable allocation_aide_retour_emploi, inutilisée

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
