### PR TITLE
Privilégie la notion de logement conventionné pour la détermination du secteur APL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# 32.0.0 [#1223](https://github.com/openfisca/openfisca-france/pull/1223)
+
+* Évolution de la législation **non rétrocompatible**
+* Périodes concernées : toutes.
+* Zones impactées : `prestations/aides_logement`.
+* Détails :
+  - Privilégie la notion de logement conventionné pour la détermination du secteur APL
+  - Les clients qui s'appuient sur `locataire_hlm` doivent utiliser `logement_conventionne`
+
 ### 31.2.1 [#1222](https://github.com/openfisca/openfisca-france/pull/1222)
 
 * Changement mineur.

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -115,9 +115,10 @@ class aide_logement_montant_brut_crds(Variable):
         aide_logement_montant_brut = famille('aide_logement_montant_brut', period)
         reduction_loyer_solidarite = famille('reduction_loyer_solidarite', period)
         logement_conventionne = famille.demandeur.menage('logement_conventionne', period)
+        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
 
         taux_rls = rls.fraction_baisse_aide_logement
-        rls_apl = reduction_loyer_solidarite * taux_rls * logement_conventionne
+        rls_apl = reduction_loyer_solidarite * taux_rls * logement_conventionne * (statut_occupation_logement != TypesStatutOccupationLogement.locataire_foyer)
         montant = max_(0, (aide_logement_montant_brut - rls_apl))
         return montant
 

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -118,7 +118,8 @@ class aide_logement_montant_brut_crds(Variable):
         statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
 
         taux_rls = rls.fraction_baisse_aide_logement
-        rls_apl = reduction_loyer_solidarite * taux_rls * logement_conventionne * (statut_occupation_logement != TypesStatutOccupationLogement.locataire_foyer)
+        condition_rls = logement_conventionne * (statut_occupation_logement != TypesStatutOccupationLogement.locataire_foyer)
+        rls_apl = reduction_loyer_solidarite * taux_rls * condition_rls
         montant = max_(0, (aide_logement_montant_brut - rls_apl))
         return montant
 

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -52,6 +52,7 @@ class apl(Variable):
 
         return aide_logement_montant * logement_conventionne
 
+
 class als(Variable):
     calculate_output = calculate_output_add
     value_type = float
@@ -68,6 +69,7 @@ class als(Variable):
         logement_conventionne = famille.demandeur.menage('logement_conventionne', period)
 
         return (al_nb_pac == 0) * not_(logement_conventionne) * not_(proprietaire_proche_famille) * aide_logement_montant
+
 
 class alf(Variable):
     calculate_output = calculate_output_add

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -48,10 +48,9 @@ class apl(Variable):
 
     def formula(famille, period):
         aide_logement_montant = famille('aide_logement_montant', period)
-        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
+        logement_conventionne = famille.demandeur.menage('logement_conventionne', period)
 
-        return aide_logement_montant * ((statut_occupation_logement == TypesStatutOccupationLogement.locataire_hlm) + (statut_occupation_logement == TypesStatutOccupationLogement.locataire_foyer))
-
+        return aide_logement_montant * logement_conventionne
 
 class als(Variable):
     calculate_output = calculate_output_add
@@ -65,16 +64,10 @@ class als(Variable):
     def formula(famille, period):
         aide_logement_montant = famille('aide_logement_montant', period)
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
-        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
         proprietaire_proche_famille = famille('proprietaire_proche_famille', period)
+        logement_conventionne = famille.demandeur.menage('logement_conventionne', period)
 
-        return (
-            (al_nb_pac == 0)
-            * (statut_occupation_logement != TypesStatutOccupationLogement.locataire_hlm)
-            * not_(proprietaire_proche_famille)
-            * aide_logement_montant
-            )
-
+        return (al_nb_pac == 0) * not_(logement_conventionne) * not_(proprietaire_proche_famille) * aide_logement_montant
 
 class alf(Variable):
     calculate_output = calculate_output_add
@@ -88,15 +81,10 @@ class alf(Variable):
     def formula(famille, period):
         aide_logement_montant = famille('aide_logement_montant', period)
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
-        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
         proprietaire_proche_famille = famille('proprietaire_proche_famille', period)
+        logement_conventionne = famille.demandeur.menage('logement_conventionne', period)
 
-        return (
-            (al_nb_pac >= 1)
-            * (statut_occupation_logement != TypesStatutOccupationLogement.locataire_hlm)
-            * not_(proprietaire_proche_famille)
-            * aide_logement_montant
-            )
+        return (al_nb_pac >= 1) * not_(logement_conventionne) * not_(proprietaire_proche_famille) * aide_logement_montant
 
 
 class aide_logement_montant(Variable):
@@ -124,11 +112,10 @@ class aide_logement_montant_brut_crds(Variable):
         rls = parameters(period).prestations.reduction_loyer_solidarite
         aide_logement_montant_brut = famille('aide_logement_montant_brut', period)
         reduction_loyer_solidarite = famille('reduction_loyer_solidarite', period)
-        statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
+        logement_conventionne = famille.demandeur.menage('logement_conventionne', period)
 
         taux_rls = rls.fraction_baisse_aide_logement
-        locataire_hlm = statut_occupation_logement == TypesStatutOccupationLogement.locataire_hlm
-        rls_apl = reduction_loyer_solidarite * taux_rls * locataire_hlm
+        rls_apl = reduction_loyer_solidarite * taux_rls * logement_conventionne
         montant = max_(0, (aide_logement_montant_brut - rls_apl))
         return montant
 
@@ -211,8 +198,8 @@ class aide_logement_montant_brut_avant_degressivite(Variable):
         montant = select([locataire, accedant + locataire_logement_foyer],
                          [montant_locataire, montant_accedant_et_foyer])
 
-        apl = (statut_occupation_logement == TypesStatutOccupationLogement.locataire_hlm)
-        type_aide = where(apl, 'apl', 'non_apl', )
+        logement_conventionne = famille.demandeur.menage('logement_conventionne', period)
+        type_aide = where(logement_conventionne, 'apl', 'non_apl', )
         seuil_versement = al.al_min.montant_min_mensuel.montant_min_apl_al[type_aide]
         minimum_atteint = montant >= seuil_versement
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "31.2.1",
+    version = "32.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/aides_logement_2018.yaml
+++ b/tests/formulas/aides_logement_2018.yaml
@@ -25,7 +25,7 @@
   relative_error_margin: 0.001
   input_variables:
     statut_occupation_logement: locataire_hlm
-    logement_conventionne: 1
+    logement_conventionne: true
     aide_logement_loyer_retenu: 100
     aide_logement_charges: 0
     aide_logement_participation_personnelle: 95

--- a/tests/formulas/aides_logement_2018.yaml
+++ b/tests/formulas/aides_logement_2018.yaml
@@ -24,7 +24,7 @@
   period: 2018-04
   relative_error_margin: 0.001
   input_variables:
-    statut_occupation_logement: locataire_hlm
+    logement_conventionne: 1
     aide_logement_loyer_retenu: 100
     aide_logement_charges: 0
     aide_logement_participation_personnelle: 95

--- a/tests/formulas/aides_logement_2018.yaml
+++ b/tests/formulas/aides_logement_2018.yaml
@@ -24,6 +24,7 @@
   period: 2018-04
   relative_error_margin: 0.001
   input_variables:
+    statut_occupation_logement: locataire_hlm
     logement_conventionne: 1
     aide_logement_loyer_retenu: 100
     aide_logement_charges: 0

--- a/tests/formulas/aides_logement_foyer.yaml
+++ b/tests/formulas/aides_logement_foyer.yaml
@@ -2,12 +2,12 @@
   period: 2017-10
   relative_error_margin: 0.02
   input_variables:
-    etudiant: 1
+    etudiant: true
     loyer: 200
     zone_apl: zone_2
     statut_occupation_logement: locataire_foyer
     etat_logement_foyer: logement_rehabilite
-    logement_crous: 1
+    logement_crous: true
   output_variables:
     aide_logement_charges: 53.67 # C
     aides_logement_k: 0.67 # K
@@ -20,14 +20,14 @@
   period: 2017-10
   relative_error_margin: 0.02
   input_variables:
-    etudiant: 1
-    logement_crous: 1
+    etudiant: true
+    logement_crous: true
     loyer: 150
     zone_apl: zone_3
     statut_occupation_logement: locataire_foyer
-    logement_chambre: 1
+    logement_chambre: true
     etat_logement_foyer: logement_rehabilite
-    boursier: 1
+    boursier: true
   output_variables:
     aide_logement_charges: 53.67 # C
     aides_logement_k: 0.7 # K
@@ -40,14 +40,14 @@
   period: 2017-10
   relative_error_margin: 0.02
   input_variables:
-    etudiant: 1
-    logement_crous: 1
+    etudiant: true
+    logement_crous: true
     loyer: 150
     zone_apl: zone_3
     statut_occupation_logement: locataire_foyer
-    logement_chambre: 1
-    logement_conventionne: 1
-    boursier: 1
+    logement_chambre: true
+    logement_conventionne: true
+    boursier: true
   output_variables:
     aide_logement_charges: 53.67 # C
     aides_logement_k: 0.77 # K
@@ -88,8 +88,8 @@
       2017: 9000
       2016: 9000
       2015: 9000
-    logement_conventionne: 1
-    logement_chambre: 1
+    logement_conventionne: true
+    logement_chambre: true
   output_variables:
     aide_logement_charges: 53.67 # C
     aides_logement_k: 0.6 # K

--- a/tests/formulas/rls_apl.yaml
+++ b/tests/formulas/rls_apl.yaml
@@ -4,7 +4,7 @@
   input_variables:
     zone_apl: zone_1
     aide_logement_montant_brut: 27
-    logement_conventionne: 1
+    logement_conventionne: true
     aide_logement_base_ressources: 900
   output_variables:
     apl: 0
@@ -16,7 +16,7 @@
   input_variables:
     zone_apl: zone_1
     aide_logement_montant_brut: 0
-    logement_conventionne: 1
+    logement_conventionne: true
     aide_logement_base_ressources: 900
   output_variables:
     apl: 0
@@ -28,7 +28,7 @@
   input_variables:
     zone_apl: zone_1
     aide_logement_montant_brut: 100
-    logement_conventionne: 1
+    logement_conventionne: true
     aide_logement_base_ressources: 900
   output_variables:
     apl: 68.45
@@ -47,7 +47,7 @@
   menages:
     personne_de_reference: "parent1"
     depcom: 31555
-    logement_conventionne: 1
+    logement_conventionne: true
     loyer: 500
     charges_locatives: 50
   output_variables:
@@ -68,7 +68,7 @@
   menages:
     personne_de_reference: "parent1"
     depcom: 31555
-    logement_conventionne: 1
+    logement_conventionne: true
     loyer: 500
     charges_locatives: 50
   output_variables:

--- a/tests/formulas/rls_apl.yaml
+++ b/tests/formulas/rls_apl.yaml
@@ -4,7 +4,7 @@
   input_variables:
     zone_apl: zone_1
     aide_logement_montant_brut: 27
-    statut_occupation_logement: locataire_hlm
+    logement_conventionne: 1
     aide_logement_base_ressources: 900
   output_variables:
     apl: 0
@@ -16,7 +16,7 @@
   input_variables:
     zone_apl: zone_1
     aide_logement_montant_brut: 0
-    statut_occupation_logement: locataire_hlm
+    logement_conventionne: 1
     aide_logement_base_ressources: 900
   output_variables:
     apl: 0
@@ -28,7 +28,7 @@
   input_variables:
     zone_apl: zone_1
     aide_logement_montant_brut: 100
-    statut_occupation_logement: locataire_hlm
+    logement_conventionne: 1
     aide_logement_base_ressources: 900
   output_variables:
     apl: 68.45
@@ -47,7 +47,7 @@
   menages:
     personne_de_reference: "parent1"
     depcom: 31555
-    statut_occupation_logement: locataire_hlm
+    logement_conventionne: 1
     loyer: 500
     charges_locatives: 50
   output_variables:
@@ -68,7 +68,7 @@
   menages:
     personne_de_reference: "parent1"
     depcom: 31555
-    statut_occupation_logement: locataire_hlm
+    logement_conventionne: 1
     loyer: 500
     charges_locatives: 50
   output_variables:


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `model/prestations/aides_logement`.
* Détails :
  - Remplace la notion locataire_hlm par la notion de logement_conventionne dans les formules où la variable locataire_hlm est utilisée à la place de la variable logement_conventionné.