### PR TITLE
Clarifie le statut de "reduction_ss_condition_revenus"

### DIFF
--- a/.circleci/has-functional-changes.sh
+++ b/.circleci/has-functional-changes.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-IGNORE_DIFF_ON="*.md Makefile .gitignore .circleci/* .github/*"
+IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .circleci/* .github/*"
 
 last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 29.4.1 [#1215](https://github.com/openfisca/openfisca-france/pull/1215)
+
+* Changement mineur.
+* Périodes concernées : à partir de 2016.
+* Zones impactées : `ir.py`.
+
+* Détails :
+  - Clarifie le statut de reduction_ss_condition_revenus
+    - Cette réduction instaurée en 2016 vise à adoucir un effet de seuil d'assujettissement à l'impôt pour les foyers fiscaux les plus modestes, elle est plus à considérer comme une "décote bis" qu'une réduction fiscale.
+  - Simplifie la formule ip_net qui n'a pas besoin d'être dupliquée, la formule de la réduction étant datée
+
+
 ### 29.4.0 [#1196](https://github.com/openfisca/openfisca-france/pull/1196)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1468,17 +1468,6 @@ class ip_net(Variable):
         cncn_info_i = foyer_fiscal.members('cncn_info', period)
         decote = foyer_fiscal('decote', period)
         ir_plaf_qf = foyer_fiscal('ir_plaf_qf', period)
-        taux = parameters(period).impot_revenu.rpns.taux16
-
-        return around(max_(0, ir_plaf_qf + foyer_fiscal.sum(cncn_info_i) * taux - decote))
-
-    def formula_2016_01_01(foyer_fiscal, period, parameters):
-        '''
-        Impôt net avant réductions
-        '''
-        cncn_info_i = foyer_fiscal.members('cncn_info', period)
-        decote = foyer_fiscal('decote', period)
-        ir_plaf_qf = foyer_fiscal('ir_plaf_qf', period)
         reduction_ss_condition_revenus = foyer_fiscal('reduction_ss_condition_revenus', period)
         taux = parameters(period).impot_revenu.rpns.taux16
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1414,6 +1414,9 @@ class reduction_ss_condition_revenus(Variable):
     def formula_2016_01_01(foyer_fiscal, period, parameters):
         '''
         Réduction d'impôt sous condition de revenus
+        Cette réduction instaurée en 2016 vise à adoucir un effet de seuil d'assujettissement
+        à l'impôt pour les foyers fiscaux les plus modestes, elle est plus à considérer comme une
+        "décote bis" qu'une réduction fiscale à proprement parler.
         '''
         ir_plaf_qf = foyer_fiscal('ir_plaf_qf', period)
         decote = foyer_fiscal('decote', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1471,8 +1471,9 @@ class ip_net(Variable):
         cncn_info_i = foyer_fiscal.members('cncn_info', period)
         decote = foyer_fiscal('decote', period)
         ir_plaf_qf = foyer_fiscal('ir_plaf_qf', period)
-        reduction_ss_condition_revenus = foyer_fiscal('reduction_ss_condition_revenus', period)
         taux = parameters(period).impot_revenu.rpns.taux16
+        # N'est pas véritablement une 'réduction', cf. la définition de cette variable
+        reduction_ss_condition_revenus = foyer_fiscal('reduction_ss_condition_revenus', period)
 
         return around(max_(0, ir_plaf_qf + foyer_fiscal.sum(cncn_info_i) * taux - decote - reduction_ss_condition_revenus))
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "29.4.0",
+    version = "29.4.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Fixes #1204 

* Changement mineur.
* Périodes concernées : à partir de 2016.
* Zones impactées : `ir.py`.
* Détails :
  - Cette réduction instaurée en 2016 vise à adoucir un effet de seuil d'assujettissement à l'impôt pour les foyers fiscaux les plus modestes, elle est plus à considérer comme une "décote bis" qu'une réduction fiscale.
  - Simplification de la formule ip_net qui n'a pas besoin d'être dupliquée, la formule de la réduction étant datée

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
