### PR TITLE
Met à jour le montant de l'AAH pour novembre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 29.2.0 [#1189](https://github.com/openfisca/openfisca-france/pull/1189)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/11/2018.
+* Zones impactées : `parameters/prestations/minima_sociaux/aah/montant`.
+* Détails :
+  - Prends en compte les revalorisations à venir de l'AAH
+
 ### 29.1.3 [#1162](https://github.com/openfisca/openfisca-france/pull/1162)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prestations/minima_sociaux/aah/montant.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aah/montant.yaml
@@ -50,3 +50,9 @@ values:
     value: 810.89
   2018-04-01:
     value: 819
+  2018-11-01:
+    value: 860
+    reference: https://www.service-public.fr/particuliers/vosdroits/F12242
+  2019-11-01:
+    value: 900
+    reference: https://www.service-public.fr/particuliers/vosdroits/F12242

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '29.1.3',
+    version = '29.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Linked to #1188

* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/11/2018.
* Zones impactées : `parameters/prestations/minima_sociaux/aah/montant`.
* Détails :
  - Prends en compte les revalorisations à venir de l'AAH
- - - -
