### PR TITLE
Réactive le crédit d'impôt pour cotisations syndicales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 34.7.1 [#1271](https://github.com/openfisca/openfisca-france/pull/1271)
+
+* Correction d'un calcul existant
+* Périodes concernées : à partir du 01/01/2012.
+* Zones impactées : `prelevements_obligatoires/impot_revenu/(credits,reductions)_impot`.
+* Détails :
+  - Introduit les variables `reduction_cotisations_syndicales` et `credit_cotisations_syndicales`
+  - Factorise le calcul de ces variables (portant le statut) via `cotsyn` (portant seulement le montant)
+
 ## 34.7.0 [#1273](https://github.com/openfisca/openfisca-france/pull/1273)
 * Correction d'un crash.
 * Périodes concernées : toutes.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -595,15 +595,7 @@ class credit_cotisations_syndicales(Variable):
         '''
         Cotisations syndicales : réduction d'impôt (2002-2011) puis crédit d'impôt (2012- )
         '''
-        cotisations_versees = foyer_fiscal.members('f7ac', period)
-        salaire_imposable = foyer_fiscal.members('salaire_imposable', period, options = [ADD])
-        chomage_imposable = foyer_fiscal.members('chomage_imposable', period, options = [ADD])
-        retraite_imposable = foyer_fiscal.members('retraite_imposable', period, options = [ADD])
-        P = parameters(period).impot_revenu.reductions_impots.cotsyn
-
-        plafond = (salaire_imposable + chomage_imposable + retraite_imposable) * P.seuil
-
-        return (P.taux * foyer_fiscal.sum(min_(cotisations_versees, plafond)))
+        return foyer_fiscal('cotsyn', period)
 
 
 class creimp_exc_2008(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -582,7 +582,7 @@ class ci_garext(Variable):
             + min_(f7gf, max1 / 2)
             + min_(f7gg, max1 / 2)
             )
-       
+
 
 class credit_cotisations_syndicales(Variable):
     value_type = float

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -588,6 +588,7 @@ class cotsyn2(Variable):
     value_type = float
     entity = FoyerFiscal
     label = u"Crédit d'impôt pour cotisations syndicales"
+    reference = u"http://bofip.impots.gouv.fr/bofip/1605-PGP"
     definition_period = YEAR
 
     def formula_2012_01_01(foyer_fiscal, period, parameters):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -190,7 +190,7 @@ class credits_impot(Variable):
         assloy = foyer_fiscal('assloy', period)
         autent = foyer_fiscal('autent', period)
         ci_garext = foyer_fiscal('ci_garext', period)
-        cotsyn2 = foyer_fiscal('cotsyn2', period)
+        credit_cotisations_syndicales = foyer_fiscal('credit_cotisations_syndicales', period)
         creimp = foyer_fiscal('creimp', period)
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
@@ -201,7 +201,7 @@ class credits_impot(Variable):
         saldom2 = foyer_fiscal('saldom2', period)
 
         return (
-            aidper + assloy + autent + ci_garext + cotsyn2 + creimp + direpa + drbail + inthab
+            aidper + assloy + autent + ci_garext + credit_cotisations_syndicales + creimp + direpa + drbail + inthab
             + preetu + prlire + quaenv + saldom2
             )
 
@@ -213,7 +213,7 @@ class credits_impot(Variable):
         assloy = foyer_fiscal('assloy', period)
         autent = foyer_fiscal('autent', period)
         ci_garext = foyer_fiscal('ci_garext', period)
-        cotsyn2 = foyer_fiscal('cotsyn2', period)
+        credit_cotisations_syndicales = foyer_fiscal('credit_cotisations_syndicales', period)
         creimp = foyer_fiscal('creimp', period)
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
@@ -224,7 +224,7 @@ class credits_impot(Variable):
         saldom2 = foyer_fiscal('saldom2', period)
 
         return (
-            aidper + assloy + autent + ci_garext + cotsyn2 + creimp + direpa + drbail + inthab
+            aidper + assloy + autent + ci_garext + credit_cotisations_syndicales + creimp + direpa + drbail + inthab
             + preetu + prlire + quaenv + saldom2
             )
 
@@ -236,7 +236,7 @@ class credits_impot(Variable):
         assloy = foyer_fiscal('assloy', period)
         autent = foyer_fiscal('autent', period)
         ci_garext = foyer_fiscal('ci_garext', period)
-        cotsyn2 = foyer_fiscal('cotsyn2', period)
+        credit_cotisations_syndicales = foyer_fiscal('credit_cotisations_syndicales', period)
         creimp = foyer_fiscal('creimp', period)
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
@@ -247,7 +247,7 @@ class credits_impot(Variable):
         saldom2 = foyer_fiscal('saldom2', period)
 
         return (
-            aidper + assloy + autent + ci_garext + cotsyn2 + creimp + direpa + drbail + inthab
+            aidper + assloy + autent + ci_garext + credit_cotisations_syndicales + creimp + direpa + drbail + inthab
             + preetu + prlire + quaenv + saldom2
             )
 
@@ -258,7 +258,7 @@ class credits_impot(Variable):
         aidper = foyer_fiscal('aidper', period)
         autent = foyer_fiscal('autent', period)
         ci_garext = foyer_fiscal('ci_garext', period)
-        cotsyn2 = foyer_fiscal('cotsyn2', period)
+        credit_cotisations_syndicales = foyer_fiscal('credit_cotisations_syndicales', period)
         creimp = foyer_fiscal('creimp', period)
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
@@ -269,7 +269,7 @@ class credits_impot(Variable):
         saldom2 = foyer_fiscal('saldom2', period)
 
         return (
-            aidper + autent + ci_garext + cotsyn2
+            aidper + autent + ci_garext + credit_cotisations_syndicales
             + creimp + direpa + drbail + inthab
             + preetu + prlire + quaenv + saldom2
             )
@@ -584,7 +584,7 @@ class ci_garext(Variable):
             )
        
 
-class cotsyn2(Variable):
+class credit_cotisations_syndicales(Variable):
     value_type = float
     entity = FoyerFiscal
     label = u"Crédit d'impôt pour cotisations syndicales"

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -190,7 +190,7 @@ class credits_impot(Variable):
         assloy = foyer_fiscal('assloy', period)
         autent = foyer_fiscal('autent', period)
         ci_garext = foyer_fiscal('ci_garext', period)
-        cotsyn = foyer_fiscal('cotsyn', period)
+        cotsyn2 = foyer_fiscal('cotsyn2', period)
         creimp = foyer_fiscal('creimp', period)
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
@@ -201,7 +201,7 @@ class credits_impot(Variable):
         saldom2 = foyer_fiscal('saldom2', period)
 
         return (
-            aidper + assloy + autent + ci_garext + cotsyn + creimp + direpa + drbail + inthab
+            aidper + assloy + autent + ci_garext + cotsyn2 + creimp + direpa + drbail + inthab
             + preetu + prlire + quaenv + saldom2
             )
 
@@ -213,7 +213,7 @@ class credits_impot(Variable):
         assloy = foyer_fiscal('assloy', period)
         autent = foyer_fiscal('autent', period)
         ci_garext = foyer_fiscal('ci_garext', period)
-        cotsyn = foyer_fiscal('cotsyn', period)
+        cotsyn2 = foyer_fiscal('cotsyn2', period)
         creimp = foyer_fiscal('creimp', period)
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
@@ -224,7 +224,7 @@ class credits_impot(Variable):
         saldom2 = foyer_fiscal('saldom2', period)
 
         return (
-            aidper + assloy + autent + ci_garext + cotsyn + creimp + direpa + drbail + inthab
+            aidper + assloy + autent + ci_garext + cotsyn2 + creimp + direpa + drbail + inthab
             + preetu + prlire + quaenv + saldom2
             )
 
@@ -236,7 +236,7 @@ class credits_impot(Variable):
         assloy = foyer_fiscal('assloy', period)
         autent = foyer_fiscal('autent', period)
         ci_garext = foyer_fiscal('ci_garext', period)
-        cotsyn = foyer_fiscal('cotsyn', period)
+        cotsyn2 = foyer_fiscal('cotsyn2', period)
         creimp = foyer_fiscal('creimp', period)
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
@@ -247,7 +247,7 @@ class credits_impot(Variable):
         saldom2 = foyer_fiscal('saldom2', period)
 
         return (
-            aidper + assloy + autent + ci_garext + cotsyn + creimp + direpa + drbail + inthab
+            aidper + assloy + autent + ci_garext + cotsyn2 + creimp + direpa + drbail + inthab
             + preetu + prlire + quaenv + saldom2
             )
 
@@ -258,7 +258,7 @@ class credits_impot(Variable):
         aidper = foyer_fiscal('aidper', period)
         autent = foyer_fiscal('autent', period)
         ci_garext = foyer_fiscal('ci_garext', period)
-        cotsyn = foyer_fiscal('cotsyn', period)
+        cotsyn2 = foyer_fiscal('cotsyn2', period)
         creimp = foyer_fiscal('creimp', period)
         direpa = foyer_fiscal('direpa', period)
         drbail = foyer_fiscal('drbail', period)
@@ -269,7 +269,7 @@ class credits_impot(Variable):
         saldom2 = foyer_fiscal('saldom2', period)
 
         return (
-            aidper + autent + ci_garext + cotsyn
+            aidper + autent + ci_garext + cotsyn2
             + creimp + direpa + drbail + inthab
             + preetu + prlire + quaenv + saldom2
             )
@@ -582,6 +582,27 @@ class ci_garext(Variable):
             + min_(f7gf, max1 / 2)
             + min_(f7gg, max1 / 2)
             )
+       
+
+class cotsyn2(Variable):
+    value_type = float
+    entity = FoyerFiscal
+    label = u"Crédit d'impôt pour cotisations syndicales"
+    definition_period = YEAR
+
+    def formula_2012_01_01(foyer_fiscal, period, parameters):
+        '''
+        Cotisations syndicales : réduction d'impôt (2002-2011) puis crédit d'impôt (2012- )
+        '''
+        cotisations_versees = foyer_fiscal.members('f7ac', period)
+        salaire_imposable = foyer_fiscal.members('salaire_imposable', period, options = [ADD])
+        chomage_imposable = foyer_fiscal.members('chomage_imposable', period, options = [ADD])
+        retraite_imposable = foyer_fiscal.members('retraite_imposable', period, options = [ADD])
+        P = parameters(period).impot_revenu.reductions_impots.cotsyn
+
+        plafond = (salaire_imposable + chomage_imposable + retraite_imposable) * P.seuil
+
+        return (P.taux * foyer_fiscal.sum(min_(cotisations_versees, plafond)))
 
 
 class creimp_exc_2008(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -505,6 +505,16 @@ class reduction_cotisations_syndicales(Variable):
         '''
         Cotisations syndicales : réduction d'impôt (2002-2011) puis crédit d'impôt (2012- )
         '''
+        return foyer_fiscal('cotsyn', period)
+
+
+class cotsyn(Variable):
+    value_type = float
+    entity = FoyerFiscal
+    label = u"Montant de la réduction ou crédit d'impôt pour cotisations syndicales"
+    definition_period = YEAR
+
+    def formula(foyer_fiscal, period, parameters):
         cotisations_versees = foyer_fiscal.members('f7ac', period)
         salaire_imposable = foyer_fiscal.members('salaire_imposable', period, options = [ADD])
         chomage_imposable = foyer_fiscal.members('chomage_imposable', period, options = [ADD])

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -24,7 +24,7 @@ class reductions(Variable):
         '''
         reductions = [
             # Depuis 2002
-            'accult', 'adhcga', 'assvie', 'cappme', 'cotsyn',
+            'accult', 'adhcga', 'assvie', 'cappme', 'reduction_cotisations_syndicales',
             'daepad', 'dfppce', 'doment', 'domlog', 'donapd',
             'ecpess', 'garext', 'intemp', 'invfor', 'invrev',
             'prcomp', 'rsceha', 'saldom', 'spfcpi',
@@ -494,10 +494,10 @@ class cappme(Variable):
             )
 
 
-class cotsyn(Variable):
+class reduction_cotisations_syndicales(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"cotsyn"
+    label = u"Réduction d'impôt pour cotisations syndicales"
     definition_period = YEAR
     end = '2011-12-31'
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "34.7.0",
+    version = "34.7.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/impot_revenu/cotsyn.yaml
+++ b/tests/impot_revenu/cotsyn.yaml
@@ -1,0 +1,37 @@
+- name: Cotisations syndicales en réduction d’impôt jusqu’à 2011, imposable largement
+  period: 2011
+  relative_error_margin: 0.01
+  input:
+    salaire_imposable: 50000.0
+    f7ac: 700
+  output:
+    ip_net: 7934.0
+    reductions: 330.0
+    reduction_cotisations_syndicales: 330.0
+    irpp: -(7934.0 - 330.0)
+
+- name: Cotisations syndicales en réduction d’impôt jusqu’à 2011, non imposable suite à réduction
+  period: 2011
+  relative_error_margin: 0.01
+  input:
+    salaire_imposable: 13000.0
+    f7ac: 700
+  output:
+    ip_net: 35.0
+    reductions: 35.0
+    reduction_cotisations_syndicales: 85.8
+    irpp: 0.0
+
+- name: Cotisations syndicales en crédit d’impôt depuis 2012, impôt négatif
+  period: 2012
+  relative_error_margin: 0.01
+  input:
+    salaire_imposable: 13300.0
+    f7ac: 700
+  output:
+    ip_net: 25.0
+    reductions: 0.0
+    reduction_cotisations_syndicales: 0.0
+    credit_cotisations_syndicales: 87.8
+    credits_impot: 87.8
+    irpp: -(25.0 - 87.8)


### PR DESCRIPTION
Contexte : *Les cotisations syndicales ouvraient droit à une réduction d'impôt jusqu'à l'imposition des revenus 2011 puis à un crédit d'impôt à partir de l'imposition des revenus 2012. Le mode de calcul reste le même. Sources : [Article 119 quarter C du CGI](https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000006191827&cidTexte=LEGITEXT000006069577)*

Dans la version actuelle d'OpenFisca, le calcul des crédits d'impôt utilise la variable `cotsyn` (réduction d'impôt pour cotisations syndicales) dont l'attribut `end` était fixé au 31/12/2011. Par conséquent, le calcul des crédits d'impôt est faux : il ne prend pas en compte le crédit d'impôt pour cotisations syndicales.
Je propose de créer une nouvelle variable `cotsyn2` spécifique à ce crédit d'impôt et utilisée dans le calcul de `credits_impot` afin de corriger cette erreur.

Lié à l'issue #1202

* Évolution du système socio-fiscal. | Amélioration technique.
* Périodes concernées : à partir du 01/01/2012.
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py`.
* Détails :
  - Renomme la variable `cotsyn` en `reduction_cotisations_syndicales`
  - Crée une nouvelle variable `credit_cotisations_syndicales`
  - Calcule les crédits d'impôt `credits_impot` en utilisant cette nouvelle variable.

- - - -

Ces changements :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.

