### PR TITLE
Supprime extra_param du calcul du RSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Détails :
   - Supprime `extra_param` du calcul du RSA. Le RSA est calculé au titre d'un mois donné (correspondant à l'argument `period`), en fonction des paramètres en vigueur durant ce mois-ci, et en fonction des ressources de `period.last_3_months`. On supprime la variable `rsa_fictif`, qui devient redondante.
   - Implique la suppression de la distinction des revenus d'activités moyennés et non-moyennés dans la base ressources : suppression des variables `indemnite_fin_contrat_net`, `primes_salaires_net` et `salaire_net_hors_revenus_exceptionnels`.
+  - Autres variables impactées : `rsa_base_ressources`, `rsa_base_ressources_minima_sociaux`, `rsa_base_ressources_prestations_familiales`, `rsa_enfant_a_charge`, `rsa_revenu_activite_individu`, `rsa_montant`.
 
 ## Guide de migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,33 @@
 # Changelog
 
+# 38.0.0 [#1284](https://github.com/openfisca/openfisca-france/pull/1284)
+
+* Évolution du système socio-fiscal **non rétrocompatible**
+* Périodes concernées : à partir de 2017.
+* Zones impactées : `prestations/minima_sociaux/rsa.py`.
+* Détails :
+  - Supprime `extra_param` du calcul du RSA. Le RSA est calculé au titre d'un mois donné (correspondant à l'argument `period`), en fonction des paramètres en vigueur durant ce mois-ci, et en fonction des ressources de `period.last_3_months`. On supprime la variable `rsa_fictif`, qui devient redondante.
+  - Implique la suppression de la distinction des revenus d'activités moyennés et non-moyennés dans la base ressources : suppression des variables `indemnite_fin_contrat_net`, `primes_salaires_net` et `salaire_net_hors_revenus_exceptionnels`.
+
+## Guide de migration
+
+- Remplacer la variable `rsa` par `rsa_fictif`
+- Remplacer `salaire_net_hors_revenus_exceptionnels` par `salaire_net`
+- Utiliser les versions brutes de `indemnite_fin_contrat` et `primes_salaires` qui sont reflétées en net dans `salaire_imposable`
+
 ### 37.0.1 [#1289](https://github.com/openfisca/openfisca-france/pull/1289)
 
 * Correction cosmétique de ce fichier (CHANGELOG.md)
 
 # 37.0.0 [#1287](https://github.com/openfisca/openfisca-france/pull/1287)
 
-* Évolution du système socio-fiscal. 
+* Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2012
 * Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu`.
 * Détails :
   - Crée une variable `f3sa` correspondant à la case 3SA réintroduite à partir de 2016
   - Renomme la variable `f3sa` (existant précédemment et correspondant à la case en 2012) en `f3sa_2012`
-  
+
 ### 36.1.1 [#1286](https://github.com/openfisca/openfisca-france/pull/1286)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -110,13 +110,6 @@ class indemnite_fin_contrat(Variable):
         return result
 
 
-class indemnite_fin_contrat_net(Variable):
-    value_type = float
-    entity = Individu
-    label = u"Indemnités de fin de contrat (licenciement, rupture conventionelle, prime de précarité) nettes"
-    definition_period = MONTH
-
-
 class reintegration_titre_restaurant_employeur(Variable):
     value_type = float
     entity = Individu

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -340,23 +340,11 @@ class rsa_enfant_a_charge(Variable):
         age = individu('age', period)
         autonomie_financiere = individu('autonomie_financiere', period)
 
-        if period.start.date >= date(2017, 1, 1):
-            m_1 = period.last_month
-            m_2 = m_1.last_month
-            m_3 = m_2.last_month
-            # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
-            ressources = (
-                individu('rsa_base_ressources_individu', period)
-                + individu('rsa_revenu_activite_individu', period, extra_params = [m_1]) / 3
-                + individu('rsa_revenu_activite_individu', period, extra_params = [m_2]) / 3
-                + individu('rsa_revenu_activite_individu', period, extra_params = [m_3]) / 3
-                )
-        else:
-            ressources = (
-                individu('rsa_base_ressources_individu', period)
-                + (1 - P_rsa.pente)
-                * individu('rsa_revenu_activite_individu', period)
-                )
+        ressources = (
+            individu('rsa_base_ressources_individu', period)
+            + (1 - P_rsa.pente)
+            * individu('rsa_revenu_activite_individu', period)
+            )
 
         # Les parametres ont changé de nom au moment où le RMI est devenu le RSA
         if period.start.date >= date(2009, 6, 1):

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -21,29 +21,6 @@ class rsa_base_ressources(Variable):
     entity = Famille
     definition_period = MONTH
 
-    def formula_2017_01_01(famille, mois_demande, parameters, mois_courant):
-        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
-        rsa_base_ressources_prestations_familiales = famille('rsa_base_ressources_prestations_familiales', mois_demande, extra_params = [mois_courant])
-        rsa_base_ressources_minima_sociaux = famille('rsa_base_ressources_minima_sociaux', mois_demande, extra_params = [mois_courant])
-
-        enfant_i = famille.members('est_enfant_dans_famille', mois_courant)
-        rsa_enfant_a_charge_i = famille.members('rsa_enfant_a_charge', mois_courant)
-
-        # Les ressources hors PF sont moyennées, à partir de mois_demande.last_3_months
-
-        ressources_individuelles_i = (
-            famille.members('rsa_base_ressources_individu', mois_demande)
-            + famille.members('rsa_revenu_activite_individu', mois_demande, extra_params = [mois_courant])
-            )
-
-        ressources_individuelles = famille.sum((not_(enfant_i) + rsa_enfant_a_charge_i) * ressources_individuelles_i)
-
-        return (
-            rsa_base_ressources_prestations_familiales
-            + rsa_base_ressources_minima_sociaux
-            + ressources_individuelles
-            )
-
     def formula_2009_06_01(famille, period):
         rsa_base_ressources_prestations_familiales = famille('rsa_base_ressources_prestations_familiales', period)
         rsa_base_ressources_minima_sociaux = famille('rsa_base_ressources_minima_sociaux', period)
@@ -212,17 +189,6 @@ class rsa_base_ressources_minima_sociaux(Variable):
     entity = Famille
     definition_period = MONTH
 
-    def formula_2017_01_01(famille, mois_demande, parameters, mois_courant):
-        # Prestations calculées que l'on réinjecte dans la BR du RSA
-        aspa = famille('aspa', mois_demande)
-
-        ass_i = famille.members('ass', mois_demande)
-        aah_i = famille.members('aah', mois_courant)
-        asi_i = famille.members('asi', mois_courant)
-        caah_i = famille.members('caah', mois_courant)
-
-        return aspa + famille.sum(ass_i) + famille.sum(aah_i + asi_i + caah_i)
-
     def formula(famille, period):
         three_previous_months = period.last_3_months
         aspa = famille('aspa', period)
@@ -300,7 +266,7 @@ class rsa_base_ressources_prestations_familiales(Variable):
 
         return result
 
-    def formula_2017_01_01(famille, mois_demande, parameters, mois_courant):
+    def formula_2017_01_01(famille, period, parameters):
         # Les prestations famillales sont prises en compte sur le mois_courant
         prestations_calculees = [
             'paje_base',
@@ -310,14 +276,14 @@ class rsa_base_ressources_prestations_familiales(Variable):
             'rsa_forfait_asf',
             ]
 
-        result = sum(famille(prestation, mois_courant)for prestation in prestations_calculees)
+        result = sum(famille(prestation, period)for prestation in prestations_calculees)
 
-        cf_non_majore_avant_cumul = famille('cf_non_majore_avant_cumul', mois_courant)
-        cf = famille('cf', mois_courant)
+        cf_non_majore_avant_cumul = famille('cf_non_majore_avant_cumul', period)
+        cf = famille('cf', period)
         cf_non_majore = (cf > 0) * cf_non_majore_avant_cumul
 
-        af_base = famille('af_base', mois_courant)
-        af = famille('af', mois_courant)
+        af_base = famille('af_base', period)
+        af = famille('af', period)
 
         # Si des AF on été injectées et sont plus faibles que le cf
         result = result + cf_non_majore + min_(af_base, af)
@@ -557,8 +523,8 @@ class rsa_revenu_activite_individu(Variable):
     entity = Individu
     definition_period = MONTH
 
-    def formula_2017_01_01(individu, mois_demande, parameters, mois_courant):
-        last_3_months = mois_demande.last_3_months
+    def formula_2017_01_01(individu, period, parameters):
+        last_3_months = period.last_3_months
 
         types_revenus_activite = [
             'salaire_net_hors_revenus_exceptionnels',
@@ -570,29 +536,26 @@ class rsa_revenu_activite_individu(Variable):
             'etr',
             'tns_auto_entrepreneur_benefice',
             'rsa_indemnites_journalieres_activite',
+            'primes_salaires_net',
+            'indemnite_fin_contrat_net',
             ]
 
-        possede_ressource_substitution = individu('rsa_has_ressources_substitution', mois_demande)
+        possede_ressource_substitution = individu('rsa_has_ressources_substitution', period)
 
         # Les revenus pros interrompus au mois M sont neutralisés s'il n'y a pas de revenus de substitution.
 
         revenus_moyennes = sum(
             individu(type_revenu, last_3_months, options = [ADD]) * not_(
-                (individu(type_revenu, mois_demande) == 0)
-                * (individu(type_revenu, mois_demande.last_month) > 0)
+                (individu(type_revenu, period) == 0)
+                * (individu(type_revenu, period.last_month) > 0)
                 * not_(possede_ressource_substitution)
                 )
             for type_revenu in types_revenus_activite
             ) / 3
 
-        revenus_tns_annualises = individu('ppa_rsa_derniers_revenus_tns_annuels_connus', mois_demande.this_year)
+        revenus_tns_annualises = individu('ppa_rsa_derniers_revenus_tns_annuels_connus', period.this_year)
 
-        revenus_non_moyennes = (
-            individu('primes_salaires_net', mois_courant)
-            + individu('indemnite_fin_contrat_net', mois_courant)
-            )
-
-        return revenus_moyennes + revenus_tns_annualises + revenus_non_moyennes
+        return revenus_moyennes + revenus_tns_annualises
 
     def formula_2009_06(individu, period):
         last_3_months = period.last_3_months
@@ -626,42 +589,12 @@ class rsa_revenu_activite_individu(Variable):
             ) / 3
 
 
-class rsa_fictif(Variable):
-    value_type = float
-    entity = Famille
-    label = "RSA fictif pour un mois"
-    definition_period = MONTH
-
-    def formula_2016_10(famille, mois_courant, parameters, mois_demande):
-        rsa_socle_non_majore = famille('rsa_socle', mois_courant)
-        rsa_socle_majore = famille('rsa_socle_majore', mois_courant)
-        rsa_socle = max_(rsa_socle_non_majore, rsa_socle_majore)
-
-        # Le rsa_forfait_logement et le rsa_base_ressources sont prises en compte sur le mois_courant(et pas sur le mois_demande)
-        rsa_forfait_logement = famille('rsa_forfait_logement', mois_courant)
-        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
-        rsa_base_ressources = famille('rsa_base_ressources', mois_demande, extra_params = [mois_courant])
-
-        montant = rsa_socle - rsa_forfait_logement - rsa_base_ressources
-        montant = max_(montant, 0)
-
-        return montant
-
-
 class rsa_montant(Variable):
     value_type = float
     label = u"Revenu de solidarité active, avant prise en compte de la non-calculabilité."
     reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=C0E3FD6701B46D63786815D26ADEAD58.tplgfr35s_2?idArticle=LEGIARTI000033979143&cidTexte=LEGITEXT000006074069&dateTexte=20180830"
     entity = Famille
     definition_period = MONTH
-
-    def formula_2017_01_01(famille, period, parameters):
-        seuil_non_versement = parameters(period).prestations.minima_sociaux.rsa.rsa_nv
-        # Le paramètre extra_params est déprécié. Ne pas s'inspirer de ce qui suit
-        rsa = famille('rsa_fictif', period.last_3_months, extra_params = [period], options = [ADD]) / 3
-        rsa = rsa * (rsa >= seuil_non_versement)
-
-        return rsa
 
     def formula_2009_06(famille, period, parameters):
         rsa_socle_non_majore = famille('rsa_socle', period)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "37.0.1",
+    version = "38.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/rsa.yaml
+++ b/tests/formulas/rsa.yaml
@@ -31,7 +31,14 @@
           2018-03: 67
           2018-02: 67
   output:
-    rsa: 522.59
+    rsa_forfait_logement:
+      2018-05: 132.22
+    rsa_socle:
+      2018-05: 550.93*1.5
+    rsa_base_ressources:
+      2018-05: 167
+    rsa:
+      2018-05: 550.93*1.5 - 132.22 - 167
 
 - name: RSA Cas N°2
   period: 2018-05
@@ -71,7 +78,7 @@
       enfant1:
         date_naissance: 2005-03-10
   output:
-    rsa: 655.58
+    rsa: 550.93*1.8*(1 - 0.165) - 167
 
 - name: RSA Cas N°3
   period: 2018-05
@@ -118,7 +125,12 @@
       enfant2:
         date_naissance: 2008-01-08
   output:
-    rsa: 689.48
+    rsa_socle:
+      2018-05: 550.93*2.1
+    rsa_forfait_logement:
+      2018-05: 550.93*1.8*0.165
+    rsa:
+      2018-05: 550.93*2.1 - 550.93*1.8*0.165 - 167 - 131.16
 
 - name: RSA Cas N°4
   period: 2018-05
@@ -172,7 +184,8 @@
       enfant3:
         date_naissance: 2010-10-15
   output:
-    rsa: 571.87
+    rsa:
+      2018-05: 550.93*2.5 - 550.93*1.8*0.165 - 167 - 299.20 - 170.71
 
 - name: RSA Cas N°5
   period: 2018-05
@@ -205,7 +218,7 @@
           2018-02: true
           2018-01: true
   output:
-    rsa: 363.30
+    rsa: 550.93 - 50 - 134
 
 - name: RSA Cas N°6
   period: 2018-05
@@ -232,7 +245,7 @@
           2018-03: 134
           2018-02: 134
   output:
-    rsa: 347.62
+    rsa: 550.93*(1-0.12) - 134
 
 - name: RSA Cas N°7
   period: 2018-05
@@ -271,7 +284,7 @@
       enfant1:
         date_naissance: 2005-03-10
   output:
-    rsa: 560.17
+    rsa: 550.93*(1.28412+0.42804) - 550.93*1.5*0.16 - 115.30 - 134
 
 - name: RSA Cas N°8
   period: 2018-05
@@ -317,7 +330,7 @@
       enfant2:
         date_naissance: 2008-01-04
   output:
-    rsa: 521.42
+    rsa: 550.93*(1.28412+2*0.42804) - 550.93*1.8*0.165 - 230.60 - 131.16 - 134
 
 - name: RSA Cas Non Passant N°1
   period: 2018-05
@@ -444,7 +457,7 @@
       enfant2:
         date_naissance: 2005-03-10
   output:
-    rsa: 0
+    rsa: 550.93*1.8 - 550.93*1.8*0.165 - 600 - 131.16 # Explication : règle CAF : un enfant ayant des resosurces > à la hausse du socle qu'il implique ne compte pas dans le calcul du RSA'
 
 - name: RSA Cas Non Passant N°4
   period: 2018-05

--- a/tests/formulas/rsa.yaml
+++ b/tests/formulas/rsa.yaml
@@ -34,11 +34,11 @@
     rsa_forfait_logement:
       2018-05: 132.22
     rsa_socle:
-      2018-05: 550.93*1.5
+      2018-05: 550.93 * 1.5
     rsa_base_ressources:
       2018-05: 167
     rsa:
-      2018-05: 550.93*1.5 - 132.22 - 167
+      2018-05: 550.93 * 1.5 - 132.22 - 167
 
 - name: RSA Cas N°2
   period: 2018-05
@@ -78,7 +78,7 @@
       enfant1:
         date_naissance: 2005-03-10
   output:
-    rsa: 550.93*1.8*(1 - 0.165) - 167
+    rsa: 550.93 * 1.8 * (1 - 0.165) - 167
 
 - name: RSA Cas N°3
   period: 2018-05
@@ -126,11 +126,11 @@
         date_naissance: 2008-01-08
   output:
     rsa_socle:
-      2018-05: 550.93*2.1
+      2018-05: 550.93 * 2.1
     rsa_forfait_logement:
-      2018-05: 550.93*1.8*0.165
+      2018-05: 550.93 * 1.8 * 0.165
     rsa:
-      2018-05: 550.93*2.1 - 550.93*1.8*0.165 - 167 - 131.16
+      2018-05: 550.93 * 2.1 - 550.93 * 1.8 * 0.165 - 167 - 131.16
 
 - name: RSA Cas N°4
   period: 2018-05
@@ -185,7 +185,7 @@
         date_naissance: 2010-10-15
   output:
     rsa:
-      2018-05: 550.93*2.5 - 550.93*1.8*0.165 - 167 - 299.20 - 170.71
+      2018-05: 550.93 * 2.5 - 550.93 * 1.8 * 0.165 - 167 - 299.20 - 170.71
 
 - name: RSA Cas N°5
   period: 2018-05
@@ -245,7 +245,7 @@
           2018-03: 134
           2018-02: 134
   output:
-    rsa: 550.93*(1-0.12) - 134
+    rsa: 550.93 * (1 - 0.12) - 134
 
 - name: RSA Cas N°7
   period: 2018-05
@@ -284,7 +284,7 @@
       enfant1:
         date_naissance: 2005-03-10
   output:
-    rsa: 550.93*(1.28412+0.42804) - 550.93*1.5*0.16 - 115.30 - 134
+    rsa: 550.93 * (1.28412 + 0.42804) - 550.93 * 1.5 * 0.16 - 115.30 - 134
 
 - name: RSA Cas N°8
   period: 2018-05
@@ -330,7 +330,7 @@
       enfant2:
         date_naissance: 2008-01-04
   output:
-    rsa: 550.93*(1.28412+2*0.42804) - 550.93*1.8*0.165 - 230.60 - 131.16 - 134
+    rsa: 550.93 * (1.28412 + 2 * 0.42804) - 550.93 * 1.8 * 0.165 - 230.60 - 131.16 - 134
 
 - name: RSA Cas Non Passant N°1
   period: 2018-05
@@ -457,7 +457,8 @@
       enfant2:
         date_naissance: 2005-03-10
   output:
-    rsa: 550.93*1.8 - 550.93*1.8*0.165 - 600 - 131.16 # Explication : règle CAF : un enfant ayant des resosurces > à la hausse du socle qu'il implique ne compte pas dans le calcul du RSA'
+    # Règle CAF : un enfant ayant des ressources > à la hausse du socle qu'il implique ne compte pas dans le calcul du RSA
+    rsa: 550.93 * 1.8 - 550.93 * 1.8 * 0.165 - 600 - 131.16
 
 - name: RSA Cas Non Passant N°4
   period: 2018-05

--- a/tests/formulas/rsa/rsa_2017.yaml
+++ b/tests/formulas/rsa/rsa_2017.yaml
@@ -196,7 +196,7 @@
     # RSA - AF - Forfait ASF
     rsa: 986.42 - 130.12 - 180
 
-- name: Le RSA est calculé sur les revenus d'acrtivité moyens des trois derniers mois
+- name: Le RSA est calculé sur les revenus d'activité moyens des trois derniers mois
   period: 2017-01
   relative_error_margin: 0.01
   input:
@@ -222,9 +222,9 @@
     rsa_forfait_logement:
       2017-01: 0
     rsa_revenu_activite_individu:
-      2017-01: (700+200+200)/3
+      2017-01: (700 + 200 + 200) / 3
     rsa:
-      2017-01: 535.17 - (700 + 200 + 200)/3
+      2017-01: 535.17 - (700 + 200 + 200) / 3
 
 - name: Les derniers benefices agricoles et autres TNS sont pris en compte dans la BR du RSA
   period: 2017-01
@@ -340,4 +340,4 @@
     rsa_forfait_logement:
       2017-01: 158.94
     rsa:
-      2017-01: 1145.37 - 158.94 - (1000+500+0)/3 - 130
+      2017-01: 1145.37 - 158.94 - (1000 + 500 + 0) / 3 - 130

--- a/tests/formulas/rsa/rsa_2017.yaml
+++ b/tests/formulas/rsa/rsa_2017.yaml
@@ -196,21 +196,17 @@
     # RSA - AF - Forfait ASF
     rsa: 986.42 - 130.12 - 180
 
-- name: Les primes sur un mois ne sont pas moyennées
+- name: Le RSA est calculé sur les revenus d'acrtivité moyens des trois derniers mois
   period: 2017-01
   relative_error_margin: 0.01
   input:
     individus:
       1:
         salaire_net:
-          2017-01: 200
+          2017-01: 1000
           2016-12: 700
           2016-11: 200
           2016-10: 200
-        primes_salaires_net:
-          2016-12: 500
-          2016-11: 0
-          2016-10: 0
     famille:
       parents:
       - 1
@@ -221,44 +217,14 @@
       personne_de_reference:
       - 1
   output:
+    rsa_socle:
+      2017-01: 535.17
+    rsa_forfait_logement:
+      2017-01: 0
+    rsa_revenu_activite_individu:
+      2017-01: (700+200+200)/3
     rsa:
-      2017-01: 223
-    rsa_fictif:
-      2016-12: 0
-      2016-11: 535.17 - 200
-      2016-10: 535.17 - 200
-
-- name: Les indemnités de licenciement sur un mois ne sont pas moyennées
-  period: 2017-01
-  relative_error_margin: 0.01
-  input:
-    individus:
-      1:
-        salaire_net:
-          2017-01: 400
-          2016-12: 400
-          2016-11: 0
-          2016-10: 2000
-        indemnite_fin_contrat_net:
-          2016-12: 0
-          2016-11: 0
-          2016-10: 1500
-    famille:
-      parents:
-      - 1
-    foyer_fiscal:
-      declarants:
-      - 1
-    menage:
-      personne_de_reference:
-      - 1
-  output:
-    rsa:
-      2017-01: 156.8
-    rsa_fictif:
-      2016-12: 535.17 - 300
-      2016-11: 535.17 - 300
-      2016-10: 0
+      2017-01: 535.17 - (700 + 200 + 200)/3
 
 - name: Les derniers benefices agricoles et autres TNS sont pris en compte dans la BR du RSA
   period: 2017-01
@@ -282,10 +248,6 @@
       2017-01: 535.17 - 200
     rsa_montant:
       2017-01: 535.17 - 200
-    rsa_fictif:
-      2016-12: 535.17 - 200
-      2016-11: 535.17 - 200
-      2016-10: 535.17 - 200
 
 - name: Les derniers benefices TNS sont pris en compte dans la BR du RSA
   period: 2017-01
@@ -311,10 +273,6 @@
       2017-01: 535.17 - 400
     rsa_montant:
       2017-01: 535.17 - 400
-    rsa_fictif:
-      2016-12: 535.17 - 400
-      2016-11: 535.17 - 400
-      2016-10: 535.17 - 400
 
 - name: Effets figés introduits en 2017 (exemple inspiré du suivi législatif)
   period: 2017-01
@@ -323,7 +281,7 @@
     individus:
       1:
         salaire_net:
-          2017-01: 1000
+          2017-01: 3000
           2016-12: 1000
           2016-11: 500
           2016-10: 0
@@ -334,14 +292,13 @@
       enfants: [2, 3]
       rsa_isolement_recent: true
       rsa_nb_enfants:
+        2017-01: 2
         2016-12: 2
-        2016-11: 2
-        2016-10: 1
+        2016-11: 1
       paje_prepare:
         2017-01: 130
-        2016-12: 130
+        2016-12: 0
         2016-11: 0
-        2016-10: 0
       af:
         2017-01: 0
         2016-12: 0
@@ -378,12 +335,9 @@
         personne_de_reference:
         - 3
   output:
-    rsa: 376.9
     rsa_socle_majore:
-      2016-12: 1145.37 # (Montant Forfaitaire MF)
-      2016-11: 1145.37 # MF
-      2016-10: 916.29 # MF
-    rsa_fictif:
-      2016-12: 1145.37 - 158.94 - (500 + 130)  # (Montant Forfaitaire MF -  Forfait logement FL - Prestations familiales PF)
-      2016-11: 1145.37 - 158.94 - 500  # (MF - FL - PF)
-      2016-10: 916.29 - 128.44 - 500  # (MF - FL - PF)
+      2017-01: 1145.37
+    rsa_forfait_logement:
+      2017-01: 158.94
+    rsa:
+      2017-01: 1145.37 - 158.94 - (1000+500+0)/3 - 130


### PR DESCRIPTION
* Évolution du système socio-fiscal **non rétrocompatible**
* Périodes concernées : à partir de 2017.
* Zones impactées : `prestations/minima_sociaux/rsa.py`.
* Détails :
  - Supprime `extra_param` du calcul du RSA. Le RSA est calculé au titre d'un mois donné (correspondant à l'argument `period`), en fonction des paramètres en vigueur durant ce mois-ci, et en fonction des ressources de `period.last_3_months`. On supprime la variable `rsa_fictif`, qui devient redondante.
  - Implique la suppression de la distinction des revenus d'activités moyennés et non-moyennés dans la base ressources : suppression des variables `indemnite_fin_contrat_net`, `primes_salaires_net` et `salaire_net_hors_revenus_exceptionnels`.
  - Autres variables impactées : `rsa_base_ressources`, `rsa_base_ressources_minima_sociaux`, `rsa_base_ressources_prestations_familiales`, `rsa_enfant_a_charge`, `rsa_revenu_activite_individu`, `rsa_montant`.


### Guide de migration

- Remplacer la variable `rsa` par `rsa_fictif`
- Remplacer `salaire_net_hors_revenus_exceptionnels` par `salaire_net`
- Utiliser les versions brutes de `indemnite_fin_contrat` et `primes_salaires` qui sont reflétées en net dans `salaire_imposable`

Cf. #1282 
