### PR TITLE
Améliore la base ressources des revenus du capital de la PPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 38.1.1 [#1291](https://github.com/openfisca/openfisca-france/pull/1291)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `prestations\minima_sociaux\ppa`.
+* Détails :
+  - Ajoute les rentes foncières à titre onéreux dans la base ressources de la PPA
+  - Appelle dans les revenus du capital le douzième de l'année N-2, et pas le mois d'il y a deux ans.
+
 ## 38.1.0 [#1270](https://github.com/openfisca/openfisca-france/pull/1270)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -239,12 +239,12 @@ class ppa_ressources_hors_activite_individu(Variable):
                 ]
 
             return (
-                sum(individu(ressource, period.offset(-2, 'year')) for ressource in ressources_individuelles_mensuelles)
+                sum(individu(ressource, period.offset(-2, 'year').this_year, options = [ADD]) for ressource in ressources_individuelles_mensuelles)
                 + (
-                    individu.foyer_fiscal('assiette_csg_plus_values', period.offset(-2, 'year').this_year) / 12
-                    + individu.foyer_fiscal('rente_viagere_titre_onereux', period.offset(-2, 'year'))
+                    individu.foyer_fiscal('assiette_csg_plus_values', period.offset(-2, 'year').this_year)
+                    + individu.foyer_fiscal('rente_viagere_titre_onereux', period.offset(-2, 'year').this_year, options = [ADD])
                     ) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
-                )
+                ) / 12
 
         ressources_hors_activite_mensuel_i = (
             + ressources_percues_au_cours_du_mois_considere()

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -238,13 +238,13 @@ class ppa_ressources_hors_activite_individu(Variable):
                 'revenus_locatifs',
                 ]
 
-            return (
-                sum(individu(ressource, period.offset(-2, 'year').this_year, options = [ADD]) for ressource in ressources_individuelles_mensuelles)
-                + (
-                    individu.foyer_fiscal('assiette_csg_plus_values', period.offset(-2, 'year').this_year)
-                    + individu.foyer_fiscal('rente_viagere_titre_onereux', period.offset(-2, 'year').this_year, options = [ADD])
-                    ) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
-                ) / 12
+            revenus_annuels = sum(individu(ressource, period.offset(-2, 'year').this_year, options = [ADD]) for ressource in ressources_individuelles_mensuelles)
+            plus_values_annuelles = (
+                individu.foyer_fiscal('assiette_csg_plus_values', period.offset(-2, 'year').this_year)
+                + individu.foyer_fiscal('rente_viagere_titre_onereux', period.offset(-2, 'year').this_year, options = [ADD])
+                ) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
+
+            return (revenus_annuels + plus_values_annuelles) / 12
 
         ressources_hors_activite_mensuel_i = (
             + ressources_percues_au_cours_du_mois_considere()

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -233,15 +233,17 @@ class ppa_ressources_hors_activite_individu(Variable):
             return sum(individu(ressource, period) for ressource in ressources)
 
         def ressources_percues_il_y_a_deux_ans():
-            plus_values = individu.foyer_fiscal('assiette_csg_plus_values', period.offset(-2, 'year').this_year) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL) / 12
-            ressources_hors_plus_values = [
+            ressources_individuelles_mensuelles = [
                 'revenus_capital',
                 'revenus_locatifs',
                 ]
 
             return (
-                sum(individu(ressource, period.offset(-2, 'year')) for ressource in ressources_hors_plus_values)
-                + plus_values
+                sum(individu(ressource, period.offset(-2, 'year')) for ressource in ressources_individuelles_mensuelles)
+                + (
+                    individu.foyer_fiscal('assiette_csg_plus_values', period.offset(-2, 'year').this_year) / 12
+                    + individu.foyer_fiscal('rente_viagere_titre_onereux', period.offset(-2, 'year'))
+                    ) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
                 )
 
         ressources_hors_activite_mensuel_i = (

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "38.1.0",
+    version = "38.1.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/ppa.yaml
+++ b/tests/formulas/ppa.yaml
@@ -584,16 +584,16 @@
     pensions_invalidite:
       2016-01: 100
     revenus_locatifs:
-      2014-01: 100
+      2014-01: 120
     prime_forfaitaire_mensuelle_reprise_activite:
       2016-01: 100
   output:
     ppa:
       2016-02: 0
     ppa_ressources_hors_activite_individu:
-      2016-01: 900
+      2016-01: 810 # Car pour revenus locatifs, on prend le douzième des revenus totaux de l'année N-2
     ppa_ressources_hors_activite:
-      2016-01: 1691.40
+      2016-01: 1601.40 # Car pour revenus locatifs, on prend le douzième des revenus totaux de l'année N-2
 
 - name: 'PPA: étudiant éligible (ressources > plancher)'
   period: 2016-01

--- a/tests/formulas/ppa/ppa_ressources_hors_activite_individu.yaml
+++ b/tests/formulas/ppa/ppa_ressources_hors_activite_individu.yaml
@@ -19,3 +19,23 @@
       2018: 1200
   output:
     ppa_ressources_hors_activite_individu: 300
+
+- name: PPA - Ressources hors activité individu - rentes viagères à titre onéreux
+  description: Sont pris en compte les rentes viagères à titre onéreux de l'avant-dernière année
+  period: 2018-06
+  input:
+    rente_viagere_titre_onereux:
+      2016-01: 1000
+      2016-02: 1000
+      2016-03: 1000
+      2016-04: 1000
+      2016-05: 1000
+      2016-06: 1000
+      2016-07: 1500
+      2016-08: 1500
+      2016-09: 1500
+      2016-10: 1500
+      2016-11: 1500
+      2016-12: 1500
+  output:
+    ppa_base_ressources: (1000 + 1500) * 6 / 12

--- a/tests/formulas/ppa/ppa_ressources_hors_activite_individu.yaml
+++ b/tests/formulas/ppa/ppa_ressources_hors_activite_individu.yaml
@@ -25,17 +25,8 @@
   period: 2018-06
   input:
     rente_viagere_titre_onereux:
-      2016-01: 1000
-      2016-02: 1000
-      2016-03: 1000
-      2016-04: 1000
-      2016-05: 1000
-      2016-06: 1000
-      2016-07: 1500
-      2016-08: 1500
-      2016-09: 1500
-      2016-10: 1500
-      2016-11: 1500
-      2016-12: 1500
+      2016-01: 10000
+      2016-12: 2000
   output:
-    ppa_base_ressources: (1000 + 1500) * 6 / 12
+    # Le douzième de l'année N-2, et non le mois d'il y a 2 ans
+    ppa_base_ressources: 1000


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `prestations\minima_sociaux\ppa`.
* Détails :
  - Ajoute les rentes foncières à titre onéreux dans la base ressources de la PPA
  - Appelle dans les revenus du capital le douzième de l'année N-2, et pas le mois d'il y a deux ans.