### PR TITLE
Met à jour les tests sur la décote 2013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 26.1.4 [#1151](https://github.com/openfisca/openfisca-france/pull/1159) [#1158](https://github.com/openfisca/openfisca-france/pull/1151)
+
+* Changement mineur.
+* Périodes concernées : 2013
+* Zones impactées : `tests/formulas/irpp.yaml`.
+* Détails :
+  - Ajoute des tests couvrant le calcul de la décote de l'IR en 2013
+
 ### 26.1.3 [#1155](https://github.com/openfisca/openfisca-france/pull/1159) [#1158](https://github.com/openfisca/openfisca-france/pull/1155)
 
 * Amélioration technique.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '26.1.3',
+    version = '26.1.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/irpp.yaml
+++ b/tests/formulas/irpp.yaml
@@ -910,6 +910,37 @@
     f4ba: 150000
   output_variables:
     irpp: -48036
+
+- name: "IRPP - Célibataire ayant des   Revenu net imposable de 12 000 € (teste la décote)"
+  period: 2013
+  absolute_error_margin: 0.9 #TODO : check why the error margin is so large, is there bottom round made by dgfip ?
+  input_variables:
+    salaire_imposable: 12000
+  output_variables:
+     irpp: 0
+     decote_gain_fiscal: 263
+
+- name: "IRPP - Célibataire ayant des   Revenu net imposable de 14 000 € (teste la décote)"
+  period: 2013
+  absolute_error_margin: 0.9 #TODO : check why the error margin is so large, is there bottom round made by dgfip ?
+  input_variables:
+    salaire_imposable: 14000
+  output_variables:
+     reduction_impot_exceptionnelle: 350
+     irpp: 0
+     decote: 301
+     ir_plaf_qf: 414
+     decote_gain_fiscal: 301
+
+- name: "IRPP - Célibataire ayant des   Revenu net imposable de 16 000 € (teste la décote)"
+  period: 2013
+  absolute_error_margin: 0.9 #TODO : check why the error margin is so large, is there bottom round made by dgfip ?
+  input_variables:
+    salaire_imposable: 16000
+  output_variables:
+    irpp: -491
+    decote_gain_fiscal: 175
+
 - name: "IRPP - Célibataire ayant des 	Revenu net imposable de 16000 € (teste la décote)"
   period: 2014
   absolute_error_margin: 0.9 #TODO : check why the error margin is so large, is there bottom round made by dgfip ?


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2013
* Zones impactées : `tests/formulas/irpp.yaml`.
* Détails :
  - Ajoute des tests couvrant le calcul de la décote de l'IR en 2013

Fixes #398 

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
