### PR TITLE
Corrige l'application d'un abattement sur produits d'assurance-vie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 34.7.2 [#1279](https://github.com/openfisca/openfisca-france/pull/1279)
+
+* Changement mineur.
+* Périodes concernées : 2018
+* Zones impactées :
+     - `prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique`
+* Détails: Corrige l'application d'un abattement sur les produits d'assurance-vie
+
 ### 34.7.1 [#1271](https://github.com/openfisca/openfisca-france/pull/1271)
 
 * Correction d'un calcul existant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ### 34.7.2 [#1279](https://github.com/openfisca/openfisca-france/pull/1279)
 
 * Changement mineur.
-* Périodes concernées : 2018
+* Périodes concernées : à partir du 01/01/2018.
 * Zones impactées :
-     - `prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique`
-* Détails: Corrige l'application d'un abattement sur les produits d'assurance-vie
+  - `prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique`.
+* Détails: Corrige l'application d'un abattement sur les produits d'assurance-vie.
 
 ### 34.7.1 [#1271](https://github.com/openfisca/openfisca-france/pull/1271)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -249,6 +249,7 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
 
         # Nouveau régime de taxation (produits au titre des primes versées à compter du 26 septembre 1997, pour les contrats souscrits à partir du 26 septembre 1997)
         assurance_vie_pfu_ir_plus8ans_19970926_primes_apres_20170927_apres_abt = max_(assurance_vie_pfu_ir_plus8ans_19970926_primes_apres_20170927 - rvcm.abat_assvie * (1 + maries_ou_pacses), 0)
+        reliquat_abt = max_(rvcm.abat_assvie * (1 + maries_ou_pacses) - assurance_vie_pfu_ir_plus8ans_19970926_primes_apres_20170927, 0)
         pfu_ir_av_nouveau_regime = -(
             (assurance_vie_pfu_ir_moins8ans_19970926_primes_apres_20170927 * P1.taux)
             + (min_(assurance_vie_pfu_ir_plus8ans_19970926_primes_apres_20170927_apres_abt, P1.seuil_taux_reduit_av) * P1.taux_reduit_av)
@@ -257,9 +258,15 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
 
         # Ancien régime de taxation (autres produits que ceux mentionnés ci-dessus)
         p_contrat_age_sup_apres_abt = (
-            max_(assurance_vie_pfu_ir_plus8ans_1990_19970926 - rvcm.abat_assvie * (1 + maries_ou_pacses), 0)
-            + max_(assurance_vie_pfu_ir_plus6ans_avant1990 - rvcm.abat_assvie * (1 + maries_ou_pacses), 0)
-            + max_(assurance_vie_pfu_ir_plus8ans_19970926_primes_avant_20170927 - rvcm.abat_assvie * (1 + maries_ou_pacses), 0)
+            max_(
+                (
+                    assurance_vie_pfu_ir_plus8ans_1990_19970926
+                    + assurance_vie_pfu_ir_plus6ans_avant1990
+                    + assurance_vie_pfu_ir_plus8ans_19970926_primes_avant_20170927
+                    )
+                - reliquat_abt,
+                0
+                )
             )
         p_contrat_age_mid = assurance_vie_pfu_ir_4_8_ans_1990_19970926 + assurance_vie_pfu_ir_4_8_ans_19970926_primes_avant_20170927
         p_contrat_age_low = assurance_vie_pfu_ir_moins4ans_1990_19970926 + assurance_vie_pfu_ir_moins4ans_19970926_primes_avant_20170927

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "34.7.1",
+    version = "34.7.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -240,9 +240,9 @@
   output:
     prelevements_sociaux_revenus_capital: -774000 # -4500000*(0.045+0.02+0.003+0.005+0.099)
     revenus_nets_du_capital: 4500000 - 774000
-    prelevement_forfaitaire_unique_ir_sur_assurance_vie: -768026.2 # =0,075*(MAX(100000-4600;0)+MAX(200000-4600;0)+MAX(500000-4600;0))+0,15*(400000+600000)+0,35*(300000+700000)+0,128*800000+0,075*150000+0,128*(MAX(900000-4600;0)-150000)
-    impots_directs: -768026.2
-    revenu_disponible: 4500000 - 774000 - 768026.2
+    prelevement_forfaitaire_unique_ir_sur_assurance_vie: -769061.2 # =0,075*150000+0,128*(900000-150000-4600)+0,075*(100000+200000+500000)+0,15*(400000+600000)+0,35*(300000+700000)+0,128*800000
+    impots_directs: -769061.2
+    revenu_disponible: 4500000 - 774000 -769061.2
 
 - name: pfu_epargne_non_solidaire_etats_non_cooperatifs_2018
   description: Test du prélèvement forfaitaire unique en 2018 pour les produits d'épargne solidaire et les produits des états non-coopératifs'


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2018
* Zones impactées : 
     - `prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique`
* Détails: Corrige l'application d'un abattement sur les produits d'assurance-vie

Fixes #1084 
