### PR TITLE
Corrige la date d'application des nouveaux barèmes de la PPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 32.2.1 [#1230](https://github.com/openfisca/openfisca-france/pull/1230)
+
+* Correction mineure.
+* Périodes concernées : à partir du 01/08/2018
+* Zones impactées :
+  - `prestations/minima_sociaux/ppa`
+* Détails :
+  - Corrige la date d'effet de paramètres de la prime d'activité
+
 ## 32.2.0 [#1224](https://github.com/openfisca/openfisca-france/pull/1224)
 
 * Amélioration technique.

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/montant_de_base.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/montant_de_base.yaml
@@ -13,6 +13,6 @@ values:
   2018-04-01:
     value: 531.51
     reference: https://www.legifrance.gouv.fr/eli/decret/2018/5/3/SSAA1805962D/jo/texte
-  2018-10-01:
+  2018-08-01:
     value: 551.51
     reference: https://www.legifrance.gouv.fr/eli/decret/2018/10/3/SSAA1822062D/jo/texte

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/pente.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/pente.yaml
@@ -4,6 +4,6 @@ unit: /1
 values:
   2016-01-01:
     value: 0.62
-  2018-10-01:
+  2018-08-01:
     value: 0.61
     reference: Décret n° 2018-836 - https://www.legifrance.gouv.fr/eli/decret/2018/10/3/SSAA1822062D/jo/texte

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "32.2.0",
+    version = "32.2.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
### 32.2.1 [#1230](https://github.com/openfisca/openfisca-france/pull/1230)

* Correction mineure.
* Périodes concernées : à partir du 01/08/2018
* Zones impactées :
  - `parameters/prestations/minima_sociaux/ppa/montant_de_base`
* Détails :
  - Corrige la date d'effet de paramètres de la prime d'activité

La date de mise à jour des paramètres dans [#1192](https://github.com/openfisca/openfisca-france/pull/1192/files) était 01/10/2018 mais le décret indique 01/08/2018 (enfin il indique août 2018).