### PR TITLE
 Répare la variable PPA versée 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 34.2.2 [#1262](https://github.com/openfisca/openfisca-france/pull/1262)
+
+* Correction d'un crash.
+* Zones impactées : `prestations/minima_sociaux/ppa.py`.
+* Détails :
+  - Répare la variable de la prime d'activité versée
+
 ### 34.2.1 [#1257](https://github.com/openfisca/openfisca-france/pull/1257)
 
 * Changement mineur.

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -469,7 +469,7 @@ class ppa_versee(Variable):
     definition_period = MONTH
 
     def formula(famille, period, parameters):
-        remainder = famille('ppa_versee_offset', period)
+        remainder = famille('ppa_indice_du_mois_trimestre_reference', period)
         return (
             + famille('ppa', period) * (remainder == 0)
             + famille('ppa', period.last_month) * (remainder == 1)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "34.2.1",
+    version = "34.2.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/ppa_index_mois_trimestre_reference.yaml
+++ b/tests/formulas/ppa_index_mois_trimestre_reference.yaml
@@ -14,5 +14,17 @@
   input:
     ppa_mois_demande:
       ETERNITY: 2017-11
+    ppa:
+      2018-08: 400
+      2018-09: 300
+      2018-10: 200
+      2018-11: 100
   output:
     ppa_indice_du_mois_trimestre_reference: 0
+    ppa_versee:
+      2018-08: 400
+      2018-09: 400
+      2018-10: 400
+      2018-11: 100
+      2018-12: 100
+      2019-01: 100


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `model/prestations/minima_sociaux/ppa.py`.
* Détails :
  - Répare la variable de la prime d'activité versée