### PR TITLE
Utilise PyTest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            nosetests `circleci tests glob "tests/**/*.py" | circleci tests split`
+            pytest `circleci tests glob "tests/**/*.py" | circleci tests split`
             openfisca-run-test `circleci tests glob "tests/**/*.{yaml,yml}" | circleci tests split`
 
   build_python3:
@@ -79,7 +79,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            nosetests `circleci tests glob "tests/**/*.py" | circleci tests split`
+            pytest `circleci tests glob "tests/**/*.py" | circleci tests split`
             openfisca-run-test `circleci tests glob "tests/**/*.{yaml,yml}" | circleci tests split`
 
   lint_yaml_files:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 29.2.3 [#1180](https://github.com/openfisca/openfisca-france/pull/1180)
+
+* Amélioration technique
+* Détails :
+  - Permet d'utiliser `pytest` pour faire tourner les tests.
+  - La librairie actuelle, `nose`, n'est plus en développement actif.
+
 ### 29.2.2 [#1166](https://github.com/openfisca/openfisca-france/pull/1166)
 
 * Amélioration technique.

--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,5 @@ check-style:
 test: clean check-syntax-errors check-style
 	@# Launch tests from openfisca_france/tests directory (and not .) because TaxBenefitSystem must be initialized
 	@# before parsing source files containing formulas.
-	nosetests tests --exe --with-doctest
+	pytest
 	openfisca-run-test --country-package openfisca_france tests

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ pip install --editable .[dev] && pip install openfisca-core[web-api]
 Vous pouvez vous assurer que votre installation s'est bien passée en exécutant :
 
 ```sh
-nosetests tests/test_basics.py # Ces test peuvent prendre jusqu'à 60 secondes.
+pytest tests/test_basics.py # Ces test peuvent prendre jusqu'à 60 secondes.
 ```
 :tada: OpenFisca-France est prêt à être utilisé !
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,9 @@ ignore       = E128,E251,F403,F405,E501,W503
 hang-closing = true
 ignore       = E128,E251,F403,F405,E501,W503
 in-place     = true
+
+[tool:pytest]
+addopts      = --showlocals --exitfirst --doctest-modules --disable-pytest-warnings
+testpaths    = tests
+python_files = **/*.py
+

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "29.2.2",
+    version = "29.2.3",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [
@@ -45,7 +45,7 @@ setup(
             "flake8 >= 3.5.0, < 3.6.0",
             "flake8-print",
             "pycodestyle >= 2.3.0, < 2.4.0",  # To avoid incompatibility with flake
-            "nose",
+            "pytest",
             "scipy >= 0.17",  # Only used to test de_net_a_brut reform
             "requests >= 2.8",
             "yamllint >= 1.11.1, < 1.12",
@@ -59,5 +59,4 @@ setup(
         ("**.py", "python", None),
         ]},
     packages = find_packages(exclude=["openfisca_france.tests*"]),
-    test_suite = "nose.collector",
     )

--- a/tests/reforms/test_plf2015.py
+++ b/tests/reforms/test_plf2015.py
@@ -2,8 +2,6 @@
 
 import datetime
 
-from nose.tools import assert_less
-
 from openfisca_core import periods
 from openfisca_france.reforms.plf2015 import plf2015
 from ..cache import tax_benefit_system
@@ -40,10 +38,10 @@ def test(year = 2013):
     reform_impots_directs = reform_simulation.calculate('impots_directs', period = year)
     ir_plaf_qf = reference_simulation.calculate('ir_plaf_qf', period = year)
     reform_ir_plaf_qf = reform_simulation.calculate('ir_plaf_qf', period = year)
-    assert_less(max(abs([0, 918] - ir_plaf_qf)), error_margin)
-    assert_less(max(abs([0, 911.4] - reform_ir_plaf_qf)), error_margin)
-    assert_less(max(abs([0, -869] - impots_directs)), error_margin)
-    assert_less(max(abs([0, -911.4 + (1135 - 911.4)] - reform_impots_directs)), error_margin)
+    assert max(abs([0, 918] - ir_plaf_qf)) < error_margin
+    assert max(abs([0, 911.4] - reform_ir_plaf_qf)) < error_margin
+    assert max(abs([0, -869] - impots_directs)) < error_margin
+    assert max(abs([0, -911.4 + (1135 - 911.4)] - reform_impots_directs)) < error_margin
 
 
 if __name__ == '__main__':

--- a/tests/reforms/test_plf2016.py
+++ b/tests/reforms/test_plf2016.py
@@ -7,7 +7,7 @@ from openfisca_france.reforms.plf2016 import plf2016, plf2016_counterfactual, pl
 from ..cache import tax_benefit_system
 
 
-def test(year = 2015):
+def test_plf2016(year = 2015):
     for reform in [plf2016, plf2016_counterfactual, plf2016_counterfactual_2014]:
         yield run, reform, year
 
@@ -41,8 +41,3 @@ def run(reform_class, year):
 
     impo = reference_simulation.calculate('impots_directs', period = year)  # noqa F841
     reform_impo = reform_simulation.calculate('impots_directs', period = year)  # noqa F841
-
-
-if __name__ == '__main__':
-    import nose
-    nose.runmodule()

--- a/tests/test_coefficient.py
+++ b/tests/test_coefficient.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from nose.tools import assert_equal
-
 from openfisca_france import FranceTaxBenefitSystem
 
 
@@ -17,10 +15,10 @@ def test_coefficient_proratisation_only_contract_periods_wide():
         contrat_de_travail_fin='2017-12-01',
         allegement_fillon_mode_recouvrement=u'progressif'))
     simulation = scenario.new_simulation()
-    assert_equal(simulation.calculate('coefficient_proratisation', '2017-11'), 1)
-    assert_equal(simulation.calculate('coefficient_proratisation', '2017-12'), 0)
-    assert_equal(simulation.calculate('coefficient_proratisation', '2017-10'), 0)
-    assert_equal(simulation.calculate_add('coefficient_proratisation', '2017'), 1)
+    assert simulation.calculate('coefficient_proratisation', '2017-11') == 1
+    assert simulation.calculate('coefficient_proratisation', '2017-12') == 0
+    assert simulation.calculate('coefficient_proratisation', '2017-10') == 0
+    assert simulation.calculate_add('coefficient_proratisation', '2017') == 1
 
 
 def test_coefficient_proratisation_only_contract_periods_narrow():
@@ -35,7 +33,7 @@ def test_coefficient_proratisation_only_contract_periods_narrow():
         contrat_de_travail_fin='2017-12-01',
         allegement_fillon_mode_recouvrement=u'progressif'))
     simulation = scenario.new_simulation()
-    assert_equal(simulation.calculate('coefficient_proratisation', '2017-11'), 1)
-    assert_equal(simulation.calculate('coefficient_proratisation', '2017-12'), 0)
-    assert_equal(simulation.calculate('coefficient_proratisation', '2017-10'), 0)
-    assert_equal(simulation.calculate_add('coefficient_proratisation', '2017'), 1)
+    assert simulation.calculate('coefficient_proratisation', '2017-11') == 1
+    assert simulation.calculate('coefficient_proratisation', '2017-12') == 0
+    assert simulation.calculate('coefficient_proratisation', '2017-10') == 0
+    assert simulation.calculate_add('coefficient_proratisation', '2017') == 1

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from nose.tools import assert_equal
-
 from .cache import tax_benefit_system
 
 
 def test_metadata():
     metadata = tax_benefit_system.get_package_metadata()
-    assert_equal(metadata['name'], 'openfisca-france')
-    assert_equal(metadata['repository_url'], 'https://github.com/openfisca/openfisca-france')
+    assert metadata['name'] == 'openfisca-france'
+    assert metadata['repository_url'] == 'https://github.com/openfisca/openfisca-france'

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -3,8 +3,6 @@
 import datetime
 import json
 
-from nose.tools import assert_equal
-
 from .cache import tax_benefit_system
 from openfisca_france.model.base import *
 
@@ -28,42 +26,38 @@ def test_2_parents_2_enfants():
     scenario.suggest()
     json.dumps(scenario.to_json(), ensure_ascii = False, indent = 2)
     simulation = scenario.new_simulation()
-    assert_equal(
-        simulation.calculate('date_naissance', period = None).tolist(),
+    assert (
+        simulation.calculate('date_naissance', period = None).tolist() ==
         [
             datetime.date(year - 40, 1, 1),
             datetime.date(year - 30, 1, 1),
             datetime.date(year - 10, 1, 1),
             datetime.date(year - 18, 1, 1),
-            ],
-        )
-    assert_equal(
-        simulation.calculate('activite', period=janvier).decode().tolist(),
+            ])
+    assert (
+        simulation.calculate('activite', period=janvier).decode().tolist() ==
         [
             TypesActivite.inactif,
             TypesActivite.inactif,
             TypesActivite.etudiant,
             TypesActivite.inactif,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age', period=janvier).tolist() ==
         [
             40,
             30,
             10,
             18,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age_en_mois', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age_en_mois', period=janvier).tolist() ==
         [
             40 * 12,
             30 * 12,
             10 * 12,
             18 * 12,
-            ],
-        )
+            ])
 
 
 def test_famille_1_parent_3_enfants():
@@ -91,42 +85,38 @@ def test_famille_1_parent_3_enfants():
     scenario.suggest()
     json.dumps(scenario.to_json(), ensure_ascii = False, indent = 2)
     simulation = scenario.new_simulation()
-    assert_equal(
-        simulation.calculate('date_naissance', period = None).tolist(),
+    assert (
+        simulation.calculate('date_naissance', period = None).tolist() ==
         [
             datetime.date(year - 40, 1, 1),
             datetime.date(year - 10, 1, 1),
             datetime.date(year - 12, 1, 1),
             datetime.date(year - 18, 1, 1),
-            ],
-        )
-    assert_equal(
-        simulation.calculate('activite', period=janvier).decode().tolist(),
+            ])
+    assert (
+        simulation.calculate('activite', period=janvier).decode().tolist() ==
         [
             TypesActivite.inactif,
             TypesActivite.etudiant,
             TypesActivite.etudiant,
             TypesActivite.inactif,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age', period=janvier).tolist() ==
         [
             40,
             10,
             12,
             18,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age_en_mois', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age_en_mois', period=janvier).tolist() ==
         [
             40 * 12,
             10 * 12,
             12 * 12,
             18 * 12,
-            ],
-        )
+            ])
 
 
 def test_famille_2_parents_2_enfants():
@@ -154,42 +144,38 @@ def test_famille_2_parents_2_enfants():
     scenario.suggest()
     json.dumps(scenario.to_json(), ensure_ascii = False, indent = 2)
     simulation = scenario.new_simulation()
-    assert_equal(
-        simulation.calculate('date_naissance', period = None).tolist(),
+    assert (
+        simulation.calculate('date_naissance', period = None).tolist() ==
         [
             datetime.date(year - 40, 1, 1),
             datetime.date(year - 30, 1, 1),
             datetime.date(year - 10, 1, 1),
             datetime.date(year - 18, 1, 1),
-            ],
-        )
-    assert_equal(
-        simulation.calculate('activite', period=janvier).decode().tolist(),
+            ])
+    assert (
+        simulation.calculate('activite', period=janvier).decode().tolist() ==
         [
             TypesActivite.inactif,
             TypesActivite.inactif,
             TypesActivite.etudiant,
             TypesActivite.inactif,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age', period=janvier).tolist() ==
         [
             40,
             30,
             10,
             18,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age_en_mois', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age_en_mois', period=janvier).tolist() ==
         [
             40 * 12,
             30 * 12,
             10 * 12,
             18 * 12,
-            ],
-        )
+            ])
 
 
 def test_foyer_fiscal_1_declarant_3_personnes_a_charge():
@@ -217,42 +203,38 @@ def test_foyer_fiscal_1_declarant_3_personnes_a_charge():
     scenario.suggest()
     json.dumps(scenario.to_json(), ensure_ascii = False, indent = 2)
     simulation = scenario.new_simulation()
-    assert_equal(
-        simulation.calculate('date_naissance', period = None).tolist(),
+    assert (
+        simulation.calculate('date_naissance', period = None).tolist() ==
         [
             datetime.date(year - 40, 1, 1),
             datetime.date(year - 10, 1, 1),
             datetime.date(year - 12, 1, 1),
             datetime.date(year - 18, 1, 1),
-            ],
-        )
-    assert_equal(
-        simulation.calculate('activite', period=janvier).decode().tolist(),
+            ])
+    assert (
+        simulation.calculate('activite', period=janvier).decode().tolist() ==
         [
             TypesActivite.inactif,
             TypesActivite.etudiant,
             TypesActivite.etudiant,
             TypesActivite.inactif,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age', period=janvier).tolist() ==
         [
             40,
             10,
             12,
             18,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age_en_mois', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age_en_mois', period=janvier).tolist() ==
         [
             40 * 12,
             10 * 12,
             12 * 12,
             18 * 12,
-            ],
-        )
+            ])
 
 
 def test_foyer_fiscal_2_declarants_2_personnes_a_charge():
@@ -280,42 +262,38 @@ def test_foyer_fiscal_2_declarants_2_personnes_a_charge():
     scenario.suggest()
     json.dumps(scenario.to_json(), ensure_ascii = False, indent = 2)
     simulation = scenario.new_simulation()
-    assert_equal(
-        simulation.calculate('date_naissance', period=janvier).tolist(),
+    assert (
+        simulation.calculate('date_naissance', period=janvier).tolist() ==
         [
             datetime.date(year - 40, 1, 1),
             datetime.date(year - 30, 1, 1),
             datetime.date(year - 10, 1, 1),
             datetime.date(year - 18, 1, 1),
-            ],
-        )
-    assert_equal(
-        simulation.calculate('activite', period=janvier).decode().tolist(),
+            ])
+    assert (
+        simulation.calculate('activite', period=janvier).decode().tolist() ==
         [
             TypesActivite.inactif,
             TypesActivite.inactif,
             TypesActivite.etudiant,
             TypesActivite.inactif,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age', period=janvier).tolist() ==
         [
             40,
             30,
             10,
             18,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age_en_mois', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age_en_mois', period=janvier).tolist() ==
         [
             40 * 12,
             30 * 12,
             10 * 12,
             18 * 12,
-            ],
-        )
+            ])
 
 
 def test_menage_1_personne_de_reference_3_enfants():
@@ -343,42 +321,38 @@ def test_menage_1_personne_de_reference_3_enfants():
     scenario.suggest()
     json.dumps(scenario.to_json(), ensure_ascii = False, indent = 2)
     simulation = scenario.new_simulation()
-    assert_equal(
-        simulation.calculate('date_naissance', period = None).tolist(),
+    assert (
+        simulation.calculate('date_naissance', period = None).tolist() ==
         [
             datetime.date(year - 40, 1, 1),
             datetime.date(year - 10, 1, 1),
             datetime.date(year - 12, 1, 1),
             datetime.date(year - 18, 1, 1),
-            ],
-        )
-    assert_equal(
-        simulation.calculate('activite', period=janvier).decode().tolist(),
+            ])
+    assert (
+        simulation.calculate('activite', period=janvier).decode().tolist() ==
         [
             TypesActivite.inactif,
             TypesActivite.etudiant,
             TypesActivite.etudiant,
             TypesActivite.inactif,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age', period=janvier).tolist() ==
         [
             40,
             10,
             12,
             18,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age_en_mois', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age_en_mois', period=janvier).tolist() ==
         [
             40 * 12,
             10 * 12,
             12 * 12,
             18 * 12,
-            ],
-        )
+            ])
 
 
 def test_menage_1_personne_de_reference_1_conjoint_2_enfants():
@@ -407,42 +381,38 @@ def test_menage_1_personne_de_reference_1_conjoint_2_enfants():
     scenario.suggest()
     json.dumps(scenario.to_json(), ensure_ascii = False, indent = 2)
     simulation = scenario.new_simulation()
-    assert_equal(
-        simulation.calculate('date_naissance', period = None).tolist(),
+    assert (
+        simulation.calculate('date_naissance', period = None).tolist() ==
         [
             datetime.date(year - 40, 1, 1),
             datetime.date(year - 30, 1, 1),
             datetime.date(year - 10, 1, 1),
             datetime.date(year - 18, 1, 1),
-            ],
-        )
-    assert_equal(
-        simulation.calculate('activite', period=janvier).decode().tolist(),
+            ])
+    assert (
+        simulation.calculate('activite', period=janvier).decode().tolist() ==
         [
             TypesActivite.inactif,
             TypesActivite.inactif,
             TypesActivite.etudiant,
             TypesActivite.inactif,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age', period=janvier).tolist() ==
         [
             40,
             30,
             10,
             18,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age_en_mois', period=janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age_en_mois', period=janvier).tolist() ==
         [
             40 * 12,
             30 * 12,
             10 * 12,
             18 * 12,
-            ],
-        )
+            ])
 
 
 if __name__ == '__main__':

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -3,8 +3,6 @@
 import datetime
 import json
 
-from nose.tools import assert_equal
-
 from .cache import tax_benefit_system
 from openfisca_france.model.base import *
 
@@ -25,42 +23,38 @@ def test_birth():
     scenario.suggest()
     json.dumps(scenario.to_json(), ensure_ascii = False, indent = 2)
     simulation = scenario.new_simulation()
-    assert_equal(
-        simulation.calculate('date_naissance', period = None).tolist(),
+    assert (
+        simulation.calculate('date_naissance', period = None).tolist() ==
         [
             datetime.date(year - 40, 1, 1),
             datetime.date(year - 10, 1, 1),
             datetime.date(year - 12, 1, 1),
             datetime.date(year - 18, 1, 1),
-            ],
-        )
-    assert_equal(
-        simulation.calculate('activite', period = janvier).decode().tolist(),
+            ])
+    assert (
+        simulation.calculate('activite', period = janvier).decode().tolist() ==
         [
             TypesActivite.inactif,
             TypesActivite.etudiant,
             TypesActivite.etudiant,
             TypesActivite.inactif,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age', period = janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age', period = janvier).tolist() ==
         [
             40,
             10,
             12,
             18,
-            ],
-        )
-    assert_equal(
-        simulation.calculate('age_en_mois', period = janvier).tolist(),
+            ])
+    assert (
+        simulation.calculate('age_en_mois', period = janvier).tolist() ==
         [
             40 * 12,
             10 * 12,
             12 * 12,
             18 * 12,
-            ],
-        )
+            ])
 
 
 if __name__ == '__main__':

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,6 @@ import datetime
 
 from openfisca_core import periods
 from openfisca_core.tools import assert_near
-from nose.tools import nottest
 
 from .cache import tax_benefit_system
 
@@ -13,7 +12,6 @@ def check_calculation(variable, calculated_value, expected_value, error_margin):
     assert_near(calculated_value, expected_value, absolute_error_margin = error_margin)
 
 
-@nottest  # this function should not be considered as a test by nosetests
 def process_tests_list(tests_list, monthly_amount = False, default_error_margin = 1, forced_error_margin = None):
     for test in tests_list:
         error_margin = forced_error_margin if forced_error_margin else test.pop("error_margin", default_error_margin)
@@ -23,7 +21,6 @@ def process_tests_list(tests_list, monthly_amount = False, default_error_margin 
             yield check_calculation, variable, calculated_value, expected_value, error_margin
 
 
-@nottest  # this function should not be considered as a test by nosetests
 def simulation_from_test(test, monthly_amount = False, default_error_margin = 1, forced_error_margin = None):
     year = test["year"]
     parent1 = dict(date_naissance = datetime.date(year - 40, 1, 1))
@@ -36,7 +33,7 @@ def simulation_from_test(test, monthly_amount = False, default_error_margin = 1,
             menage[variable] = value
         elif tax_benefit_system.variables[variable].entity == 'ind':
             parent1[variable] = value
-# TODO: if the person is a child
+            # TODO: if the person is a child
         elif tax_benefit_system.variables[variable].entity == 'foy':
             foyer_fiscal[variable] = value
 


### PR DESCRIPTION
Depends on openfisca/openfisca-core#746

* Amélioration technique
* Détails :
  - Permet d'utiliser `pytest` pour faire tourner les tests.
  - La librairie actuelle, `nose`, n'est plus en développement actif.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] ~Documentez votre contribution avec des références législatives.~
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
