### PR TITLE
Ajoute des références législatives à la PPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 34.4.1 [#1265](https://github.com/openfisca/openfisca-france/pull/1265)
+
+* Changement mineur.
+* Détails :
+  - Ajoute des références législatives à une variable de la prime d'activité
+
 ## 34.4.0 [#1264](https://github.com/openfisca/openfisca-france/pull/1264)
 
 * Évolution du système socio-fiscal. 

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -130,6 +130,12 @@ class ppa_revenu_activite_individu(Variable):
     entity = Individu
     label = u"Revenu d'activité pris en compte pour la PPA (Individu) pour un mois"
     definition_period = MONTH
+    reference = [
+        'Article L842-4 du code de la sécurité sociale',
+        'https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=358C45A1DF4FA63CC63BEC9456F63F18.tplgfr21s_3?idArticle=LEGIARTI000033813782&cidTexte=LEGITEXT000006073189',
+        'Article R844-1 du code de la sécurité sociale',
+        'https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=358C45A1DF4FA63CC63BEC9456F63F18.tplgfr21s_3?idArticle=LEGIARTI000031675756&cidTexte=LEGITEXT000006073189'
+        ]
 
     def formula(individu, period, parameters):
         P = parameters(period)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "34.4.0",
+    version = "34.4.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Détails :
  - Ajoute des références législatives à une variable de la prime d'activité