### PR TITLE
Corrige la version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 33.0.0 [#1251](https://github.com/openfisca/openfisca-france/pull/1251)
+
+* Changement majeur.
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `prelevements_obligatoires/impot_revenu/ir.py`
+  - `prestations/minima_sociaux/aah.py`
+* Détails :
+  - Corrige le changement de version de la PR [#1250](https://github.com/openfisca/openfisca-france/pull/1250) qui est un changement majeur car suppression de variables.
+
 ### 32.4.2 [#1250](https://github.com/openfisca/openfisca-france/pull/1250)
 
 * Changement mineur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 33.0.0 [#1251](https://github.com/openfisca/openfisca-france/pull/1251)
+# 33.0.0 [#1251](https://github.com/openfisca/openfisca-france/pull/1251)
 
 * Changement majeur.
 * Périodes concernées : toutes.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "32.4.2",
+    version = "33.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement majeur
* Périodes concernées : toutes.
* Zones impactées :
  - `prelevements_obligatoires/impot_revenu/ir.py`
  - `prestations/minima_sociaux/aah.py`
* Détails :
  - Corrige le changement de version de la PR [#1250](https://github.com/openfisca/openfisca-france/pull/1250) qui est un changement majeur car suppression de variables.

