### PR TITLE
Précise pourquoi on exclut l'AAH de la base ressources ASPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 29.2.5 [#1183](https://github.com/openfisca/openfisca-france/pull/1183)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `asi_aspa`.
+* Détails :
+  - Corrige un commentaire avec une référence législative
+
 ### 29.2.4 [#1193](https://github.com/openfisca/openfisca-france/pull/1193)
 
 * Amélioration de calculs existants.

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -75,7 +75,10 @@ class asi_aspa_base_ressources_individu(Variable):
         aspa_eligibilite = individu('aspa_eligibilite', period)
         asi_eligibilite = individu('asi_eligibilite', period)
 
+        # Exclut l'AAH si éligible ASPA, retraite ou pension invalidité
+        # en application du II.B. de http://www.legislation.cnav.fr/Pages/texte.aspx?Nom=LE_MIN_19031982
         aah = individu('aah', three_previous_months, options = [ADD], max_nb_cycles = 0)
+        aah = aah * not_(aspa_eligibilite) * not_(asi_eligibilite) * not_(pension_invalidite)
 
         pensions_alimentaires_versees = individu(
             'pensions_alimentaires_versees_individu', three_previous_months, options = [ADD]

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -75,9 +75,7 @@ class asi_aspa_base_ressources_individu(Variable):
         aspa_eligibilite = individu('aspa_eligibilite', period)
         asi_eligibilite = individu('asi_eligibilite', period)
 
-        # Inclus l'AAH si conjoint non éligible ASPA, retraite et pension invalidité
         aah = individu('aah', three_previous_months, options = [ADD], max_nb_cycles = 0)
-        aah = aah * not_(aspa_eligibilite) * not_(asi_eligibilite) * not_(pension_invalidite)
 
         pensions_alimentaires_versees = individu(
             'pensions_alimentaires_versees_individu', three_previous_months, options = [ADD]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "29.2.4",
+    version = "29.2.5",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `asi_aspa`.
* Détails :
  - Corrige un commentaire avec une référence législative

Fixes #876 

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
