### PR TITLE
Réintroduit la case 3SA à partir de 2016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 37.0.0 [#1287](https://github.com/openfisca/openfisca-france/pull/1286è
+* Évolution du système socio-fiscal. 
+* Périodes concernées : à partir du 01/01/2012
+* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu`.
+* Détails :
+  - Crée une variable `f3sa` correspondant à la case 3SA réintroduite à partir de 2016
+  - Renomme la variable `f3sa` (existant précédemment et correspondant à la case en 2012) en `f3sa_2012`
+  
 ### 36.1.1 [#1286](https://github.com/openfisca/openfisca-france/pull/1286)
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2015.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1681,7 +1681,7 @@ class taxation_plus_values_hors_bareme(Variable):
         """
         Taxation des plus values
         """
-        f3sa = foyer_fiscal('f3sa_2012', period)
+        f3sa_2012 = foyer_fiscal('f3sa_2012', period)
         f3sj = foyer_fiscal('f3sj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3vg = foyer_fiscal('f3vg', period)
@@ -1707,7 +1707,7 @@ class taxation_plus_values_hors_bareme(Variable):
             + plus_values.taux_pv_mob_pro * f3vl
             + plus_values.pea.taux_avant_2_ans * f3vm
             + plus_values.pea.taux_posterieur * f3vt
-            + plus_values.taux_pv_entrep * f3sa
+            + plus_values.taux_pv_entrep * f3sa_2012
             + plus_values.taux3 * f3vi
             + plus_values.taux4 * f3vf
             + plus_values.taux_plus_values_bspce * f3sj
@@ -1811,7 +1811,7 @@ class rfr_plus_values_hors_rni(Variable):
         """
         Plus-values 2012 entrant dans le calcul du revenu fiscal de référence
         """
-        f3sa = foyer_fiscal('f3sa_2012', period)
+        f3sa_2012 = foyer_fiscal('f3sa_2012', period)
         f3sj = foyer_fiscal('f3sj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3vc = foyer_fiscal('f3vc', period)
@@ -1834,7 +1834,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3sa + f3sj + f3sk + f3vc + f3vd + f3vf + f3vg + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz + f3we + rpns_pvce
+        return f3sa_2012 + f3sj + f3sk + f3vc + f3vd + f3vf + f3vg + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz + f3we + rpns_pvce
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         """

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1681,7 +1681,7 @@ class taxation_plus_values_hors_bareme(Variable):
         """
         Taxation des plus values
         """
-        f3sa = foyer_fiscal('f3sa', period)
+        f3sa = foyer_fiscal('f3sa_2012', period)
         f3sj = foyer_fiscal('f3sj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3vg = foyer_fiscal('f3vg', period)
@@ -1811,7 +1811,7 @@ class rfr_plus_values_hors_rni(Variable):
         """
         Plus-values 2012 entrant dans le calcul du revenu fiscal de référence
         """
-        f3sa = foyer_fiscal('f3sa', period)
+        f3sa = foyer_fiscal('f3sa_2012', period)
         f3sj = foyer_fiscal('f3sj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3vc = foyer_fiscal('f3vc', period)

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -210,7 +210,7 @@ class f3sb(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values en report d'imposition, dont le report a expiré cette année"
+    label = u"Plus-values en report d'imposition, dont le report a expiré cette année; montant imposable"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -478,7 +478,7 @@ class f3vl(Variable):
     definition_period = YEAR
 
 
-class f3sa(Variable):
+class f3sa_2012(Variable):
     cerfa_field = u"3SA"
     value_type = int
     entity = FoyerFiscal

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -196,6 +196,15 @@ class f3tz(Variable):
     definition_period = YEAR
 
 
+class f3sa(Variable):
+    cerfa_field = u"3SA"
+    value_type = int
+    entity = FoyerFiscal
+    label = u"Plus-values en report d'imposition, dont le report a expiré cette année; montant avant abattement"
+    # start_date = date(2016, 1, 1)
+    definition_period = YEAR
+
+
 class f3sb(Variable):
     cerfa_field = u"3SB"
     value_type = int

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "36.1.1",
+    version = "37.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Contexte : 
- La case 3SA était utilisée dans le formulaire de déclaration de l'IR sur revenus 2012. Ensuite elle disparait.
- La case 3SA est réintroduite (nouvelle signification) en 2016.
- Problème : La variable `f3sa` dans OF avait une end date en 2012 et n'était pas réintroduite en 2016. Le calcul de l'impôt sur le revenu (depuis les revenus 2016) était donc incorrect puisqu'il faisait appel à une variable "neutralisée".

* Évolution du système socio-fiscal. 
* Périodes concernées : à partir du 01/01/2012
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu`.
* Détails :
  - Crée une variable `f3sa` correspondant à la case 3SA réintroduite à partir de 2016
  - Renomme la variable `f3sa` (existant précédemment et correspondant à la case en 2012) en `f3sa_2012`

- - - -

Ces changements :

- Modifient l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.