### PR TITLE
Revalorisation de l'allocation de solidarité aux personnes âgées au 1er janvier 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 34.8.0 [#1280](https://github.com/openfisca/openfisca-france/pull/1280)
+
+* Revalorisation périodique
+* Périodes concernées : à partir du 01/01/2019.
+* Zones impactées : `parameters/prestations/minima_sociaux/aspa`.
+* Détails :
+  - Revalorise l'allocation de solidarité aux personnes âgées au 1er janvier 2019 et au 1er janvier 2020.
+
 ### 34.7.3 [#1276](https://github.com/openfisca/openfisca-france/pull/1276)
 
 * Amélioration technique

--- a/openfisca_france/parameters/prestations/minima_sociaux/aspa/montant_annuel_couple.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aspa/montant_annuel_couple.yaml
@@ -33,3 +33,6 @@ values:
   2019-01-01:
     value: 16174.59
     reference: https://www.legifrance.gouv.fr/eli/decret/2018/3/30/SSAS1805864D/jo/article_1
+  2020-01-01:
+    value: 16826.64
+    reference: https://www.legifrance.gouv.fr/eli/decret/2018/3/30/SSAS1805864D/jo/article_1

--- a/openfisca_france/parameters/prestations/minima_sociaux/aspa/montant_annuel_couple.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aspa/montant_annuel_couple.yaml
@@ -30,3 +30,6 @@ values:
     value: 14963.65
   2018-04-01:
     value: 15522.54
+  2019-01-01:
+    value: 16174.59
+    reference: https://www.legifrance.gouv.fr/eli/decret/2018/3/30/SSAS1805864D/jo/article_1

--- a/openfisca_france/parameters/prestations/minima_sociaux/aspa/montant_annuel_seul.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aspa/montant_annuel_seul.yaml
@@ -33,3 +33,6 @@ values:
   2019-01-01:
     value: 10418.40
     reference: https://www.legifrance.gouv.fr/eli/decret/2018/3/30/SSAS1805864D/jo/article_1
+  2020-01-01:
+    value: 10838.40
+    reference: https://www.legifrance.gouv.fr/eli/decret/2018/3/30/SSAS1805864D/jo/article_1

--- a/openfisca_france/parameters/prestations/minima_sociaux/aspa/montant_annuel_seul.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aspa/montant_annuel_seul.yaml
@@ -30,3 +30,6 @@ values:
     value: 9638.42
   2018-04-01:
     value: 9998.40
+  2019-01-01:
+    value: 10418.40
+    reference: https://www.legifrance.gouv.fr/eli/decret/2018/3/30/SSAS1805864D/jo/article_1

--- a/openfisca_france/parameters/prestations/minima_sociaux/aspa/plafond_ressources_couple.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aspa/plafond_ressources_couple.yaml
@@ -1,5 +1,5 @@
-description: Plafond de ressources annuelles pour un couple pour percevoir l'ASPA
-reference: https://www.ipp.eu/outils/baremes-ipp/
+description: Plafond de ressources annuelles pour un couple pour percevoir l'ASPA, identique au montant annuel (cf référence)
+reference: https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=52312F95C78DFC864FEE6DDC3A2F6A8D.tplgfr38s_1?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000020562591&dateTexte=20190221&categorieLien=cid#LEGIARTI000020562591
 unit: currency
 values:
   2006-01-01:

--- a/openfisca_france/parameters/prestations/minima_sociaux/aspa/plafond_ressources_couple.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aspa/plafond_ressources_couple.yaml
@@ -33,3 +33,6 @@ values:
   2019-01-01:
     value: 16174.59
     reference: https://www.legifrance.gouv.fr/eli/decret/2018/3/30/SSAS1805864D/jo/article_1
+  2020-01-01:
+    value: 16826.64
+    reference: https://www.legifrance.gouv.fr/eli/decret/2018/3/30/SSAS1805864D/jo/article_1

--- a/openfisca_france/parameters/prestations/minima_sociaux/aspa/plafond_ressources_couple.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aspa/plafond_ressources_couple.yaml
@@ -30,3 +30,6 @@ values:
     value: 14963.65
   2018-04-01:
     value: 15522.54
+  2019-01-01:
+    value: 16174.59
+    reference: https://www.legifrance.gouv.fr/eli/decret/2018/3/30/SSAS1805864D/jo/article_1

--- a/openfisca_france/parameters/prestations/minima_sociaux/aspa/plafond_ressources_seul.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aspa/plafond_ressources_seul.yaml
@@ -1,5 +1,6 @@
 description: Plafond de ressources annuelles pour une personne seule pour percevoir
-  l'ASPA
+  l'ASPA, identique au montant annuel (cf référence)
+reference: https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=52312F95C78DFC864FEE6DDC3A2F6A8D.tplgfr38s_1?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000020562591&dateTexte=20190221&categorieLien=cid#LEGIARTI000020562591
 unit: currency
 values:
   2002-01-01:

--- a/openfisca_france/parameters/prestations/minima_sociaux/aspa/plafond_ressources_seul.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aspa/plafond_ressources_seul.yaml
@@ -38,3 +38,6 @@ values:
     value: 9638.42
   2018-04-01:
     value: 9998.40
+  2019-01-01:
+    value: 10418.40
+    reference: https://www.legifrance.gouv.fr/eli/decret/2018/3/30/SSAS1805864D/jo/article_1

--- a/openfisca_france/parameters/prestations/minima_sociaux/aspa/plafond_ressources_seul.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/aspa/plafond_ressources_seul.yaml
@@ -41,3 +41,6 @@ values:
   2019-01-01:
     value: 10418.40
     reference: https://www.legifrance.gouv.fr/eli/decret/2018/3/30/SSAS1805864D/jo/article_1
+  2020-01-01:
+    value: 10838.40
+    reference: https://www.legifrance.gouv.fr/eli/decret/2018/3/30/SSAS1805864D/jo/article_1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "34.7.3",
+    version = "34.8.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Revalorisation périodique
* Périodes concernées : à partir du 01/01/2019.
* Zones impactées : `parameters/prestations/minima_sociaux/aspa`.
* Détails :
  - Revalorise l'allocation de solidarité aux personnes âgées au 1er janvier 2019 et au 1er janvier 2020.