### PR TITLE
Supprime la TEHR à partir de 2015

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+### 36.1.1 [#1286](https://github.com/openfisca/openfisca-france/pull/1286)
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2015.
+* Zones impactées : `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite`.
+* Détails :
+  - Supprime la taxe exceptionnelle sur les hauts revenus à partir de 2015 (variable `tehr`), car taxation en vigueur seulement sur les revenus de 2013 et 2014.
+
 ## 36.1.0 [#1274](https://github.com/openfisca/openfisca-france/pull/1274)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : toutes.
-* Zones impactées : 
+* Zones impactées :
   - `model/prestations/minima_sociaux/aah`.
   - `parameters/prestations/minima_sociaux/aah/mva`.
   - `parameters/prestations/minima_sociaux/aah/taux_aah_hospitalise_ou_incarcere`.
@@ -12,8 +19,8 @@
   - `parameters/prestations/minima_sociaux/caah/garantie_ressources`.
 
 * Détails :
-  - Implémente des compléments à l'AAH : 
-    - le complément de ressources 
+  - Implémente des compléments à l'AAH :
+    - le complément de ressources
     - la majoration pour vie autonome (MVA) a désormais une formule de calcul.
   - Applique un montant minimal de l'AAH en cas d'hospitalisation ou incarcération.
   - Ajoute les variables:

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -252,6 +252,7 @@ class tehr(Variable):
     reference = u"http://vosdroits.service-public.fr/professionnels-entreprises/F32096.xhtml"
     calculate_output = calculate_output_divide
     definition_period = YEAR
+    end = '2015-01-01'
 
     def formula(individu, period, parameters):
         salaire_de_base = individu('salaire_de_base', period, options = [ADD])  # TODO: check base

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -249,7 +249,7 @@ class tehr(Variable):
     value_type = float
     entity = Individu
     label = u"Taxe exceptionnelle de solidarité sur les hautes rémunérations versées par les entreprises"
-    reference = u"art. 15 de la loi 2013-1278 (https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=1AACF2E1F7F065EF9C92B6B91E024EBE.tpdjo02v_1?idArticle=LEGIARTI000028402680&cidTexte=LEGITEXT000028402464&dateTexte=20140113)
+    reference = u"art. 15 de la loi 2013-1278 (https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=1AACF2E1F7F065EF9C92B6B91E024EBE.tpdjo02v_1?idArticle=LEGIARTI000028402680&cidTexte=LEGITEXT000028402464&dateTexte=20140113)"
     calculate_output = calculate_output_divide
     definition_period = YEAR
     end = '2015-01-01'

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -248,8 +248,8 @@ class salaire_net(Variable):
 class tehr(Variable):
     value_type = float
     entity = Individu
-    label = u"Taxe exceptionnelle de solidarité sur les très hautes rémunérations"
-    reference = u"http://vosdroits.service-public.fr/professionnels-entreprises/F32096.xhtml"
+    label = u"Taxe exceptionnelle de solidarité sur les hautes rémunérations versées par les entreprises"
+    reference = u"art. 15 de la loi 2013-1278 (https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=1AACF2E1F7F065EF9C92B6B91E024EBE.tpdjo02v_1?idArticle=LEGIARTI000028402680&cidTexte=LEGITEXT000028402464&dateTexte=20140113)
     calculate_output = calculate_output_divide
     definition_period = YEAR
     end = '2015-01-01'

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
@@ -29,7 +29,7 @@ class categorie_non_salarie(Variable):
 class cotisations_non_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisations sociales contributives des travailleurs non salaries"
+    label = u"Cotisations sociales des travailleurs non salaries"
     definition_period = YEAR
     calculate_output = calculate_output_add
 

--- a/openfisca_france/parameters/cotsoc/tehr.yaml
+++ b/openfisca_france/parameters/cotsoc/tehr.yaml
@@ -2,9 +2,13 @@ brackets:
 - rate:
     2013-01-01:
       value: 0.5
+    2015-01-01:
+      value: null
   threshold:
     2013-01-01:
       value: 1000000.0
+    2015-01-01:
+      value: null
 description: Taxes exceptionnelles sur les hauts revenus
 metadata:
   threshold_unit: currency

--- a/openfisca_france/parameters/cotsoc/tehr.yaml
+++ b/openfisca_france/parameters/cotsoc/tehr.yaml
@@ -1,3 +1,5 @@
+description: Taxe exceptionnelle de solidarité sur les hautes rémunérations versées par les entreprises
+reference: art. 15 de la loi 2013-1278 (https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=1AACF2E1F7F065EF9C92B6B91E024EBE.tpdjo02v_1?idArticle=LEGIARTI000028402680&cidTexte=LEGITEXT000028402464&dateTexte=20140113)
 brackets:
 - rate:
     2013-01-01:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "36.1.0",
+    version = "36.1.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2015.
* Zones impactées : `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite`.
* Détails :
  - Supprime la taxe exceptionnelle sur les hauts revenus à partir de 2015 (variable `tehr`), car taxation en vigueur seulement sur les revenus de 2013 et 2014.