### PR TITLE
Ajoute des références législatives pour l'ASS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 33.0.1 [#1246](https://github.com/openfisca/openfisca-france/pull/1246)
+### 33.0.2 [#1244](https://github.com/openfisca/openfisca-france/pull/1244)
+
+* Changement mineur.
+* Zones impactées : `prestations/minima_sociaux/ass`.
+* Détails :
+  - Ajoute des références pour l'allocation de solidarité spécifique
+
+### 33.0.1 [#1246](https://github.com/openfisca/openfisca-france/pull/1246)
 
 * Changement mineur
 * Périodes concernées : toutes

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -65,6 +65,10 @@ class ass_base_ressources_individu(Variable):
     label = u"Base de ressources individuelle de l'ASS"
     entity = Individu
     definition_period = MONTH
+    reference = [
+        # Articles R5423-1 à 6 du code du travail
+        u'https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000018525086&cidTexte=LEGITEXT000006072050&dateTexte=20181227'
+        ]
 
     def formula(individu, period):
         # Rolling year
@@ -93,6 +97,7 @@ class ass_base_ressources_individu(Variable):
             return revenus_auto_entrepreneur + tns_micro_entreprise_benefice + tns_benefice_exploitant_agricole + tns_autres_revenus
 
         pensions_alimentaires_percues = individu('pensions_alimentaires_percues', previous_year, options = [ADD])
+        # Article R5423-4 du code du travail
         pensions_alimentaires_versees_individu = individu('pensions_alimentaires_versees_individu', previous_year, options = [ADD])
 
         aah = individu('aah', previous_year, options = [ADD])

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "33.0.1",
+    version = "33.0.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION

* Changement mineur.
* Zones impactées : `prestations/minima_sociaux/ass`.
* Détails :
  - Ajoute des références pour l'allocation de solidarité spécifique
- - - -

Je laisse l'équipe Core modifier `setup.py` à partir ces éléments ici et en fonction des intégrations qui précèdent celle-ci.
