### PR TITLE
Teste contre la version build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
           name: Install dependencies
           command: |
             make install
+            make build
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
 
       - save_cache:
@@ -58,6 +59,7 @@ jobs:
           name: Install dependencies
           command: |
             make install
+            make build
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          keys:
-            - v1-py2-deps-{{ checksum "setup.py" }}
+          key: v1-py2-deps-{{ checksum "setup.py" }}
 
       - run:
           name: Create a virtualenv
@@ -52,8 +51,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          keys:
-            - v1-py3-deps-{{ checksum "setup.py" }}
+          key: v1-py3-deps-{{ checksum "setup.py" }}
 
       - run:
           name: Create a virtualenv
@@ -92,8 +90,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          keys:
-            - v1-py3-deps-{{ checksum "setup.py" }}
+          key: v1-py3-deps-{{ checksum "setup.py" }}
 
       - run:
           name: Activate virtualenv
@@ -113,8 +110,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          keys:
-            - v1-py3-deps-{{ checksum "setup.py" }}
+          key: v1-py3-deps-{{ checksum "setup.py" }}
 
       - run:
           name: Activate virtualenv
@@ -151,9 +147,10 @@ jobs:
       - checkout
 
       - restore_cache:
-          keys:
-            - v1-py2-deps-{{ checksum "setup.py" }}
-            - v1-py2-build-{{ .Revision }}
+          key: v1-py2-deps-{{ checksum "setup.py" }}
+
+      - restore_cache:
+          key: v1-py2-build-{{ .Revision }}
 
       - run:
           name: Check for functional changes
@@ -184,9 +181,10 @@ jobs:
       - checkout
 
       - restore_cache:
-          keys:
-            - v1-py3-deps-{{ checksum "setup.py" }}
-            - v1-py3-build-{{ .Revision }}
+          key: v1-py3-deps-{{ checksum "setup.py" }}
+
+      - restore_cache:
+          key: v1-py3-build-{{ .Revision }}
 
       - run:
           name: Check for functional changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py2-{{ checksum "setup.py" }}
+          keys:
+            - v1-py2-deps-{{ checksum "setup.py" }}
 
       - run:
           name: Create a virtualenv
@@ -22,14 +23,19 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            make install
             make build
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
 
       - save_cache:
-          key: v1-py2-{{ checksum "setup.py" }}
+          key: v1-py2-deps-{{ checksum "setup.py" }}
           paths:
             - /tmp/venv/openfisca_france
+            - dist
+
+      - save_cache:
+          key: v1-py2-build-{{ .Revision }}
+          paths:
+            - dist
 
       - run:
           name: Run tests
@@ -46,7 +52,8 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py3-{{ checksum "setup.py" }}
+          keys:
+            - v1-py3-deps-{{ checksum "setup.py" }}
 
       - run:
           name: Create a virtualenv
@@ -58,14 +65,18 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            make install
             make build
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
 
       - save_cache:
-          key: v1-py3-{{ checksum "setup.py" }}
+          key: v1-py3-deps-{{ checksum "setup.py" }}
           paths:
             - /tmp/venv/openfisca_france
+
+      - save_cache:
+          key: v1-py3-build-{{ .Revision }}
+          paths:
+            - dist
 
       - run:
           name: Run tests
@@ -81,7 +92,8 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py3-{{ checksum "setup.py" }}
+          keys:
+            - v1-py3-deps-{{ checksum "setup.py" }}
 
       - run:
           name: Activate virtualenv
@@ -101,7 +113,8 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py3-{{ checksum "setup.py" }}
+          keys:
+            - v1-py3-deps-{{ checksum "setup.py" }}
 
       - run:
           name: Activate virtualenv
@@ -111,7 +124,6 @@ jobs:
       - run:
           name: Lint files
           command: |
-            make check-no-prints
             make check-syntax-errors
             .circleci/lint-changed-python-files.sh
 
@@ -139,7 +151,9 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py2-{{ checksum "setup.py" }}
+          keys:
+            - v1-py2-deps-{{ checksum "setup.py" }}
+            - v1-py2-build-{{ .Revision }}
 
       - run:
           name: Check for functional changes
@@ -149,7 +163,7 @@ jobs:
           name: Upload a Python package to Pypi
           command: |
             source /tmp/venv/openfisca_france/bin/activate
-            .circleci/publish-python-package.sh
+            twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
 
       - run:
           name: Publish a git tag
@@ -170,7 +184,9 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py3-{{ checksum "setup.py" }}
+          keys:
+            - v1-py3-deps-{{ checksum "setup.py" }}
+            - v1-py3-build-{{ .Revision }}
 
       - run:
           name: Check for functional changes
@@ -180,7 +196,7 @@ jobs:
           name: Upload a Python package to Pypi
           command: |
             source /tmp/venv/openfisca_france/bin/activate
-            .circleci/publish-python-package.sh
+            twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
 
 workflows:
   version: 2

--- a/.circleci/has-functional-changes.sh
+++ b/.circleci/has-functional-changes.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-IGNORE_DIFF_ON="README.md CONTRIBUTING.md .gitignore .circleci/* .github/*"
+IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .circleci/* .github/*"
 
 last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
 

--- a/.circleci/publish-python-package.sh
+++ b/.circleci/publish-python-package.sh
@@ -1,5 +1,0 @@
-#! /usr/bin/env bash
-
-rm -rf dist
-python setup.py bdist_wheel  # build this package in the dist directory
-twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD  # publish

--- a/.circleci/publish-python-package.sh
+++ b/.circleci/publish-python-package.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
 
+rm -rf dist
 python setup.py bdist_wheel  # build this package in the dist directory
 twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD  # publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### 29.2.1 [#1178](https://github.com/openfisca/openfisca-france/pull/1178)
 
 * Changement mineur
-* Périodes concernées : toutes
 * Détails :
   - Lors de l'ajout d'un fichier statique requis pour le fonctionnement de la librairie, nous devons le rendre découvrable par `wheel`
   - Pour éviter des soucis involontaires de packaging, on _build_ désormais la librairie, et on exécute les tests contre la version qui sera mise à disposition des usagers
@@ -19,7 +18,6 @@
 ### 29.1.3 [#1162](https://github.com/openfisca/openfisca-france/pull/1162)
 
 * Changement mineur.
-* Périodes concernées : toutes.
 * Zones impactées : `openfisca_france/parameters/**/*.yaml`.
 * Détails :
   - Unifie les références législatives associées aux paramètres
@@ -105,8 +103,6 @@
 ### 27.1.1 [#1171](https://github.com/openfisca/openfisca-france/pull/1171)
 
 * Changement mineur.
-* Périodes concernées : à partir du 01/04/2018.
-* Zones impactées : `tests/formulas/cf_2018_04`.
 * Détails :
   - Ajoute des tests pour la revalorisation du complément familial (CF) au 1er avril 2018.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 29.2.1 [#1178](https://github.com/openfisca/openfisca-france/pull/1178)
+
+* Changement mineur
+* Périodes concernées : toutes
+* Détails :
+  - Lors de l'ajout d'un fichier statique requis pour le fonctionnement de la librairie, nous devons le rendre découvrable par `wheel`
+  - Pour éviter des soucis involontaires de packaging, on _build_ désormais la librairie, et on exécute les tests contre la version qui sera mise à disposition des usagers
+
 ## 29.2.0 [#1189](https://github.com/openfisca/openfisca-france/pull/1189)
 
 * Évolution du système socio-fiscal.
@@ -113,7 +121,6 @@
 ### 27.0.5 [#1173](https://github.com/openfisca/openfisca-france/pull/1173)
 
 * Amélioration technique
-* Zones impactées : `**/*`.
 * Détails :
   - Corrige et uniformise le style des fichiers
 
@@ -229,7 +236,6 @@
 ### 24.14.9 [#1153](https://github.com/openfisca/openfisca-france/pull/1153)
 
 * Amélioration technique
-* Zones impactées : `openfisca_france/**/*`
 * Détails :
   - Corrige et uniformise le style des fichiers
 
@@ -246,7 +252,6 @@
 ### 24.14.7 [#1147](https://github.com/openfisca/openfisca-france/pull/1147)
 
 * Amélioration technique
-* Zones impactées : `openfisca_france/model/revenus/**/*`
 * Détails :
   - Corrige et uniformise le style des fichiers
   - Règle W504 : saut de ligne avant opérateur binaire
@@ -254,7 +259,6 @@
 ### 24.14.6 [#1146](https://github.com/openfisca/openfisca-france/pull/1146)
 
 * Amélioration technique
-* Zones impactées : `openfisca_france/model/prestations/**/*`
 * Détails :
   - Corrige et uniformise le style des fichiers
   - Règle W504 : saut de ligne avant opérateur binaire
@@ -262,7 +266,6 @@
 ### 24.14.5 [#1145](https://github.com/openfisca/openfisca-france/pull/1145)
 
 * Amélioration technique
-* Zones impactées : `openfisca_france/model/prelevements_obligatoires/**/*`
 * Détails :
   - Corrige et uniformise le style des fichiers
   - Règle W504 : saut de ligne avant opérateur binaire
@@ -270,28 +273,24 @@
 ### 24.14.4 [#1144](https://github.com/openfisca/openfisca-france/pull/1144)
 
 * Amélioration technique
-* Zones impactées : `openfisca_france/model/**/*`
 * Détails :
   - Corrige et uniformise le style des fichiers
 
 ### 24.14.3 [#1142](https://github.com/openfisca/openfisca-france/pull/1142)
 
 * Amélioration technique
-* Zones impactées : `openfisca_france/model/prestations/**/*`
 * Détails :
   - Corrige et uniformise le style des fichiers
 
 ### 24.14.2 [#1143](https://github.com/openfisca/openfisca-france/pull/1143)
 
 * Amélioration technique
-* Zones impactées : `openfisca_france/model/prelevements_obligatoires/**/*`
 * Détails :
   - Corrige et uniformise le style des fichiers
 
 ### 24.14.1 [#1139](https://github.com/openfisca/openfisca-france/pull/1139)
 
 * Amélioration technique
-* Zones impactées : `openfisca_france/model/revenus/**/*`
 * Détails :
   - Corrige et uniformise le style des fichiers
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,4 @@
-recursive-include openfisca_france/assets/apl *
-recursive-include openfisca_france/assets/versement_transport *
-recursive-include openfisca_france/decompositions *
-recursive-include openfisca_france/parameters *
-recursive-include openfisca_france/reforms/parameters *
-recursive-include openfisca_france/scripts *
-recursive-include openfisca_france/situation_examples *
+recursive-include openfisca_france *
 include openfisca_france/tests/__init__.py
 include openfisca_france/tests/base.py
 include openfisca_france/tests/test_basics.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,1 @@
 recursive-include openfisca_france *
-include openfisca_france/tests/__init__.py
-include openfisca_france/tests/base.py
-include openfisca_france/tests/test_basics.py

--- a/Makefile
+++ b/Makefile
@@ -8,40 +8,38 @@ clean:
 	find . -name '*.pyc' -exec rm \{\} \;
 
 deps:
-	@# Install common library dependencies.
 	pip install --upgrade pip twine wheel
-	pip install --upgrade openfisca-core[web-api]
 
 install: deps
-	@# Install library and dependencies in editable mode, for development.
-	pip install --editable --upgrade .[dev]
+	@# Install OpenFisca-France for development.
+	@# `make install` installs the editable version of OpenFisca-France.
+	@# This allows contributors to test as they code.
+	pip install --editable .[dev] --upgrade
+	pip install openfisca-core[web-api]
 
 build: clean deps
-	@# Build and install library and dependencies, for CI and CD.
+	@# Install OpenFisca-France for deployment and publishing.
+	@# `make build` allows us to be be sure tests are run against the packaged version
+	@# of OpenFisca-France, the same we put in the hands of users and reusers.
 	python setup.py bdist_wheel
 	find dist -name "*.whl" -exec pip install --upgrade {}[dev] \;
-
-check-no-prints:
-	@test -z "`git grep -w print openfisca_france/model`"
+	pip install openfisca-core[web-api]
 
 check-syntax-errors:
 	python -m compileall -q .
-
-check-style:
-	@# Do not analyse .gitignored files.
-	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
-	flake8 `git ls-files | grep "\.py$$"`
 
 format-style:
 	@# Do not analyse .gitignored files.
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
 	autopep8 `git ls-files | grep "\.py$$"`
 
-test: clean check-syntax-errors check-no-prints check-style format-style
+check-style:
+	@# Do not analyse .gitignored files.
+	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
+	flake8 `git ls-files | grep "\.py$$"`
+
+test: clean check-syntax-errors check-style
 	@# Launch tests from openfisca_france/tests directory (and not .) because TaxBenefitSystem must be initialized
 	@# before parsing source files containing formulas.
 	nosetests tests --exe --with-doctest
 	openfisca-run-test --country-package openfisca_france tests
-
-performance:
-	python openfisca_france/scripts/performance_tests/test_tests.py

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ install:
 	pip install --upgrade pip twine wheel
 	pip install --editable .[dev] --upgrade && pip install openfisca-core[web-api]
 
+build:
+	python setup.py bdist_wheel
+	find dist/*.whl | xargs pip install --upgrade
+
 clean:
 	rm -rf build dist
 	find . -name '*.pyc' -exec rm \{\} \;

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,23 @@ all: test
 uninstall:
 	pip freeze | grep -v "^-e" | xargs pip uninstall -y
 
-install:
-	pip install --upgrade pip twine wheel
-	pip install --editable .[dev] --upgrade && pip install openfisca-core[web-api]
-
-build:
-	python setup.py bdist_wheel
-	find dist/*.whl | xargs pip install --upgrade
-
 clean:
 	rm -rf build dist
 	find . -name '*.pyc' -exec rm \{\} \;
+
+deps:
+	@# Install common library dependencies.
+	pip install --upgrade pip twine wheel
+	pip install --upgrade openfisca-core[web-api]
+
+install: deps
+	@# Install library and dependencies in editable mode, for development.
+	pip install --editable --upgrade .[dev]
+
+build: clean deps
+	@# Build and install library and dependencies, for CI and CD.
+	python setup.py bdist_wheel
+	find dist -name "*.whl" -exec pip install --upgrade {}[dev] \;
 
 check-no-prints:
 	@test -z "`git grep -w print openfisca_france/model`"

--- a/openfisca_france/assets/apl/extract_subcommunes.py
+++ b/openfisca_france/assets/apl/extract_subcommunes.py
@@ -16,7 +16,7 @@ import sys
 
 
 app_name = os.path.splitext(os.path.basename(__file__))[0]
-log = logging.getLogger(app_name)
+logger = logging.getLogger(app_name)
 
 
 def main():
@@ -36,7 +36,7 @@ def main():
                 commune_depcom = row['POLE']
                 commune_depcom_by_subcommune_depcom[subcommune_depcom] = commune_depcom
 
-    print(json.dumps(commune_depcom_by_subcommune_depcom, encoding = 'utf-8', ensure_ascii = False, indent = 2))
+    logger.debug(json.dumps(commune_depcom_by_subcommune_depcom, encoding = 'utf-8', ensure_ascii = False, indent = 2))
     return 0
 
 

--- a/openfisca_france/scripts/parameters/baremes_ipp/merge_ipp_xml_files_with_openfisca_parameters.py
+++ b/openfisca_france/scripts/parameters/baremes_ipp/merge_ipp_xml_files_with_openfisca_parameters.py
@@ -12,6 +12,7 @@ Let the user commit or not the diff using git. The script `../format_parameters.
 
 
 import argparse
+import logging
 import os
 import sys
 
@@ -20,8 +21,11 @@ from openfisca_core import legislationsxml
 
 from openfisca_france.france_taxbenefitsystem import FranceTaxBenefitSystem, COUNTRY_DIR
 
-
 parameters_dir_path = os.path.join(COUNTRY_DIR, 'parameters')
+
+# Create logger
+logging.basicConfig(level = logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def replace_children(element, children):
@@ -129,14 +133,14 @@ def merge_ipp_xml_files_with_openfisca_parameters(ipp_xml_dir, parser):
         if file_name.endswith('.xml')
         ]
     if not ipp_file_paths:
-        print("Warning : no IPP XML found.")
+        logger.warning("Warning : no IPP XML found.")
     ipp_xml_tree_by_file_name = get_xml_tree_by_file_name(xmlschema, ipp_file_paths)
 
     for openfisca_file_name, openfisca_xml_tree in openfisca_xml_tree_by_file_name.items():
         openfisca_xml_root_element = openfisca_xml_tree.getroot()
         ipp_xml_tree = ipp_xml_tree_by_file_name.get(openfisca_file_name)
         if ipp_xml_tree is not None:
-            print('Processing {}...'.format(openfisca_file_name))
+            logger.info('Processing {}...'.format(openfisca_file_name))
             ipp_xml_root_element = ipp_xml_tree.getroot()
             merge_elements(openfisca_xml_root_element, ipp_xml_root_element)  # Mutates `openfisca_xml_root_element`
         output_tree = etree.ElementTree(openfisca_xml_root_element)

--- a/openfisca_france/scripts/parameters/explore_parameters_unit.py
+++ b/openfisca_france/scripts/parameters/explore_parameters_unit.py
@@ -43,13 +43,20 @@ def get_parameters_by_unit(parameter, parameters_by_unit = None):
 
 
 if __name__ == '__main__':
-    parameters_by_unit = get_parameters_by_unit(parameters)
-    print('Distribution of parameters types:')
-    for type_, sub_parameters in parameters_by_unit.items():
-        print(type_, len(parameters_by_unit[type_]))
+    import logging
 
-    print('\n')
-    print('List of parameters with no units')
+    logging.basicConfig(level = logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    parameters_by_unit = get_parameters_by_unit(parameters)
+
+    logger.info('Distribution of parameters types:')
+
+    for type_, sub_parameters in parameters_by_unit.items():
+        logger.info(type_, len(parameters_by_unit[type_]))
+
+    logger.info('\n')
+    logger.info('List of parameters with no units')
 
     for param in parameters_by_unit['none']:
-        print(param.name)
+        logger.info(param.name)

--- a/openfisca_france/scripts/parameters/reduce_parameters_paths.py
+++ b/openfisca_france/scripts/parameters/reduce_parameters_paths.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 import shutil
 import yaml
@@ -12,6 +13,10 @@ PARAMETERS_DIRECTORY = os.path.join(PARENT_DIRECTORY, 'parameters')
 PATH_MAX_LENGTH = 150
 
 INDEX_FILENAME = 'index.yaml'
+
+# Create logger
+logging.basicConfig(level = logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def clean_from_filename(relative_path):
@@ -100,13 +105,13 @@ def parse_and_clean(directory, paths_to_clean):
             if functional_path in paths_to_clean:
                 yaml_path = os.path.join(directory, item + ".yaml")
 
-                print(os.linesep + "Cleaning long directory into: " + yaml_path)
+                logger.info(os.linesep + "Cleaning long directory into: " + yaml_path)
                 content = harvest(item_path)
                 with open(yaml_path, 'w') as yaml_file:
                     yaml_file.write(yaml.dump(content[item], default_flow_style=False, allow_unicode=True))
 
                 # Delete harvested directory
-                print("Deleting " + item_path)
+                logger.info("Deleting " + item_path)
                 shutil.rmtree(item_path)
 
             else:
@@ -114,7 +119,7 @@ def parse_and_clean(directory, paths_to_clean):
 
 
 long_parameters_paths = list_long_paths(PARAMETERS_DIRECTORY)
-print("{} directories have files with more than {} characters in their paths starting from this directory: {}".format(len(long_parameters_paths), PATH_MAX_LENGTH, PARENT_DIRECTORY).encode('utf-8'))
+logger.info(u"{} directories have files with more than {} characters in their paths starting from this directory: {}".format(len(long_parameters_paths), PATH_MAX_LENGTH, PARENT_DIRECTORY).encode('utf-8'))
 
 while len(long_parameters_paths) > 0:
     parse_and_clean(PARAMETERS_DIRECTORY, long_parameters_paths)

--- a/openfisca_france/scripts/performance/measure_calculations_performance.py
+++ b/openfisca_france/scripts/performance/measure_calculations_performance.py
@@ -22,7 +22,7 @@ from openfisca_france import FranceTaxBenefitSystem
 
 
 args = None
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def add_member(entity, **variables_value_by_name):
@@ -84,8 +84,8 @@ def timeit(method):
     def timed(*args, **kwargs):
         start_time = time.time()
         result = method(*args, **kwargs)
-        # print '%r (%r, %r) %2.9f s' % (method.__name__, args, kw, time.time() - start_time)
-        print('{:2.6f} s'.format(time.time() - start_time))
+        # logger.debug '%r (%r, %r) %2.9f s' % (method.__name__, args, kw, time.time() - start_time)
+        logger.debug('{:2.6f} s'.format(time.time() - start_time))
         return result
 
     return timed
@@ -124,7 +124,7 @@ def main():
     args = parser.parse_args()
     logging.basicConfig(level = logging.DEBUG if args.verbose else logging.WARNING, stream = sys.stdout)
 
-    print('salaire_imposable')
+    logger.debug('salaire_imposable')
 
     test_irpp(2010, -1181, salaire_imposable = 20000)
     test_irpp(2010, -7934, salaire_imposable = 50000)
@@ -139,7 +139,7 @@ def main():
     test_irpp(2013, -7889, salaire_imposable = 50000)
     test_irpp(2013, -43076, salaire_imposable = 150000)
 
-    print('retraite_imposable')
+    logger.debug('retraite_imposable')
 
     test_irpp(2010, -1181, retraite_imposable = 20000)
     test_irpp(2010, -8336, retraite_imposable = 50000)
@@ -154,7 +154,7 @@ def main():
     test_irpp(2013, -8283, retraite_imposable = 50000)
     test_irpp(2013, -46523, retraite_imposable = 150000)
 
-    print('f2da')
+    logger.debug('f2da')
 
     test_irpp(2010, 0, f2da = 20000)
     test_irpp(2010, 0, f2da = 50000)
@@ -169,7 +169,7 @@ def main():
     # test_irpp(2013, 0, f2da = 50000)
     # test_irpp(2013, 0, f2da = 150000)
 
-    print('f2dc')
+    logger.debug('f2dc')
 
     test_irpp(2010, 0, f2dc = 20000)
     test_irpp(2010, -2976, f2dc = 50000)
@@ -184,7 +184,7 @@ def main():
     # test_irpp(2013, 0, f2dc = 50000)
     # test_irpp(2013, 0, f2dc = 150000)
 
-    print('f2dh')
+    logger.debug('f2dh')
 
     test_irpp(2010, 345, f2dh = 20000)
     test_irpp(2010, 345, f2dh = 50000)
@@ -199,7 +199,7 @@ def main():
     test_irpp(2013, 345, f2dh = 50000)
     test_irpp(2013, 345, f2dh = 150000)
 
-    print('f2tr')
+    logger.debug('f2tr')
 
     test_irpp(2010, -1461, f2tr = 20000)
     test_irpp(2010, -9434, f2tr = 50000)
@@ -214,7 +214,7 @@ def main():
     test_irpp(2013, -9389, f2tr = 50000)
     test_irpp(2013, -48036, f2tr = 150000)
 
-    print('f2ts')
+    logger.debug('f2ts')
 
     test_irpp(2010, -1461, f2ts = 20000)
     test_irpp(2010, -9434, f2ts = 50000)
@@ -229,7 +229,7 @@ def main():
     test_irpp(2013, -9389, f2ts = 50000)
     test_irpp(2013, -48036, f2ts = 150000)
 
-    print('f3vg')
+    logger.debug('f3vg')
 
     test_irpp(2010, -3600, f3vg = 20000)
     test_irpp(2010, -9000, f3vg = 50000)
@@ -244,7 +244,7 @@ def main():
     test_irpp(2013, -9389, f3vg = 50000)
     test_irpp(2013, -48036, f3vg = 150000)
 
-    print('f3vz')
+    logger.debug('f3vz')
 
     # test_irpp(2010, 0, f3vz = 20000)
     # test_irpp(2010, 0, f3vz = 50000)
@@ -259,7 +259,7 @@ def main():
     test_irpp(2013, 0, f3vz = 50000)
     test_irpp(2013, 0, f3vz = 150000)
 
-    print('f4ba')
+    logger.debug('f4ba')
 
     test_irpp(2010, -1461, f4ba = 20000)
     test_irpp(2010, -9434, f4ba = 50000)

--- a/openfisca_france/scripts/performance/measure_tests_performance.py
+++ b/openfisca_france/scripts/performance/measure_tests_performance.py
@@ -17,6 +17,9 @@ import pkg_resources
 from openfisca_core.tools.test_runner import run_tests
 from openfisca_france import CountryTaxBenefitSystem
 
+# Create logger
+logging.basicConfig(level = logging.INFO)
+logger = logging.getLogger(__name__)
 
 # Baselines for comparision - unit : seconds
 BASELINE_TBS_LOAD_TIME = 9.10831403732
@@ -43,15 +46,15 @@ def compare_performance(baseline, test_result):
     delta = (test_result - baseline) * 100 / baseline
 
     if test_result > baseline * 1.2:
-        logging.warning("The perfomance seems to have worsen by {} %.".format(delta))
+        logger.warning("The perfomance seems to have worsen by {} %.".format(delta))
     elif test_result < baseline * 0.8:
-        logging.info("The performance seems to have been improved by {} %.".format(delta))
+        logger.info("The performance seems to have been improved by {} %.".format(delta))
     else:
         logging.info("The performance seems steady ({} %).".format(delta))
 
 
-print("Generate Tax Benefit System: --- {}s seconds ---".format(time_spent_tbs))
+logger.info("Generate Tax Benefit System: --- {}s seconds ---".format(time_spent_tbs))
 compare_performance(BASELINE_TBS_LOAD_TIME, time_spent_tbs)
 
-print("Pass Mes-aides tests: --- {}s seconds ---".format(time_spent_tests))
+logger.info("Pass Mes-aides tests: --- {}s seconds ---".format(time_spent_tests))
 compare_performance(BASELINE_YAML_TESTS_TIME, time_spent_tests)

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ from setuptools import setup, find_packages
 
 
 setup(
-    name = 'OpenFisca-France',
-    version = '29.2.0',
-    author = 'OpenFisca Team',
-    author_email = 'contact@openfisca.fr',
+    name = "OpenFisca-France",
+    version = "29.2.1",
+    author = "OpenFisca Team",
+    author_email = "contact@openfisca.fr",
     classifiers = [
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Affero General Public License v3",
@@ -17,46 +17,47 @@ setup(
         "Programming Language :: Python",
         "Topic :: Scientific/Engineering :: Information Analysis",
         ],
-    description = u'French tax and benefit system for OpenFisca',
-    keywords = 'benefit france microsimulation social tax',
-    license = 'http://www.fsf.org/licensing/licenses/agpl-3.0.html',
-    url = 'https://github.com/openfisca/openfisca-france',
+    description = "French tax and benefit system for OpenFisca",
+    keywords = "benefit france microsimulation social tax",
+    license = "http://www.fsf.org/licensing/licenses/agpl-3.0.html",
+    url = "https://github.com/openfisca/openfisca-france",
 
     data_files = [
-        ('share/openfisca/openfisca-france', ['CHANGELOG.md', 'LICENSE.AGPL.txt', 'README.md']),
+        ("share/openfisca/openfisca-france", ["CHANGELOG.md", "LICENSE.AGPL.txt", "README.md"]),
         ],
     extras_require = {
-        'baremes_ipp': [
-            'xlrd >= 1.0.0',
-            'lxml >= 3.8.0, < 4.0',
-            'Biryani[datetimeconv] >= 0.10.4',
+        "baremes_ipp": [
+            "xlrd >= 1.0.0",
+            "lxml >= 3.8.0, < 4.0",
+            "Biryani[datetimeconv] >= 0.10.4",
             ],
-        'inversion_revenus': [
-            'scipy >= 0.17',
+        "inversion_revenus": [
+            "scipy >= 0.17",
             ],
-        'de_net_a_brut': [
-            'scipy >= 0.17',
+        "de_net_a_brut": [
+            "scipy >= 0.17",
             ],
-        'taxipp': [
-            'pandas >= 0.13',
+        "taxipp": [
+            "pandas >= 0.13",
             ],
-        'dev': [
-            'nose',
-            'flake8 >= 3.5.0, < 3.6.0',
-            'autopep8 >= 1.4.0, < 1.5.0',
-            'pycodestyle < 2.4.0',  # To avoid incompatibility with flake8
-            'scipy >= 0.17',  # Only used to test de_net_a_brut reform
-            'requests >= 2.8',
-            'yamllint >= 1.11.1, < 1.12',
+        "dev": [
+            "autopep8 == 1.4.0",
+            "flake8 >= 3.5.0, < 3.6.0",
+            "flake8-print",
+            "pycodestyle >= 2.3.0, < 2.4.0",  # To avoid incompatibility with flake
+            "nose",
+            "scipy >= 0.17",  # Only used to test de_net_a_brut reform
+            "requests >= 2.8",
+            "yamllint >= 1.11.1, < 1.12",
             ],
         },
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
-        'OpenFisca-Core >= 24.6, < 25.0',
+        "OpenFisca-Core >= 24.6, < 25.0",
         ],
-    message_extractors = {'openfisca_france': [
-        ('**.py', 'python', None),
+    message_extractors = {"openfisca_france": [
+        ("**.py", "python", None),
         ]},
-    packages = find_packages(exclude=['openfisca_france.tests*']),
-    test_suite = 'nose.collector',
+    packages = find_packages(exclude=["openfisca_france.tests*"]),
+    test_suite = "nose.collector",
     )

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -47,6 +47,9 @@ if __name__ == '__main__':
     import sys
 
     logging.basicConfig(level = logging.ERROR, stream = sys.stdout)
+    logger = logging.getLogger(__name__)
+
     for _, simulation, period in test_basics():
         check_run(simulation, period)
-    print(u'OpenFisca-France basic test was executed successfully.'.encode('utf-8'))
+
+    logger.info(u'OpenFisca-France basic test was executed successfully.'.encode('utf-8'))

--- a/tests/test_decomposition_fiches_de_paie.py
+++ b/tests/test_decomposition_fiches_de_paie.py
@@ -39,7 +39,7 @@ def test_decomposition(print_decomposition = False):
     simulations = [simulation]
     response = decompositions.calculate(simulations, decomposition_json)
     if print_decomposition:
-        print(to_unicode(
+        logger.debug(to_unicode(
             json.dumps(response, encoding = 'utf-8', ensure_ascii = False, indent = 2)
             ))
 
@@ -53,5 +53,6 @@ if __name__ == '__main__':
     parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = "increase output verbosity")
     args = parser.parse_args()
     logging.basicConfig(level = logging.DEBUG if args.verbose else logging.WARNING, stream = sys.stdout)
+    logger = logging.getLogger(__name__)
 
 #    test_decomposition(print_decomposition = True)


### PR DESCRIPTION
Child of #1177 

* Changement mineur
* Détails :
  - Lors de l'ajout d'un fichier statique requis pour le fonctionnement de la librairie, nous devons le rendre découvrable par `wheel`
  - Pour éviter des soucis involontaires de packaging, on _build_ désormais la librairie, et on exécute les tests contre la version qui sera mise à disposition des usagers

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] ~Documentez votre contribution avec des références législatives.~
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus