### PR TITLE
Adapte France au déploiement sur PaaS (Scalingo, Heroku)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: openfisca serve --bind 0.0.0.0:$PORT --workers "$WORKERS" --tracker-idsite "$TRACKER_ID" --tracker-url "TRACKER_URL" --country-package openfisca_france --tracker-token "$TRACKER_TOKEN" --welcome-message "$WELCOME"
+

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,21 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 
 from setuptools import setup, find_packages
 
+openfisca_core_version = " >=31.0,<33.0"
+local_requires = [
+    "OpenFisca-Core" + openfisca_core_version
+    ]
+server_requires = [
+    "OpenFisca-Core[web-api]" + openfisca_core_version,
+    "OpenFisca-Tracker >=0.4.0,<1.0.0"
+    ]
+server = os.environ.get('SERVER', None)
+
+install_requires = server_requires if server else local_requires
 
 setup(
     name = "OpenFisca-France",
@@ -48,9 +60,7 @@ setup(
             ],
         },
     include_package_data = True,  # Will read MANIFEST.in
-    install_requires = [
-        "OpenFisca-Core >=31.0,<33.0",
-        ],
+    install_requires = install_requires,
     message_extractors = {"openfisca_france": [
         ("**.py", "python", None),
         ]},


### PR DESCRIPTION
* Amélioration technique.
* Détails :
  - Fournit un fichier Procfile permettant l'automatisation du déploiement
  - Adapte `setup.py` pour intégrer les dépendances appropriées en environnement serveur

- - - -

Ces changements

- Modifient des éléments non fonctionnels de ce dépôt

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
