### PR TITLE
Inclut les revenus du capital dans le calcul de l'AAH

### DIFF
--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1779,6 +1779,156 @@ class taxation_plus_values_hors_bareme(Variable):
             )
 
 
+class plus_values_taxees_hors_bareme(Variable):
+    value_type = float
+    entity = FoyerFiscal
+    label = u"Plus-values taxées hors barème"
+    definition_period = YEAR
+    end = '2017-12-31'
+
+    def formula_2007_01_01(foyer_fiscal, period):  # f3sd is in f3vd holder
+        f3vg = foyer_fiscal('f3vg', period)
+        f3vh = foyer_fiscal('f3vh', period)
+        f3vl = foyer_fiscal('f3vl', period)
+        f3vm = foyer_fiscal('f3vm', period)
+        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
+
+        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
+        f3vd = foyer_fiscal.declarant_principal('f3vd', period)  # noqa F841
+        f3sd = foyer_fiscal.conjoint('f3vd', period)  # noqa F841
+        f3vi = foyer_fiscal.declarant_principal('f3vi', period)
+        f3si = foyer_fiscal.conjoint('f3vi', period)  # noqa F841
+        f3vf = foyer_fiscal.declarant_principal('f3vf', period)
+        f3sf = foyer_fiscal.conjoint('f3vf', period)  # noqa F841
+        #  TODO: remove this todo use sum for all fields after checking
+        # revenus taxés à un taux proportionnel
+
+        return round_(
+            rpns_pvce
+            + max_(0, f3vg - f3vh)
+            + f3vl
+            + f3vm
+            + f3vi
+            + f3vf
+            )
+
+    def formula_2008_01_01(foyer_fiscal, period):  # f3sd is in f3vd holder
+        f3vg = foyer_fiscal('f3vg', period)
+        f3vh = foyer_fiscal('f3vh', period)
+        f3vl = foyer_fiscal('f3vl', period)
+        f3vm = foyer_fiscal('f3vm', period)
+        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
+
+        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
+        f3vd = foyer_fiscal.declarant_principal('f3vd', period)
+        f3sd = foyer_fiscal.conjoint('f3vd', period)  # noqa F841
+        f3vi = foyer_fiscal.declarant_principal('f3vi', period)
+        f3si = foyer_fiscal.conjoint('f3vi', period)  # noqa F841
+        f3vf = foyer_fiscal.declarant_principal('f3vf', period)
+        f3sf = foyer_fiscal.conjoint('f3vf', period)  # noqa F841
+        #  TODO: remove this todo use sum for all fields after checking
+        # revenus taxés à un taux proportionnel
+
+        return round_(
+            rpns_pvce
+            + max_(0, f3vg - f3vh)
+            + f3vl
+            + f3vm
+            + f3vi
+            + f3vf
+            + f3vd
+            )
+
+    def formula_2012_01_01(foyer_fiscal, period):
+        f3sa = foyer_fiscal('f3sa', period)
+        f3sj = foyer_fiscal('f3sj', period)
+        f3sk = foyer_fiscal('f3sk', period)
+        f3vg = foyer_fiscal('f3vg', period)
+        f3vh = foyer_fiscal('f3vh', period)
+        f3vl = foyer_fiscal('f3vl', period)
+        f3vt = foyer_fiscal('f3vt', period)
+        f3vm = foyer_fiscal('f3vm', period)
+        f3vd_i = foyer_fiscal.members('f3vd', period)
+        f3vi_i = foyer_fiscal.members('f3vi', period)
+        f3vf_i = foyer_fiscal.members('f3vf', period)
+        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
+
+        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
+        f3vd = foyer_fiscal.sum(f3vd_i)
+        f3vi = foyer_fiscal.sum(f3vi_i)
+        f3vf = foyer_fiscal.sum(f3vf_i)
+
+        return round_(
+            rpns_pvce
+            + max_(0, f3vg - f3vh)
+            + f3vd
+            + f3vl
+            + f3vm
+            + f3vt
+            + f3sa
+            + f3vi
+            + f3vf
+            + f3sj
+            + f3sk
+            )
+
+    def formula_2013_01_01(foyer_fiscal, period):
+        f3sj = foyer_fiscal('f3sj', period)
+        f3sk = foyer_fiscal('f3sk', period)
+        f3vm = foyer_fiscal('f3vm', period)
+        f3vt = foyer_fiscal('f3vt', period)
+        f3vd_i = foyer_fiscal.members('f3vd', period)
+        f3vi_i = foyer_fiscal.members('f3vi', period)
+        f3vf_i = foyer_fiscal.members('f3vf', period)
+        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
+
+        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
+        f3vd = foyer_fiscal.sum(f3vd_i)
+        f3vi = foyer_fiscal.sum(f3vi_i)
+        f3vf = foyer_fiscal.sum(f3vf_i)
+
+        return round_(
+            rpns_pvce
+            + f3vm
+            + f3vt
+            + f3vd
+            + f3vi
+            + f3vf
+            + f3sj
+            + f3sk
+            )
+
+    def formula_2016_01_01(foyer_fiscal, period):
+        f3sj = foyer_fiscal('f3sj', period)
+        f3sk = foyer_fiscal('f3sk', period)
+        f3vm = foyer_fiscal('f3vm', period)
+        f3vt = foyer_fiscal('f3vt', period)
+        f3vd_i = foyer_fiscal.members('f3vd', period)
+        f3vi_i = foyer_fiscal.members('f3vi', period)
+        f3vf_i = foyer_fiscal.members('f3vf', period)
+        f3wi = foyer_fiscal('f3wi', period)
+        f3wj = foyer_fiscal('f3wj', period)
+        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
+
+        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
+        f3vd = foyer_fiscal.sum(f3vd_i)
+        f3vi = foyer_fiscal.sum(f3vi_i)
+        f3vf = foyer_fiscal.sum(f3vf_i)
+
+        return round_(
+            rpns_pvce
+            + f3vm
+            + f3vt
+            + f3vd
+            + f3vi
+            + f3vf
+            + f3sj
+            + f3sk
+            + f3wi
+            + f3wj
+            )
+
+
 class rfr_plus_values_hors_rni(Variable):
     value_type = float
     entity = FoyerFiscal

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -62,8 +62,8 @@ class aah_base_ressources(Variable):
             return base_ressource_demandeur + assiette_conjoint(base_ressource_conjoint)
 
         def base_ressource_eval_annuelle():
-            base_ressource_demandeur = assiette_revenu_activite_demandeur(famille.demandeur('aah_base_ressources_eval_annuelle', period))
-            base_ressource_conjoint = famille.conjoint('aah_base_ressources_eval_annuelle', period)
+            base_ressource_demandeur = assiette_revenu_activite_demandeur(famille.demandeur('aah_base_ressources_eval_annuelle_salaires_rpns_pensions', period))
+            base_ressource_conjoint = famille.conjoint('aah_base_ressources_eval_annuelle_salaires_rpns_pensions', period)
             base_ressource_capital = (
                 famille.demandeur('aah_base_ressources_eval_annuelle_capital', period)
                 + famille.conjoint('aah_base_ressources_eval_annuelle_capital', period)
@@ -180,7 +180,7 @@ class aah_base_ressources_hors_activite_eval_trimestrielle(Variable):
         return ressources * 4
 
 
-class aah_base_ressources_eval_annuelle(Variable):
+class aah_base_ressources_eval_annuelle_salaires_rpns_pensions(Variable):
     value_type = float
     label = u"Base de ressources de l'AAH pour un individu, évaluation annuelle"
     entity = Individu

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -70,7 +70,6 @@ class aah_base_ressources(Variable):
                 )
             return base_ressource_demandeur + assiette_conjoint(base_ressource_conjoint) + base_ressource_capital
 
-
         return where(
             demandeur_en_activite,
             base_ressource_eval_trim(),

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -210,6 +210,7 @@ class aah_base_ressources_eval_annuelle_capital(Variable):
         plus_values = (
             individu.foyer_fiscal('revenu_categoriel_plus_values', period.n_2)
             + individu.foyer_fiscal('plus_values_taxees_hors_bareme', period.n_2)
+            + individu.foyer_fiscal('plus_values_prelevement_forfaitaire_unique_ir', period.n_2)
             )
 
         return (

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -62,7 +62,7 @@ class aah_base_ressources(Variable):
             return base_ressource_demandeur + assiette_conjoint(base_ressource_conjoint)
 
         def base_ressource_eval_annuelle():
-            base_ressource_demandeur = assiette_revenu_activite_demandeur(famille.demandeur('salaire_imposable', period.n_2, options = [ADD]) + famille.demandeur('rpns_individu', period.n_2)) + famille.demandeur('revenu_assimile_pension', period.n_2)
+            base_ressource_demandeur = assiette_revenu_activite_demandeur(famille.demandeur('aah_base_ressources_eval_annuelle', period))
             base_ressource_conjoint = famille.conjoint('aah_base_ressources_eval_annuelle', period)
 
             return base_ressource_demandeur + assiette_conjoint(base_ressource_conjoint)

--- a/tests/formulas/aah.yaml
+++ b/tests/formulas/aah.yaml
@@ -755,7 +755,7 @@
   absolute_error_margin: 0.1
   period: 2018-04
   input:
-    aah_eligible: True
+    aah_eligible: true
     salaire_imposable: 10
     revenu_categoriel_foncier:
       2018: 20000
@@ -768,7 +768,7 @@
   absolute_error_margin: 0.1
   period: 2018-04
   input:
-    aah_eligible: True
+    aah_eligible: true
     salaire_imposable: 0
     revenu_categoriel_foncier:
       2016: 20000

--- a/tests/formulas/aah.yaml
+++ b/tests/formulas/aah.yaml
@@ -750,3 +750,29 @@
         - enfant2
   output:
     aah: 0
+
+- name: AAH avec revenus fonciers durant les trois derniers mois et évaluation trimestrielle des ressources (i.e. si salaire_imposable>0)'
+  absolute_error_margin: 0.1
+  period: 2018-04
+  input:
+    aah_eligible: True
+    salaire_imposable: 10
+    revenu_categoriel_foncier:
+      2018: 20000
+  output:
+    aah_base_ressources_hors_activite_eval_trimestrielle: 20000
+    aah_base_ressources: 20000 # Pas de salaire dans la base ressources les salaires pris en compte sont ceux des trois derniers mois
+    aah: 0
+
+- name: AAH avec revenus fonciers en N-2 et évaluation annuelle des ressources (i.e. si salaire_imposable=0)'
+  absolute_error_margin: 0.1
+  period: 2018-04
+  input:
+    aah_eligible: True
+    salaire_imposable: 0
+    revenu_categoriel_foncier:
+      2016: 20000
+  output:
+    aah_base_ressources_eval_annuelle_capital: 20000
+    aah_base_ressources: 20000
+    aah: 0


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées:
    - `prestations/minima_sociaux/aah`
    - `prelevements_obligatoires/impot_revenu/ir`
* Détails : inclut les revenus du capital dans l'évaluation annuelle des ressources de l'AAH.

Résout #1234 
