### PR TITLE
Traite les codes postaux comme chaînes et non tableaux d'octets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### 26.0.1 [#1160](https://github.com/openfisca/openfisca-france/pull/1160)
+
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `model/caracteristiques_socio_demographiques/logement`
+  - `model/prelevements_obligatoires/impot_revenu/ir`
+  - `model/prestations/anah/eligibilite_anah`
+  - `model/prestations/logement_social`
+* Détails :
+  - Traite les codes postaux comme chaînes et non tableaux d'octets
+  - Corrige une différence d'encoding entre Python 2 et Python 3 pour les variables de type str
+
 # 26.0.0 [#1157](https://github.com/openfisca/openfisca-france/pull/1157)
 
 * Évolution du système socio-fiscal **non rétro-compatibles**

--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -141,7 +141,7 @@ class residence_saint_bartelemy(Variable):
 
     def formula(menage, period, parameters):
         depcom = menage('depcom', period)
-        return startswith(depcom, b'977')
+        return startswith(depcom, '977')
 
 
 class residence_saint_martin(Variable):
@@ -151,4 +151,4 @@ class residence_saint_martin(Variable):
 
     def formula(menage, period, parameters):
         depcom = menage('depcom', period)
-        return startswith(depcom, b'978')
+        return startswith(depcom, '978')

--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -91,7 +91,7 @@ class residence_guadeloupe(Variable):
 
     def formula(menage, period, parameters):
         depcom = menage('depcom', period)
-        return startswith(depcom, b'971')
+        return startswith(depcom, '971')
 
 
 class residence_martinique(Variable):
@@ -101,7 +101,7 @@ class residence_martinique(Variable):
 
     def formula(menage, period, parameters):
         depcom = menage('depcom', period)
-        return startswith(depcom, b'972')
+        return startswith(depcom, '972')
 
 
 class residence_guyane(Variable):
@@ -111,7 +111,7 @@ class residence_guyane(Variable):
 
     def formula(menage, period, parameters):
         depcom = menage('depcom', period)
-        return startswith(depcom, b'973')
+        return startswith(depcom, '973')
 
 
 class residence_reunion(Variable):
@@ -121,7 +121,7 @@ class residence_reunion(Variable):
 
     def formula(menage, period, parameters):
         depcom = menage('depcom', period)
-        return startswith(depcom, b'974')
+        return startswith(depcom, '974')
 
 
 class residence_mayotte(Variable):
@@ -131,7 +131,7 @@ class residence_mayotte(Variable):
 
     def formula(menage, period, parameters):
         depcom = menage('depcom', period)
-        return startswith(depcom, b'976')
+        return startswith(depcom, '976')
 
 
 class residence_saint_bartelemy(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -145,7 +145,7 @@ class residence_fiscale_guadeloupe(Variable):
 
     def formula(foyer_fiscal, period, parameters):
         depcom_foyer = foyer_fiscal('depcom_foyer', period)
-        return startswith(depcom_foyer, b'971')
+        return startswith(depcom_foyer, '971')
 
 
 class residence_fiscale_martinique(Variable):
@@ -155,7 +155,7 @@ class residence_fiscale_martinique(Variable):
 
     def formula(foyer_fiscal, period, parameters):
         depcom_foyer = foyer_fiscal('depcom_foyer', period)
-        return startswith(depcom_foyer, b'972')
+        return startswith(depcom_foyer, '972')
 
 
 class residence_fiscale_guyane(Variable):
@@ -165,7 +165,7 @@ class residence_fiscale_guyane(Variable):
 
     def formula(foyer_fiscal, period, parameters):
         depcom_foyer = foyer_fiscal('depcom_foyer', period)
-        return startswith(depcom_foyer, b'973')
+        return startswith(depcom_foyer, '973')
 
 
 class residence_fiscale_reunion(Variable):
@@ -175,7 +175,7 @@ class residence_fiscale_reunion(Variable):
 
     def formula(foyer_fiscal, period, parameters):
         depcom_foyer = foyer_fiscal('depcom_foyer', period)
-        return startswith(depcom_foyer, b'974')
+        return startswith(depcom_foyer, '974')
 
 
 class residence_fiscale_mayotte(Variable):
@@ -185,7 +185,7 @@ class residence_fiscale_mayotte(Variable):
 
     def formula(foyer_fiscal, period, parameters):
         depcom_foyer = foyer_fiscal('depcom_foyer', period)
-        return startswith(depcom_foyer, b'976')
+        return startswith(depcom_foyer, '976')
 
 
 class nb_adult(Variable):

--- a/openfisca_france/model/prestations/anah/eligibilite_anah.py
+++ b/openfisca_france/model/prestations/anah/eligibilite_anah.py
@@ -23,7 +23,7 @@ class eligibilite_anah(Variable):
     def formula(menage, period):
         depcom = menage('depcom', period.first_month)
 
-        departements_idf = [b'75', b'77', b'78', b'91', b'92', b'93', b'94', b'95']
+        departements_idf = ['75', '77', '78', '91', '92', '93', '94', '95']
         in_idf = sum([startswith(depcom, departement_idf) for departement_idf in departements_idf])
 
         rfr_declarants_principaux_du_menage = menage.members.has_role(FoyerFiscal.DECLARANT_PRINCIPAL) * menage.members.foyer_fiscal('rfr', period.n_2)

--- a/openfisca_france/model/prestations/logement_social.py
+++ b/openfisca_france/model/prestations/logement_social.py
@@ -4,46 +4,46 @@ from numpy.core.defchararray import startswith
 from openfisca_france.model.base import *
 
 paris_communes_limitrophes = [
-    b'75056',  # Paris
-    b'93001',  # Bagnolet
-    b'93006',  # Boulogne-Billancourt
-    b'94018',  # Charenton-le-Pont
-    b'92024',  # Clichy-la-Garenne
-    b'94033',  # Fontenay-sous-Bois
-    b'94037',  # Gentilly
-    b'92040',  # Issy-les-Moulineaux
-    b'94041',  # Ivry-sur-Seine
-    b'94042',  # Joinville-le-Pont
-    b'94043',  # Le Kremlin-Bicêtre
-    b'93045',  # Les Lilas
-    b'93061',  # Le Pré-Saint-Gervais
-    b'92044',  # Levallois-Perret
-    b'92046',  # Malakoff
-    b'93048',  # Montreuil
-    b'92049',  # Montrouge
-    b'92051',  # Neuilly-sur-Seine
-    b'94052',  # Nogent-sur-Marne
-    b'93055',  # Pantin
-    b'92062',  # Puteaux
-    b'92064',  # Saint-Cloud
-    b'93066',  # Saint-Denis
-    b'94067',  # Saint-Mandé
-    b'94069',  # Saint-Maurice
-    b'93070',  # Saint-Ouen
-    b'92073',  # Suresnes
-    b'92075',  # Vanves
-    b'94080',  # Vincennes
+    '75056',  # Paris
+    '93001',  # Bagnolet
+    '93006',  # Boulogne-Billancourt
+    '94018',  # Charenton-le-Pont
+    '92024',  # Clichy-la-Garenne
+    '94033',  # Fontenay-sous-Bois
+    '94037',  # Gentilly
+    '92040',  # Issy-les-Moulineaux
+    '94041',  # Ivry-sur-Seine
+    '94042',  # Joinville-le-Pont
+    '94043',  # Le Kremlin-Bicêtre
+    '93045',  # Les Lilas
+    '93061',  # Le Pré-Saint-Gervais
+    '92044',  # Levallois-Perret
+    '92046',  # Malakoff
+    '93048',  # Montreuil
+    '92049',  # Montrouge
+    '92051',  # Neuilly-sur-Seine
+    '94052',  # Nogent-sur-Marne
+    '93055',  # Pantin
+    '92062',  # Puteaux
+    '92064',  # Saint-Cloud
+    '93066',  # Saint-Denis
+    '94067',  # Saint-Mandé
+    '94069',  # Saint-Maurice
+    '93070',  # Saint-Ouen
+    '92073',  # Suresnes
+    '92075',  # Vanves
+    '94080',  # Vincennes
     ]
 
 departements_idf = [
-    b'75',
-    b'77',
-    b'78',
-    b'91',
-    b'92',
-    b'93',
-    b'94',
-    b'95',
+    '75',
+    '77',
+    '78',
+    '91',
+    '92',
+    '93',
+    '94',
+    '95',
     ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '26.0.0',
+    version = '26.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         },
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
-        'OpenFisca-Core >= 24.0.0, < 25',
+        'OpenFisca-Core >= 24.5.4, < 25',
         ],
     message_extractors = {'openfisca_france': [
         ('**.py', 'python', None),

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -110,7 +110,7 @@ def test_transpose_string():
 
     depcom_famille = famille.first_person.menage('depcom', period = reference_period)
 
-    assert((depcom_famille == [b"93400", b"89300"]).all())
+    assert((depcom_famille == ["93400", "89300"]).all())
 
 def test_value_from_person():
     test_case = deepcopy(TEST_CASE_AGES)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -6,7 +6,7 @@ from openfisca_core.taxbenefitsystems import TaxBenefitSystem
 from openfisca_core.tools import assert_near
 
 from openfisca_france.scenarios import Scenario
-from openfisca_france.entities import entities, Individu, Famille, FoyerFiscal, Menage
+from openfisca_france.entities import entities, Individu, Famille, Menage
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 
@@ -16,17 +16,20 @@ class af(Variable):
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
+
 class salaire(Variable):
     value_type = float
     entity = Individu
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
+
 class age(Variable):
     value_type = int
     entity = Individu
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
+
 
 class autonomie_financiere(Variable):
     value_type = bool
@@ -42,6 +45,7 @@ class depcom(Variable):
     label = u"""Code INSEE "depcom" de la commune de résidence de la famille"""
     definition_period = ETERNITY
 
+
 # This tests are more about core than france, but we need france entities to run some of them.
 # We use a dummy TBS to run the tests faster
 class DummyTaxBenefitSystem(TaxBenefitSystem):
@@ -50,10 +54,11 @@ class DummyTaxBenefitSystem(TaxBenefitSystem):
         self.Scenario = Scenario
         self.add_variables(af, salaire, age, autonomie_financiere, depcom)
 
+
 tax_benefit_system = DummyTaxBenefitSystem()
 
 TEST_CASE = {
-    'individus': [{'id': 'ind0'}, {'id': 'ind1'}, {'id': 'ind2'}, {'id': 'ind3'},{'id': 'ind4'}, {'id': 'ind5'}],
+    'individus': [{'id': 'ind0'}, {'id': 'ind1'}, {'id': 'ind2'}, {'id': 'ind3'}, {'id': 'ind4'}, {'id': 'ind5'}],
     'familles': [
         {'enfants': ['ind2', 'ind3'], 'parents': ['ind0', 'ind1']},
         {'enfants': ['ind5'], 'parents': ['ind4']}
@@ -70,8 +75,8 @@ TEST_CASE = {
 
 TEST_CASE_AGES = deepcopy(TEST_CASE)
 AGES = [40, 37, 7, 9, 54, 20]
-for (individu, age) in zip(TEST_CASE_AGES['individus'], AGES):
-        individu['age'] = age
+for (individu, age_individu) in zip(TEST_CASE_AGES['individus'], AGES):
+        individu['age'] = age_individu
 
 reference_period = 2013
 
@@ -80,7 +85,7 @@ def new_simulation(test_case):
     return tax_benefit_system.new_scenario().init_from_test_case(
         period = reference_period,
         test_case = test_case
-    ).new_simulation()
+        ).new_simulation()
 
 
 def test_transpose():
@@ -100,6 +105,7 @@ def test_transpose():
 
     assert_near(af_foyer_fiscal, [20000, 10000, 10000])
 
+
 def test_transpose_string():
     test_case = deepcopy(TEST_CASE)
     test_case['menages'][0]['depcom'] = "93400"
@@ -112,15 +118,15 @@ def test_transpose_string():
 
     assert((depcom_famille == ["93400", "89300"]).all())
 
+
 def test_value_from_person():
     test_case = deepcopy(TEST_CASE_AGES)
     simulation = new_simulation(test_case)
 
     foyer_fiscal = simulation.foyer_fiscal
-    age = foyer_fiscal.members('age', period='2013-01')
-
     age_conjoint = foyer_fiscal.conjoint('age', period='2013-01')
     assert_near(age_conjoint, [37, 0])
+
 
 def test_combination_projections():
     test_case = deepcopy(TEST_CASE_AGES)
@@ -131,6 +137,7 @@ def test_combination_projections():
     age_parent1 = individu.famille.demandeur('age', period='2013-01')
 
     assert_near(age_parent1, [40, 40, 40, 40, 54, 54])
+
 
 def test_complex_chain_2():
     test_case = {
@@ -152,7 +159,6 @@ def test_complex_chain_2():
             {'personne_de_reference': 'ind3'},
             ],
         }
-
 
     simulation = new_simulation(test_case)
 


### PR DESCRIPTION
Connected to openfisca/openfisca-core#737

* Correction d'un crash. 
* Périodes concernées : toutes.
* Zones impactées : 
  * `caracteristiques_socio_demographiques/logement.py`
  * `prelevements_obligatoires/impot_revenu/ir.py`
  * `prestations/anah/eligibilite_anah.py`
  * `prestations/logement_social.py`
* Détails :
  - Traite les codes postaux comme chaînes et non tableaux d'octets
  - Corrige une différence d'encoding entre Python 2 et Python 3 pour les variables de type `str`

- - - -

Ces changements :
- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)