### PR TITLE
Fix multidimension cheque_energie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 29.3.12 [#1212](https://github.com/openfisca/openfisca-france/pull/1212)
+
+* Correction d'un crash.
+* Zones impactées : `model/prestations/cheque_energie`.
+* Détails :
+  - Remplace l'utilisation de `a < b < x` par `(a < b) * (b < c)` car la première notion ne fonctionne pas avec des vecteurs `numpy`.
+
 ### 29.3.11 [#1182](https://github.com/openfisca/openfisca-france/pull/1182)
 
 * Changement mineur.

--- a/openfisca_france/model/prestations/cheque_energie.py
+++ b/openfisca_france/model/prestations/cheque_energie.py
@@ -83,8 +83,8 @@ class cheque_energie_montant(Variable):
 
         return (
             + (ressources_par_uc < seuils.tranche_une) * montants[uc].tranche_une
-            + (seuils.tranche_une <= ressources_par_uc < seuils.tranche_deux) * montants[uc].tranche_deux
-            + (seuils.tranche_deux <= ressources_par_uc < seuils.tranche_trois) * montants[uc].tranche_trois
+            + (seuils.tranche_une <= ressources_par_uc) * (ressources_par_uc < seuils.tranche_deux) * montants[uc].tranche_deux
+            + (seuils.tranche_deux <= ressources_par_uc) * (ressources_par_uc < seuils.tranche_trois) * montants[uc].tranche_trois
             )
 
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
             "flake8 >= 3.5.0, < 3.6.0",
             "flake8-print",
             "pycodestyle >= 2.3.0, < 2.4.0",  # To avoid incompatibility with flake
-            "pytest",
+            "pytest < 4.0",
             "scipy >= 0.17",  # Only used to test de_net_a_brut reform
             "requests >= 2.8",
             "yamllint >= 1.11.1, < 1.12",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "29.3.11",
+    version = "29.3.12",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/cheque_energie/montant.yaml
+++ b/tests/formulas/cheque_energie/montant.yaml
@@ -127,3 +127,24 @@
   output_variables:
     cheque_energie:
       2017-01: 0
+
+- name: Plusieurs foyers
+  period: 2018
+  individus:
+    - id: faustine
+    - id: jocelyne
+  familles:
+    - parents: [faustine]
+    - parents: [jocelyne]
+  menages:
+    - personne_de_reference: faustine
+      cheque_energie_unites_consommation: 1
+    - personne_de_reference: jocelyne
+      cheque_energie_unites_consommation: 2
+  foyers_fiscaux:
+    - declarants: [faustine]
+    - declarants: [jocelyne]
+  output_variables:
+    cheque_energie_montant:
+      - 144
+      - 227


### PR DESCRIPTION
* Correction d'un crash.
* Zones impactées : `model/prestations/cheque_energie`.
* Détails :
  - Remplace l'utilisation de `a < b < x` par `(a < b) * (b < c)` car la première notion ne fonctionne pas avec des vecteurs `numpy`.
- - - -
