### PR TITLE
Ajoute de valeurs manquantes pour les paramètres de l'aide au logement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 32.1.0 [#1225](https://github.com/openfisca/openfisca-france/pull/1225)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2014 jusqu'au 01/01/2017.
+* Zones impactées : `parameters/prestations/aides_logement`.
+* Détails :
+  - Ajout d'anciennes valeurs manquantes pour les paramètres de l'aide au logement
+
 ### 32.0.1 [#1217](https://github.com/openfisca/openfisca-france/pull/1217)
 
 * Correction mineure.

--- a/openfisca_france/parameters/prestations/aides_logement/autres/nr_seuil.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/autres/nr_seuil.yaml
@@ -5,5 +5,8 @@ values:
     value: 16.0
   2011-01-01:
     value: 21.0
-  2018-01-01:
+  2014-01-01:
+    value: 22.0
+  2017-01-01:
     value: 23.0
+    reference: https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=481E3574E9A301CED3336AF168A5EF33.tplgfr44s_1?idArticle=LEGIARTI000035671411&cidTexte=LEGITEXT000006073189&categorieLien=id&dateTexte=

--- a/openfisca_france/parameters/prestations/aides_logement/participation_min/montant_forfaitaire.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/participation_min/montant_forfaitaire.yaml
@@ -26,6 +26,9 @@ values:
     value: 34.53
   2014-10-01:
     value: 34.73
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/affichTexte.do;jsessionid=6266F81B53CA2E899FB2ED7741308B21.tplgfr43s_2?idSectionTA=LEGISCTA000006108548&cidTexte=JORFTEXT000000838203&dateTexte=20160122
+    value: 34.76
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_2
     value: 35.02

--- a/openfisca_france/parameters/prestations/aides_logement/ressources/dar_8.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/ressources/dar_8.yaml
@@ -15,6 +15,14 @@ values:
     value: 1248.55
   2013-01-01:
     value: 1273.52
+  2014-01-01:
+    value: 1283.71
+  2015-01-01:
+    value: 1290.13
+  2016-01-01:
+    value: 1291.42
+  2017-01-01:
+    value: 1292.71
   2018-01-01:
     value: 1305.64
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/12/29/TERL1732837A/jo/texte

--- a/openfisca_france/parameters/prestations/aides_logement/ressources/dar_9.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/ressources/dar_9.yaml
@@ -15,6 +15,14 @@ values:
     value: 1872.83
   2013-01-01:
     value: 1910.29
+  2014-01-01:
+    value: 1925.57
+  2015-01-01:
+    value: 1935.20
+  2016-01-01:
+    value: 1937.14
+  2017-01-01:
+    value: 1939.08
   2018-01-01:
     value: 1958.47
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/12/29/TERL1732837A/jo/texte

--- a/openfisca_france/parameters/prestations/aides_logement/ressources/efress/dar_2a.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/ressources/efress/dar_2a.yaml
@@ -27,5 +27,8 @@ values:
     value: 9541.0
   2015-01-01:
     value: 9571.45
+  2016-01-01:
+    reference: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694502&cidTexte=LEGITEXT000006073189&dateTexte=20181012&oldAction=rechCodeArticle&fastReqId=1024869826&nbResultRech=1
+    value: 9672.95
   2017-10-01:
     value: 9754.15

--- a/openfisca_france/parameters/prestations/aides_logement/ressources/efress/dar_2b.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/ressources/efress/dar_2b.yaml
@@ -28,5 +28,12 @@ values:
     value: 14100.0
   2013-07-01:
     value: 14145.0
+  2014-07-01:
+    value: 114295.0
+  2015-07-01:
+    value: 14415.0
+  2016-07-01:
+    reference: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694502&cidTexte=LEGITEXT000006073189&dateTexte=20181012&oldAction=rechCodeArticle&fastReqId=1024869826&nbResultRech=1
+    value: 14505.0
   2017-10-01:
     value: 14640.0

--- a/openfisca_france/parameters/prestations/al_etudiant/autres_dont_les_etudiants_en_chambres_rehabilitees_de_residences_universitaires/menages.yaml
+++ b/openfisca_france/parameters/prestations/al_etudiant/autres_dont_les_etudiants_en_chambres_rehabilitees_de_residences_universitaires/menages.yaml
@@ -19,6 +19,9 @@ values:
     value: 258.09
   2014-10-01:
     value: 259.56
+  2015-10-01:
+  reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_1
+    value: 259.77
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11
     value: 261.72

--- a/openfisca_france/parameters/prestations/al_etudiant/autres_dont_les_etudiants_en_chambres_rehabilitees_de_residences_universitaires/menages.yaml
+++ b/openfisca_france/parameters/prestations/al_etudiant/autres_dont_les_etudiants_en_chambres_rehabilitees_de_residences_universitaires/menages.yaml
@@ -20,7 +20,7 @@ values:
   2014-10-01:
     value: 259.56
   2015-10-01:
-  reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_1
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_1
     value: 259.77
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11

--- a/openfisca_france/parameters/prestations/al_etudiant/autres_dont_les_etudiants_en_chambres_rehabilitees_de_residences_universitaires/personnes_isolees.yaml
+++ b/openfisca_france/parameters/prestations/al_etudiant/autres_dont_les_etudiants_en_chambres_rehabilitees_de_residences_universitaires/personnes_isolees.yaml
@@ -19,6 +19,9 @@ values:
     value: 166.06
   2014-10-01:
     value: 167.01
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_1
+    value: 167.14
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11
     value: 168.39

--- a/openfisca_france/parameters/prestations/al_etudiant/loyer_considere_comme_paye_par_les_etudiants_logeant_en_residence_universitaire/menages.yaml
+++ b/openfisca_france/parameters/prestations/al_etudiant/loyer_considere_comme_paye_par_les_etudiants_logeant_en_residence_universitaire/menages.yaml
@@ -35,6 +35,9 @@ values:
     value: 127.88
   2014-10-01:
     value: 128.61
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_1
+    value: 128.71
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11
     value: 129.68

--- a/openfisca_france/parameters/prestations/al_etudiant/loyer_considere_comme_paye_par_les_etudiants_logeant_en_residence_universitaire/personnes_isolees.yaml
+++ b/openfisca_france/parameters/prestations/al_etudiant/loyer_considere_comme_paye_par_les_etudiants_logeant_en_residence_universitaire/personnes_isolees.yaml
@@ -35,6 +35,9 @@ values:
     value: 82.13
   2014-10-01:
     value: 82.6
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_1
+    value: 82.67
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11
     value: 83.29

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_1_enfant.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_1_enfant.yaml
@@ -41,6 +41,9 @@ values:
     value: 401.01
   2014-09-01:
     value: 403.3
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 403.62
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 406.65

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_2_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_2_enfants.yaml
@@ -41,6 +41,9 @@ values:
     value: 412.22
   2014-09-01:
     value: 414.57
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 414.9
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 418.01

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_3_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_3_enfants.yaml
@@ -41,6 +41,9 @@ values:
     value: 423.81
   2014-09-01:
     value: 426.23
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 426.57
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 429.77

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_4_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_4_enfants.yaml
@@ -41,6 +41,9 @@ values:
     value: 435.18
   2014-09-01:
     value: 437.66
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 438.01
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 441.3

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_5_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_5_enfants.yaml
@@ -41,6 +41,9 @@ values:
     value: 444.4
   2014-09-01:
     value: 446.93
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 447.29
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 450.64

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_par_enfant_en_plus.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_par_enfant_en_plus.yaml
@@ -39,6 +39,9 @@ values:
     value: 38.7
   2014-09-01:
     value: 38.92
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 38.95
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 39.24

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_seul.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_seul.yaml
@@ -41,6 +41,9 @@ values:
     value: 372.95
   2014-09-01:
     value: 375.08
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 375.38
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 378.2

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/personne_isolee_sans_enfant.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/personne_isolee_sans_enfant.yaml
@@ -25,6 +25,9 @@ values:
     value: 309.47
   2014-09-01:
     value: 311.23
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 311.48
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 313.82

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_1_enfant.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_1_enfant.yaml
@@ -41,6 +41,9 @@ values:
     value: 360.3
   2014-09-01:
     value: 362.35
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 362.64
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 365.36

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_2_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_2_enfants.yaml
@@ -41,6 +41,9 @@ values:
     value: 372.78
   2014-09-01:
     value: 374.9
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 375.2
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 378.01

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_3_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_3_enfants.yaml
@@ -41,6 +41,9 @@ values:
     value: 385.63
   2014-09-01:
     value: 387.83
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 388.14
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 391.05

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_4_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_4_enfants.yaml
@@ -41,6 +41,9 @@ values:
     value: 398.29
   2014-09-01:
     value: 400.56
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 400.88
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 403.89

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_5_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_5_enfants.yaml
@@ -41,6 +41,9 @@ values:
     value: 426.49
   2014-09-01:
     value: 428.92
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 429.26
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 432.48

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_par_enfant_en_plus.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_par_enfant_en_plus.yaml
@@ -39,6 +39,9 @@ values:
     value: 37.08
   2014-09-01:
     value: 37.29
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 37.32
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 37.6

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_seul.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_seul.yaml
@@ -41,6 +41,9 @@ values:
     value: 332.83
   2014-09-01:
     value: 334.73
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 335.0
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 337.51

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/personne_isolee_sans_enfant.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/personne_isolee_sans_enfant.yaml
@@ -25,6 +25,9 @@ values:
     value: 271.49
   2014-09-01:
     value: 273.04
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 273.26
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 275.31

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_1_enfant.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_1_enfant.yaml
@@ -41,6 +41,9 @@ values:
     value: 336.79
   2014-09-01:
     value: 338.71
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 338.98
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 341.52

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_2_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_2_enfants.yaml
@@ -41,6 +41,9 @@ values:
     value: 350.71
   2014-09-01:
     value: 352.71
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 352.99
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 355.64

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_3_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_3_enfants.yaml
@@ -41,6 +41,9 @@ values:
     value: 364.84
   2014-09-01:
     value: 366.92
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 367.21
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 369.96

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_4_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_4_enfants.yaml
@@ -41,6 +41,9 @@ values:
     value: 378.74
   2014-09-01:
     value: 380.9
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 381.2
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 384.06

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_5_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_5_enfants.yaml
@@ -41,6 +41,9 @@ values:
     value: 406.96
   2014-09-01:
     value: 409.28
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 409.61
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 412.68

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_par_enfant_en_plus.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_par_enfant_en_plus.yaml
@@ -39,6 +39,9 @@ values:
     value: 35.28
   2014-09-01:
     value: 35.48
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 35.51
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 35.78

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_seul.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_seul.yaml
@@ -41,6 +41,9 @@ values:
     value: 308.91
   2014-09-01:
     value: 310.67
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 310.92
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 313.25

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/personne_isolee_sans_enfant.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/personne_isolee_sans_enfant.yaml
@@ -25,6 +25,9 @@ values:
     value: 254.69
   2014-09-01:
     value: 256.14
+  2015-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2015/10/16/AFSS1524789A/jo/article_2
+    value: 256.34
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 258.26

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "32.0.1",
+    version = "32.1.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2014 jusqu'au 01/01/2017.
* Zones impactées : `parameters/prestations/aides_logement`.
* Détails :
  - Ajout d'anciennes valeurs manquantes pour les paramètres de l'aide au logement

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.