### PR TITLE
Supprime __future__ imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 34.7.2 [#1279](https://github.com/openfisca/openfisca-france/pull/1279)
+
+* Changement mineur.
+* Périodes concernées : à partir du 01/01/2018.
+* Zones impactées :
+  - `prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique`.
+* Détails: Corrige l'application d'un abattement sur les produits d'assurance-vie.
+
 ### 34.7.1 [#1271](https://github.com/openfisca/openfisca-france/pull/1271)
 
 * Correction d'un calcul existant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 34.7.3 [#1276](https://github.com/openfisca/openfisca-france/pull/1276)
+
+* Amélioration technique
+* Périodes concernées : n/a
+* Zones impactées : n/a
+* Détails :
+  - Supprime **__future__** imports, car trivials après l'arrêt du support Python2
+
 ### 34.7.2 [#1279](https://github.com/openfisca/openfisca-france/pull/1279)
 
 * Changement mineur.

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
-
 from openfisca_france.model.base import *
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import logging
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import logging
 
 from numpy import around, logical_or as or_

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
-
 import logging
 
 from numpy import datetime64, timedelta64, logical_xor as xor_, round as round_, around

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -249,6 +249,7 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
 
         # Nouveau régime de taxation (produits au titre des primes versées à compter du 26 septembre 1997, pour les contrats souscrits à partir du 26 septembre 1997)
         assurance_vie_pfu_ir_plus8ans_19970926_primes_apres_20170927_apres_abt = max_(assurance_vie_pfu_ir_plus8ans_19970926_primes_apres_20170927 - rvcm.abat_assvie * (1 + maries_ou_pacses), 0)
+        reliquat_abt = max_(rvcm.abat_assvie * (1 + maries_ou_pacses) - assurance_vie_pfu_ir_plus8ans_19970926_primes_apres_20170927, 0)
         pfu_ir_av_nouveau_regime = -(
             (assurance_vie_pfu_ir_moins8ans_19970926_primes_apres_20170927 * P1.taux)
             + (min_(assurance_vie_pfu_ir_plus8ans_19970926_primes_apres_20170927_apres_abt, P1.seuil_taux_reduit_av) * P1.taux_reduit_av)
@@ -257,9 +258,15 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
 
         # Ancien régime de taxation (autres produits que ceux mentionnés ci-dessus)
         p_contrat_age_sup_apres_abt = (
-            max_(assurance_vie_pfu_ir_plus8ans_1990_19970926 - rvcm.abat_assvie * (1 + maries_ou_pacses), 0)
-            + max_(assurance_vie_pfu_ir_plus6ans_avant1990 - rvcm.abat_assvie * (1 + maries_ou_pacses), 0)
-            + max_(assurance_vie_pfu_ir_plus8ans_19970926_primes_avant_20170927 - rvcm.abat_assvie * (1 + maries_ou_pacses), 0)
+            max_(
+                (
+                    assurance_vie_pfu_ir_plus8ans_1990_19970926
+                    + assurance_vie_pfu_ir_plus6ans_avant1990
+                    + assurance_vie_pfu_ir_plus8ans_19970926_primes_avant_20170927
+                    )
+                - reliquat_abt,
+                0
+                )
             )
         p_contrat_age_mid = assurance_vie_pfu_ir_4_8_ans_1990_19970926 + assurance_vie_pfu_ir_4_8_ans_19970926_primes_avant_20170927
         p_contrat_age_low = assurance_vie_pfu_ir_moins4ans_1990_19970926 + assurance_vie_pfu_ir_moins4ans_19970926_primes_avant_20170927

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
 import logging
 from openfisca_france.model.base import *
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/prelevement_forfaitaire_liberatoire.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/prelevement_forfaitaire_liberatoire.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
 import logging
 from openfisca_france.model.base import *
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/variables_communes.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/variables_communes.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
 import logging
 from openfisca_france.model.base import *
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import logging
 
 from numpy import around

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_france.model.base import *
 
 # Variables apparaissant dans la feuille de déclaration de patrimoine soumis à l'ISF

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import logging
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
 import logging
 from openfisca_france.model.base import *
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
 import logging
 from openfisca_france.model.base import *
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import logging
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import logging
 
 from numpy import busday_count, datetime64, logical_or as or_, logical_and as and_, timedelta64

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/apprentissage.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/apprentissage.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from numpy import datetime64, timedelta64
 
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/contrat_professionnalisation.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/contrat_professionnalisation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_france.model.base import *
 
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
-
 from numpy import datetime64, timedelta64
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/preprocessing.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/preprocessing.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import copy
 import logging
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/stage.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/stage.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
-
 from openfisca_france.model.base import *
 from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotisations_sociales.base import apply_bareme_for_relevant_type_sal
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import math
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
-
 import logging
 
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import logging
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_totaux.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_totaux.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
-
 import logging
 
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import logging
 
 import numpy as np

--- a/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
+++ b/openfisca_france/model/prelevements_obligatoires/taxe_habitation.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_france.model.base import *
 
 

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import csv
 import codecs
 import json

--- a/openfisca_france/model/prestations/autonomie.py
+++ b/openfisca_france/model/prestations/autonomie.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_france.model.base import *
 
 

--- a/openfisca_france/model/prestations/bourses_superieur.py
+++ b/openfisca_france/model/prestations/bourses_superieur.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_france.model.base import *
 
 

--- a/openfisca_france/model/prestations/cheque_energie.py
+++ b/openfisca_france/model/prestations/cheque_energie.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_france.model.base import *
 
 

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_france.model.base import *
 
 

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -1,7 +1,5 @@
 
 # -*- coding: utf-8 -*-
-from __future__ import division
-
 from openfisca_france.model.base import *
 
 # Références juridiques - Code de la sécurité sociale

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_france.model.base import *
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf
 

--- a/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
+++ b/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from numpy import floor, logical_and as and_, logical_or as or_
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from numpy import abs as abs_, logical_or as or_
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from numpy import absolute as abs_, logical_and as and_
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from numpy import absolute as abs_, logical_or as or_
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_france.model.base import *
 
 from numpy import round as round_, logical_or as or_, remainder as remainder_, datetime64

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
-
 from numpy import datetime64, logical_and as and_, logical_or as or_
 
 from openfisca_core import periods

--- a/openfisca_france/model/prestations/prestations_familiales/aeeh.py
+++ b/openfisca_france/model/prestations/prestations_familiales/aeeh.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_france.model.base import *
 
 

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from numpy import logical_or as or_
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_france.model.base import *
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf
 

--- a/openfisca_france/model/prestations/prestations_familiales/asf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/asf.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_france.model.base import *
 
 

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from numpy import logical_or as or_
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from numpy import round, logical_or as or_
 
 from openfisca_france.model.base import *

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from numpy import round, floor, datetime64, maximum
 
 from openfisca_france.model.base import *

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import os
 
 from ..model.base import *

--- a/openfisca_france/reforms/cesthra_invalidee.py
+++ b/openfisca_france/reforms/cesthra_invalidee.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import os
 
 from openfisca_france.model.base import *

--- a/openfisca_france/reforms/de_net_a_brut.py
+++ b/openfisca_france/reforms/de_net_a_brut.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 from openfisca_core.reforms import Reform
 
 try:

--- a/openfisca_france/reforms/inversion_directe_salaires.py
+++ b/openfisca_france/reforms/inversion_directe_salaires.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 
 from openfisca_core.reforms import Reform

--- a/openfisca_france/reforms/inversion_revenus.py
+++ b/openfisca_france/reforms/inversion_revenus.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
-
 from openfisca_core import reforms
 from openfisca_core.columns import MONTH, YEAR
 from openfisca_core.entities import ADD, DIVIDE

--- a/openfisca_france/reforms/landais_piketty_saez.py
+++ b/openfisca_france/reforms/landais_piketty_saez.py
@@ -6,8 +6,6 @@
 
 """Impôt Landais, Piketty, Saez"""
 
-from __future__ import division
-
 import os
 
 from openfisca_france.model.base import *

--- a/openfisca_france/reforms/plf2015.py
+++ b/openfisca_france/reforms/plf2015.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import os
 
 from ..model.base import *

--- a/openfisca_france/reforms/plf2016.py
+++ b/openfisca_france/reforms/plf2016.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-from __future__ import division
-
 import os
 
 from ..model.base import *

--- a/openfisca_france/reforms/plf2016_ayrault_muet.py
+++ b/openfisca_france/reforms/plf2016_ayrault_muet.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import os
 
 from ..model.base import *

--- a/openfisca_france/reforms/plfr2014.py
+++ b/openfisca_france/reforms/plfr2014.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import os
 
 from ..model.base import *

--- a/openfisca_france/reforms/trannoy_wasmer.py
+++ b/openfisca_france/reforms/trannoy_wasmer.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import os
 
 from ..model.base import *

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "34.7.1",
+    version = "34.7.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "34.7.2",
+    version = "34.7.3",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -240,9 +240,9 @@
   output:
     prelevements_sociaux_revenus_capital: -774000 # -4500000*(0.045+0.02+0.003+0.005+0.099)
     revenus_nets_du_capital: 4500000 - 774000
-    prelevement_forfaitaire_unique_ir_sur_assurance_vie: -768026.2 # =0,075*(MAX(100000-4600;0)+MAX(200000-4600;0)+MAX(500000-4600;0))+0,15*(400000+600000)+0,35*(300000+700000)+0,128*800000+0,075*150000+0,128*(MAX(900000-4600;0)-150000)
-    impots_directs: -768026.2
-    revenu_disponible: 4500000 - 774000 - 768026.2
+    prelevement_forfaitaire_unique_ir_sur_assurance_vie: -769061.2 # =0,075*150000+0,128*(900000-150000-4600)+0,075*(100000+200000+500000)+0,15*(400000+600000)+0,35*(300000+700000)+0,128*800000
+    impots_directs: -769061.2
+    revenu_disponible: 4500000 - 774000 -769061.2
 
 - name: pfu_epargne_non_solidaire_etats_non_cooperatifs_2018
   description: Test du prélèvement forfaitaire unique en 2018 pour les produits d'épargne solidaire et les produits des états non-coopératifs'

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import datetime
 
 from .cache import tax_benefit_system

--- a/tests/test_decomposition_fiches_de_paie.py
+++ b/tests/test_decomposition_fiches_de_paie.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
-
 import json
 import os
 


### PR DESCRIPTION
* Amélioration technique
* Détails :
  - Supprime __future__ imports car trivials après l'arrêt du support Python2

- - - -

Ces changements :

- Suppriment du code redondant

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
