### PR TITLE
Intégre les modifications de la prime d'activité (Octobre 2018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 29.1.1 [#1192](https://github.com/openfisca/openfisca-france/pull/1192)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/10/2018.
+* Zones impactées : `parameters/prestations/minima_sociaux/ppa`.
+* Détails :
+  - Intègre la revalorisation exceptionnelle de la prime d'activité (+20 euros en octobre 2018)
+  - Intègre la hausse du taux de dégressivité de la prime d'activité (octobre 2018)
+
 ### 29.0.1 [#1181](https://github.com/openfisca/openfisca-france/pull/1181)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/montant_de_base.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/montant_de_base.yaml
@@ -13,3 +13,6 @@ values:
   2018-04-01:
     value: 531.51
     reference: https://www.legifrance.gouv.fr/eli/decret/2018/5/3/SSAA1805962D/jo/texte
+  2018-10-01:
+    value: 551.51
+    reference: https://www.legifrance.gouv.fr/eli/decret/2018/10/3/SSAA1822062D/jo/texte

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/pente.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/pente.yaml
@@ -4,3 +4,6 @@ unit: /1
 values:
   2016-01-01:
     value: 0.62
+  2018-01-01:
+    value: 0.61
+    reference: Décret n° 2018-836 - https://www.legifrance.gouv.fr/eli/decret/2018/10/3/SSAA1822062D/jo/texte

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/pente.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/pente.yaml
@@ -4,6 +4,6 @@ unit: /1
 values:
   2016-01-01:
     value: 0.62
-  2018-01-01:
+  2018-10-01:
     value: 0.61
     reference: Décret n° 2018-836 - https://www.legifrance.gouv.fr/eli/decret/2018/10/3/SSAA1822062D/jo/texte

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-France',
-    version = '29.0.1',
+    version = '29.1.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Le [Décret n° 2018-836 du 3 octobre 2018](https://www.legifrance.gouv.fr/eli/decret/2018/10/3/SSAA1822062D/jo/texte) a introduit une revalorisation exceptionnelle de la prime d'activité, mais également une hausse de sa dégressivité (i.e. une baisse du paramètre `pente` de la prime d'activité).

* Évolution du système socio-fiscal. 
* Périodes concernées : à partir du 01/10/2018.
* Zones impactées : `parameters/prestations/minima_sociaux/ppa`.
* Détails :
  - Intègre la revalorisation exceptionnelle de la prime d'activité (+20 euros en octobre 2018)
  - Intègre la hausse du taux de dégressivité de la prime d'activité (octobre 2018)

- - - -

Ces changements  :
- Corrigent ou améliorent un calcul déjà existant.