### PR TITLE
Corrige le calcul des revenus bruts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,12 @@
 
 ## 34.6.0 [#1258](https://github.com/openfisca/openfisca-france/pull/1258)
 
-- Revalorisation périodique.
-- Périodes concernées : à partir de janvier 2019.
-- Zones impactées :
+* Revalorisation périodique.
+* Périodes concernées : à partir de janvier 2019.
+* Zones impactées :
   - `prestations/cheque_energie.py`
   - `parameters/cheque_energie.yaml`
-- Détails :
+* Détails :
   - Met à jour le chèque énergie avec les nouveaux barèmes : les montants changent et il y a une nouvelle tranche de revenus.
   - Exige une version de Core supérieure à 25.3, permettant de reformuler le barème du Chèque Energie comme un SingleAmountTaxScale.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Détails :
   - Tient compte de la CASA dans le calcul de `revenus_remplacement_pensions_bruts_menage`
 
-### 34.8.0 [#1280](https://github.com/openfisca/openfisca-france/pull/1280)
+## 34.8.0 [#1280](https://github.com/openfisca/openfisca-france/pull/1280)
 
 * Revalorisation périodique
 * Périodes concernées : à partir du 01/01/2019.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 34.8.1 [#1272](https://github.com/openfisca/openfisca-france/pull/1272)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `mesures.py`.
+* Détails :
+  - Tient compte de la CASA dans le calcul de `revenus_remplacement_pensions_bruts_menage`
+
 ### 34.8.0 [#1280](https://github.com/openfisca/openfisca-france/pull/1280)
 
 * Revalorisation périodique

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -366,6 +366,7 @@ class revenus_remplacement_pensions_bruts_menage(Variable):
         Revenus de remplacement et pensions bruts du ménage : avant CSG et CRDS
         '''
         pensions_nettes_i = menage.members('pensions_nettes', period)
+        casa_i = menage.members('casa', period, options = [ADD])
         csg_imposable_chomage_i = menage.members('csg_imposable_chomage', period, options = [ADD])
         csg_deductible_chomage_i = menage.members('csg_deductible_chomage', period, options = [ADD])
         csg_imposable_retraite_i = menage.members('csg_imposable_retraite', period, options = [ADD])
@@ -374,6 +375,7 @@ class revenus_remplacement_pensions_bruts_menage(Variable):
         crds_retraite_i = menage.members('crds_retraite', period, options = [ADD])
 
         pensions_nettes = menage.sum(pensions_nettes_i)
+        casa = menage.sum(casa_i)
         csg_imposable_chomage = menage.sum(csg_imposable_chomage_i)
         csg_deductible_chomage = menage.sum(csg_deductible_chomage_i)
         csg_imposable_retraite = menage.sum(csg_imposable_retraite_i)
@@ -383,6 +385,7 @@ class revenus_remplacement_pensions_bruts_menage(Variable):
 
         return (
             + pensions_nettes
+            - casa
             - csg_imposable_chomage  # On veut ajouter le montant de cotisations. Vu que ce montant est négatif, on met un "moins". Idem pour les autres items ci-dessous
             - csg_deductible_chomage
             - csg_imposable_retraite

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "34.8.0",
+    version = "34.8.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Le calcul des revenus bruts dans le module `mesures.py` se fait en partant des revenus nets et en y ajoutant l'ensemble des prélèvements retranchés des revenus bruts. La contribution additionnelle de solidarité et d'autonomie (CASA) fait partie des prélèvements appliqués aux revenus bruts de remplacement (retraite). Elle doit donc être intégrée à ce calcul.

* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/mesures.py`.
* Détails :
  - Ajoute la CASA dans le calcul de `revenus_remplacement_pensions_bruts_menage`
- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.
