### PR TITLE
Revalorisation du Revenu de solidarité active (RSA) au 1er avril 2019 en métropole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 42.2.0 [#1319](https://github.com/openfisca/openfisca-france/pull/1319)
+
+* Revalorisation périodique.
+* Périodes concernées : à partir du 01/04/2019.
+* Zones impactées : `parameters/prestations/minima_sociaux/rsa/montant_de_base_du_rsa`.
+* Détails :
+  - Revalorise le montant de base du rsa au 1 avril 2019.
+
 ### 42.1.2 [#1317](https://github.com/openfisca/openfisca-france/pull/1317)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prestations/minima_sociaux/rsa/montant_de_base_du_rsa.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/rsa/montant_de_base_du_rsa.yaml
@@ -35,3 +35,6 @@ values:
   2018-04-01:
     value: 550.93
     reference: https://www.legifrance.gouv.fr/eli/decret/2018/5/3/SSAA1805966D/jo/article_1
+  2019-04-01:
+    value: 559.74
+    reference: https://www.legifrance.gouv.fr/eli/decret/2019/5/2/2019-400/jo/texte

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "42.1.2",
+    version = "42.2.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Revalorisation périodique.
* Périodes concernées : à partir du 01/04/2019.
* Zones impactées : `parameters/prestations/minima_sociaux/rsa/montant_de_base_du_rsa`.
* Détails :
  - Revalorise le montant de base du rsa au 1 avril 2019.