### PR TITLE
Améliore la gestion des crédits d'impôt sur valeurs étrangères

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 29.3.14 [#1209](https://github.com/openfisca/openfisca-france/pull/1209)
+
+* Changement mineur
+* Périodes concernées : toutes.
+* Zones impactées:
+  - `revenus/capital/financier.py`
+  - `prelevements_obligatoires/impot_revenu/ir.py`
+* Détails :
+  - Enlève la variable `avoirs_credits_fiscaux` des variables de mesure de revenus du capital
+  - Renomme `avoirs_credits_fiscaux` en `credits_impot_sur_valeurs_etrangeres`
+  - Déplace l'utilisation de cette variable directement dans `assiette_csg_revenus_capital`
+
 ### 29.3.13 [#1200](https://github.com/openfisca/openfisca-france/pull/1200)
 
 * Changement mineur.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2178,7 +2178,7 @@ class glo(Variable):
         return f3vf + f3vi + f3vj
 
 
-class avoirs_credits_fiscaux(Variable):
+class credits_impot_sur_valeurs_etrangeres(Variable):
     value_type = float
     entity = FoyerFiscal
     label = u"Avoir fiscal et crédits d'impôt"

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -200,7 +200,7 @@ class assiette_csg_revenus_capital(Variable):
         assurance_vie_ps_exoneree_irpp_pl = foyer_fiscal('assurance_vie_ps_exoneree_irpp_pl', period)
 
         # Crédits d'impôt sur valeurs étrangères déduits de la base CSG
-        credits_impot_sur_valeurs_etrangeres = foyer_fiscal('credits_impot_sur_valeurs_etrangeres', year)
+        credits_impot_sur_valeurs_etrangeres = foyer_fiscal('credits_impot_sur_valeurs_etrangeres', period)
 
         return max_(
             revenus_capitaux_prelevement_bareme
@@ -254,7 +254,7 @@ class assiette_csg_revenus_capital(Variable):
         assurance_vie_ps_exoneree_irpp_pl = foyer_fiscal('assurance_vie_ps_exoneree_irpp_pl', period)
 
         # Crédits d'impôt sur valeurs étrangères déduits de la base CSG
-        credits_impot_sur_valeurs_etrangeres = foyer_fiscal('credits_impot_sur_valeurs_etrangeres', year)
+        credits_impot_sur_valeurs_etrangeres = foyer_fiscal('credits_impot_sur_valeurs_etrangeres', period)
 
         return max_(
             revenus_capitaux_prelevement_forfaitaire_unique_ir

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -199,8 +199,8 @@ class assiette_csg_revenus_capital(Variable):
         # produits d'assurance-vie exonérés d'impôt sur le revenu et de prélèvement forfaitaire libératoire (et donc non présents dans revenus_capitaux_prelevement_bareme et revenus_capitaux_prelevement_liberatoire)
         assurance_vie_ps_exoneree_irpp_pl = foyer_fiscal('assurance_vie_ps_exoneree_irpp_pl', period)
 
-        # Crédit d'impôt sur valeurs étrangères déduits de la base CSG
-        avoirs_credits_fiscaux = foyer_fiscal('avoirs_credits_fiscaux', year)
+        # Crédits d'impôt sur valeurs étrangères déduits de la base CSG
+        credits_impot_sur_valeurs_etrangeres = foyer_fiscal('credits_impot_sur_valeurs_etrangeres', year)
 
         return max_(
             revenus_capitaux_prelevement_bareme
@@ -211,7 +211,7 @@ class assiette_csg_revenus_capital(Variable):
             + rev_cat_rfon
             + assiette_csg_plus_values
             + assurance_vie_ps_exoneree_irpp_pl
-            - avoirs_credits_fiscaux,
+            - credits_impot_sur_valeurs_etrangeres,
             0
             )
 
@@ -253,8 +253,8 @@ class assiette_csg_revenus_capital(Variable):
         # produits d'assurance-vie exonérés d'impôt sur le revenu et de prélèvement forfaitaire libératoire (et donc non présents dans revenus_capitaux_prelevement_bareme et revenus_capitaux_prelevement_liberatoire)
         assurance_vie_ps_exoneree_irpp_pl = foyer_fiscal('assurance_vie_ps_exoneree_irpp_pl', period)
 
-        # Crédit d'impôt sur valeurs étrangères déduits de la base CSG
-        avoirs_credits_fiscaux = foyer_fiscal('avoirs_credits_fiscaux', year)
+        # Crédits d'impôt sur valeurs étrangères déduits de la base CSG
+        credits_impot_sur_valeurs_etrangeres = foyer_fiscal('credits_impot_sur_valeurs_etrangeres', year)
 
         return max_(
             revenus_capitaux_prelevement_forfaitaire_unique_ir
@@ -266,7 +266,7 @@ class assiette_csg_revenus_capital(Variable):
             + rev_cat_rfon
             + assiette_csg_plus_values
             + assurance_vie_ps_exoneree_irpp_pl
-            - avoirs_credits_fiscaux,
+            - credits_impot_sur_valeurs_etrangeres,
             0
             )
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -199,7 +199,10 @@ class assiette_csg_revenus_capital(Variable):
         # produits d'assurance-vie exonérés d'impôt sur le revenu et de prélèvement forfaitaire libératoire (et donc non présents dans revenus_capitaux_prelevement_bareme et revenus_capitaux_prelevement_liberatoire)
         assurance_vie_ps_exoneree_irpp_pl = foyer_fiscal('assurance_vie_ps_exoneree_irpp_pl', period)
 
-        return (
+        # Crédit d'impôt sur valeurs étrangères déduits de la base CSG
+        avoirs_credits_fiscaux = foyer_fiscal('avoirs_credits_fiscaux', year)
+
+        return max_(
             revenus_capitaux_prelevement_bareme
             + revenus_capitaux_prelevement_liberatoire
             + rente_viagere_titre_onereux_net
@@ -208,6 +211,8 @@ class assiette_csg_revenus_capital(Variable):
             + rev_cat_rfon
             + assiette_csg_plus_values
             + assurance_vie_ps_exoneree_irpp_pl
+            - avoirs_credits_fiscaux,
+            0
             )
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
@@ -248,7 +253,10 @@ class assiette_csg_revenus_capital(Variable):
         # produits d'assurance-vie exonérés d'impôt sur le revenu et de prélèvement forfaitaire libératoire (et donc non présents dans revenus_capitaux_prelevement_bareme et revenus_capitaux_prelevement_liberatoire)
         assurance_vie_ps_exoneree_irpp_pl = foyer_fiscal('assurance_vie_ps_exoneree_irpp_pl', period)
 
-        return (
+        # Crédit d'impôt sur valeurs étrangères déduits de la base CSG
+        avoirs_credits_fiscaux = foyer_fiscal('avoirs_credits_fiscaux', year)
+
+        return max_(
             revenus_capitaux_prelevement_forfaitaire_unique_ir
             + rente_viagere_titre_onereux_net
             + interets_plan_epargne_logement_moins_de_12_ans_ouvert_avant_2018
@@ -258,6 +266,8 @@ class assiette_csg_revenus_capital(Variable):
             + rev_cat_rfon
             + assiette_csg_plus_values
             + assurance_vie_ps_exoneree_irpp_pl
+            - avoirs_credits_fiscaux,
+            0
             )
 
 

--- a/openfisca_france/model/revenus/capital/financier.py
+++ b/openfisca_france/model/revenus/capital/financier.py
@@ -418,12 +418,11 @@ class revenus_capitaux_prelevement_bareme(Variable):
         f2go = foyer_fiscal('f2go', year)
         f2tr = foyer_fiscal('f2tr', year)
         f2fu = foyer_fiscal('f2fu', year)
-        avoirs_credits_fiscaux = foyer_fiscal('avoirs_credits_fiscaux', year)
-        f2da = foyer_fiscal('f2da', year)  # noqa: F841
-        f2ee = foyer_fiscal('f2ee', year)  # noqa: F841
+        f2da = foyer_fiscal('f2da', year)
+        f2ee = foyer_fiscal('f2ee', year)
         majoration_revenus_reputes_distribues = parameters(period).impot_revenu.rvcm.majoration_revenus_reputes_distribues
 
-        return (f2dc + f2gr + f2ch + f2ts + f2go * majoration_revenus_reputes_distribues + f2tr + f2fu - avoirs_credits_fiscaux) / 12
+        return (f2dc + f2gr + f2ch + f2ts + f2go * majoration_revenus_reputes_distribues + f2tr + f2fu) / 12
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         year = period.this_year
@@ -433,10 +432,9 @@ class revenus_capitaux_prelevement_bareme(Variable):
         f2go = foyer_fiscal('f2go', year)
         f2tr = foyer_fiscal('f2tr', year)
         f2fu = foyer_fiscal('f2fu', year)
-        avoirs_credits_fiscaux = foyer_fiscal('avoirs_credits_fiscaux', year)
         majoration_revenus_reputes_distribues = parameters(period).impot_revenu.rvcm.majoration_revenus_reputes_distribues
 
-        return (f2dc + f2ch + f2ts + f2go * majoration_revenus_reputes_distribues + f2tr + f2fu - avoirs_credits_fiscaux) / 12
+        return (f2dc + f2ch + f2ts + f2go * majoration_revenus_reputes_distribues + f2tr + f2fu) / 12
 
     def formula_2016_01_01(foyer_fiscal, period, parameters):
         year = period.this_year
@@ -447,10 +445,9 @@ class revenus_capitaux_prelevement_bareme(Variable):
         f2tr = foyer_fiscal('f2tr', year)
         f2fu = foyer_fiscal('f2fu', year)
         f2tt_2016 = foyer_fiscal('f2tt_2016', year)
-        avoirs_credits_fiscaux = foyer_fiscal('avoirs_credits_fiscaux', year)
         majoration_revenus_reputes_distribues = parameters(period).impot_revenu.rvcm.majoration_revenus_reputes_distribues
 
-        return (f2dc + f2ch + f2ts + f2go * majoration_revenus_reputes_distribues + f2tr + f2fu + f2tt_2016 - avoirs_credits_fiscaux) / 12
+        return (f2dc + f2ch + f2ts + f2go * majoration_revenus_reputes_distribues + f2tr + f2fu + f2tt_2016) / 12
 
     def formula_2017_01_01(foyer_fiscal, period, parameters):
         '''
@@ -466,10 +463,9 @@ class revenus_capitaux_prelevement_bareme(Variable):
         f2tr = foyer_fiscal('f2tr', year)
         f2fu = foyer_fiscal('f2fu', year)
         f2tt = foyer_fiscal('f2tt', year)
-        avoirs_credits_fiscaux = foyer_fiscal('avoirs_credits_fiscaux', year)
         majoration_revenus_reputes_distribues = parameters(period).impot_revenu.rvcm.majoration_revenus_reputes_distribues
 
-        return (f2dc + f2ch + f2ts + f2go * majoration_revenus_reputes_distribues + f2tr + f2fu + f2tt - avoirs_credits_fiscaux) / 12
+        return (f2dc + f2ch + f2ts + f2go * majoration_revenus_reputes_distribues + f2tr + f2fu + f2tt) / 12
 
 
 class revenus_capitaux_prelevement_liberatoire(Variable):

--- a/openfisca_france/model/revenus/capital/financier.py
+++ b/openfisca_france/model/revenus/capital/financier.py
@@ -418,8 +418,6 @@ class revenus_capitaux_prelevement_bareme(Variable):
         f2go = foyer_fiscal('f2go', year)
         f2tr = foyer_fiscal('f2tr', year)
         f2fu = foyer_fiscal('f2fu', year)
-        f2da = foyer_fiscal('f2da', year)
-        f2ee = foyer_fiscal('f2ee', year)
         majoration_revenus_reputes_distribues = parameters(period).impot_revenu.rvcm.majoration_revenus_reputes_distribues
 
         return (f2dc + f2gr + f2ch + f2ts + f2go * majoration_revenus_reputes_distribues + f2tr + f2fu) / 12

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "29.3.13",
+    version = "29.3.14",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur
* Périodes concernées : toutes.
* Zones impactées:
  - `revenus/capital/financier.py`
  - `prelevements_obligatoires/impot_revenu/ir.py`
* Détails :
  - Enlève la variable `avoirs_credits_fiscaux` des variables de mesure de revenus du capital
  - Renomme `avoirs_credits_fiscaux` en `credits_impot_sur_valeurs_etrangeres`
  - Déplace l'utilisation de cette variable directement dans `assiette_csg_revenus_capital`
