### PR TITLE
Corrige la CRDS sur les prestations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 34.7.0 [#1273](https://github.com/openfisca/openfisca-france/pull/1273)
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées:
+    - `prestations/minima_sociaux/rsa.py`
+    - `mesures.py`
+* Détails :
+  - Actualise la formule de la variable `crds_mini`
+  - Introduit `crds_mini` et `crds_pfam` dans la chaîne de calcul du revenu disponible
+
 ## 34.6.0 [#1258](https://github.com/openfisca/openfisca-france/pull/1258)
 
 - Revalorisation périodique.

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -517,8 +517,9 @@ class prestations_familiales(Variable):
         aeeh = famille('aeeh', period, options = [ADD])
         paje = famille('paje', period, options = [ADD])
         asf = famille('asf', period, options = [ADD])
+        crds_pfam = famille('crds_pfam', period)
 
-        return af + cf + ars + aeeh + paje + asf
+        return af + cf + ars + aeeh + paje + asf + crds_pfam
 
 
 class minimum_vieillesse(Variable):
@@ -553,8 +554,9 @@ class minima_sociaux(Variable):
         rsa = famille('rsa', period, options = [ADD])
         ppa = famille('ppa', period, options = [ADD])
         psa = famille('psa', period, options = [ADD])
+        crds_mini = famille('crds_mini', period, options = [ADD])
 
-        return aah + caah + minimum_vieillesse + rsa + aefa + api + ass + psa + ppa
+        return aah + caah + minimum_vieillesse + rsa + aefa + api + ass + psa + ppa + crds_mini
 
 
 class aides_logement(Variable):

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -334,6 +334,12 @@ class crds_mini(Variable):
     label = u"CRDS versée sur les minimas sociaux"
     definition_period = MONTH
 
+    def formula_2016_01_01(famille, period, parameters):
+        ppa = famille('ppa', period)
+        taux_crds = parameters(period).prelevements_sociaux.contributions.crds.taux
+
+        return - taux_crds * ppa
+
     def formula_2009_06_01(famille, period, parameters):
         rsa_activite = famille('rsa_activite', period)
         taux_crds = parameters(period).prelevements_sociaux.contributions.crds.taux

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "34.6.0",
+    version = "34.7.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées:
    - `prestations/minima_sociaux/rsa.py`
    - `mesures.py`
* Détails :
  - Actualise la formule de la variable `crds_mini`
  - Introduit `crds_mini` et `crds_pfam` dans la chaîne de calcul du revenu disponible

Fixes #1108 
