### PR TITLE
Adapte France au remaniement des classes Entity/Population

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 42.0.2 [#1307](https://github.com/openfisca/openfisca-france/pull/1307)
+
+* Amélioration technique
+* Périodes concernées : toutes.
+* Détails :
+  - Transforme les références aux rôles de la forme `famille.PARENT` en `Famille.PARENT`.
+  - (Ces changements sont rétro-compatibles et n'exigent pas d'ajuster la version de Core requise par France)
+
 ### 42.0.1 [#1304](https://github.com/openfisca/openfisca-france/pull/1304)
 
 * Changement mineur.

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -203,7 +203,7 @@ class nb_parents(Variable):
         # Note : Cette variable est "instantanée" : quelque soit la période demandée, elle retourne la valeur au premier
         # jour, sans changer la période.
 
-        return famille.nb_persons(role = famille.PARENT)
+        return famille.nb_persons(role = Famille.PARENT)
 
 
 class maries(Variable):
@@ -218,7 +218,7 @@ class maries(Variable):
         statut_marital = famille.members('statut_marital', period)
         individu_marie = (statut_marital == TypesStatutMarital.marie)
 
-        return famille.any(individu_marie, role = famille.PARENT)
+        return famille.any(individu_marie, role = Famille.PARENT)
 
 
 class en_couple(Variable):

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -139,7 +139,7 @@ class pensions_nettes(Variable):
         pensions_alimentaires_versees = foyer_fiscal('pensions_alimentaires_versees', period)
         rente_viagere_titre_onereux = foyer_fiscal('rente_viagere_titre_onereux', period, options = [ADD])
         pen_foyer_fiscal = pensions_alimentaires_versees + rente_viagere_titre_onereux
-        pen_foyer_fiscal_projetees = pen_foyer_fiscal * (individu.has_role(foyer_fiscal.DECLARANT_PRINCIPAL))
+        pen_foyer_fiscal_projetees = pen_foyer_fiscal * (individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL))
 
         return (
             chomage_net
@@ -279,7 +279,7 @@ class revenus_nets_du_capital(Variable):
             revenus_du_capital_cap_avant_prelevements_sociaux
             + prelevements_sociaux_revenus_capital
             )
-        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(foyer_fiscal.DECLARANT_PRINCIPAL)
+        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         return revenus_foyer_fiscal_projetes
 

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -163,7 +163,7 @@ class cmu_c_plafond(Variable):
             [cmu.coeff_p2, cmu.coeff_p3_p4, cmu.coeff_p5_plus]
             ) * coeff_garde_alt_i
 
-        coeff_monoparental = 1 + famille.sum(coeff_enfant_i, role = famille.ENFANT)
+        coeff_monoparental = 1 + famille.sum(coeff_enfant_i, role = Famille.ENFANT)
 
         # Couple
 
@@ -172,7 +172,7 @@ class cmu_c_plafond(Variable):
             [cmu.coeff_p3_p4, cmu.coeff_p5_plus]
             ) * coeff_garde_alt_i
 
-        coeff_couple = 1 + cmu.coeff_p2 + famille.sum(coeff_enfant_i, role = famille.ENFANT)
+        coeff_couple = 1 + cmu.coeff_p2 + famille.sum(coeff_enfant_i, role = Famille.ENFANT)
 
         coefficient_famille = where(is_couple, coeff_couple, coeff_monoparental)
         coefficient_dom = 1 + cmu_eligible_majoration_dom * cmu.majoration_dom

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -110,9 +110,9 @@ class biactivite(Variable):
             + famille.members('revenu_assimile_salaire_apres_abattements', annee_fiscale_n_2)
             >= seuil_rev
             )
-        deux_parents = famille.nb_persons(role = famille.PARENT) == 2
+        deux_parents = famille.nb_persons(role = Famille.PARENT) == 2
 
-        return deux_parents * famille.all(condition_ressource, role = famille.PARENT)
+        return deux_parents * famille.all(condition_ressource, role = Famille.PARENT)
 
 
 class rev_coll(Variable):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "42.0.1",
+    version = "42.0.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Amélioration technique
* Périodes concernées : toutes.
* Détails :
  - Transforme les références aux rôles de la forme `famille.PARENT` en `Famille.PARENT`.
  - (Ces changements sont rétro-compatibles et n'exigent pas d'ajuster la version de Core requise par France)

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
