### PR TITLE
Ajoute un epsilon aux delta temps pour fiabiliser le calcul des âges

### DIFF
--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -5,7 +5,7 @@ from __future__ import division
 
 import logging
 
-from numpy import datetime64, logical_xor as xor_, round as round_
+from numpy import datetime64, timedelta64, logical_xor as xor_, round as round_
 from numpy.core.defchararray import startswith
 
 from openfisca_core.model_api import *
@@ -93,7 +93,8 @@ class age(Variable):
                             )
 
         date_naissance = individu('date_naissance', period)
-        return (datetime64(period.start) - date_naissance).astype('timedelta64[Y]')
+        epsilon = timedelta64(1)
+        return (datetime64(period.start) - date_naissance + epsilon).astype('timedelta64[Y]')
 
 
 class age_en_mois(Variable):
@@ -124,7 +125,8 @@ class age_en_mois(Variable):
             if has_age:
                 return individu('age', period) * 12
         date_naissance = individu('date_naissance', period)
-        return (datetime64(period.start) - date_naissance).astype('timedelta64[M]')
+        epsilon = timedelta64(1)
+        return (datetime64(period.start) - date_naissance + epsilon).astype('timedelta64[M]')
 
 
 class depcom_foyer(Variable):


### PR DESCRIPTION
* Amélioration technique.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`.
* Détails :
  - Fiabilise le calcul de l'âge en années et en mois

Fixes #782 (selon la suggestion de @MattiSG)

Pas de tests unitaires, j'arbitre consciemment pour l'augmentation légère de la dette technique en faveur de la réduction du WIP.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
