### PR TITLE
Corrige le calcul des aides au logement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 29.3.13 [#1200](https://github.com/openfisca/openfisca-france/pull/1200)
+
+* Changement mineur.
+* Zones impactées : `model/mesures.py`.
+* Détails :
+  - Corrige le double compte de la CRDS logement dans `aides_logement`
+  - Ajoute un test vérifiant l'égalité de `aides_logement` (annuelle) et `aide_logement` (mensuelle)
+
 ### 29.3.12 [#1212](https://github.com/openfisca/openfisca-france/pull/1212)
 
 * Correction d'un crash.

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -401,7 +401,7 @@ class minima_sociaux(Variable):
 class aides_logement(Variable):
     value_type = float
     entity = Famille
-    label = u"Aides logement nets"
+    label = u"Aides logement nettes"
     reference = "http://vosdroits.service-public.fr/particuliers/N20360.xhtml"
     definition_period = YEAR
 
@@ -409,9 +409,8 @@ class aides_logement(Variable):
         apl = famille('apl', period, options = [ADD])
         als = famille('als', period, options = [ADD])
         alf = famille('alf', period, options = [ADD])
-        crds_logement = famille('crds_logement', period, options = [ADD])
 
-        return apl + als + alf + crds_logement
+        return apl + als + alf
 
 
 class irpp_economique(Variable):

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -406,11 +406,7 @@ class aides_logement(Variable):
     definition_period = YEAR
 
     def formula(famille, period):
-        apl = famille('apl', period, options = [ADD])
-        als = famille('als', period, options = [ADD])
-        alf = famille('alf', period, options = [ADD])
-
-        return apl + als + alf
+        return famille('aide_logement', period, options = [ADD])
 
 
 class irpp_economique(Variable):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "29.3.12",
+    version = "29.3.13",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/aides_logement_2018.yaml
+++ b/tests/formulas/aides_logement_2018.yaml
@@ -47,5 +47,4 @@
     crds_logement: -300 * 0.005
     # AL après déduction de la CRDS
     aide_logement_montant: 295 - 300 * 0.005
-    aides_logement:
-      2018: 295 - 300 * 0.005
+    aide_logement: 295 - 300 * 0.005

--- a/tests/formulas/aides_logement_2018.yaml
+++ b/tests/formulas/aides_logement_2018.yaml
@@ -30,3 +30,22 @@
     aide_logement_participation_personnelle: 95
   output_variables:
     aide_logement_montant_brut_avant_degressivite: 5
+
+- name: aides_logement_2018_01
+  description: "Vérifie qu'il n'y ait pas de doubles comptes de la CRDS logement dans les aides au logement nettes"
+  period: 2018-01
+  absolute_error_margin: 1
+  input_variables:
+    statut_occupation_logement: locataire_vide
+    aide_logement_loyer_retenu: 400
+    aide_logement_charges: 100
+    aide_logement_participation_personnelle: 200
+  output_variables:
+    aide_logement_montant_brut_avant_degressivite: 300
+    # AL après application de la dégressivité
+    aide_logement_montant_brut_crds: 295
+    crds_logement: -300 * 0.005
+    # AL après déduction de la CRDS
+    aide_logement_montant: 295 - 300 * 0.005
+    aides_logement:
+      2018: 295 - 300 * 0.005

--- a/tests/formulas/aides_logement_2018.yaml
+++ b/tests/formulas/aides_logement_2018.yaml
@@ -37,9 +37,45 @@
   absolute_error_margin: 1
   input_variables:
     statut_occupation_logement: locataire_vide
-    aide_logement_loyer_retenu: 400
-    aide_logement_charges: 100
-    aide_logement_participation_personnelle: 200
+    aide_logement_loyer_retenu:
+      2018-01: 400
+      2018-02: 400
+      2018-03: 400
+      2018-04: 400
+      2018-05: 400
+      2018-06: 400
+      2018-07: 400
+      2018-08: 400
+      2018-09: 400
+      2018-10: 400
+      2018-11: 400
+      2018-12: 400
+    aide_logement_charges:
+      2018-01: 100
+      2018-02: 100
+      2018-03: 100
+      2018-04: 100
+      2018-05: 100
+      2018-06: 100
+      2018-07: 100
+      2018-08: 100
+      2018-09: 100
+      2018-10: 100
+      2018-11: 100
+      2018-12: 100
+    aide_logement_participation_personnelle:
+      2018-01: 200
+      2018-02: 200
+      2018-03: 200
+      2018-04: 200
+      2018-05: 200
+      2018-06: 200
+      2018-07: 200
+      2018-08: 200
+      2018-09: 200
+      2018-10: 200
+      2018-11: 200
+      2018-12: 200
   output_variables:
     aide_logement_montant_brut_avant_degressivite: 300
     # AL après application de la dégressivité
@@ -48,3 +84,5 @@
     # AL après déduction de la CRDS
     aide_logement_montant: 295 - 300 * 0.005
     aide_logement: 295 - 300 * 0.005
+    aides_logement:
+      2018: (295 - 300 * 0.005) * 12


### PR DESCRIPTION
Problème : il y' a un double compte de la CRDS logement dans la variable `aides_logement` : 

`crds_logement` => `aide_logement_montant` => `apl` => `aides_logement`
`crds_logement` => `aides_logement`

Cette PR corrige le calcul de la variable à `aides_logement` pour éviter ce double compte.

* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `chemin/vers/le/fichier/contenant/les/variables/impactées`.
* Détails :
  - Corrige le double compte de la CRDS logement dans `aides_logement`

- - - -

Ces changements :
- Corrigent ou améliorent un calcul déjà existant.