### PR TITLE
Déprécier extra_params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 29.2.6 [#1154](https://github.com/openfisca/openfisca-france/pull/1154)
+
+* Changement mineur.
+* Périodes concernées : toutes
+* Zones impactées : `prestations/minima_sociaux/[rsa,ppa].py`.
+* Détails :
+  - Déprécie explicitement l'usage de extra_params dans France
+
 ### 29.2.5 [#1183](https://github.com/openfisca/openfisca-france/pull/1183)
 
 * Changement mineur.

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -42,6 +42,7 @@ class ppa_eligibilite_etudiants(Variable):
             )
 
         def condition_ressource(period2):
+            # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
             revenu_activite = famille.members('ppa_revenu_activite_individu', period2, extra_params = [period])
             return revenu_activite > plancher_ressource
 
@@ -114,6 +115,7 @@ class ppa_revenu_activite(Variable):
     definition_period = MONTH
 
     def formula(famille, period, parameters, mois_demande):
+        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         ppa_revenu_activite_i = famille.members(
             'ppa_revenu_activite_individu', period, extra_params = [mois_demande])
         ppa_revenu_activite = famille.sum(ppa_revenu_activite_i)
@@ -185,6 +187,7 @@ class ppa_ressources_hors_activite(Variable):
 
     def formula(famille, period, parameters, mois_demande):
         aspa = famille('aspa', mois_demande)
+        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         pf = famille('ppa_base_ressources_prestations_familiales', period, extra_params = [mois_demande])
 
         ass_i = famille.members('ass', mois_demande)
@@ -216,6 +219,7 @@ class ppa_ressources_hors_activite_individu(Variable):
             'rsa_indemnites_journalieres_hors_activite',
             ]
 
+        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         ressources_hors_activite_mensuel_i = sum(individu(ressource, period) for ressource in ressources)
         revenus_activites = individu('ppa_revenu_activite_individu', period, extra_params = [mois_demande])
 
@@ -266,6 +270,7 @@ class ppa_base_ressources(Variable):
     definition_period = MONTH
 
     def formula(famille, period, parameters, mois_demande):
+        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         ppa_revenu_activite = famille('ppa_revenu_activite', period, extra_params = [mois_demande])
         ppa_ressources_hors_activite = famille('ppa_ressources_hors_activite', period, extra_params = [mois_demande])
         return ppa_revenu_activite + ppa_ressources_hors_activite
@@ -281,6 +286,7 @@ class ppa_bonification(Variable):
         P = parameters(mois_demande)
         smic_horaire = P.cotsoc.gen.smic_h_b
         ppa_base = P.prestations.minima_sociaux.ppa.montant_de_base
+        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         revenu_activite = individu('ppa_revenu_activite_individu', period, extra_params = [mois_demande])
         seuil_1 = P.prestations.minima_sociaux.ppa.bonification.seuil_bonification * smic_horaire
         seuil_2 = P.prestations.minima_sociaux.ppa.bonification.seuil_max_bonification * smic_horaire
@@ -347,6 +353,7 @@ class ppa_fictive(Variable):
     def formula(famille, period, parameters, mois_demande):
         forfait_logement = famille('ppa_forfait_logement', mois_demande)
         ppa_majoree_eligibilite = famille('rsa_majore_eligibilite', mois_demande)
+        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         elig = famille('ppa_eligibilite', period, extra_params = [mois_demande])
         pente = parameters(mois_demande).prestations.minima_sociaux.ppa.pente
         mff_non_majore = famille('ppa_montant_forfaitaire_familial_non_majore', period, extra_params = [mois_demande])
@@ -391,6 +398,7 @@ class ppa(Variable):
         # éligibilité étudiants
 
         ppa_eligibilite_etudiants = famille('ppa_eligibilite_etudiants', period)
+        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         ppa = famille('ppa_fictive', period.last_3_months, extra_params = [period], options = [ADD]) / 3
         ppa = ppa * ppa_eligibilite_etudiants * (ppa >= seuil_non_versement)
 

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -24,6 +24,7 @@ class rsa_base_ressources(Variable):
     definition_period = MONTH
 
     def formula_2017_01_01(famille, mois_demande, parameters, mois_courant):
+        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         rsa_base_ressources_prestations_familiales = famille('rsa_base_ressources_prestations_familiales', mois_demande, extra_params = [mois_courant])
         rsa_base_ressources_minima_sociaux = famille('rsa_base_ressources_minima_sociaux', mois_demande, extra_params = [mois_courant])
 
@@ -373,6 +374,7 @@ class rsa_enfant_a_charge(Variable):
             m_1 = period.last_month
             m_2 = m_1.last_month
             m_3 = m_2.last_month
+            # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
             ressources = (
                 individu('rsa_base_ressources_individu', period)
                 + individu('rsa_revenu_activite_individu', period, extra_params = [m_1]) / 3
@@ -633,6 +635,7 @@ class rsa_fictif(Variable):
 
         # Le rsa_forfait_logement et le rsa_base_ressources sont prises en compte sur le mois_courant(et pas sur le mois_demande)
         rsa_forfait_logement = famille('rsa_forfait_logement', mois_courant)
+        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         rsa_base_ressources = famille('rsa_base_ressources', mois_demande, extra_params = [mois_courant])
 
         montant = rsa_socle - rsa_forfait_logement - rsa_base_ressources
@@ -650,6 +653,7 @@ class rsa_montant(Variable):
 
     def formula_2017_01_01(famille, period, parameters):
         seuil_non_versement = parameters(period).prestations.minima_sociaux.rsa.rsa_nv
+        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         rsa = famille('rsa_fictif', period.last_3_months, extra_params = [period], options = [ADD]) / 3
         rsa = rsa * (rsa >= seuil_non_versement)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "29.2.5",
+    version = "29.2.6",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Connected to #629 

* Changement mineur.
* Périodes concernées : toutes
* Zones impactées : `openfisca_france/model/prestations/minima_sociaux/[rsa,ppa].py`.
* Détails :
  - Déprécie explicitement l'usage de extra_params dans France

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels du modèle (commentaires)
