### PR TITLE
 Prends en compte les ressources du capital dans le calcul de la prime d'activité

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 34.1.0 [#1243](https://github.com/openfisca/openfisca-france/pull/1243)
+
+* Amélioration d'un calcul existant
+* Périodes concernées : toutes pour la prime d'activité, ie. à partir de janvier 2016.
+* Zones impactées : `prestations/minima_sociaux/ppa`.
+* Détails :
+  - Prise en compte des revenus du capital dans le calcul de la prime d'activité
+
 # 34.0.0 [#1216](https://github.com/openfisca/openfisca-france/pull/1216)
 
 * Changement majeur.

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -213,24 +213,37 @@ class ppa_ressources_hors_activite_individu(Variable):
         P = parameters(period)
         smic_horaire = P.cotsoc.gen.smic_h_b
 
-        ressources = [
-            'asi',
-            'chomage_net',
-            'retraite_nette',
-            'retraite_combattant',
-            'revenus_capital',
-            'revenus_locatifs',
-            'pensions_invalidite',
-            'pensions_alimentaires_percues',
-            'prestation_compensatoire',
-            'prime_forfaitaire_mensuelle_reprise_activite',
-            'rsa_indemnites_journalieres_hors_activite',
-            ]
+        def ressources_percues_au_cours_du_mois_considere():
+            ressources = [
+                'asi',
+                'chomage_net',
+                'retraite_nette',
+                'retraite_combattant',
+                'pensions_invalidite',
+                'pensions_alimentaires_percues',
+                'prestation_compensatoire',
+                'prime_forfaitaire_mensuelle_reprise_activite',
+                'rsa_indemnites_journalieres_hors_activite',
+                ]
 
-        ressources_hors_activite_mensuel_i = sum(individu(ressource, period) for ressource in ressources)
+            return sum(individu(ressource, period) for ressource in ressources)
+
+        def ressources_percues_il_y_a_deux_ans():
+            ressources = [
+                'revenus_capital',
+                'revenus_locatifs',
+                ]
+
+            return sum(individu(ressource, period.offset(-2, 'year')) for ressource in ressources)
+
+        ressources_hors_activite_mensuel_i = (
+            + ressources_percues_au_cours_du_mois_considere()
+            + ressources_percues_il_y_a_deux_ans()
+            )
+
         revenus_activites = individu('ppa_revenu_activite_individu', period)
 
-        # L'aah est pris en compte comme revenu d'activité si  revenu d'activité hors aah > 29 * smic horaire brut
+        # L'AAH est prise en compte comme revenu d'activité si revenu d'activité hors aah > 29 * smic horaire brut
         seuil_aah_activite = P.prestations.minima_sociaux.ppa.seuil_aah_activite * smic_horaire
         aah_hors_activite = (revenus_activites < seuil_aah_activite) * individu('aah', period)
 

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -27,7 +27,7 @@ class ppa_eligibilite_etudiants(Variable):
     entity = Famille
     label = u"Eligibilité à la PPA (condition sur tout le trimestre)"
     reference = [
-        u"Article L842-2 du Code de la Sécurité Sociale",
+        # Article L842-2 du Code de la Sécurité Sociale
         u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=F2B88CEFCB83FCAFA4AA31671DAC89DD.tplgfr26s_3?idArticle=LEGIARTI000031087615&cidTexte=LEGITEXT000006073189&dateTexte=20181226"
         ]
     definition_period = MONTH
@@ -203,9 +203,9 @@ class ppa_ressources_hors_activite_individu(Variable):
     label = u"Revenu hors activité pris en compte pour la PPA (Individu) pour un mois"
     definition_period = MONTH
     reference = [
-        u"Article L842-4 du code de la sécurité sociale",
+        # Article L842-4 du code de la sécurité sociale
         u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=B1D8827D50F7B3CC603BB7D398E71AA8.tplgfr28s_3?idArticle=LEGIARTI000033813782&cidTexte=LEGITEXT000006073189&dateTexte=20181226",
-        u"Article R843-1 du code de la sécurité sociale",
+        # Article R843-1 du code de la sécurité sociale
         u"https://www.legifrance.gouv.fr/affichCode.do;jsessionid=3D8AB2FEC931285820291B1F952160BA.tpdila22v_2?idSectionTA=LEGISCTA000031694323&cidTexte=LEGITEXT000006073189&dateTexte=20160215"
         ]
 

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -29,7 +29,7 @@ class ppa_eligibilite_etudiants(Variable):
     reference = [
         u"Article L842-2 du Code de la Sécurité Sociale",
         u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=F2B88CEFCB83FCAFA4AA31671DAC89DD.tplgfr26s_3?idArticle=LEGIARTI000031087615&cidTexte=LEGITEXT000006073189&dateTexte=20181226"
-    ]
+        ]
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -202,6 +202,12 @@ class ppa_ressources_hors_activite_individu(Variable):
     entity = Individu
     label = u"Revenu hors activité pris en compte pour la PPA (Individu) pour un mois"
     definition_period = MONTH
+    reference = [
+        u"Article L842-4 du code de la sécurité sociale",
+        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=B1D8827D50F7B3CC603BB7D398E71AA8.tplgfr28s_3?idArticle=LEGIARTI000033813782&cidTexte=LEGITEXT000006073189&dateTexte=20181226",
+        u"Article R843-1 du code de la sécurité sociale",
+        u"https://www.legifrance.gouv.fr/affichCode.do;jsessionid=3D8AB2FEC931285820291B1F952160BA.tpdila22v_2?idSectionTA=LEGISCTA000031694323&cidTexte=LEGITEXT000006073189&dateTexte=20160215"
+        ]
 
     def formula(individu, period, parameters):
         P = parameters(period)
@@ -212,6 +218,7 @@ class ppa_ressources_hors_activite_individu(Variable):
             'chomage_net',
             'retraite_nette',
             'retraite_combattant',
+            'revenus_capital',
             'revenus_locatifs',
             'pensions_invalidite',
             'pensions_alimentaires_percues',

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -26,6 +26,10 @@ class ppa_eligibilite_etudiants(Variable):
     value_type = bool
     entity = Famille
     label = u"Eligibilité à la PPA (condition sur tout le trimestre)"
+    reference = [
+        u"Article L842-2 du Code de la Sécurité Sociale",
+        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=F2B88CEFCB83FCAFA4AA31671DAC89DD.tplgfr26s_3?idArticle=LEGIARTI000031087615&cidTexte=LEGITEXT000006073189&dateTexte=20181226"
+    ]
     definition_period = MONTH
 
     def formula(famille, period, parameters):

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -229,7 +229,7 @@ class ppa_ressources_hors_activite_individu(Variable):
             return sum(individu(ressource, period) for ressource in ressources)
 
         def ressources_percues_il_y_a_deux_ans():
-            plus_values = individu.foyer_fiscal('assiette_csg_plus_values', period.offset(-2, 'year').this_year) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
+            plus_values = individu.foyer_fiscal('assiette_csg_plus_values', period.offset(-2, 'year').this_year) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL) / 12
             ressources_hors_plus_values = [
                 'revenus_capital',
                 'revenus_locatifs',

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -229,12 +229,16 @@ class ppa_ressources_hors_activite_individu(Variable):
             return sum(individu(ressource, period) for ressource in ressources)
 
         def ressources_percues_il_y_a_deux_ans():
-            ressources = [
+            plus_values = individu.foyer_fiscal('assiette_csg_plus_values', period.offset(-2, 'year').this_year) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
+            ressources_hors_plus_values = [
                 'revenus_capital',
                 'revenus_locatifs',
                 ]
 
-            return sum(individu(ressource, period.offset(-2, 'year')) for ressource in ressources)
+            return (
+                sum(individu(ressource, period.offset(-2, 'year')) for ressource in ressources_hors_plus_values)
+                + plus_values
+                )
 
         ressources_hors_activite_mensuel_i = (
             + ressources_percues_au_cours_du_mois_considere()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "34.0.0",
+    version = "34.1.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/ppa.yaml
+++ b/tests/formulas/ppa.yaml
@@ -584,7 +584,7 @@
     pensions_invalidite:
       2016-01: 100
     revenus_locatifs:
-      2016-01: 100
+      2014-01: 100
     prime_forfaitaire_mensuelle_reprise_activite:
       2016-01: 100
   output:

--- a/tests/formulas/ppa/ppa_ressources_hors_activite_individu.yaml
+++ b/tests/formulas/ppa/ppa_ressources_hors_activite_individu.yaml
@@ -1,0 +1,5 @@
+- period: 2018-12
+  input:
+    revenus_capital: 100
+  output:
+    ppa_ressources_hors_activite_individu: 100

--- a/tests/formulas/ppa/ppa_ressources_hors_activite_individu.yaml
+++ b/tests/formulas/ppa/ppa_ressources_hors_activite_individu.yaml
@@ -1,5 +1,21 @@
-- period: 2018-12
+- name: PPA - Ressources hors activité individu - Revenus du capital
+  description: Sont pris en compte les revenus de capital de l'avant-dernière année
+  period: 2018-12
   input:
-    revenus_capital: 100
+    revenus_capital:
+      2016: 1200
+      2017: 2400
+      2018: 3600
   output:
     ppa_ressources_hors_activite_individu: 100
+
+- name: PPA - Ressources hors activité individu - Revenus locatifs
+  description: Sont pris en compte les revenus locatifs de l'avant-dernière année
+  period: 2018-12
+  input:
+    revenus_locatifs:
+      2016: 3600
+      2017: 2400
+      2018: 1200
+  output:
+    ppa_ressources_hors_activite_individu: 300


### PR DESCRIPTION
Fixes #1242.

* Amélioration d'un calcul existant
* Périodes concernées : toutes pour la prime d'activité, ie. à partir de janvier 2016.
* Zones impactées : `prestations/minima_sociaux/ppa`.
* Détails :
  - Prise en compte des revenus du capital dans le calcul de la prime d'activité
- - - -
- Corrigent ou améliorent un calcul déjà existant.

- - - -
Je laisse l'équipe Core modifier `setup.py` à partir ces éléments ici et en fonction des intégrations qui précèdent celle-ci.
