### PR TITLE
 Facilite la réutilisation de l'enum de scolarité

### DIFF
--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -59,5 +59,12 @@ class TypesStatutOccupationLogement(Enum):
     sans_domicile = u"Sans domicile stable"
 
 
+class TypesScolarite(Enum):
+    __order__ = 'inconnue college lycee'  # Needed to preserve the enum order in Python 2
+    inconnue = u"Inconnue"
+    college = u"Collège"
+    lycee = u"Lycée"
+
+
 # Taux de prime moyen de la fonction publique
 TAUX_DE_PRIME = 0.195  # primes_fonction_publique (hors suppl. familial et indemnité de résidence)/rémunération brute

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -292,13 +292,6 @@ class bourse_lycee(Variable):
         return montant
 
 
-class TypesScolarite(Enum):
-    __order__ = 'inconnue college lycee'  # Needed to preserve the enum order in Python 2
-    inconnue = u"Inconnue"
-    college = u"Collège"
-    lycee = u"Lycée"
-
-
 class scolarite(Variable):
     value_type = Enum
     possible_values = TypesScolarite


### PR DESCRIPTION
* Changement mineur.
* Détails :
  - Déplace `TypesScolarite` de  `prestations/education` vers `base`

- - - -
