### PR TITLE
Modification du calcul du plafond de ressources pour les bénéficiaires de l’allocation adulte handicapé en couple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
+## 34.4.0 [#1264](https://github.com/openfisca/openfisca-france/pull/1264)
+
+* Évolution du système socio-fiscal. 
+* Périodes concernées : à partir du 01/11/2018.
+* Zones impactées : `prestations/minima_sociaux/aah`
+* Détails :
+  - Diminue le plafond de ressources à 89% (au lieu de 100%) pour les bénéficiaires de l'allocation adulte handicapé en couple.
+
 ### 34.3.1 [#1263](https://github.com/openfisca/openfisca-france/pull/1263)
 
 * Changement mineur
 * Zones impactées :
    - `reductions_impot`.
 * Détails :
-  - Correction d'une typo en plusieurs endroits.
+  - Corrige une typo en plusieurs endroits.
 
 ## 34.3.0 [#1259](https://github.com/openfisca/openfisca-france/pull/1259)
 
@@ -16,7 +24,7 @@
    - `parameters/prestations/aides_logement`.
    - `parameters/prestations/reduction_loyer_solidarite`.
 * Détails :
-  - Revalorisation des aides au logement au 1er janvier 2019 en métropole.
+  - Revalorise les aides au logement au 1er janvier 2019 en métropole.
 
 ### 34.2.2 [#1262](https://github.com/openfisca/openfisca-france/pull/1262)
 

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -265,7 +265,8 @@ class aah_plafond_ressources(Variable):
         en_couple = individu.famille('en_couple', period)
         af_nbenf = individu.famille('af_nbenf', period)
         montant_max = law.minima_sociaux.aah.montant
-        return montant_max * (1 + en_couple + law.minima_sociaux.aah.tx_plaf_supp * af_nbenf)
+        return montant_max * (1 + en_couple * law.minima_sociaux.aah.majoration_du_plafond_pour_un_couple +
+                              law.minima_sociaux.aah.tx_plaf_supp * af_nbenf)
 
 
 class aah_base(Variable):

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -265,7 +265,8 @@ class aah_plafond_ressources(Variable):
         en_couple = individu.famille('en_couple', period)
         af_nbenf = individu.famille('af_nbenf', period)
         montant_max = law.minima_sociaux.aah.montant
-        return montant_max * (1 + en_couple * law.minima_sociaux.aah.majoration_du_plafond_pour_un_couple +
+        return montant_max * (1 +
+                              en_couple * law.minima_sociaux.aah.majoration_du_plafond_pour_un_couple +
                               law.minima_sociaux.aah.tx_plaf_supp * af_nbenf)
 
 

--- a/openfisca_france/parameters/prestations/minima_sociaux/aah/majoration_du_plafond_pour_un_couple.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aah/majoration_du_plafond_pour_un_couple.yaml
@@ -3,3 +3,6 @@ unit: /1
 values:
   2000-01-01:
     value: 1.0
+  2018-11-01:
+    value: 0.89
+    reference: https://www.legifrance.gouv.fr/eli/decret/2018/10/31/SSAA1822428D/jo/article_2

--- a/openfisca_france/parameters/prestations/minima_sociaux/aah/montant.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aah/montant.yaml
@@ -52,7 +52,7 @@ values:
     value: 819
   2018-11-01:
     value: 860
-    reference: https://www.service-public.fr/particuliers/vosdroits/F12242
+    reference: https://www.legifrance.gouv.fr/eli/decret/2018/10/31/SSAA1822428D/jo/article_1
   2019-11-01:
     value: 900
     reference: https://www.service-public.fr/particuliers/vosdroits/F12242

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "34.3.1",
+    version = "34.4.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/aah_couple.yaml
+++ b/tests/formulas/aah_couple.yaml
@@ -1,0 +1,107 @@
+- name: AAH niveau Famille - concubinage, sans enfants, une personne éligible, ressources inférieures au plafond
+  description: Montant AAH au niveau de la famille
+  period: 2018-11
+  absolute_error_margin: 1
+  input:
+    famille:
+      parents: [parent1, parent2]
+      en_couple: true
+      af_nbenf: 0
+      aah_base_ressources: 16790.72
+    individus:
+      parent1:
+        aah_eligible: true
+      parent2:
+        aah_eligible: false
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+    menages:
+      menage_0:
+        personne_de_reference:
+        - parent1
+      menage_1:
+        personne_de_reference:
+        - parent2
+  output:
+    individus:
+      parent1:
+        aah_base: 226.17
+      parent2:
+        aah_base: 0
+
+- name: AAH niveau Famille - couple, sans enfants, une personne éligible, ressources inférieures au plafond
+  description: Montant AAH au niveau de la famille
+  period: 2018-11
+  absolute_error_margin: 1
+  input:
+    famille:
+      parents: [parent1, parent2]
+      en_couple: true
+      af_nbenf: 0
+      aah_base_ressources: 8777.70
+    individus:
+      parent1:
+        aah_eligible: true
+      parent2:
+        aah_eligible: false
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+    menages:
+      menage_0:
+        personne_de_reference:
+        - parent1
+      menage_1:
+        personne_de_reference:
+        - parent2
+  output:
+    individus:
+      parent1:
+        aah_base: 860.0
+      parent2:
+        aah_base: 0
+
+- name: AAH niveau Famille - couple, sans enfants, une personne éligible, ressources inférieures au plafond
+  description: Montant AAH au niveau de la famille
+  period: 2018-11
+  absolute_error_margin: 1
+  input:
+    famille:
+      parents: [parent1, parent2]
+      en_couple: true
+      af_nbenf: 0
+      aah_base_ressources: 12585.68
+    individus:
+      parent1:
+        aah_eligible: false
+      parent2:
+        aah_eligible: true
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+    menages:
+      menage_0:
+        personne_de_reference:
+        - parent1
+      menage_1:
+        personne_de_reference:
+        - parent2
+  output:
+    individus:
+      parent1:
+        aah_base: 0
+      parent2:
+        aah_base: 576.59


### PR DESCRIPTION
* Évolution du système socio-fiscal. 
* Périodes concernées : à partir du 01/11/2018.
* Zones impactées : 
  - `model/prestations/minima_sociaux/aah`.
  - `parameters/prestations/minima_sociaux/aah/majoration_du_plafond_pour_un_couple`.

* Détails :
  - Diminution du plafond de ressources à 89% (au lieu de 100%) pour les bénéficiaires de l'allocation adulte handicapé en couple.
  - Utilisation du paramètre "majoration_du_plafond_pour_un_couple" qui existe déjà dans openfisca, dans la formule de calcul du plafond des ressources.