### PR TITLE
Supprime trois variables de revenu d'activité

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 32.4.2 [#1250](https://github.com/openfisca/openfisca-france/pull/1250)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `prelevements_obligatoires/impot_revenu/ir.py`
+  - `prestations/minima_sociaux/aah.py`
+* Détails :
+  - Supprime les variables `revenu_activite`, `revenu_activite_salariee` et `revenu_activite_non_salariee` qui incorporaient juste `salaire_imposable` et `rpns_individu` et n'étaient utilisées que pour l'AAH.
+
 ## 32.4.1 [#1245](https://github.com/openfisca/openfisca-france/pull/1245)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -433,44 +433,6 @@ class revenu_assimile_salaire_apres_abattements(Variable):
             )
 
 
-class revenu_activite_salariee(Variable):
-    value_type = float
-    entity = Individu
-    label = u"Revenu d'activité salariée"
-    definition_period = YEAR
-
-    def formula(individu, period, parameters):
-        salaire_imposable = individu('salaire_imposable', period, options = [ADD])
-
-        return salaire_imposable
-
-
-class revenu_activite_non_salariee(Variable):
-    value_type = float
-    entity = Individu
-    label = u"Revenu d'activité non salariée"
-    definition_period = YEAR
-
-    def formula(individu, period, parameters):
-        rpns_i = individu('rpns_individu', period)
-
-        return rpns_i  # TODO: vérifier cette définition
-
-
-class revenu_activite(Variable):
-    value_type = float
-    entity = Individu
-    label = u"Revenus d'activités"
-    definition_period = YEAR
-
-    def formula(individu, period, parameters):
-        ''' Revenus d'activités '''
-        revenu_activite_non_salariee = individu('revenu_activite_non_salariee', period)
-        revenu_activite_salariee = individu('revenu_activite_salariee', period)
-
-        return revenu_activite_non_salariee + revenu_activite_salariee
-
-
 class revenu_assimile_pension(Variable):
     value_type = float
     entity = Individu

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -46,7 +46,7 @@ class aah_base_ressources(Variable):
             return base_ressource_demandeur + assiette_conjoint(base_ressource_conjoint)
 
         def base_ressource_eval_annuelle():
-            base_ressource_demandeur = assiette_revenu_activite_demandeur(famille.demandeur('revenu_activite', period.n_2)) + famille.demandeur('revenu_assimile_pension', period.n_2)
+            base_ressource_demandeur = assiette_revenu_activite_demandeur(famille.demandeur('salaire_imposable', period.n_2, options = [ADD]) + famille.demandeur('rpns_individu', period.n_2)) + famille.demandeur('revenu_assimile_pension', period.n_2)
             base_ressource_conjoint = famille.conjoint('aah_base_ressources_eval_annuelle', period)
 
             return base_ressource_demandeur + assiette_conjoint(base_ressource_conjoint)
@@ -167,7 +167,11 @@ class aah_base_ressources_eval_annuelle(Variable):
     definition_period = MONTH
 
     def formula(individu, period, parameters):
-        return individu('revenu_activite', period.n_2) + individu('revenu_assimile_pension', period.n_2)
+        return (
+            individu('salaire_imposable', period.n_2, options = [ADD])
+            + individu('rpns_individu', period.n_2)
+            + individu('revenu_assimile_pension', period.n_2)
+            )
 
 
 class aah_restriction_substantielle_durable_acces_emploi(Variable):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "32.4.1",
+    version = "32.4.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : 
  - `prelevements_obligatoires/impot_revenu/ir.py`
  - `prestations/minima_sociaux/aah.py`
* Détails :
  - Supprime les variables `revenu_activite`, `revenu_activite_salariee` et `revenu_activite_non_salariee` qui incorporaient juste `salaire_imposable` et `rpns_individu` et n'étaient utilisées que pour l'AAH.
