### PR TITLE
Corrige un double compte des revenus du capital dans le RSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 27.0.4 [#1176](https://github.com/openfisca/openfisca-france/pull/1176)
+
+* Amélioration d'un calcul existant
+* Périodes concernées : toutes
+* Zones impactées : `prestations/minima_sociaux/rsa`.
+* Détails :
+  - Corrige un double compte de revenus du capital
+
 ### 27.0.3 [#1174](https://github.com/openfisca/openfisca-france/pull/1174) [#1170](https://github.com/openfisca/openfisca-france/pull/1170)
 
 * Amélioration technique.

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -730,7 +730,7 @@ class rsa_base_ressources_patrimoine_individu(Variable):
         livret_a = individu('livret_a', period)
         taux_livret_a = parameters(period).epargne.livret_a.taux
         epargne_revenus_non_imposables = individu('epargne_revenus_non_imposables', period)
-        revenus_capital = individu('revenus_capital', period)
+        revenus_capital = individu('revenus_capital', period) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
         valeur_locative_immo_non_loue = individu('valeur_locative_immo_non_loue', period)
         valeur_locative_terrains_non_loues = individu('valeur_locative_terrains_non_loues', period)
         revenus_locatifs = individu('revenus_locatifs', period)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '27.0.3',
+    version = '27.0.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/rsa.yaml
+++ b/tests/formulas/rsa.yaml
@@ -548,3 +548,25 @@
       date_naissance: 2005-03-10
   output_variables:
     rsa: 0
+
+
+- name: "RSA avec revenus du capital"
+  description: Calcule le RSA avec revenus du capital (et vérifie notamment l'absence de double compte via revenus_capital)
+  period: 2018-09
+  absolute_error_margin: 0.02
+  familles:
+    parents: ["parent1", "parent2"]
+  foyers_fiscaux:
+    declarants: ["parent1", "parent2"]
+    f2dh:
+      2018: 200 * 12
+  menages:
+    personne_de_reference: "parent1"
+    conjoint: "parent2"
+  individus:
+    - id: "parent1"
+      age: 38
+    - id: "parent2"
+      age: 35
+  output_variables:
+    rsa: 826.40 - 200


### PR DESCRIPTION
* Amélioration d'un calcul existant
* Périodes concernées : toutes
* Zones impactées : `prestations/minima_sociaux/rsa`.
* Détails :
  - Corrige un double compte de revenus du capital