### PR TITLE
Ajoute les revenus non individualisables dans la base ressources du CF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 41.2.0 [#1303](https://github.com/openfisca/openfisca-france/pull/1303)
 
-* Correction d'un crash.
+* Amélioration de modélisation.
 * Périodes concernées : toutes.
 * Zones impactées :
    - `prestations/prestations_familiales/base_ressources`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 41.2.0 [#1303](https://github.com/openfisca/openfisca-france/pull/1303)
+
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées :
+   - `prestations/prestations_familiales/base_ressources`
+   - `prestations/prestations_familiales/cf`
+* Détails :
+  - Injecte les revenus fiscaux non individualisables dans la base ressources du CF
+  - Crée une variable `prestations_familiales_base_ressources_communes` pour mutualiser cette opération pour les différentes bases ressources des prestations familiales
+  - Renomme `cf_ressources` par `cf_base_ressources` et `cf_ressources_individu` par `cf_base_ressources_individu`.
+
 ## 41.1.0 [#1302](https://github.com/openfisca/openfisca-france/pull/1302)
 
 * Revalorisation périodique.
@@ -49,7 +61,7 @@
 
 * Amélioration technique **non rétrocompatible**
 * Détails :
-  - Met à jour à la syntaxe Core v.29 (suivre le [guide de migration de Core](https://github.com/openfisca/openfisca-core/blob/232bca40e51c9eb5adaf030c70e0db362e84ec66/CHANGELOG.md#2900-843)). 
+  - Met à jour à la syntaxe Core v.29 (suivre le [guide de migration de Core](https://github.com/openfisca/openfisca-core/blob/232bca40e51c9eb5adaf030c70e0db362e84ec66/CHANGELOG.md#2900-843)).
 
 ### 38.1.1 [#1291](https://github.com/openfisca/openfisca-france/pull/1291)
 

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -191,13 +191,6 @@ class prestations_familiales_base_ressources(Variable):
     definition_period = MONTH
 
     def formula(famille, period):
-        '''
-        Base ressource des prestations familiales de la famille
-        'fam'
-        '''
-        # period_legacy = period.start.offset('first-of', 'month').period('year')
-        annee_fiscale_n_2 = period.n_2
-
         base_ressources_i = famille.members('prestations_familiales_base_ressources_individu', period)
         enfant_i = famille.members('est_enfant_dans_famille', period)
         enfant_a_charge_i = famille.members('prestations_familiales_enfant_a_charge', period)

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -84,7 +84,7 @@ class cf_dom_enfant_trop_jeune(Variable):
         return condition_age * est_enfant_dans_famille
 
 
-class cf_ressources_individu(Variable):
+class cf_base_ressources_individu(Variable):
     value_type = float
     entity = Individu
     label = u"Complément familial - Ressources de l'individu prises en compte"
@@ -164,15 +164,15 @@ class cf_majore_plafond(Variable):
         return plafond_base * pfam.cf.plafond_cf_majore
 
 
-class cf_ressources(Variable):
+class cf_base_ressources(Variable):
     value_type = float
     entity = Famille
     label = u"Ressources prises en compte pour l'éligibilité au complément familial"
     definition_period = MONTH
 
     def formula(famille, period):
-        cf_ressources_individu_i = famille.members('cf_ressources_individu', period)
-        ressources_i_total = famille.sum(cf_ressources_individu_i)
+        cf_base_ressources_individu_i = famille.members('cf_base_ressources_individu', period)
+        ressources_i_total = famille.sum(cf_base_ressources_individu_i)
         ressources_communes = famille('prestations_familiales_base_ressources_communes', period)
         return ressources_i_total + ressources_communes
 
@@ -223,7 +223,7 @@ class cf_non_majore_avant_cumul(Variable):
     def formula(famille, period, parameters):
         eligibilite_base = famille('cf_eligibilite_base', period)
         eligibilite_dom = famille('cf_eligibilite_dom', period)
-        ressources = famille('cf_ressources', period)
+        ressources = famille('cf_base_ressources', period)
         plafond = famille('cf_plafond', period)
 
         pfam = parameters(period).prestations.prestations_familiales
@@ -264,7 +264,7 @@ class cf_majore_avant_cumul(Variable):
     def formula_2014_04_01(famille, period, parameters):
         eligibilite_base = famille('cf_eligibilite_base', period)
         eligibilite_dom = famille('cf_eligibilite_dom', period)
-        ressources = famille('cf_ressources', period)
+        ressources = famille('cf_base_ressources', period)
         plafond_majore = famille('cf_majore_plafond', period)
 
         pfam = parameters(period).prestations.prestations_familiales

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -172,8 +172,9 @@ class cf_ressources(Variable):
 
     def formula(famille, period):
         cf_ressources_individu_i = famille.members('cf_ressources_individu', period)
-        ressources = famille.sum(cf_ressources_individu_i)
-        return ressources
+        ressources_i_total = famille.sum(cf_ressources_individu_i)
+        ressources_communes = famille('prestations_familiales_base_ressources_communes', period)
+        return ressources_i_total + ressources_communes
 
 
 class cf_eligibilite_base(Variable):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "41.1.0",
+    version = "41.2.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/cf.yaml
+++ b/tests/formulas/cf.yaml
@@ -1,0 +1,9 @@
+- name: revenus_fonciers_base_ressources_cf
+  description: Prise en compte des revenus fonciers dans la base ressources du complément familial
+  period: 2018-01
+  absolute_error_margin: 1
+  input:
+    revenu_categoriel_foncier:
+      2016: 20000
+  output:
+    cf_ressources: 20000

--- a/tests/formulas/cf.yaml
+++ b/tests/formulas/cf.yaml
@@ -6,4 +6,4 @@
     revenu_categoriel_foncier:
       2016: 20000
   output:
-    cf_ressources: 20000
+    cf_base_ressources: 20000


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées :
   - `prestations/prestations_familiales/base_ressources`
   - `prestations/prestations_familiales/cf`
* Détails :
  - Injecte les revenus fiscaux non individualisables dans la base ressources du CF
  - Crée une variable `prestations_familiales_base_ressources_communes` pour mutualiser cette opération pour les différentes bases ressources des prestations familiales
  - Renomme `cf_ressources` par `cf_base_ressources` et `cf_ressources_individu` par `cf_base_ressources_individu`.

Résout #1299 
