### PR TITLE
Revalorisations PFs au 1er Avril 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 41.1.0 [#1302](https://github.com/openfisca/openfisca-france/pull/1302)
+
+* Revalorisation périodique.
+* Périodes concernées : à partir du 01/04/2019.
+* Zones impactées :
+  - `parameters/prestations/prestations_familiales/af`.
+  - `parameters/cmu`.
+  - `parameters/prestations/minima_sociaux/asi`.
+* Détails :
+  - Revalorise l'allocation familiale (AF) au 1er avril 2019 en métropole .
+  - Revalorise l'aide CMU-c et ACS au 01 avril 2019 en métropole .
+  - Revalorise l’allocation supplémentaire d’invalidité (ASI) au 1er avril 2019.
+
 # 41.0.0 [#1261](https://github.com/openfisca/openfisca-france/pull/1261)
 
 * Evolution technique **non rétrocompatible**

--- a/openfisca_france/parameters/cmu/plafond_base.yaml
+++ b/openfisca_france/parameters/cmu/plafond_base.yaml
@@ -31,3 +31,6 @@ values:
     value: 8723.0
   2018-04-01:
     value: 8810.23
+  2019-04-01:
+    value: 8951.00
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/3/20/SSAS1908400A/jo/article_1

--- a/openfisca_france/parameters/prestations/minima_sociaux/asi/montant_couple.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/asi/montant_couple.yaml
@@ -28,3 +28,6 @@ values:
     value: 8027.27
   2018-04-01:
     value: 8107.54
+  2019-04-01:
+    value: 8237.26
+    reference: http://circulaires.legifrance.gouv.fr/pdf/2019/03/cir_44460.pdf

--- a/openfisca_france/parameters/prestations/minima_sociaux/asi/montant_seul.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/asi/montant_seul.yaml
@@ -28,3 +28,6 @@ values:
     value: 4864.56
   2018-04-01:
     value: 4913.20
+  2019-04-01:
+    value: 4991.81
+    reference: http://circulaires.legifrance.gouv.fr/pdf/2019/03/cir_44460.pdf

--- a/openfisca_france/parameters/prestations/minima_sociaux/asi/plafond_ressource_couple.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/asi/plafond_ressource_couple.yaml
@@ -29,3 +29,6 @@ values:
     value: 14814.38
   2018-04-01:
     value: 14962.52
+  2019-04-01:
+    value: 15201.92
+    reference: http://circulaires.legifrance.gouv.fr/pdf/2019/03/cir_44460.pdf

--- a/openfisca_france/parameters/prestations/minima_sociaux/asi/plafond_ressource_seul.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/asi/plafond_ressource_seul.yaml
@@ -29,3 +29,6 @@ values:
     value: 8457.76
   2018-04-01:
     value: 8542.33
+  2019-04-01:
+    value: 8679.00
+    reference: http://circulaires.legifrance.gouv.fr/pdf/2019/03/cir_44460.pdf

--- a/openfisca_france/parameters/prestations/prestations_familiales/af/bmaf.yaml
+++ b/openfisca_france/parameters/prestations/prestations_familiales/af/bmaf.yaml
@@ -107,3 +107,5 @@ values:
   2018-04-01:
     value: 411.92
     reference : http://circulaires.legifrance.gouv.fr/pdf/2018/03/cir_43190.pdf
+  2019-04-01:
+    value: 413.16

--- a/openfisca_france/parameters/prestations/prestations_familiales/af/bmaf.yaml
+++ b/openfisca_france/parameters/prestations/prestations_familiales/af/bmaf.yaml
@@ -106,6 +106,7 @@ values:
     value: 407.84
   2018-04-01:
     value: 411.92
-    reference : http://circulaires.legifrance.gouv.fr/pdf/2018/03/cir_43190.pdf
+    reference: http://circulaires.legifrance.gouv.fr/pdf/2018/03/cir_43190.pdf
   2019-04-01:
     value: 413.16
+    reference: http://circulaires.legifrance.gouv.fr/pdf/2019/03/cir_44472.pdf

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "41.0.0",
+    version = "41.1.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Revalorisation périodique.
* Périodes concernées : à partir du 01/04/2019.
* Zones impactées : 
  - `parameters/prestations/prestations_familiales/af`.
  - `parameters/cmu`.
  - `parameters/prestations/minima_sociaux/asi`.
* Détails :
  - Revalorise l'allocation familiale (AF) au 1er avril 2019 en métropole .
  - Revalorise l'aide CMU-c et ACS au 01 avril 2019 en métropole .
  - Revalorise l’allocation supplémentaire d’invalidité (ASI) au 1er avril 2019.
  