### PR TITLE
Amélioration des calculs de prime d'activité

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 32.3.0 [#1232](https://github.com/openfisca/openfisca-france/pull/1232)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes pour la PPA c'est à dire à partir du 01/10/2015.
+* Zones impactées : `prestations/minima_sociaux/ppa`.
+* Détails :
+  - Fiabilise le calcul de la PPA en remplaçant par de nouvelles variables dont `ppa_mois_demande` le mécanisme précédent.
+
 ### 32.2.1 [#1230](https://github.com/openfisca/openfisca-france/pull/1230)
 
 * Correction mineure.

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -350,18 +350,18 @@ class ppa_fictive(Variable):
     label = u"Prime pour l'activité fictive pour un mois"
     definition_period = MONTH
 
-    def formula(famille, period, parameters, mois_demande):
-        forfait_logement = famille('ppa_forfait_logement', mois_demande)
-        ppa_majoree_eligibilite = famille('rsa_majore_eligibilite', mois_demande)
+    def formula(famille, period, parameters):
+        forfait_logement = famille('ppa_forfait_logement', period)
+        ppa_majoree_eligibilite = famille('rsa_majore_eligibilite', period)
         # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
-        elig = famille('ppa_eligibilite', period, extra_params = [mois_demande])
-        pente = parameters(mois_demande).prestations.minima_sociaux.ppa.pente
-        mff_non_majore = famille('ppa_montant_forfaitaire_familial_non_majore', period, extra_params = [mois_demande])
-        mff_majore = famille('ppa_montant_forfaitaire_familial_majore', period, extra_params = [mois_demande])
+        elig = famille('ppa_eligibilite', period, extra_params = [period])
+        pente = parameters(period).prestations.minima_sociaux.ppa.pente
+        mff_non_majore = famille('ppa_montant_forfaitaire_familial_non_majore', period, extra_params = [period])
+        mff_majore = famille('ppa_montant_forfaitaire_familial_majore', period, extra_params = [period])
         montant_forfaitaire_familialise = where(ppa_majoree_eligibilite, mff_majore, mff_non_majore)
-        ppa_base_ressources = famille('ppa_base_ressources', period, extra_params = [mois_demande])
-        ppa_revenu_activite = famille('ppa_revenu_activite', period, extra_params = [mois_demande])
-        bonification_i = famille.members('ppa_bonification', period, extra_params = [mois_demande])
+        ppa_base_ressources = famille('ppa_base_ressources', period, extra_params = [period])
+        ppa_revenu_activite = famille('ppa_revenu_activite', period, extra_params = [period])
+        bonification_i = famille.members('ppa_bonification', period, extra_params = [period])
         bonification = famille.sum(bonification_i)
 
         ppa_montant_base = (
@@ -399,7 +399,7 @@ class ppa(Variable):
 
         ppa_eligibilite_etudiants = famille('ppa_eligibilite_etudiants', period)
         # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
-        ppa = famille('ppa_fictive', period.last_3_months, extra_params = [period], options = [ADD]) / 3
+        ppa = famille('ppa_fictive', period.last_3_months, options = [ADD]) / 3
         ppa = ppa * ppa_eligibilite_etudiants * (ppa >= seuil_non_versement)
 
         return ppa

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -185,7 +185,6 @@ class ppa_ressources_hors_activite(Variable):
 
     def formula(famille, period, parameters):
         aspa = famille('aspa', period)
-        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         pf = famille('ppa_base_ressources_prestations_familiales', period)
 
         ass_i = famille.members('ass', period)
@@ -217,7 +216,6 @@ class ppa_ressources_hors_activite_individu(Variable):
             'rsa_indemnites_journalieres_hors_activite',
             ]
 
-        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         ressources_hors_activite_mensuel_i = sum(individu(ressource, period) for ressource in ressources)
         revenus_activites = individu('ppa_revenu_activite_individu', period)
 
@@ -411,7 +409,6 @@ class ppa(Variable):
         # éligibilité étudiants
 
         ppa_eligibilite_etudiants = famille('ppa_eligibilite_etudiants', period)
-        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         ppa = famille('ppa_fictive', period.last_3_months, options = [ADD]) / 3
         ppa = ppa * ppa_eligibilite_etudiants * (ppa >= seuil_non_versement)
 

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -13,8 +13,8 @@ class ppa_eligibilite(Variable):
     label = u"Eligibilité à la PPA pour un mois"
     definition_period = MONTH
 
-    def formula(famille, period, parameters, mois_demande):
-        P = parameters(mois_demande).prestations
+    def formula(famille, period, parameters):
+        P = parameters(period).prestations
         age_min = P.minima_sociaux.ppa.age_min
         condition_age_i = famille.members('age', period) >= age_min
         condition_age = famille.any(condition_age_i)
@@ -42,8 +42,7 @@ class ppa_eligibilite_etudiants(Variable):
             )
 
         def condition_ressource(period2):
-            # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
-            revenu_activite = famille.members('ppa_revenu_activite_individu', period2, extra_params = [period])
+            revenu_activite = famille.members('ppa_revenu_activite_individu', period2)
             return revenu_activite > plancher_ressource
 
         m_1 = period.offset(-1, 'month')
@@ -68,11 +67,11 @@ class ppa_montant_forfaitaire_familial_non_majore(Variable):
     label = u"Montant forfaitaire familial (sans majoration)"
     definition_period = MONTH
 
-    def formula(famille, period, parameters, mois_demande):
+    def formula(famille, period, parameters):
         nb_parents = famille('nb_parents', period)
         nb_enfants = famille('rsa_nb_enfants', period)
         ppa_majoree_eligibilite = famille('rsa_majore_eligibilite', period)  # noqa F841
-        ppa = parameters(mois_demande).prestations.minima_sociaux.ppa
+        ppa = parameters(period).prestations.minima_sociaux.ppa
 
         nb_personnes = nb_parents + nb_enfants
 
@@ -95,9 +94,9 @@ class ppa_montant_forfaitaire_familial_majore(Variable):
     label = u"Montant forfaitaire familial (avec majoration)"
     definition_period = MONTH
 
-    def formula(famille, period, parameters, mois_demande):
+    def formula(famille, period, parameters):
         nb_enfants = famille('rsa_nb_enfants', period)
-        ppa = parameters(mois_demande).prestations.minima_sociaux.ppa
+        ppa = parameters(period).prestations.minima_sociaux.ppa
 
         taux_majore = (
             ppa.majoration_isolement_femme_enceinte
@@ -114,10 +113,9 @@ class ppa_revenu_activite(Variable):
     label = u"Revenu d'activité pris en compte pour la PPA"
     definition_period = MONTH
 
-    def formula(famille, period, parameters, mois_demande):
-        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
+    def formula(famille, period, parameters):
         ppa_revenu_activite_i = famille.members(
-            'ppa_revenu_activite_individu', period, extra_params = [mois_demande])
+            'ppa_revenu_activite_individu', period)
         ppa_revenu_activite = famille.sum(ppa_revenu_activite_i)
 
         return ppa_revenu_activite
@@ -129,8 +127,8 @@ class ppa_revenu_activite_individu(Variable):
     label = u"Revenu d'activité pris en compte pour la PPA (Individu) pour un mois"
     definition_period = MONTH
 
-    def formula(individu, period, parameters, mois_demande):
-        P = parameters(mois_demande)
+    def formula(individu, period, parameters):
+        P = parameters(period)
         smic_horaire = P.cotsoc.gen.smic_h_b
 
         ressources = [
@@ -144,7 +142,7 @@ class ppa_revenu_activite_individu(Variable):
 
         revenus_mensualises = sum(individu(ressource, period) for ressource in ressources)
 
-        revenus_tns_annualises = individu('ppa_rsa_derniers_revenus_tns_annuels_connus', mois_demande.this_year)
+        revenus_tns_annualises = individu('ppa_rsa_derniers_revenus_tns_annuels_connus', period.this_year)
 
         revenus_activites = revenus_mensualises + revenus_tns_annualises
 
@@ -185,13 +183,13 @@ class ppa_ressources_hors_activite(Variable):
     label = u"Revenu hors activité pris en compte pour la PPA"
     definition_period = MONTH
 
-    def formula(famille, period, parameters, mois_demande):
-        aspa = famille('aspa', mois_demande)
+    def formula(famille, period, parameters):
+        aspa = famille('aspa', period)
         # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
-        pf = famille('ppa_base_ressources_prestations_familiales', period, extra_params = [mois_demande])
+        pf = famille('ppa_base_ressources_prestations_familiales', period)
 
-        ass_i = famille.members('ass', mois_demande)
-        ressources_hors_activite_i = famille.members('ppa_ressources_hors_activite_individu', period, extra_params = [mois_demande])
+        ass_i = famille.members('ass', period)
+        ressources_hors_activite_i = famille.members('ppa_ressources_hors_activite_individu', period)
 
         return aspa + pf + famille.sum(ass_i + ressources_hors_activite_i)
 
@@ -202,8 +200,8 @@ class ppa_ressources_hors_activite_individu(Variable):
     label = u"Revenu hors activité pris en compte pour la PPA (Individu) pour un mois"
     definition_period = MONTH
 
-    def formula(individu, period, parameters, mois_demande):
-        P = parameters(mois_demande)
+    def formula(individu, period, parameters):
+        P = parameters(period)
         smic_horaire = P.cotsoc.gen.smic_h_b
 
         ressources = [
@@ -221,7 +219,7 @@ class ppa_ressources_hors_activite_individu(Variable):
 
         # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
         ressources_hors_activite_mensuel_i = sum(individu(ressource, period) for ressource in ressources)
-        revenus_activites = individu('ppa_revenu_activite_individu', period, extra_params = [mois_demande])
+        revenus_activites = individu('ppa_revenu_activite_individu', period)
 
         # L'aah est pris en compte comme revenu d'activité si  revenu d'activité hors aah > 29 * smic horaire brut
         seuil_aah_activite = P.prestations.minima_sociaux.ppa.seuil_aah_activite * smic_horaire
@@ -236,27 +234,23 @@ class ppa_base_ressources_prestations_familiales(Variable):
     label = u"Prestations familiales prises en compte dans le calcul de la PPA"
     definition_period = MONTH
 
-    def formula(famille, period, parameters, mois_demande):
-        prestations_calculees = [
-            'rsa_forfait_asf',
+    def formula(famille, period, parameters):
+        prestations = [
             'paje_base',
-            ]
-
-        prestations_autres = [
             'paje_clca',
             'paje_prepare',
             'paje_colca',
+            'rsa_forfait_asf'
             ]
 
-        result = sum(famille(prestation, mois_demande) for prestation in prestations_calculees)
-        result += sum(famille(prestation, period) for prestation in prestations_autres)
-        cf_non_majore_avant_cumul = famille('cf_non_majore_avant_cumul', mois_demande)
-        cf = famille('cf', mois_demande)
+        result = sum(famille(prestation, period) for prestation in prestations)
+        cf_non_majore_avant_cumul = famille('cf_non_majore_avant_cumul', period)
+        cf = famille('cf', period)
         # Seul le montant non majoré est pris en compte dans la base de ressources du RSA
         cf_non_majore = (cf > 0) * cf_non_majore_avant_cumul
 
-        af_base = famille('af_base', mois_demande)
-        af = famille('af', mois_demande)
+        af_base = famille('af_base', period)
+        af = famille('af', period)
 
         result = result + cf_non_majore + min_(af_base, af)
 
@@ -269,10 +263,9 @@ class ppa_base_ressources(Variable):
     label = u"Bases ressource prise en compte pour la PPA"
     definition_period = MONTH
 
-    def formula(famille, period, parameters, mois_demande):
-        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
-        ppa_revenu_activite = famille('ppa_revenu_activite', period, extra_params = [mois_demande])
-        ppa_ressources_hors_activite = famille('ppa_ressources_hors_activite', period, extra_params = [mois_demande])
+    def formula(famille, period, parameters):
+        ppa_revenu_activite = famille('ppa_revenu_activite', period)
+        ppa_ressources_hors_activite = famille('ppa_ressources_hors_activite', period)
         return ppa_revenu_activite + ppa_ressources_hors_activite
 
 
@@ -282,12 +275,11 @@ class ppa_bonification(Variable):
     label = u"Bonification de la PPA pour un individu"
     definition_period = MONTH
 
-    def formula(individu, period, parameters, mois_demande):
-        P = parameters(mois_demande)
+    def formula(individu, period, parameters):
+        P = parameters(period)
         smic_horaire = P.cotsoc.gen.smic_h_b
         ppa_base = P.prestations.minima_sociaux.ppa.montant_de_base
-        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
-        revenu_activite = individu('ppa_revenu_activite_individu', period, extra_params = [mois_demande])
+        revenu_activite = individu('ppa_revenu_activite_individu', period)
         seuil_1 = P.prestations.minima_sociaux.ppa.bonification.seuil_bonification * smic_horaire
         seuil_2 = P.prestations.minima_sociaux.ppa.bonification.seuil_max_bonification * smic_horaire
         bonification_max = round_(P.prestations.minima_sociaux.ppa.bonification.taux_bonification_max * ppa_base, 2)

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -422,25 +422,16 @@ class ppa_mois_demande(Variable):
     label = u"Date de la demande de la prime pour l'activité"
 
 
-class ppa_versee_offset_total(Variable):
-    value_type = int
-    entity = Famille
-    label = u"Nombre de mois depuis la demande initiale de prime d'activité"
-    definition_period = MONTH
-
-    def formula(famille, period, parameters):
-        ppa_mois_demande = famille('ppa_mois_demande', period)
-        return (datetime64(period.start).astype('datetime64[M]') - ppa_mois_demande.astype('datetime64[M]')).astype('int')
-
-
-class ppa_versee_offset(Variable):
+class ppa_indice_du_mois_trimestre_reference(Variable):
     value_type = int
     entity = Famille
     label = u"Nombre de mois par rapport au mois de du précédent recalcul de la prime d'activité"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
-        return remainder_(famille('ppa_versee_offset_total', period), 3)
+        ppa_mois_demande = famille('ppa_mois_demande', period)
+        nombre_mois = (datetime64(period.start).astype('datetime64[M]') - ppa_mois_demande.astype('datetime64[M]')).astype('int')
+        return remainder_(nombre_mois, 3)
 
 
 class ppa_versee(Variable):

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -337,7 +337,7 @@ class ppa_forfait_logement(Variable):
 class ppa_fictive_ressource_activite(Variable):
     value_type = float
     entity = Famille
-    label = u"Prime pour l'activité fictive pour un mois"
+    label = u"Proportion de ressources provenant de l'activité prise en compte pour la primie d'activité fictive"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -350,7 +350,7 @@ class ppa_fictive_ressource_activite(Variable):
 class ppa_fictive_montant_forfaitaire(Variable):
     value_type = float
     entity = Famille
-    label = u"Prime pour l'activité fictive pour un mois"
+    label = u"Montant forfaitaire de la prime d'activité fictive"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -419,12 +419,13 @@ class ppa_mois_demande(Variable):
     value_type = date
     entity = Famille
     definition_period = ETERNITY
+    label = u"Date de la demande de la prime pour l'activité"
 
 
 class ppa_versee_offset_total(Variable):
     value_type = int
     entity = Famille
-    label = u"Prime Pour l'Activité Versée en prenant en compte la date de la demande"
+    label = u"Nombre de mois depuis la demande initiale de prime d'activité"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -435,7 +436,7 @@ class ppa_versee_offset_total(Variable):
 class ppa_versee_offset(Variable):
     value_type = int
     entity = Famille
-    label = u"Prime Pour l'Activité Versée en prenant en compte la date de la demande"
+    label = u"Nombre de mois par rapport au mois de du précédent recalcul de la prime d'activité"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -445,7 +446,7 @@ class ppa_versee_offset(Variable):
 class ppa_versee(Variable):
     value_type = float
     entity = Famille
-    label = u"Prime Pour l'Activité Versée en prenant en compte la date de la demande"
+    label = u"Prime pour l'activité versée en prenant en compte la date de la demande"
     definition_period = MONTH
 
     def formula(famille, period, parameters):

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -344,7 +344,7 @@ class ppa_fictive_ressource_activite(Variable):
 
     def formula(famille, period, parameters):
         pente = parameters(period).prestations.minima_sociaux.ppa.pente
-        ppa_revenu_activite = famille('ppa_revenu_activite', period, extra_params = [period])
+        ppa_revenu_activite = famille('ppa_revenu_activite', period)
 
         return pente * ppa_revenu_activite
 
@@ -357,8 +357,8 @@ class ppa_fictive_montant_forfaitaire(Variable):
 
     def formula(famille, period, parameters):
         ppa_majoree_eligibilite = famille('rsa_majore_eligibilite', period)
-        mff_non_majore = famille('ppa_montant_forfaitaire_familial_non_majore', period, extra_params = [period])
-        mff_majore = famille('ppa_montant_forfaitaire_familial_majore', period, extra_params = [period])
+        mff_non_majore = famille('ppa_montant_forfaitaire_familial_non_majore', period)
+        mff_majore = famille('ppa_montant_forfaitaire_familial_majore', period)
 
         return where(ppa_majoree_eligibilite, mff_majore, mff_non_majore)
 
@@ -371,12 +371,11 @@ class ppa_fictive(Variable):
 
     def formula(famille, period, parameters):
         forfait_logement = famille('ppa_forfait_logement', period)
-        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
-        elig = famille('ppa_eligibilite', period, extra_params = [period])
+        elig = famille('ppa_eligibilite', period)
         montant_forfaitaire_familialise = famille('ppa_fictive_montant_forfaitaire', period)
-        ppa_base_ressources = famille('ppa_base_ressources', period, extra_params = [period])
+        ppa_base_ressources = famille('ppa_base_ressources', period)
         ppa_fictive_ressource_activite = famille('ppa_fictive_ressource_activite', period)
-        bonification_i = famille.members('ppa_bonification', period, extra_params = [period])
+        bonification_i = famille.members('ppa_bonification', period)
         bonification = famille.sum(bonification_i)
 
         ppa_montant_base = (

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/age_min.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/age_min.yaml
@@ -1,5 +1,5 @@
 description: Âge minimal pour bénéficier de la PPA
 unit: year
 values:
-  2016-01-01:
+  2015-10-01:
     value: 18.0

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/bonification/seuil_bonification.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/bonification/seuil_bonification.yaml
@@ -2,5 +2,5 @@ description: Seuil de salaire minimum pour bénéficier de la bonification, en m
   du smic horaire brut.
 reference: https://www.ipp.eu/outils/baremes-ipp/
 values:
-  2016-01-01:
+  2015-10-01:
     value: 59.0

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/bonification/seuil_max_bonification.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/bonification/seuil_max_bonification.yaml
@@ -2,5 +2,5 @@ description: Seuil de salaire pour bénéficier de la bonification maximale, en 
   du smic horaire brut.
 reference: https://www.ipp.eu/outils/baremes-ipp/
 values:
-  2016-01-01:
+  2015-10-01:
     value: 95.0

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/bonification/taux_bonification_max.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/bonification/taux_bonification_max.yaml
@@ -2,5 +2,5 @@ description: Bonification maximale, en pourcentage du montant de base du RSA
 reference: https://www.ipp.eu/outils/baremes-ipp/
 unit: /1
 values:
-  2016-01-01:
+  2015-10-01:
     value: 0.12782

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/majoration_isolement_enf_charge.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/majoration_isolement_enf_charge.yaml
@@ -1,5 +1,5 @@
 reference: https://www.ipp.eu/outils/baremes-ipp/
 unit: /1
 values:
-  2016-01-01:
+  2015-10-01:
     value: 0.42804

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/majoration_isolement_femme_enceinte.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/majoration_isolement_femme_enceinte.yaml
@@ -1,5 +1,5 @@
 reference: https://www.ipp.eu/outils/baremes-ipp/
 unit: /1
 values:
-  2016-01-01:
+  2015-10-01:
     value: 1.28412

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/montant_de_base.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/montant_de_base.yaml
@@ -1,7 +1,7 @@
 description: Montant forfaitaire de base
 unit: currency
 values:
-  2016-01-01:
+  2015-10-01:
     value: 524.16
     reference: https://www.legifrance.gouv.fr/eli/decret/2015/12/21/AFSA1521306D/jo/article_1
   2016-04-01:

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/pente.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/pente.yaml
@@ -2,7 +2,7 @@ description: Pente appliquée aux revenus d'activité pour la prime d'activité
 reference: https://www.ipp.eu/outils/baremes-ipp/
 unit: /1
 values:
-  2016-01-01:
+  2015-10-01:
     value: 0.62
   2018-08-01:
     value: 0.61

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/seuil_aah_activite.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/seuil_aah_activite.yaml
@@ -1,5 +1,5 @@
 description: Revenu d'activité minimal perçu pour que l'AAH d'un individu soit considéré
   comme un revenu d'activité, en multiple du smic horaire brut
 values:
-  2016-01-01:
+  2015-10-01:
     value: 29.0

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/seuil_non_versement.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/seuil_non_versement.yaml
@@ -2,5 +2,5 @@ description: Seuil de non versement de la PPA
 reference: https://www.ipp.eu/outils/baremes-ipp/
 unit: currency
 values:
-  2016-01-01:
+  2015-10-01:
     value: 15.0

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_deuxieme_personne.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_deuxieme_personne.yaml
@@ -2,5 +2,5 @@ description: Taux pour une 2nde personne
 reference: https://www.ipp.eu/outils/baremes-ipp/
 unit: /1
 values:
-  2016-01-01:
+  2015-10-01:
     value: 0.5

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_deuxieme_personne.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_deuxieme_personne.yaml
@@ -2,5 +2,5 @@ description: Taux pour une 2nde personne
 reference: https://www.ipp.eu/outils/baremes-ipp/
 unit: /1
 values:
-  2015-10-01:
+  2016-01-01:
     value: 0.5

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_forfait_logement/foyer_1_personne.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_forfait_logement/foyer_1_personne.yaml
@@ -1,5 +1,5 @@
 reference: https://www.ipp.eu/outils/baremes-ipp/
 unit: /1
 values:
-  2016-01-01:
+  2015-10-01:
     value: 0.12

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_forfait_logement/foyer_2_personnes.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_forfait_logement/foyer_2_personnes.yaml
@@ -1,5 +1,5 @@
 reference: https://www.ipp.eu/outils/baremes-ipp/
 unit: /1
 values:
-  2016-01-01:
+  2015-10-01:
     value: 0.16

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_forfait_logement/foyer_3_personnes.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_forfait_logement/foyer_3_personnes.yaml
@@ -1,5 +1,5 @@
 reference: https://www.ipp.eu/outils/baremes-ipp/
 unit: /1
 values:
-  2016-01-01:
+  2015-10-01:
     value: 0.165

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_personne_supp.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_personne_supp.yaml
@@ -2,5 +2,5 @@ description: Taux par personne supplémentaire
 reference: https://www.ipp.eu/outils/baremes-ipp/
 unit: /1
 values:
-  2016-01-01:
+  2015-10-01:
     value: 0.4

--- a/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_troisieme_personne.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/ppa/taux_troisieme_personne.yaml
@@ -2,5 +2,5 @@ description: Taux pour une 3e personne
 reference: https://www.ipp.eu/outils/baremes-ipp/
 unit: /1
 values:
-  2016-01-01:
+  2015-10-01:
     value: 0.3

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "32.2.1",
+    version = "32.3.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/ppa.yaml
+++ b/tests/formulas/ppa.yaml
@@ -502,7 +502,10 @@
   relative_error_margin: 0.05
   input:
     age: 40
-    statut_occupation_logement: proprietaire
+    statut_occupation_logement:
+      2015-12: proprietaire
+      2015-11: proprietaire
+      2015-10: proprietaire
     salaire_net:
       2016-01: 918 # > 95 smic horaire brut
       2015-12: 918

--- a/tests/formulas/ppa_2018.yaml
+++ b/tests/formulas/ppa_2018.yaml
@@ -11,7 +11,6 @@
       personne1:
         date_naissance: 1980-01-01
         salaire_net:
-          2018-05: 134
           2018-04: 134
           2018-03: 134
           2018-02: 134
@@ -29,7 +28,6 @@
       parents: [personne1]
       enfants: [enfant1]
       asf:
-        2018-05: 115.30
         2018-04: 115.30
         2018-03: 109.65
         2018-02: 109.65
@@ -44,7 +42,6 @@
       personne1:
         date_naissance: 1980-01-01
         salaire_net:
-          2018-05: 134
           2018-04: 134
           2018-03: 134
           2018-02: 134
@@ -61,12 +58,10 @@
       parents: [personne1]
       enfants: [enfant1, enfant2]
       asf:
-        2018-05: 230.60
         2018-04: 230.60
         2018-03: 219.30
         2018-02: 219.30
       af:
-        2018-05: 131.16
         2018-04: 131.16
         2018-03: 129.86
         2018-02: 129.86
@@ -81,7 +76,6 @@
       personne1:
         date_naissance: 1980-01-01
         salaire_net:
-          2018-05: 134
           2018-04: 134
           2018-03: 134
           2018-02: 134
@@ -108,14 +102,12 @@
       personne1:
         date_naissance: 1980-01-01
         salaire_net:
-          2018-05: 100
           2018-04: 100
           2018-03: 100
           2018-02: 100
       personne2:
         date_naissance: 1982-02-02
         salaire_net:
-          2018-05: 67
           2018-04: 67
           2018-03: 67
           2018-02: 67
@@ -141,14 +133,12 @@
       personne1:
         date_naissance: 1980-01-01
         salaire_net:
-          2018-05: 250
           2018-04: 250
           2018-03: 250
           2018-02: 250
       personne2:
         date_naissance: 1982-02-02
         salaire_net:
-          2018-05: 400
           2018-04: 400
           2018-03: 400
           2018-02: 400
@@ -165,7 +155,6 @@
       parents: [personne1, personne2]
       enfants: [enfant1, enfant2]
       af:
-        2018-05: 131.16
         2018-04: 131.16
         2018-03: 129.86
         2018-02: 129.86
@@ -181,14 +170,12 @@
       personne1:
         date_naissance: 1980-01-01
         salaire_net:
-          2018-05: 250
           2018-04: 250
           2018-03: 250
           2018-02: 250
       personne2:
         date_naissance: 1982-02-02
         salaire_net:
-          2018-05: 400
           2018-04: 400
           2018-03: 400
           2018-02: 400
@@ -254,7 +241,6 @@
     famille:
       parents: [personne1, personne2]
       aide_logement:
-        2018-05: 200
         2018-04: 200
         2018-03: 200
         2018-02: 200
@@ -268,14 +254,12 @@
       personne1:
         date_naissance: 1980-01-01
         salaire_net:
-          2018-05: 1200
           2018-04: 1200
           2018-03: 1200
           2018-02: 1200
       personne2:
         date_naissance: 1982-02-02
         salaire_net:
-          2018-05: 1000
           2018-04: 1000
           2018-03: 1000
           2018-02: 1000
@@ -290,7 +274,6 @@
       parents: [personne1, personne2]
       enfants: [enfant1]
       aide_logement:
-        2018-05: 80
         2018-04: 80
         2018-03: 80
         2018-02: 80
@@ -306,14 +289,12 @@
       personne1:
         date_naissance: 1980-01-01
         salaire_net:
-          2018-05: 1200
           2018-04: 1200
           2018-03: 1200
           2018-02: 1200
       personne2:
         date_naissance: 1982-02-02
         salaire_net:
-          2018-05: 1500
           2018-04: 1500
           2018-03: 1500
           2018-02: 1500
@@ -330,7 +311,6 @@
       parents: [personne1, personne2]
       enfants: [enfant1, enfant2]
       af:
-        2018-05: 131.16
         2018-04: 131.16
         2018-03: 129.86
         2018-02: 129.86
@@ -346,21 +326,18 @@
       personne1:
         date_naissance: 1980-01-01
         salaire_net:
-          2018-05: 1200
           2018-04: 1200
           2018-03: 1200
           2018-02: 1200
       personne2:
         date_naissance: 1982-02-02
         salaire_net:
-          2018-05: 1450
           2018-04: 1450
           2018-03: 1450
           2018-02: 1450
       enfant1:
         date_naissance: 2000-01-10
         salaire_net:
-          2018-05: 400
           2018-04: 400
           2018-03: 400
           2018-02: 400
@@ -376,7 +353,6 @@
     famille:
       parents: [personne1]
       aide_logement:
-          2018-05: 80
           2018-04: 80
           2018-03: 80
           2018-02: 80
@@ -389,7 +365,6 @@
       personne1:
         date_naissance: 1980-01-01
         salaire_net:
-          2018-05: 1450
           2018-04: 1450
           2018-03: 1450
           2018-02: 1450
@@ -404,12 +379,10 @@
       parents: [personne1]
       enfants: [enfant1]
       aide_logement:
-        2018-05: 150
         2018-04: 150
         2018-03: 150
         2018-02: 150
       asf:
-        2018-05: 115.30
         2018-04: 115.30
         2018-03: 109.65
         2018-02: 109.65
@@ -424,7 +397,6 @@
       personne1:
         date_naissance: 1980-01-01
         salaire_net:
-          2018-05: 2000
           2018-04: 2000
           2018-03: 2000
           2018-02: 2000

--- a/tests/formulas/ppa_2018.yaml
+++ b/tests/formulas/ppa_2018.yaml
@@ -4,7 +4,6 @@
   input:
     famille:
       parents: [personne1]
-      aide_logement: 80
     menage:
       personne_de_reference: personne1
       statut_occupation_logement: locataire_vide
@@ -29,7 +28,6 @@
     famille:
       parents: [personne1]
       enfants: [enfant1]
-      aide_logement: 150
       asf:
         2018-05: 115.30
         2018-04: 115.30
@@ -62,7 +60,6 @@
     famille:
       parents: [personne1]
       enfants: [enfant1, enfant2]
-      aide_logement: 200
       asf:
         2018-05: 230.60
         2018-04: 230.60
@@ -101,7 +98,6 @@
   input:
     famille:
       parents: [personne1, personne2]
-      aide_logement: 200
     foyer_fiscal:
       declarants: [personne1, personne2]
     menage:
@@ -133,7 +129,6 @@
     famille:
       parents: [personne1, personne2]
       enfants: [enfant1]
-      aide_logement: 200
     foyer_fiscal:
       declarants: [personne1, personne2]
       personnes_a_charge: [enfant1]
@@ -169,7 +164,6 @@
     famille:
       parents: [personne1, personne2]
       enfants: [enfant1, enfant2]
-      aide_logement: 250
       af:
         2018-05: 131.16
         2018-04: 131.16
@@ -212,7 +206,6 @@
     famille:
       parents: [personne1, personne2]
       enfants: [enfant1, enfant2, enfant3]
-      aide_logement: 280
       af:
         2018-04: 299.20
         2018-03: 296.24
@@ -336,7 +329,6 @@
     famille:
       parents: [personne1, personne2]
       enfants: [enfant1, enfant2]
-      aide_logement: 100
       af:
         2018-05: 131.16
         2018-04: 131.16

--- a/tests/formulas/ppa_2018.yaml
+++ b/tests/formulas/ppa_2018.yaml
@@ -375,7 +375,11 @@
   input:
     famille:
       parents: [personne1]
-      aide_logement: 80
+      aide_logement:
+          2018-05: 80
+          2018-04: 80
+          2018-03: 80
+          2018-02: 80
     foyer_fiscal:
       declarants: [personne1]
     menage:

--- a/tests/formulas/ppa_2018.yaml
+++ b/tests/formulas/ppa_2018.yaml
@@ -260,7 +260,11 @@
   input:
     famille:
       parents: [personne1, personne2]
-      aide_logement: 200
+      aide_logement:
+        2018-05: 200
+        2018-04: 200
+        2018-03: 200
+        2018-02: 200
     foyer_fiscal:
       declarants: [personne1, personne2]
     menage:
@@ -292,7 +296,11 @@
     famille:
       parents: [personne1, personne2]
       enfants: [enfant1]
-      aide_logement: 80
+      aide_logement:
+        2018-05: 80
+        2018-04: 80
+        2018-03: 80
+        2018-02: 80
     foyer_fiscal:
       declarants: [personne1, personne2]
       personnes_a_charge: [enfant1]
@@ -399,7 +407,11 @@
     famille:
       parents: [personne1]
       enfants: [enfant1]
-      aide_logement: 150
+      aide_logement:
+        2018-05: 150
+        2018-04: 150
+        2018-03: 150
+        2018-02: 150
       asf:
         2018-05: 115.30
         2018-04: 115.30

--- a/tests/formulas/ppa_index_mois_trimestre_reference.yaml
+++ b/tests/formulas/ppa_index_mois_trimestre_reference.yaml
@@ -3,13 +3,7 @@
     ppa_mois_demande:
       ETERNITY: 2018-11
   output:
-    ppa_versee_offset_total:
-      2018-11: 0
-      2018-12: 1
-      2019-01: 2
-      2019-02: 3
-      2019-03: 4
-    ppa_versee_offset:
+    ppa_indice_du_mois_trimestre_reference:
       2018-11: 0
       2018-12: 1
       2019-01: 2
@@ -21,5 +15,4 @@
     ppa_mois_demande:
       ETERNITY: 2017-11
   output:
-    ppa_versee_offset_total: 12
-    ppa_versee_offset: 0
+    ppa_indice_du_mois_trimestre_reference: 0

--- a/tests/formulas/ppa_offset.yaml
+++ b/tests/formulas/ppa_offset.yaml
@@ -1,8 +1,8 @@
 - period: 2018-11
-  input_variables:
+  input:
     ppa_mois_demande:
       ETERNITY: 2018-11
-  output_variables:
+  output:
     ppa_versee_offset_total:
       2018-11: 0
       2018-12: 1
@@ -17,9 +17,9 @@
       2019-03: 1
 
 - period: 2018-11
-  input_variables:
+  input:
     ppa_mois_demande:
       ETERNITY: 2017-11
-  output_variables:
+  output:
     ppa_versee_offset_total: 12
     ppa_versee_offset: 0

--- a/tests/formulas/ppa_offset.yaml
+++ b/tests/formulas/ppa_offset.yaml
@@ -1,0 +1,25 @@
+- period: 2018-11
+  input_variables:
+    ppa_mois_demande:
+      ETERNITY: 2018-11
+  output_variables:
+    ppa_versee_offset_total:
+      2018-11: 0
+      2018-12: 1
+      2019-01: 2
+      2019-02: 3
+      2019-03: 4
+    ppa_versee_offset:
+      2018-11: 0
+      2018-12: 1
+      2019-01: 2
+      2019-02: 0
+      2019-03: 1
+
+- period: 2018-11
+  input_variables:
+    ppa_mois_demande:
+      ETERNITY: 2017-11
+  output_variables:
+    ppa_versee_offset_total: 12
+    ppa_versee_offset: 0


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : toutes pour la PPA c'est à dire à partir du 01/10/2015.
* Zones impactées : `prestations/minima_sociaux/ppa`.
* Détails :
  - Supprime la distinction en mois de demande et mois de ressource dans les calculs de la PPA.
- - -
