### PR TITLE
Prise en compte de la RLS dans le calcul des prestations sociales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### 32.0.1 [#1217](https://github.com/openfisca/openfisca-france/pull/1217)
+
+* Correction mineure.
+* Périodes concernées : à partir du 01/01/2018
+* Zones impactées :
+  - `mesures.py`
+  - `prestations/reduction_loyer_solidarite.py`
+* Détails :
+  - Ajoute la RLS au montant des prestations sociales
+  - Ajoute une date d'effet à `reduction_loyer_solidarite` et la limite aux familles éligibles
+  - Affine la condition d'éligibilité en écartant les logements-foyers
+  - Met à jour les tests en ce sens
+
 # 32.0.0 [#1223](https://github.com/openfisca/openfisca-france/pull/1223)
 
 * Évolution de la législation **non rétrocompatible**

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -502,7 +502,7 @@ class prestations_sociales(Variable):
         prestations_familiales = famille('prestations_familiales', period)
         minima_sociaux = famille('minima_sociaux', period)
         aides_logement = famille('aides_logement', period)
-        reduction_loyer_solidarite = famille('reduction_loyer_solidarite', period)
+        reduction_loyer_solidarite = famille('reduction_loyer_solidarite', period, options = [ADD])
 
         return prestations_familiales + minima_sociaux + aides_logement + reduction_loyer_solidarite
 

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -502,8 +502,9 @@ class prestations_sociales(Variable):
         prestations_familiales = famille('prestations_familiales', period)
         minima_sociaux = famille('minima_sociaux', period)
         aides_logement = famille('aides_logement', period)
+        reduction_loyer_solidarite = famille('reduction_loyer_solidarite', period)
 
-        return prestations_familiales + minima_sociaux + aides_logement
+        return prestations_familiales + minima_sociaux + aides_logement + reduction_loyer_solidarite
 
 
 class prestations_familiales(Variable):

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -114,8 +114,6 @@ class aide_logement_montant_brut_crds(Variable):
         rls = parameters(period).prestations.reduction_loyer_solidarite
         aide_logement_montant_brut = famille('aide_logement_montant_brut', period)
         reduction_loyer_solidarite = famille('reduction_loyer_solidarite', period)
-        logement_conventionne = famille.demandeur.menage('logement_conventionne', period)
-        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
 
         taux_rls = rls.fraction_baisse_aide_logement
         rls_apl = reduction_loyer_solidarite * taux_rls

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -118,10 +118,9 @@ class aide_logement_montant_brut_crds(Variable):
         statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
 
         taux_rls = rls.fraction_baisse_aide_logement
-        condition_rls = logement_conventionne * (statut_occupation_logement != TypesStatutOccupationLogement.locataire_foyer)
-        rls_apl = reduction_loyer_solidarite * taux_rls * condition_rls
-        montant = max_(0, (aide_logement_montant_brut - rls_apl))
-        return montant
+        rls_apl = reduction_loyer_solidarite * taux_rls
+
+        return max_(0, (aide_logement_montant_brut - rls_apl))
 
     def formula(famille, period, parameters):
         return famille('aide_logement_montant_brut', period)

--- a/openfisca_france/model/prestations/reduction_loyer_solidarite.py
+++ b/openfisca_france/model/prestations/reduction_loyer_solidarite.py
@@ -108,8 +108,7 @@ class reduction_loyer_solidarite(Variable):
         # necessité de diviser par 12 pour comparer au plafond mensuel
         ressources = famille('aide_logement_base_ressources', period) / 12
         plafond = famille('reduction_loyer_solidarite_plafond_ressources', period)
-        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period) 
-        
+        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
 
         montant = famille('reduction_loyer_solidarite_montant', period)
         return (ressources < plafond) * montant * (statut_occupation_logement == TypesStatutOccupationLogement.locataire_hlm)

--- a/openfisca_france/model/prestations/reduction_loyer_solidarite.py
+++ b/openfisca_france/model/prestations/reduction_loyer_solidarite.py
@@ -109,6 +109,9 @@ class reduction_loyer_solidarite(Variable):
         ressources = famille('aide_logement_base_ressources', period) / 12
         plafond = famille('reduction_loyer_solidarite_plafond_ressources', period)
         statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
+        logement_conventionne = famille.demandeur.menage('logement_conventionne', period)
+        locataire_foyer = statut_occupation_logement == TypesStatutOccupationLogement.locataire_foyer
 
+        eligible = (ressources < plafond) * logement_conventionne * not_(locataire_foyer)
         montant = famille('reduction_loyer_solidarite_montant', period)
-        return (ressources < plafond) * montant * (statut_occupation_logement == TypesStatutOccupationLogement.locataire_hlm)
+        return eligible * montant

--- a/openfisca_france/model/prestations/reduction_loyer_solidarite.py
+++ b/openfisca_france/model/prestations/reduction_loyer_solidarite.py
@@ -103,7 +103,7 @@ class reduction_loyer_solidarite(Variable):
         ]
     definition_period = MONTH
 
-    def formula(famille, period):
+    def formula_2018_01_01(famille, period):
         # les ressources renvoyés sont recombiné pour donner une valeur annuelle
         # necessité de diviser par 12 pour comparer au plafond mensuel
         ressources = famille('aide_logement_base_ressources', period) / 12

--- a/openfisca_france/model/prestations/reduction_loyer_solidarite.py
+++ b/openfisca_france/model/prestations/reduction_loyer_solidarite.py
@@ -95,7 +95,7 @@ class reduction_loyer_solidarite_montant(Variable):
 class reduction_loyer_solidarite(Variable):
     value_type = float
     entity = Famille
-    label = u"Éligibilibité à la réduction du loyer de solidarité"
+    label = u"Réduction du loyer de solidarité effectivement versée"
     reference = [
         u"https://www.anil.org/aj-reduction-loyer-solidarite-rls-apl/",
         u"https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036650010&dateTexte=&categorieLien=id",
@@ -108,6 +108,8 @@ class reduction_loyer_solidarite(Variable):
         # necessité de diviser par 12 pour comparer au plafond mensuel
         ressources = famille('aide_logement_base_ressources', period) / 12
         plafond = famille('reduction_loyer_solidarite_plafond_ressources', period)
+        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period) 
+        
 
         montant = famille('reduction_loyer_solidarite_montant', period)
-        return (ressources < plafond) * montant
+        return (ressources < plafond) * montant * (statut_occupation_logement == TypesStatutOccupationLogement.locataire_hlm)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "32.0.0",
+    version = "32.0.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/aides_logement_2018.yaml
+++ b/tests/formulas/aides_logement_2018.yaml
@@ -24,6 +24,7 @@
   period: 2018-04
   relative_error_margin: 0.001
   input_variables:
+    statut_occupation_logement: locataire_hlm
     logement_conventionne: true
     aide_logement_loyer_retenu: 100
     aide_logement_charges: 0

--- a/tests/formulas/aides_logement_2018.yaml
+++ b/tests/formulas/aides_logement_2018.yaml
@@ -24,7 +24,6 @@
   period: 2018-04
   relative_error_margin: 0.001
   input_variables:
-    statut_occupation_logement: locataire_hlm
     logement_conventionne: true
     aide_logement_loyer_retenu: 100
     aide_logement_charges: 0

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -304,8 +304,8 @@
   input_variables:
     zone_apl: zone_1
     aide_logement_montant_brut: 100
-    statut_occupation_logement:
-      2017-12: locataire_hlm
+    logement_conventionne:
+      2017-12: true
     aide_logement_base_ressources: 900
     minima_sociaux:
       2017: 5000
@@ -325,9 +325,9 @@
   input_variables:
     zone_apl: zone_1
     aide_logement_montant_brut: 100
-    statut_occupation_logement:
-      2018-01: locataire_hlm
-      2018-02: non_renseigne
+    logement_conventionne:
+      2018-01: true
+      2018-02: false
     aide_logement_base_ressources: 900
     minima_sociaux:
       2018: 5000

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -305,8 +305,7 @@
     zone_apl: zone_1
     aide_logement_montant_brut: 100
     statut_occupation_logement:
-      2018-01: locataire_hlm
-      2018-02: non_renseigne
+      2017-12: locataire_hlm
     aide_logement_base_ressources: 900
     minima_sociaux:
       2017: 5000
@@ -326,7 +325,7 @@
   input_variables:
     zone_apl: zone_1
     aide_logement_montant_brut: 100
-    statut_occupation_logement: 
+    statut_occupation_logement:
       2018-01: locataire_hlm
       2018-02: non_renseigne
     aide_logement_base_ressources: 900

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -297,3 +297,47 @@
     irpp: 0
     impots_directs: -0.19*100000
     # revenu_disponible: 100000*(1-(0.19+0.045+0.02+0.003+0.005+0.099))
+
+- name: Revenu disponible avec APL avant RLS
+  absolute_error_margin: 0.1
+  period: 2017-12
+  input_variables:
+    zone_apl: zone_1
+    aide_logement_montant_brut: 100
+    statut_occupation_logement:
+      2018-01: locataire_hlm
+      2018-02: non_renseigne
+    aide_logement_base_ressources: 900
+    minima_sociaux:
+      2017: 5000
+  output_variables:
+    apl:
+      2017-12: 99.5
+    revenu_disponible:
+      2017: 5099.5
+    prestations_sociales:
+      2017: 5099.5
+    aides_logement:
+      2017: 99.5
+
+- name: Revenu disponible avec APL après RLS
+  absolute_error_margin: 0.1
+  period: 2018-01
+  input_variables:
+    zone_apl: zone_1
+    aide_logement_montant_brut: 100
+    statut_occupation_logement: 
+      2018-01: locataire_hlm
+      2018-02: non_renseigne
+    aide_logement_base_ressources: 900
+    minima_sociaux:
+      2018: 5000
+  output_variables:
+    apl: 68.45
+    reduction_loyer_solidarite: 31.83
+    revenu_disponible:
+      2018: 5100.28
+    prestations_sociales:
+      2018: 5100.28
+    aides_logement:
+      2018: 68.45

--- a/tests/formulas/rls.yaml
+++ b/tests/formulas/rls.yaml
@@ -1,6 +1,7 @@
 - name: Zone 2 isolé
   period: 2018-01
   input_variables:
+    statut_occupation_logement: locataire_hlm
     zone_apl: zone_2
     aide_logement_base_ressources: 100
   output_variables:
@@ -10,6 +11,7 @@
 - name: Zone 2 avec 8 personnes à charges
   period: 2018-01
   input_variables:
+    statut_occupation_logement: locataire_hlm
     zone_apl: zone_2
     al_nb_personnes_a_charge: 8
     aide_logement_base_ressources: 100
@@ -20,6 +22,7 @@
 - name: Zone 1 isolé
   period: 2018-01
   input_variables:
+    statut_occupation_logement: locataire_hlm
     aide_logement_base_ressources: 100
     zone_apl: zone_1
   output_variables:
@@ -29,6 +32,7 @@
 - name: Zone 1 avec 8 personnes à charges
   period: 2018-01
   input_variables:
+    statut_occupation_logement: locataire_hlm
     zone_apl: zone_1
     al_nb_personnes_a_charge: 8
     aide_logement_base_ressources: 100
@@ -39,6 +43,7 @@
 - name: Zone 3 isolé
   period: 2018-01
   input_variables:
+    statut_occupation_logement: locataire_hlm
     aide_logement_base_ressources: 100
     zone_apl: zone_3
   output_variables:
@@ -48,6 +53,7 @@
 - name: Zone 3 avec 8 personnes à charges
   period: 2018-01
   input_variables:
+    statut_occupation_logement: locataire_hlm
     zone_apl: zone_3
     al_nb_personnes_a_charge: 8
     aide_logement_base_ressources: 100

--- a/tests/formulas/rls.yaml
+++ b/tests/formulas/rls.yaml
@@ -1,7 +1,7 @@
 - name: Zone 2 isolé
   period: 2018-01
   input_variables:
-    statut_occupation_logement: locataire_hlm
+    logement_conventionne: true
     zone_apl: zone_2
     aide_logement_base_ressources: 100
   output_variables:
@@ -11,7 +11,7 @@
 - name: Zone 2 avec 8 personnes à charges
   period: 2018-01
   input_variables:
-    statut_occupation_logement: locataire_hlm
+    logement_conventionne: true
     zone_apl: zone_2
     al_nb_personnes_a_charge: 8
     aide_logement_base_ressources: 100
@@ -22,7 +22,7 @@
 - name: Zone 1 isolé
   period: 2018-01
   input_variables:
-    statut_occupation_logement: locataire_hlm
+    logement_conventionne: true
     aide_logement_base_ressources: 100
     zone_apl: zone_1
   output_variables:
@@ -32,7 +32,7 @@
 - name: Zone 1 avec 8 personnes à charges
   period: 2018-01
   input_variables:
-    statut_occupation_logement: locataire_hlm
+    logement_conventionne: true
     zone_apl: zone_1
     al_nb_personnes_a_charge: 8
     aide_logement_base_ressources: 100
@@ -43,7 +43,7 @@
 - name: Zone 3 isolé
   period: 2018-01
   input_variables:
-    statut_occupation_logement: locataire_hlm
+    logement_conventionne: true
     aide_logement_base_ressources: 100
     zone_apl: zone_3
   output_variables:
@@ -53,7 +53,7 @@
 - name: Zone 3 avec 8 personnes à charges
   period: 2018-01
   input_variables:
-    statut_occupation_logement: locataire_hlm
+    logement_conventionne: true
     zone_apl: zone_3
     al_nb_personnes_a_charge: 8
     aide_logement_base_ressources: 100


### PR DESCRIPTION
Suite à la mise en place de la réduction de loyer de solidarité (RLS), les familles qui bénéficient de cette réduction voient leur montant d'aide au logement diminuer de 98% de leur RLS. 

- La RLS et la baisse d'aides au logment associée sont simulés dans OpenFisca.
- Mais la RLS n'est pas prise en compte dans le calcul du revenu disponible. Cette réforme fait donc baisser artificiellement le revenu disponible des ménages locataires (via la baisse des aides au logement) dans les simulations OpenFisca alors que dans la réalité elle est quasi neutre pour les ménages locataires.

1) Pour bien prendre en compte les effets de la mise en place de la RLS, on propose de la rajouter dans la variable `prestations_sociales`.
2) On propose également de préciser l'éligibilité à la RLS au sein de la formule `reduction_loyer_solidarite` 

En effet, la RLS est réservée aux familles locataires dans le parc social (éligibles aux APL). La formule de la variable `reduction_loyer_solidarite` est aujourd'hui calculée pour toutes les familles dont la base ressources AL est inférieure à un certain plafond, ce qui est plus large que la varie éligibilité. Cela ne posait pas de problèmes jusqu'ici, puisque la RLS n'était utilisée que dans le calcul de la baisse des aides au logement associée (et on prenait bien en compte le fait que cette baisse ne s'appliquait qu'aux locataires HLM, cf. formule `aide_logement_montant_brut_crds`) mais désormais il faut s'assurer qu'elle n'est calculée que pour les familles éligibles.

* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2018
* Zones impactées : 
  - `model/mesures.py`
  - `model/prestations/reduction_loyer_solidarite.py`
  - `tests/formulas/rls.yaml`
* Détails :
  - Ajoute la RLS au montant des prestations sociales
  - Ajoute une start date à la RLS et restreint le calcul de la RLS aux familles éligibles
  - Update les tests en ce sens

- - - -

Ces changements :

- Modifient l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).
- Corrigent ou améliorent un calcul déjà existant.
