### PR TITLE
Mets à jour la réduction d'impôt "Pinel" pour 2018 (IR 2019 sur revenus 2018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### 43.0.0 [#1325](https://github.com/openfisca/openfisca-france/pull/1325)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2015.
+* Zones impactées : `model/prelevements_obligatoires/impot_revenu/`.
+* Détails :
+  - Ajoute comme inputs variables les nouvelles cases de la déclaration IR 2018 liée à la réduction Pinel.
+  - Renomme les anciennes inputs variables du même nom, selon la méthode habituelle 
+  - Mets à jour la formule de calcul de la réduction (introduction des investissements réalisés en 2018 et ajout du report des investissements 2017)
+  - Factorise les formules de la réduction Pinel
+  - Renomme le paramètre `seuil` en `plafond`
+  - Ajoute 2 tests issus des résultats du [calculateur en ligne du site impots.gouv](https://www3.impots.gouv.fr/simulateur/calcul_impot/2019/index.htm)
+
 ### 42.5.1 [#1334](https://github.com/openfisca/openfisca-france/pull/1334)
 
 * Correction d'un crash.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4552,6 +4552,103 @@ class rpinel(Variable):
             + report
             )
 
+    def formula_2018_01_01(foyer_fiscal, period, parameters):
+        '''
+        Investissement locatif privé - Dispositif Pinel
+        2018
+        '''
+        f7ai = foyer_fiscal('f7ai', period)
+        f7bi = foyer_fiscal('f7bi', period)
+        f7bz = foyer_fiscal('f7bz', period)
+        f7ci = foyer_fiscal('f7ci', period)
+        f7cz = foyer_fiscal('f7cz', period)
+        f7di = foyer_fiscal('f7di', period)
+        f7dz = foyer_fiscal('f7dz', period)
+        invest_metropole_2014 = foyer_fiscal('f7ek', period)
+        invest_domtom_2014 = foyer_fiscal('f7el', period)
+        f7ez = foyer_fiscal('f7ez', period)
+        f7qa = foyer_fiscal('f7qa', period)
+        f7qb = foyer_fiscal('f7qb', period)
+        f7qc = foyer_fiscal('f7qc', period)
+        f7qd = foyer_fiscal('f7qd', period)
+        f7qe = foyer_fiscal('f7qe', period)
+        f7qf = foyer_fiscal('f7qf', period)
+        f7qg = foyer_fiscal('f7qg', period)
+        f7qh = foyer_fiscal('f7qh', period)
+        f7qi = foyer_fiscal('f7qi', period)
+        f7qj = foyer_fiscal('f7qj', period)
+        f7qk = foyer_fiscal('f7qk', period)
+        f7ql = foyer_fiscal('f7ql', period)
+        f7qm = foyer_fiscal('f7qm', period)
+        f7qn = foyer_fiscal('f7qn', period)
+        f7qo = foyer_fiscal('f7qo', period)
+        f7qp = foyer_fiscal('f7qp', period)
+        f7qr = foyer_fiscal('f7qr', period)
+        f7qs = foyer_fiscal('f7qs', period)
+        f7qt = foyer_fiscal('f7qt', period)
+        f7qu = foyer_fiscal('f7qu', period)s
+        f7qz = foyer_fiscal('f7qz', period)
+        f7ra = foyer_fiscal('f7ra', period)
+        f7rb = foyer_fiscal('f7rb', period)
+        f7rc = foyer_fiscal('f7rc', period)
+        f7rd = foyer_fiscal('f7rd', period)
+        f7rz = foyer_fiscal('f7rz', period)
+        f7sz = foyer_fiscal('f7sz', period)
+        f7tz = foyer_fiscal('f7tz', period)
+
+        P = parameters(period).impot_revenu.reductions_impots.rpinel
+
+        max1 = max_(0, P.seuil - invest_domtom_2014 - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
+        max2 = max_(0, max1 - f7qc)
+        max3 = max_(0, max2 - invest_metropole_2014 - f7qb)
+
+        reduc_invest_real_2014 = (
+            around(P.taux29 * min_(max_(0, P.seuil - invest_domtom_2014), f7qd) / 9)
+            + around(P.taux23 * min_(max1, f7qc) / 6)
+            + around(P.taux18 * min_(max_(0, max2 - invest_metropole_2014), f7qb) / 9)
+            + around(P.taux12 * min_(max3, f7qa) / 6)
+            )
+
+        reduc_invest_real_2015 = (
+            around(P.taux29 * min_(P.seuil, f7qh) / 9)
+            + around(P.taux23 * min_(max_(0, P.seuil - f7qh), f7qg) / 6)
+            + around(P.taux18 * min_(max_(0, P.seuil - f7qh - f7qg), f7qf) / 9)
+            + around(P.taux12 * min_(max_(0, P.seuil - f7qh - f7qg - f7qf), f7qe) / 6)
+            )
+
+        reduc_invest_real_2016 = (
+            around(P.taux29 * min_(P.seuil, f7ql) / 9)
+            + around(P.taux23 * min_(max_(0, P.seuil - f7ql), f7qk) / 6)
+            + around(P.taux18 * min_(max_(0, P.seuil - f7ql - f7qk), f7qj) / 9)
+            + around(P.taux12 * min_(max_(0, P.seuil - f7ql - f7qk - f7qj), f7qi) / 6)
+            )
+
+        reduc_invest_real_2017 = (
+            around(P.taux29 * min_(P.seuil, f7qp) / 9)
+            + around(P.taux23 * min_(max_(0, P.seuil - f7qp), f7qo) / 6)
+            + around(P.taux18 * min_(max_(0, P.seuil - f7qp - f7qo), f7qn) / 9)
+            + around(P.taux12 * min_(max_(0, P.seuil - f7qp - f7qo - f7qn), f7qm) / 6)
+            )
+        
+        reduc_invest_real_2018 = (
+            around(P.taux29 * min_(P.seuil, f7qu) / 9)
+            + around(P.taux23 * min_(max_(0, P.seuil - f7qu), f7qt) / 6)
+            + around(P.taux18 * min_(max_(0, P.seuil - f7qu - f7qt), f7qs) / 9)
+            + around(P.taux12 * min_(max_(0, P.seuil - f7qu - f7qt - f7qs), f7qr) / 6)
+            )
+
+        report = f7ai + f7bi + f7ci + f7di + f7bz + f7cz + f7dz + f7ez + f7qz + f7rz + f7sz + f7tz + f7ra + f7rb + f7rc + f7rd
+
+        return (
+            reduc_invest_real_2014
+            + reduc_invest_real_2015
+            + reduc_invest_real_2016
+            + reduc_invest_real_2017
+            + reduc_invest_real_2018
+            + report
+            )
+
+
 
 class rsceha(Variable):
     value_type = float

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4543,44 +4543,42 @@ class rpinel(Variable):
         Investissement locatif privé - Dispositif Pinel
         2018
         '''
-        f7ai = foyer_fiscal('f7ai', period)
-        f7bi = foyer_fiscal('f7bi', period)
-        f7bz = foyer_fiscal('f7bz', period)
-        f7ci = foyer_fiscal('f7ci', period)
-        f7cz = foyer_fiscal('f7cz', period)
-        f7di = foyer_fiscal('f7di', period)
-        f7dz = foyer_fiscal('f7dz', period)
         f7ek = foyer_fiscal('f7ek', period)
         f7el = foyer_fiscal('f7el', period)
-        f7ez = foyer_fiscal('f7ez', period)
         f7qa = foyer_fiscal('f7qa', period)
         f7qb = foyer_fiscal('f7qb', period)
         f7qc = foyer_fiscal('f7qc', period)
         f7qd = foyer_fiscal('f7qd', period)
-        f7qe = foyer_fiscal('f7qe', period)
-        f7qf = foyer_fiscal('f7qf', period)
-        f7qg = foyer_fiscal('f7qg', period)
-        f7qh = foyer_fiscal('f7qh', period)
-        f7qi = foyer_fiscal('f7qi', period)
-        f7qj = foyer_fiscal('f7qj', period)
-        f7qk = foyer_fiscal('f7qk', period)
-        f7ql = foyer_fiscal('f7ql', period)
-        f7qm = foyer_fiscal('f7qm', period)
-        f7qn = foyer_fiscal('f7qn', period)
-        f7qo = foyer_fiscal('f7qo', period)
-        f7qp = foyer_fiscal('f7qp', period)
-        f7qr = foyer_fiscal('f7qr', period)
-        f7qs = foyer_fiscal('f7qs', period)
-        f7qt = foyer_fiscal('f7qt', period)
-        f7qu = foyer_fiscal('f7qu', period)
-        f7qz = foyer_fiscal('f7qz', period)
-        f7ra = foyer_fiscal('f7ra', period)
-        f7rb = foyer_fiscal('f7rb', period)
-        f7rc = foyer_fiscal('f7rc', period)
-        f7rd = foyer_fiscal('f7rd', period)
-        f7rz = foyer_fiscal('f7rz', period)
-        f7sz = foyer_fiscal('f7sz', period)
-        f7tz = foyer_fiscal('f7tz', period)
+
+        cases_investissement = {
+            "2015": [
+                ('f7qh', 9, 'outremer'),
+                ('f7qg', 6, 'outremer'),
+                ('f7qf', 9, 'metropole'),
+                ('f7qe', 6, 'metropole')],
+            "2016": [
+                ('f7ql', 9, 'outremer'),
+                ('f7qk', 6, 'outremer'),
+                ('f7qj', 9, 'metropole'),
+                ('f7qi', 6, 'metropole')],
+            "2017": [
+                ('f7qp', 9, 'outremer'),
+                ('f7qo', 6, 'outremer'),
+                ('f7qn', 9, 'metropole'),
+                ('f7qm', 6, 'metropole')],
+            "2018": [
+                ('f7qu', 9, 'outremer'),
+                ('f7qt', 6, 'outremer'),
+                ('f7qs', 9, 'metropole'),
+                ('f7qr', 6, 'metropole')]
+            }
+
+        cases_report = {
+            "2014": ['f7ai', 'f7bi', 'f7ci', 'f7di'],
+            "2015": ['f7bz', 'f7cz', 'f7dz', 'f7ez'],
+            "2016": ['f7qz', 'f7rz', 'f7sz', 'f7tz'],
+            "2017": ['f7ra', 'f7rb', 'f7rc', 'f7rd'],
+            }
 
         P = parameters(period).impot_revenu.reductions_impots.rpinel
 
@@ -4595,44 +4593,21 @@ class rpinel(Variable):
             + around(P.taux12 * min_(max3, f7qa) / 6)
             )
 
-        reduc_invest_real_2015 = (
-            around(P.taux29 * min_(P.plafond, f7qh) / 9)
-            + around(P.taux23 * min_(max_(0, P.plafond - f7qh), f7qg) / 6)
-            + around(P.taux18 * min_(max_(0, P.plafond - f7qh - f7qg), f7qf) / 9)
-            + around(P.taux12 * min_(max_(0, P.plafond - f7qh - f7qg - f7qf), f7qe) / 6)
-            )
+        def calcul_reduction_investissement(cases):
+            reduction = foyer_fiscal.empty_array()
+            depenses_cumulees = foyer_fiscal.empty_array()
+            for case in cases:
+                variable, duree, zone = case
+                depense = foyer_fiscal(variable, period)
+                taux = P.taux[zone][str(duree) + '_ans']
+                reduction += around(taux * min_(max_(0, P.plafond - depenses_cumulees), depense) / duree)
+                depenses_cumulees += depense
+            return reduction
 
-        reduc_invest_real_2016 = (
-            around(P.taux29 * min_(P.plafond, f7ql) / 9)
-            + around(P.taux23 * min_(max_(0, P.plafond - f7ql), f7qk) / 6)
-            + around(P.taux18 * min_(max_(0, P.plafond - f7ql - f7qk), f7qj) / 9)
-            + around(P.taux12 * min_(max_(0, P.plafond - f7ql - f7qk - f7qj), f7qi) / 6)
-            )
+        reduction_cumulee = reduc_invest_real_2014 + sum([calcul_reduction_investissement(cases) for cases in cases_investissement.values()])
+        report = sum([foyer_fiscal(case, period) for year in cases_report.keys() for case in cases_report[year]])
 
-        reduc_invest_real_2017 = (
-            around(P.taux29 * min_(P.plafond, f7qp) / 9)
-            + around(P.taux23 * min_(max_(0, P.plafond - f7qp), f7qo) / 6)
-            + around(P.taux18 * min_(max_(0, P.plafond - f7qp - f7qo), f7qn) / 9)
-            + around(P.taux12 * min_(max_(0, P.plafond - f7qp - f7qo - f7qn), f7qm) / 6)
-            )
-
-        reduc_invest_real_2018 = (
-            around(P.taux29 * min_(P.plafond, f7qu) / 9)
-            + around(P.taux23 * min_(max_(0, P.plafond - f7qu), f7qt) / 6)
-            + around(P.taux18 * min_(max_(0, P.plafond - f7qu - f7qt), f7qs) / 9)
-            + around(P.taux12 * min_(max_(0, P.plafond - f7qu - f7qt - f7qs), f7qr) / 6)
-            )
-
-        report = f7ai + f7bi + f7ci + f7di + f7bz + f7cz + f7dz + f7ez + f7qz + f7rz + f7sz + f7tz + f7ra + f7rb + f7rc + f7rd
-
-        return (
-            reduc_invest_real_2014
-            + reduc_invest_real_2015
-            + reduc_invest_real_2016
-            + reduc_invest_real_2017
-            + reduc_invest_real_2018
-            + report
-            )
+        return reduction_cumulee + report
 
 
 class rsceha(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4506,7 +4506,6 @@ class rpinel(Variable):
             "2014": ['f7ai', 'f7bi', 'f7ci', 'f7di'],
             "2015": ['f7bz', 'f7cz', 'f7dz', 'f7ez'],
             "2016": ['f7qz', 'f7rz', 'f7sz', 'f7tz'],
-            "2017": ['f7ra', 'f7rb', 'f7rc', 'f7rd']
             }
 
         P = parameters(period).impot_revenu.reductions_impots.rpinel

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4501,7 +4501,7 @@ class rpinel(Variable):
                 ('f7qn', 9, 'metropole'),
                 ('f7qm', 6, 'metropole')]
             }
-        
+
         cases_report = {
             "2014": ['f7ai', 'f7bi', 'f7ci', 'f7di'],
             "2015": ['f7bz', 'f7cz', 'f7dz', 'f7ez'],
@@ -4535,9 +4535,9 @@ class rpinel(Variable):
 
         reduction_cumulee = reduc_invest_real_2014 + sum([calcul_reduction_investissement(cases) for cases in cases_investissement.values()])
         report = sum([foyer_fiscal(case, period) for year in cases_report.keys() for case in cases_report[year]])
-        
+
         return reduction_cumulee + report
-    
+
     def formula_2018_01_01(foyer_fiscal, period, parameters):
         '''
         Investissement locatif privé - Dispositif Pinel

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4376,101 +4376,112 @@ class rpinel(Variable):
         Investissement locatif privé - Dispositif Pinel
         2015
         '''
-        f7ai = foyer_fiscal('f7ai', period)
-        f7bi = foyer_fiscal('f7bi', period)
-        f7ci = foyer_fiscal('f7ci', period)
-        f7di = foyer_fiscal('f7di', period)
-        invest_metropole_2014 = foyer_fiscal('f7ek', period)
-        invest_domtom_2014 = foyer_fiscal('f7el', period)
+        f7ek = foyer_fiscal('f7ek', period)
+        f7el = foyer_fiscal('f7el', period)
         f7qa = foyer_fiscal('f7qa', period)
         f7qb = foyer_fiscal('f7qb', period)
         f7qc = foyer_fiscal('f7qc', period)
         f7qd = foyer_fiscal('f7qd', period)
-        f7qe = foyer_fiscal('f7qe', period)
-        f7qf = foyer_fiscal('f7qf', period)
-        f7qg = foyer_fiscal('f7qg', period)
-        f7qh = foyer_fiscal('f7qh', period)
+
+        cases_investissement = {
+            "2015": [
+                ('f7qh', 9, 'outremer'),
+                ('f7qg', 6, 'outremer'),
+                ('f7qf', 9, 'metropole'),
+                ('f7qe', 6, 'metropole')],
+            }
+
+        cases_report = {
+            "2014": ['f7ai', 'f7bi', 'f7ci', 'f7di'],
+            }
+
         P = parameters(period).impot_revenu.reductions_impots.rpinel
 
-        max1 = max_(0, P.plafond - invest_domtom_2014 - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
+        max1 = max_(0, P.plafond - f7el - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
         max2 = max_(0, max1 - f7qc)
-        max3 = max_(0, max2 - invest_metropole_2014 - f7qb)
+        max3 = max_(0, max2 - f7ek - f7qb)
 
-        reduc_invest_real_2014 = around(
-            P.taux29 * min_(max_(0, P.plafond - invest_domtom_2014), f7qd) / 9
-            + P.taux23 * min_(max1, f7qc) / 6
-            + P.taux18 * min_(max_(0, max2 - invest_metropole_2014), f7qb) / 9
-            + P.taux12 * min_(max3, f7qa) / 6
+        reduc_invest_real_2014 = (
+            around(P.taux29 * min_(max_(0, P.plafond - f7el), f7qd) / 9)
+            + around(P.taux23 * min_(max1, f7qc) / 6)
+            + around(P.taux18 * min_(max_(0, max2 - f7ek), f7qb) / 9)
+            + around(P.taux12 * min_(max3, f7qa) / 6)
             )
 
-        reduc_invest_real_2015 = around(
-            P.taux29 * min_(P.plafond, f7qh) / 9
-            + P.taux23 * min_(max_(0, P.plafond - f7qh), f7qg) / 6
-            + P.taux18 * min_(max_(0, P.plafond - f7qh - f7qg), f7qf) / 9
-            + P.taux12 * min_(max_(0, P.plafond - f7qh - f7qg - f7qf), f7qe) / 6
-            )
+        def calcul_reduction_investissement(cases):
+            reduction = foyer_fiscal.empty_array()
+            depenses_cumulees = foyer_fiscal.empty_array()
+            for case in cases:
+                variable, duree, zone = case
+                depense = foyer_fiscal(variable, period)
+                taux = P.taux[zone][str(duree) + '_ans']
+                reduction += around(taux * min_(max_(0, P.plafond - depenses_cumulees), depense) / duree)
+                depenses_cumulees += depense
+            return reduction
 
-        report = f7ai + f7bi + f7ci + f7di
+        reduction_cumulee = reduc_invest_real_2014 + sum([calcul_reduction_investissement(cases) for cases in cases_investissement.values()])
+        report = sum([foyer_fiscal(case, period) for year in cases_report.keys() for case in cases_report[year]])
 
-        return reduc_invest_real_2014 + reduc_invest_real_2015 + report
+        return reduction_cumulee + report
 
     def formula_2016_01_01(foyer_fiscal, period, parameters):
         '''
         Investissement locatif privé - Dispositif Pinel
         2016
         '''
-        f7ai = foyer_fiscal('f7ai', period)
-        f7bi = foyer_fiscal('f7bi', period)
-        f7bz = foyer_fiscal('f7bz', period)
-        f7ci = foyer_fiscal('f7ci', period)
-        f7cz = foyer_fiscal('f7cz', period)
-        f7di = foyer_fiscal('f7di', period)
-        f7dz = foyer_fiscal('f7dz', period)
-        invest_metropole_2014 = foyer_fiscal('f7ek', period)
-        invest_domtom_2014 = foyer_fiscal('f7el', period)
-        f7ez = foyer_fiscal('f7ez', period)
+        f7ek = foyer_fiscal('f7ek', period)
+        f7el = foyer_fiscal('f7el', period)
         f7qa = foyer_fiscal('f7qa', period)
         f7qb = foyer_fiscal('f7qb', period)
         f7qc = foyer_fiscal('f7qc', period)
         f7qd = foyer_fiscal('f7qd', period)
-        f7qe = foyer_fiscal('f7qe', period)
-        f7qf = foyer_fiscal('f7qf', period)
-        f7qg = foyer_fiscal('f7qg', period)
-        f7qh = foyer_fiscal('f7qh', period)
-        f7qi = foyer_fiscal('f7qi', period)
-        f7qj = foyer_fiscal('f7qj', period)
-        f7qk = foyer_fiscal('f7qk', period)
-        f7ql = foyer_fiscal('f7ql', period)
+
+        cases_investissement = {
+            "2015": [
+                ('f7qh', 9, 'outremer'),
+                ('f7qg', 6, 'outremer'),
+                ('f7qf', 9, 'metropole'),
+                ('f7qe', 6, 'metropole')],
+            "2016": [
+                ('f7ql', 9, 'outremer'),
+                ('f7qk', 6, 'outremer'),
+                ('f7qj', 9, 'metropole'),
+                ('f7qi', 6, 'metropole')],
+            }
+
+        cases_report = {
+            "2014": ['f7ai', 'f7bi', 'f7ci', 'f7di'],
+            "2015": ['f7bz', 'f7cz', 'f7dz', 'f7ez'],
+            }
+
         P = parameters(period).impot_revenu.reductions_impots.rpinel
 
-        max1 = max_(0, P.plafond - invest_domtom_2014 - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
+        max1 = max_(0, P.plafond - f7el - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
         max2 = max_(0, max1 - f7qc)
-        max3 = max_(0, max2 - invest_metropole_2014 - f7qb)
+        max3 = max_(0, max2 - f7ek - f7qb)
 
-        reduc_invest_real_2014 = around(
-            (P.taux29 * min_(max_(0, P.plafond - invest_domtom_2014), f7qd) / 9)
-            + (P.taux23 * min_(max1, f7qc) / 6)
-            + (P.taux18 * min_(max_(0, max2 - invest_metropole_2014), f7qb) / 9)
-            + (P.taux12 * min_(max3, f7qa) / 6)
+        reduc_invest_real_2014 = (
+            around(P.taux29 * min_(max_(0, P.plafond - f7el), f7qd) / 9)
+            + around(P.taux23 * min_(max1, f7qc) / 6)
+            + around(P.taux18 * min_(max_(0, max2 - f7ek), f7qb) / 9)
+            + around(P.taux12 * min_(max3, f7qa) / 6)
             )
 
-        reduc_invest_real_2015 = around(
-            (P.taux29 * min_(P.plafond, f7qh) / 9)
-            + (P.taux23 * min_(max_(0, P.plafond - f7qh), f7qg) / 6)
-            + (P.taux18 * min_(max_(0, P.plafond - f7qh - f7qg), f7qf) / 9)
-            + (P.taux12 * min_(max_(0, P.plafond - f7qh - f7qg - f7qf), f7qe) / 6)
-            )
+        def calcul_reduction_investissement(cases):
+            reduction = foyer_fiscal.empty_array()
+            depenses_cumulees = foyer_fiscal.empty_array()
+            for case in cases:
+                variable, duree, zone = case
+                depense = foyer_fiscal(variable, period)
+                taux = P.taux[zone][str(duree) + '_ans']
+                reduction += around(taux * min_(max_(0, P.plafond - depenses_cumulees), depense) / duree)
+                depenses_cumulees += depense
+            return reduction
 
-        reduc_invest_real_2016 = around(
-            (P.taux29 * min_(P.plafond, f7ql) / 9)
-            + (P.taux23 * min_(max_(0, P.plafond - f7ql), f7qk) / 6)
-            + (P.taux18 * min_(max_(0, P.plafond - f7ql - f7qk), f7qj) / 9)
-            + (P.taux12 * min_(max_(0, P.plafond - f7ql - f7qk - f7qj), f7qi) / 6)
-            )
+        reduction_cumulee = reduc_invest_real_2014 + sum([calcul_reduction_investissement(cases) for cases in cases_investissement.values()])
+        report = sum([foyer_fiscal(case, period) for year in cases_report.keys() for case in cases_report[year]])
 
-        report = f7ai + f7bi + f7ci + f7di + f7bz + f7cz + f7dz + f7ez
-
-        return reduc_invest_real_2014 + reduc_invest_real_2015 + reduc_invest_real_2016 + report
+        return reduction_cumulee + report
 
     def formula_2017_01_01(foyer_fiscal, period, parameters):
         '''

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4586,7 +4586,7 @@ class rpinel(Variable):
         f7qr = foyer_fiscal('f7qr', period)
         f7qs = foyer_fiscal('f7qs', period)
         f7qt = foyer_fiscal('f7qt', period)
-        f7qu = foyer_fiscal('f7qu', period)s
+        f7qu = foyer_fiscal('f7qu', period)
         f7qz = foyer_fiscal('f7qz', period)
         f7ra = foyer_fiscal('f7ra', period)
         f7rb = foyer_fiscal('f7rb', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4352,22 +4352,22 @@ class rpinel(Variable):
         Investissement locatif privé - Dispositif Pinel
         2014
         '''
-        invest_metropole_2014 = foyer_fiscal('f7ek', period)
-        invest_domtom_2014 = foyer_fiscal('f7el', period)
+        f7ek = foyer_fiscal('f7ek', period)
+        f7el = foyer_fiscal('f7el', period)
         f7qa = foyer_fiscal('f7qa', period)
         f7qb = foyer_fiscal('f7qb', period)
         f7qc = foyer_fiscal('f7qc', period)
         f7qd = foyer_fiscal('f7qd', period)
         P = parameters(period).impot_revenu.reductions_impots.rpinel
 
-        max1 = max_(0, P.plafond - invest_domtom_2014 - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
+        max1 = max_(0, P.plafond - f7el - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
         max2 = max_(0, max1 - f7qc)
-        max3 = max_(0, max2 - invest_metropole_2014 - f7qb)
+        max3 = max_(0, max2 - f7ek - f7qb)
 
         return around(
-            P.taux29 * min_(max_(0, P.plafond - invest_domtom_2014), f7qd) / 9
+            P.taux29 * min_(max_(0, P.plafond - f7el), f7qd) / 9
             + P.taux23 * min_(max1, f7qc) / 6
-            + P.taux18 * min_(max_(0, max2 - invest_metropole_2014), f7qb) / 9
+            + P.taux18 * min_(max_(0, max2 - f7ek), f7qb) / 9
             + P.taux12 * min_(max3, f7qa) / 6
             )
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4360,12 +4360,12 @@ class rpinel(Variable):
         f7qd = foyer_fiscal('f7qd', period)
         P = parameters(period).impot_revenu.reductions_impots.rpinel
 
-        max1 = max_(0, P.seuil - invest_domtom_2014 - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
+        max1 = max_(0, P.plafond - invest_domtom_2014 - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
         max2 = max_(0, max1 - f7qc)
         max3 = max_(0, max2 - invest_metropole_2014 - f7qb)
 
         return around(
-            P.taux29 * min_(max_(0, P.seuil - invest_domtom_2014), f7qd) / 9
+            P.taux29 * min_(max_(0, P.plafond - invest_domtom_2014), f7qd) / 9
             + P.taux23 * min_(max1, f7qc) / 6
             + P.taux18 * min_(max_(0, max2 - invest_metropole_2014), f7qb) / 9
             + P.taux12 * min_(max3, f7qa) / 6
@@ -4392,22 +4392,22 @@ class rpinel(Variable):
         f7qh = foyer_fiscal('f7qh', period)
         P = parameters(period).impot_revenu.reductions_impots.rpinel
 
-        max1 = max_(0, P.seuil - invest_domtom_2014 - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
+        max1 = max_(0, P.plafond - invest_domtom_2014 - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
         max2 = max_(0, max1 - f7qc)
         max3 = max_(0, max2 - invest_metropole_2014 - f7qb)
 
         reduc_invest_real_2014 = around(
-            P.taux29 * min_(max_(0, P.seuil - invest_domtom_2014), f7qd) / 9
+            P.taux29 * min_(max_(0, P.plafond - invest_domtom_2014), f7qd) / 9
             + P.taux23 * min_(max1, f7qc) / 6
             + P.taux18 * min_(max_(0, max2 - invest_metropole_2014), f7qb) / 9
             + P.taux12 * min_(max3, f7qa) / 6
             )
 
         reduc_invest_real_2015 = around(
-            P.taux29 * min_(P.seuil, f7qh) / 9
-            + P.taux23 * min_(max_(0, P.seuil - f7qh), f7qg) / 6
-            + P.taux18 * min_(max_(0, P.seuil - f7qh - f7qg), f7qf) / 9
-            + P.taux12 * min_(max_(0, P.seuil - f7qh - f7qg - f7qf), f7qe) / 6
+            P.taux29 * min_(P.plafond, f7qh) / 9
+            + P.taux23 * min_(max_(0, P.plafond - f7qh), f7qg) / 6
+            + P.taux18 * min_(max_(0, P.plafond - f7qh - f7qg), f7qf) / 9
+            + P.taux12 * min_(max_(0, P.plafond - f7qh - f7qg - f7qf), f7qe) / 6
             )
 
         report = f7ai + f7bi + f7ci + f7di
@@ -4443,29 +4443,29 @@ class rpinel(Variable):
         f7ql = foyer_fiscal('f7ql', period)
         P = parameters(period).impot_revenu.reductions_impots.rpinel
 
-        max1 = max_(0, P.seuil - invest_domtom_2014 - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
+        max1 = max_(0, P.plafond - invest_domtom_2014 - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
         max2 = max_(0, max1 - f7qc)
         max3 = max_(0, max2 - invest_metropole_2014 - f7qb)
 
         reduc_invest_real_2014 = around(
-            (P.taux29 * min_(max_(0, P.seuil - invest_domtom_2014), f7qd) / 9)
+            (P.taux29 * min_(max_(0, P.plafond - invest_domtom_2014), f7qd) / 9)
             + (P.taux23 * min_(max1, f7qc) / 6)
             + (P.taux18 * min_(max_(0, max2 - invest_metropole_2014), f7qb) / 9)
             + (P.taux12 * min_(max3, f7qa) / 6)
             )
 
         reduc_invest_real_2015 = around(
-            (P.taux29 * min_(P.seuil, f7qh) / 9)
-            + (P.taux23 * min_(max_(0, P.seuil - f7qh), f7qg) / 6)
-            + (P.taux18 * min_(max_(0, P.seuil - f7qh - f7qg), f7qf) / 9)
-            + (P.taux12 * min_(max_(0, P.seuil - f7qh - f7qg - f7qf), f7qe) / 6)
+            (P.taux29 * min_(P.plafond, f7qh) / 9)
+            + (P.taux23 * min_(max_(0, P.plafond - f7qh), f7qg) / 6)
+            + (P.taux18 * min_(max_(0, P.plafond - f7qh - f7qg), f7qf) / 9)
+            + (P.taux12 * min_(max_(0, P.plafond - f7qh - f7qg - f7qf), f7qe) / 6)
             )
 
         reduc_invest_real_2016 = around(
-            (P.taux29 * min_(P.seuil, f7ql) / 9)
-            + (P.taux23 * min_(max_(0, P.seuil - f7ql), f7qk) / 6)
-            + (P.taux18 * min_(max_(0, P.seuil - f7ql - f7qk), f7qj) / 9)
-            + (P.taux12 * min_(max_(0, P.seuil - f7ql - f7qk - f7qj), f7qi) / 6)
+            (P.taux29 * min_(P.plafond, f7ql) / 9)
+            + (P.taux23 * min_(max_(0, P.plafond - f7ql), f7qk) / 6)
+            + (P.taux18 * min_(max_(0, P.plafond - f7ql - f7qk), f7qj) / 9)
+            + (P.taux12 * min_(max_(0, P.plafond - f7ql - f7qk - f7qj), f7qi) / 6)
             )
 
         report = f7ai + f7bi + f7ci + f7di + f7bz + f7cz + f7dz + f7ez
@@ -4584,43 +4584,43 @@ class rpinel(Variable):
 
         P = parameters(period).impot_revenu.reductions_impots.rpinel
 
-        max1 = max_(0, P.seuil - f7el - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
+        max1 = max_(0, P.plafond - f7el - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
         max2 = max_(0, max1 - f7qc)
         max3 = max_(0, max2 - f7ek - f7qb)
 
         reduc_invest_real_2014 = (
-            around(P.taux29 * min_(max_(0, P.seuil - f7el), f7qd) / 9)
+            around(P.taux29 * min_(max_(0, P.plafond - f7el), f7qd) / 9)
             + around(P.taux23 * min_(max1, f7qc) / 6)
             + around(P.taux18 * min_(max_(0, max2 - f7ek), f7qb) / 9)
             + around(P.taux12 * min_(max3, f7qa) / 6)
             )
 
         reduc_invest_real_2015 = (
-            around(P.taux29 * min_(P.seuil, f7qh) / 9)
-            + around(P.taux23 * min_(max_(0, P.seuil - f7qh), f7qg) / 6)
-            + around(P.taux18 * min_(max_(0, P.seuil - f7qh - f7qg), f7qf) / 9)
-            + around(P.taux12 * min_(max_(0, P.seuil - f7qh - f7qg - f7qf), f7qe) / 6)
+            around(P.taux29 * min_(P.plafond, f7qh) / 9)
+            + around(P.taux23 * min_(max_(0, P.plafond - f7qh), f7qg) / 6)
+            + around(P.taux18 * min_(max_(0, P.plafond - f7qh - f7qg), f7qf) / 9)
+            + around(P.taux12 * min_(max_(0, P.plafond - f7qh - f7qg - f7qf), f7qe) / 6)
             )
 
         reduc_invest_real_2016 = (
-            around(P.taux29 * min_(P.seuil, f7ql) / 9)
-            + around(P.taux23 * min_(max_(0, P.seuil - f7ql), f7qk) / 6)
-            + around(P.taux18 * min_(max_(0, P.seuil - f7ql - f7qk), f7qj) / 9)
-            + around(P.taux12 * min_(max_(0, P.seuil - f7ql - f7qk - f7qj), f7qi) / 6)
+            around(P.taux29 * min_(P.plafond, f7ql) / 9)
+            + around(P.taux23 * min_(max_(0, P.plafond - f7ql), f7qk) / 6)
+            + around(P.taux18 * min_(max_(0, P.plafond - f7ql - f7qk), f7qj) / 9)
+            + around(P.taux12 * min_(max_(0, P.plafond - f7ql - f7qk - f7qj), f7qi) / 6)
             )
 
         reduc_invest_real_2017 = (
-            around(P.taux29 * min_(P.seuil, f7qp) / 9)
-            + around(P.taux23 * min_(max_(0, P.seuil - f7qp), f7qo) / 6)
-            + around(P.taux18 * min_(max_(0, P.seuil - f7qp - f7qo), f7qn) / 9)
-            + around(P.taux12 * min_(max_(0, P.seuil - f7qp - f7qo - f7qn), f7qm) / 6)
+            around(P.taux29 * min_(P.plafond, f7qp) / 9)
+            + around(P.taux23 * min_(max_(0, P.plafond - f7qp), f7qo) / 6)
+            + around(P.taux18 * min_(max_(0, P.plafond - f7qp - f7qo), f7qn) / 9)
+            + around(P.taux12 * min_(max_(0, P.plafond - f7qp - f7qo - f7qn), f7qm) / 6)
             )
 
         reduc_invest_real_2018 = (
-            around(P.taux29 * min_(P.seuil, f7qu) / 9)
-            + around(P.taux23 * min_(max_(0, P.seuil - f7qu), f7qt) / 6)
-            + around(P.taux18 * min_(max_(0, P.seuil - f7qu - f7qt), f7qs) / 9)
-            + around(P.taux12 * min_(max_(0, P.seuil - f7qu - f7qt - f7qs), f7qr) / 6)
+            around(P.taux29 * min_(P.plafond, f7qu) / 9)
+            + around(P.taux23 * min_(max_(0, P.plafond - f7qu), f7qt) / 6)
+            + around(P.taux18 * min_(max_(0, P.plafond - f7qu - f7qt), f7qs) / 9)
+            + around(P.taux12 * min_(max_(0, P.plafond - f7qu - f7qt - f7qs), f7qr) / 6)
             )
 
         report = f7ai + f7bi + f7ci + f7di + f7bz + f7cz + f7dz + f7ez + f7qz + f7rz + f7sz + f7tz + f7ra + f7rb + f7rc + f7rd

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4365,10 +4365,10 @@ class rpinel(Variable):
         max3 = max_(0, max2 - f7ek - f7qb)
 
         return around(
-            P.taux29 * min_(max_(0, P.plafond - f7el), f7qd) / 9
-            + P.taux23 * min_(max1, f7qc) / 6
-            + P.taux18 * min_(max_(0, max2 - f7ek), f7qb) / 9
-            + P.taux12 * min_(max3, f7qa) / 6
+            P.taux['outremer']['9_ans'] * min_(max_(0, P.plafond - f7el), f7qd) / 9
+            + P.taux['outremer']['6_ans'] * min_(max1, f7qc) / 6
+            + P.taux['metropole']['9_ans'] * min_(max_(0, max2 - f7ek), f7qb) / 9
+            + P.taux['metropole']['6_ans'] * min_(max3, f7qa) / 6
             )
 
     def formula_2015_01_01(foyer_fiscal, period, parameters):
@@ -4401,11 +4401,11 @@ class rpinel(Variable):
         max2 = max_(0, max1 - f7qc)
         max3 = max_(0, max2 - f7ek - f7qb)
 
-        reduc_invest_real_2014 = (
-            around(P.taux29 * min_(max_(0, P.plafond - f7el), f7qd) / 9)
-            + around(P.taux23 * min_(max1, f7qc) / 6)
-            + around(P.taux18 * min_(max_(0, max2 - f7ek), f7qb) / 9)
-            + around(P.taux12 * min_(max3, f7qa) / 6)
+        reduc_invest_real_2014 = around(
+            P.taux['outremer']['9_ans'] * min_(max_(0, P.plafond - f7el), f7qd) / 9
+            + P.taux['outremer']['6_ans'] * min_(max1, f7qc) / 6
+            + P.taux['metropole']['9_ans'] * min_(max_(0, max2 - f7ek), f7qb) / 9
+            + P.taux['metropole']['6_ans'] * min_(max3, f7qa) / 6
             )
 
         def calcul_reduction_investissement(cases):
@@ -4460,11 +4460,11 @@ class rpinel(Variable):
         max2 = max_(0, max1 - f7qc)
         max3 = max_(0, max2 - f7ek - f7qb)
 
-        reduc_invest_real_2014 = (
-            around(P.taux29 * min_(max_(0, P.plafond - f7el), f7qd) / 9)
-            + around(P.taux23 * min_(max1, f7qc) / 6)
-            + around(P.taux18 * min_(max_(0, max2 - f7ek), f7qb) / 9)
-            + around(P.taux12 * min_(max3, f7qa) / 6)
+        reduc_invest_real_2014 = around(
+            P.taux['outremer']['9_ans'] * min_(max_(0, P.plafond - f7el), f7qd) / 9
+            + P.taux['outremer']['6_ans'] * min_(max1, f7qc) / 6
+            + P.taux['metropole']['9_ans'] * min_(max_(0, max2 - f7ek), f7qb) / 9
+            + P.taux['metropole']['6_ans'] * min_(max3, f7qa) / 6
             )
 
         def calcul_reduction_investissement(cases):
@@ -4525,11 +4525,11 @@ class rpinel(Variable):
         max2 = max_(0, max1 - f7qc)
         max3 = max_(0, max2 - f7ek - f7qb)
 
-        reduc_invest_real_2014 = (
-            around(P.taux29 * min_(max_(0, P.plafond - f7el), f7qd) / 9)
-            + around(P.taux23 * min_(max1, f7qc) / 6)
-            + around(P.taux18 * min_(max_(0, max2 - f7ek), f7qb) / 9)
-            + around(P.taux12 * min_(max3, f7qa) / 6)
+        reduc_invest_real_2014 = around(
+            P.taux['outremer']['9_ans'] * min_(max_(0, P.plafond - f7el), f7qd) / 9
+            + P.taux['outremer']['6_ans'] * min_(max1, f7qc) / 6
+            + P.taux['metropole']['9_ans'] * min_(max_(0, max2 - f7ek), f7qb) / 9
+            + P.taux['metropole']['6_ans'] * min_(max3, f7qa) / 6
             )
 
         def calcul_reduction_investissement(cases):
@@ -4596,11 +4596,11 @@ class rpinel(Variable):
         max2 = max_(0, max1 - f7qc)
         max3 = max_(0, max2 - f7ek - f7qb)
 
-        reduc_invest_real_2014 = (
-            around(P.taux29 * min_(max_(0, P.plafond - f7el), f7qd) / 9)
-            + around(P.taux23 * min_(max1, f7qc) / 6)
-            + around(P.taux18 * min_(max_(0, max2 - f7ek), f7qb) / 9)
-            + around(P.taux12 * min_(max3, f7qa) / 6)
+        reduc_invest_real_2014 = around(
+            P.taux['outremer']['9_ans'] * min_(max_(0, P.plafond - f7el), f7qd) / 9
+            + P.taux['outremer']['6_ans'] * min_(max1, f7qc) / 6
+            + P.taux['metropole']['9_ans'] * min_(max_(0, max2 - f7ek), f7qb) / 9
+            + P.taux['metropole']['6_ans'] * min_(max3, f7qa) / 6
             )
 
         def calcul_reduction_investissement(cases):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4629,7 +4629,7 @@ class rpinel(Variable):
             + around(P.taux18 * min_(max_(0, P.seuil - f7qp - f7qo), f7qn) / 9)
             + around(P.taux12 * min_(max_(0, P.seuil - f7qp - f7qo - f7qn), f7qm) / 6)
             )
-        
+
         reduc_invest_real_2018 = (
             around(P.taux29 * min_(P.seuil, f7qu) / 9)
             + around(P.taux23 * min_(max_(0, P.seuil - f7qu), f7qt) / 6)
@@ -4647,7 +4647,6 @@ class rpinel(Variable):
             + reduc_invest_real_2018
             + report
             )
-
 
 
 class rsceha(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4618,7 +4618,7 @@ class rpinel(Variable):
         range_year_investissement = list(set([year for year in range(2015, annee_fiscale + 1)]) & set([year for year in cases_investissement.keys()]))
         range_year_report = list(set([year for year in range(2014, annee_fiscale)]) & set([year for year in cases_report.keys()]))
 
-        reduction_cumulee = reduc_invest_real_2014 + sum([calcul_reduction_investissement(cases_investissement[year]) for year in range_year_investissement ])
+        reduction_cumulee = reduc_invest_real_2014 + sum([calcul_reduction_investissement(cases_investissement[year]) for year in range_year_investissement])
         report = sum([foyer_fiscal(case, period) for year in range_year_report for case in cases_report[year]])
 
         return reduction_cumulee + report

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4561,22 +4561,22 @@ class rpinel(Variable):
         f7qd = foyer_fiscal('f7qd', period)
 
         cases_investissement = {
-            "2015": [
+            2015: [
                 ('f7qh', 9, 'outremer'),
                 ('f7qg', 6, 'outremer'),
                 ('f7qf', 9, 'metropole'),
                 ('f7qe', 6, 'metropole')],
-            "2016": [
+            2016: [
                 ('f7ql', 9, 'outremer'),
                 ('f7qk', 6, 'outremer'),
                 ('f7qj', 9, 'metropole'),
                 ('f7qi', 6, 'metropole')],
-            "2017": [
+            2017: [
                 ('f7qp', 9, 'outremer'),
                 ('f7qo', 6, 'outremer'),
                 ('f7qn', 9, 'metropole'),
                 ('f7qm', 6, 'metropole')],
-            "2018": [
+            2018: [
                 ('f7qu', 9, 'outremer'),
                 ('f7qt', 6, 'outremer'),
                 ('f7qs', 9, 'metropole'),
@@ -4584,10 +4584,10 @@ class rpinel(Variable):
             }
 
         cases_report = {
-            "2014": ['f7ai', 'f7bi', 'f7ci', 'f7di'],
-            "2015": ['f7bz', 'f7cz', 'f7dz', 'f7ez'],
-            "2016": ['f7qz', 'f7rz', 'f7sz', 'f7tz'],
-            "2017": ['f7ra', 'f7rb', 'f7rc', 'f7rd'],
+            2014: ['f7ai', 'f7bi', 'f7ci', 'f7di'],
+            2015: ['f7bz', 'f7cz', 'f7dz', 'f7ez'],
+            2016: ['f7qz', 'f7rz', 'f7sz', 'f7tz'],
+            2017: ['f7ra', 'f7rb', 'f7rc', 'f7rd'],
             }
 
         P = parameters(period).impot_revenu.reductions_impots.rpinel
@@ -4614,8 +4614,10 @@ class rpinel(Variable):
                 depenses_cumulees += depense
             return reduction
 
-        reduction_cumulee = reduc_invest_real_2014 + sum([calcul_reduction_investissement(cases) for cases in cases_investissement.values()])
-        report = sum([foyer_fiscal(case, period) for year in cases_report.keys() for case in cases_report[year]])
+        annee_fiscale = period.start.year
+
+        reduction_cumulee = reduc_invest_real_2014 + sum([calcul_reduction_investissement(cases_investissement[year]) for year in range(2015, annee_fiscale + 1)])
+        report = sum([foyer_fiscal(case, period) for year in range(2014, annee_fiscale) for case in cases_report[year]])
 
         return reduction_cumulee + report
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -862,7 +862,7 @@ class doment(Variable):
         f7qo = foyer_fiscal('f7qo_2012', period)
         f7qp = foyer_fiscal('f7qp_2012', period)
         f7qq = foyer_fiscal('f7qq', period)
-        f7qr = foyer_fiscal('f7qr', period)
+        f7qr = foyer_fiscal('f7qr_2012', period)
         f7qs = foyer_fiscal('f7qs', period)
         f7mm = foyer_fiscal('f7mm', period)
         f7ma = foyer_fiscal('f7ma', period)
@@ -913,7 +913,7 @@ class doment(Variable):
         f7qi = foyer_fiscal('f7qi', period)
         f7qo = foyer_fiscal('f7qo_2012', period)
         f7qp = foyer_fiscal('f7qp_2012', period)
-        f7qr = foyer_fiscal('f7qr', period)
+        f7qr = foyer_fiscal('f7qr_2012', period)
         f7qv = foyer_fiscal('f7qv', period)
 
         return (
@@ -971,7 +971,7 @@ class doment(Variable):
         f7qi = foyer_fiscal('f7qi', period)
         f7qo = foyer_fiscal('f7qo_2012', period)
         f7qp = foyer_fiscal('f7qp_2012', period)
-        f7qr = foyer_fiscal('f7qr', period)
+        f7qr = foyer_fiscal('f7qr_2012', period)
         f7qv = foyer_fiscal('f7qv', period)
         f7qz = foyer_fiscal('f7qz_2012', period)
         f7rg = foyer_fiscal('f7rg', period)
@@ -1735,7 +1735,7 @@ class domlog(Variable):
         f7qc = foyer_fiscal('f7qc', period)
         f7qd = foyer_fiscal('f7qd', period)
         f7ql = foyer_fiscal('f7ql', period)
-        f7qt = foyer_fiscal('f7qt', period)
+        f7qt = foyer_fiscal('f7qt_2012', period)
         f7qm = foyer_fiscal('f7qm_2012', period)
 
         return f7qb + f7qc + f7qd + f7ql + f7qt + f7qm
@@ -1751,7 +1751,7 @@ class domlog(Variable):
         f7qd = foyer_fiscal('f7qd', period)
         f7ql = foyer_fiscal('f7ql', period)
         f7qm = foyer_fiscal('f7qm_2012', period)
-        f7qt = foyer_fiscal('f7qt', period)
+        f7qt = foyer_fiscal('f7qt_2012', period)
         f7oa = foyer_fiscal('f7oa', period)
         f7ob = foyer_fiscal('f7ob', period)
         f7oc = foyer_fiscal('f7oc', period)
@@ -1773,7 +1773,7 @@ class domlog(Variable):
         f7qd = foyer_fiscal('f7qd', period)
         f7ql = foyer_fiscal('f7ql', period)
         f7qm = foyer_fiscal('f7qm_2012', period)
-        f7qt = foyer_fiscal('f7qt', period)
+        f7qt = foyer_fiscal('f7qt_2012', period)
         f7oa = foyer_fiscal('f7oa', period)
         f7ob = foyer_fiscal('f7ob', period)
         f7oc = foyer_fiscal('f7oc', period)
@@ -2146,7 +2146,7 @@ class domsoc(Variable):
         '''
         f7qn = foyer_fiscal('f7qn_2012', period)
         f7qk = foyer_fiscal('f7qk', period)
-        f7qu = foyer_fiscal('f7qu', period)
+        f7qu = foyer_fiscal('f7qu_2012', period)
         f7kg = foyer_fiscal('f7kg', period)
         f7kh = foyer_fiscal('f7kh', period)
         f7ki = foyer_fiscal('f7ki', period)
@@ -2160,7 +2160,7 @@ class domsoc(Variable):
         '''
         f7qn = foyer_fiscal('f7qn_2012', period)
         f7qk = foyer_fiscal('f7qk', period)
-        f7qu = foyer_fiscal('f7qu', period)
+        f7qu = foyer_fiscal('f7qu_2012', period)
         f7kg = foyer_fiscal('f7kg', period)
         f7kh = foyer_fiscal('f7kh', period)
         f7ki = foyer_fiscal('f7ki', period)
@@ -4200,8 +4200,8 @@ class resimm(Variable):
         Travaux de restauration immobilière (cases 7RA et 7RB)
         2009-2010
         '''
-        f7ra = foyer_fiscal('f7ra', period)
-        f7rb = foyer_fiscal('f7rb', period)
+        f7ra = foyer_fiscal('f7ra_2015', period)
+        f7rb = foyer_fiscal('f7rb_2015', period)
         P = parameters(period).impot_revenu.reductions_impots.resimm
 
         max1 = P.max
@@ -4213,10 +4213,10 @@ class resimm(Variable):
         Travaux de restauration immobilière (cases 7RA, 7RB, 7RC, 7RD)
         2011
         '''
-        f7ra = foyer_fiscal('f7ra', period)
-        f7rb = foyer_fiscal('f7rb', period)
-        f7rc = foyer_fiscal('f7rc', period)
-        f7rd = foyer_fiscal('f7rd', period)
+        f7ra = foyer_fiscal('f7ra_2015', period)
+        f7rb = foyer_fiscal('f7rb_2015', period)
+        f7rc = foyer_fiscal('f7rc_2015', period)
+        f7rd = foyer_fiscal('f7rd_2015', period)
         P = parameters(period).impot_revenu.reductions_impots.resimm
 
         max1 = P.max
@@ -4236,10 +4236,10 @@ class resimm(Variable):
         Travaux de restauration immobilière (cases 7RA, 7RB, 7RC, 7RD, 7RE, 7RF)
         2012
         '''
-        f7ra = foyer_fiscal('f7ra', period)
-        f7rb = foyer_fiscal('f7rb', period)
-        f7rc = foyer_fiscal('f7rc', period)
-        f7rd = foyer_fiscal('f7rd', period)
+        f7ra = foyer_fiscal('f7ra_2015', period)
+        f7rb = foyer_fiscal('f7rb_2015', period)
+        f7rc = foyer_fiscal('f7rc_2015', period)
+        f7rd = foyer_fiscal('f7rd_2015', period)
         f7re = foyer_fiscal('f7re', period)
         f7rf = foyer_fiscal('f7rf', period)
         P = parameters(period).impot_revenu.reductions_impots.resimm
@@ -4263,10 +4263,10 @@ class resimm(Variable):
         Travaux de restauration immobilière (cases 7RA, 7RB, 7RC, 7RD, 7RE, 7RF, 7SX, 7SY)
         2013-2015
         '''
-        f7ra = foyer_fiscal('f7ra', period)
-        f7rb = foyer_fiscal('f7rb', period)
-        f7rc = foyer_fiscal('f7rc', period)
-        f7rd = foyer_fiscal('f7rd', period)
+        f7ra = foyer_fiscal('f7ra_2015', period)
+        f7rb = foyer_fiscal('f7rb_2015', period)
+        f7rc = foyer_fiscal('f7rc_2015', period)
+        f7rd = foyer_fiscal('f7rd_2015', period)
         f7re = foyer_fiscal('f7re', period)
         f7rf = foyer_fiscal('f7rf', period)
         f7sx = foyer_fiscal('f7sx', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4615,9 +4615,11 @@ class rpinel(Variable):
             return reduction
 
         annee_fiscale = period.start.year
+        range_year_investissement = list(set([year for year in range(2015, annee_fiscale + 1)]) & set([year for year in cases_investissement.keys()]))
+        range_year_report = list(set([year for year in range(2014, annee_fiscale)]) & set([year for year in cases_report.keys()]))
 
-        reduction_cumulee = reduc_invest_real_2014 + sum([calcul_reduction_investissement(cases_investissement[year]) for year in range(2015, annee_fiscale + 1)])
-        report = sum([foyer_fiscal(case, period) for year in range(2014, annee_fiscale) for case in cases_report[year]])
+        reduction_cumulee = reduc_invest_real_2014 + sum([calcul_reduction_investissement(cases_investissement[year]) for year in range_year_investissement ])
+        report = sum([foyer_fiscal(case, period) for year in range_year_report for case in cases_report[year]])
 
         return reduction_cumulee + report
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -4477,81 +4477,67 @@ class rpinel(Variable):
         Investissement locatif privé - Dispositif Pinel
         2017
         '''
-        f7ai = foyer_fiscal('f7ai', period)
-        f7bi = foyer_fiscal('f7bi', period)
-        f7bz = foyer_fiscal('f7bz', period)
-        f7ci = foyer_fiscal('f7ci', period)
-        f7cz = foyer_fiscal('f7cz', period)
-        f7di = foyer_fiscal('f7di', period)
-        f7dz = foyer_fiscal('f7dz', period)
-        invest_metropole_2014 = foyer_fiscal('f7ek', period)
-        invest_domtom_2014 = foyer_fiscal('f7el', period)
-        f7ez = foyer_fiscal('f7ez', period)
+        f7ek = foyer_fiscal('f7ek', period)
+        f7el = foyer_fiscal('f7el', period)
         f7qa = foyer_fiscal('f7qa', period)
         f7qb = foyer_fiscal('f7qb', period)
         f7qc = foyer_fiscal('f7qc', period)
         f7qd = foyer_fiscal('f7qd', period)
-        f7qe = foyer_fiscal('f7qe', period)
-        f7qf = foyer_fiscal('f7qf', period)
-        f7qg = foyer_fiscal('f7qg', period)
-        f7qh = foyer_fiscal('f7qh', period)
-        f7qi = foyer_fiscal('f7qi', period)
-        f7qj = foyer_fiscal('f7qj', period)
-        f7qk = foyer_fiscal('f7qk', period)
-        f7ql = foyer_fiscal('f7ql', period)
-        f7qm = foyer_fiscal('f7qm', period)
-        f7qn = foyer_fiscal('f7qn', period)
-        f7qo = foyer_fiscal('f7qo', period)
-        f7qp = foyer_fiscal('f7qp', period)
-        f7qz = foyer_fiscal('f7qz', period)
-        f7rz = foyer_fiscal('f7rz', period)
-        f7sz = foyer_fiscal('f7sz', period)
-        f7tz = foyer_fiscal('f7tz', period)
+
+        cases_investissement = {
+            "2015": [
+                ('f7qh', 9, 'outremer'),
+                ('f7qg', 6, 'outremer'),
+                ('f7qf', 9, 'metropole'),
+                ('f7qe', 6, 'metropole')],
+            "2016": [
+                ('f7ql', 9, 'outremer'),
+                ('f7qk', 6, 'outremer'),
+                ('f7qj', 9, 'metropole'),
+                ('f7qi', 6, 'metropole')],
+            "2017": [
+                ('f7qp', 9, 'outremer'),
+                ('f7qo', 6, 'outremer'),
+                ('f7qn', 9, 'metropole'),
+                ('f7qm', 6, 'metropole')]
+            }
+        
+        cases_report = {
+            "2014": ['f7ai', 'f7bi', 'f7ci', 'f7di'],
+            "2015": ['f7bz', 'f7cz', 'f7dz', 'f7ez'],
+            "2016": ['f7qz', 'f7rz', 'f7sz', 'f7tz'],
+            "2017": ['f7ra', 'f7rb', 'f7rc', 'f7rd']
+            }
 
         P = parameters(period).impot_revenu.reductions_impots.rpinel
 
-        max1 = max_(0, P.seuil - invest_domtom_2014 - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
+        max1 = max_(0, P.plafond - f7el - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
         max2 = max_(0, max1 - f7qc)
-        max3 = max_(0, max2 - invest_metropole_2014 - f7qb)
+        max3 = max_(0, max2 - f7ek - f7qb)
 
         reduc_invest_real_2014 = (
-            around(P.taux29 * min_(max_(0, P.seuil - invest_domtom_2014), f7qd) / 9)
+            around(P.taux29 * min_(max_(0, P.plafond - f7el), f7qd) / 9)
             + around(P.taux23 * min_(max1, f7qc) / 6)
-            + around(P.taux18 * min_(max_(0, max2 - invest_metropole_2014), f7qb) / 9)
+            + around(P.taux18 * min_(max_(0, max2 - f7ek), f7qb) / 9)
             + around(P.taux12 * min_(max3, f7qa) / 6)
             )
 
-        reduc_invest_real_2015 = (
-            around(P.taux29 * min_(P.seuil, f7qh) / 9)
-            + around(P.taux23 * min_(max_(0, P.seuil - f7qh), f7qg) / 6)
-            + around(P.taux18 * min_(max_(0, P.seuil - f7qh - f7qg), f7qf) / 9)
-            + around(P.taux12 * min_(max_(0, P.seuil - f7qh - f7qg - f7qf), f7qe) / 6)
-            )
+        def calcul_reduction_investissement(cases):
+            reduction = foyer_fiscal.empty_array()
+            depenses_cumulees = foyer_fiscal.empty_array()
+            for case in cases:
+                variable, duree, zone = case
+                depense = foyer_fiscal(variable, period)
+                taux = P.taux[zone][str(duree) + '_ans']
+                reduction += around(taux * min_(max_(0, P.plafond - depenses_cumulees), depense) / duree)
+                depenses_cumulees += depense
+            return reduction
 
-        reduc_invest_real_2016 = (
-            around(P.taux29 * min_(P.seuil, f7ql) / 9)
-            + around(P.taux23 * min_(max_(0, P.seuil - f7ql), f7qk) / 6)
-            + around(P.taux18 * min_(max_(0, P.seuil - f7ql - f7qk), f7qj) / 9)
-            + around(P.taux12 * min_(max_(0, P.seuil - f7ql - f7qk - f7qj), f7qi) / 6)
-            )
-
-        reduc_invest_real_2017 = (
-            around(P.taux29 * min_(P.seuil, f7qp) / 9)
-            + around(P.taux23 * min_(max_(0, P.seuil - f7qp), f7qo) / 6)
-            + around(P.taux18 * min_(max_(0, P.seuil - f7qp - f7qo), f7qn) / 9)
-            + around(P.taux12 * min_(max_(0, P.seuil - f7qp - f7qo - f7qn), f7qm) / 6)
-            )
-
-        report = f7ai + f7bi + f7ci + f7di + f7bz + f7cz + f7dz + f7ez + f7qz + f7rz + f7sz + f7tz
-
-        return (
-            reduc_invest_real_2014
-            + reduc_invest_real_2015
-            + reduc_invest_real_2016
-            + reduc_invest_real_2017
-            + report
-            )
-
+        reduction_cumulee = reduc_invest_real_2014 + sum([calcul_reduction_investissement(cases) for cases in cases_investissement.values()])
+        report = sum([foyer_fiscal(case, period) for year in cases_report.keys() for case in cases_report[year]])
+        
+        return reduction_cumulee + report
+    
     def formula_2018_01_01(foyer_fiscal, period, parameters):
         '''
         Investissement locatif privé - Dispositif Pinel
@@ -4564,8 +4550,8 @@ class rpinel(Variable):
         f7cz = foyer_fiscal('f7cz', period)
         f7di = foyer_fiscal('f7di', period)
         f7dz = foyer_fiscal('f7dz', period)
-        invest_metropole_2014 = foyer_fiscal('f7ek', period)
-        invest_domtom_2014 = foyer_fiscal('f7el', period)
+        f7ek = foyer_fiscal('f7ek', period)
+        f7el = foyer_fiscal('f7el', period)
         f7ez = foyer_fiscal('f7ez', period)
         f7qa = foyer_fiscal('f7qa', period)
         f7qb = foyer_fiscal('f7qb', period)
@@ -4598,14 +4584,14 @@ class rpinel(Variable):
 
         P = parameters(period).impot_revenu.reductions_impots.rpinel
 
-        max1 = max_(0, P.seuil - invest_domtom_2014 - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
+        max1 = max_(0, P.seuil - f7el - f7qd)  # 2014 : plafond commun 'duflot' et 'rpinel'
         max2 = max_(0, max1 - f7qc)
-        max3 = max_(0, max2 - invest_metropole_2014 - f7qb)
+        max3 = max_(0, max2 - f7ek - f7qb)
 
         reduc_invest_real_2014 = (
-            around(P.taux29 * min_(max_(0, P.seuil - invest_domtom_2014), f7qd) / 9)
+            around(P.taux29 * min_(max_(0, P.seuil - f7el), f7qd) / 9)
             + around(P.taux23 * min_(max1, f7qc) / 6)
-            + around(P.taux18 * min_(max_(0, max2 - invest_metropole_2014), f7qb) / 9)
+            + around(P.taux18 * min_(max_(0, max2 - f7ek), f7qb) / 9)
             + around(P.taux12 * min_(max3, f7qa) / 6)
             )
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -3603,7 +3603,7 @@ class f7my(Variable):
 
 
 # 2012 et 2013 ok
-class f7ra(Variable):
+class f7ra_2015(Variable):
     cerfa_field = u"7RA"
     value_type = int
     unit = 'currency'
@@ -3614,7 +3614,7 @@ class f7ra(Variable):
     definition_period = YEAR
 
 
-class f7rb(Variable):
+class f7rb_2015(Variable):
     cerfa_field = u"7RB"
     value_type = int
     unit = 'currency'
@@ -3625,7 +3625,7 @@ class f7rb(Variable):
     definition_period = YEAR
 
 
-class f7rc(Variable):
+class f7rc_2015(Variable):
     cerfa_field = u"7RC"
     value_type = int
     unit = 'currency'
@@ -3636,7 +3636,7 @@ class f7rc(Variable):
     definition_period = YEAR
 
 
-class f7rd(Variable):
+class f7rd_2015(Variable):
     cerfa_field = u"7RD"
     value_type = int
     unit = 'currency'
@@ -4240,7 +4240,7 @@ class f7ql(Variable):
     definition_period = YEAR
 
 
-class f7qt(Variable):
+class f7qt_2012(Variable):
     cerfa_field = u"7QT"
     value_type = int
     unit = 'currency'
@@ -4274,11 +4274,12 @@ class fhqm(Variable):
     definition_period = YEAR
 
 
-class f7qu(Variable):
+class f7qu_2012(Variable):
     cerfa_field = u"7QU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
+    end = '2012-12-31'
     definition_period = YEAR
 
 
@@ -4378,11 +4379,12 @@ class f7qq(Variable):
     definition_period = YEAR
 
 
-class f7qr(Variable):
+class f7qr_2012(Variable):
     cerfa_field = u"7QR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
+    end = '2012-12-31'
     definition_period = YEAR
 
 
@@ -4394,11 +4396,12 @@ class fhqr(Variable):
     definition_period = YEAR
 
 
-class f7qs(Variable):
+class f7qs_2012(Variable):
     cerfa_field = u"7QS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
+    end = '2012-12-31'
     definition_period = YEAR
 
 
@@ -8331,6 +8334,46 @@ class f7qp(Variable):
     definition_period = YEAR
 
 
+class f7qr(Variable):
+    cerfa_field = u"7QR"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements locatifs intermédiaires en métropole réalisés en 2018 avec engagement de location 6 ans"
+    # start_date = date(2018, 1, 1)
+    definition_period = YEAR
+
+
+class f7qs(Variable):
+    cerfa_field = u"7QS"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements locatifs intermédiaires en métropole réalisés en 2018 avec engagement de location 9 ans"
+    # start_date = date(2018, 1, 1)
+    definition_period = YEAR
+
+
+class f7qt(Variable):
+    cerfa_field = u"7QT"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements locatifs intermédiaires en outre-mer réalisés en 2018 avec engagement de location 6 ans"
+    # start_date = date(2018, 1, 1)
+    definition_period = YEAR
+
+
+class f7qu(Variable):
+    cerfa_field = u"7QU"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Investissements locatifs intermédiaires en outre-mer réalisés en 2018 avec engagement de location 9 ans"
+    # start_date = date(2018, 1, 1)
+    definition_period = YEAR
+
+
 class f7qz(Variable):
     cerfa_field = u"7QZ"
     value_type = int
@@ -8368,6 +8411,46 @@ class f7tz(Variable):
     entity = FoyerFiscal
     label = u"Report concernant les investissements locatifs intermédiaires en outre-mer en 2016 avec engagement de location 9 ans"
     # start_date = date(2017, 1, 1)
+    definition_period = YEAR
+
+
+class f7ra(Variable):
+    cerfa_field = u"7RA"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Report concernant les investissements locatifs intermédiaires en métropole en 2017 avec engagement de location 6 ans"
+    # start_date = date(2018, 1, 1)
+    definition_period = YEAR
+
+
+class f7rb(Variable):
+    cerfa_field = u"7RB"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Report concernant les investissements locatifs intermédiaires en métropole en 2017 avec engagement de location 9 ans"
+    # start_date = date(2018, 1, 1)
+    definition_period = YEAR
+
+
+class f7rc(Variable):
+    cerfa_field = u"7RC"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Report concernant les investissements locatifs intermédiaires en outre-mer en 2017 avec engagement de location 6 ans"
+    # start_date = date(2018, 1, 1)
+    definition_period = YEAR
+
+
+class f7rd(Variable):
+    cerfa_field = u"7RD"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Report concernant les investissements locatifs intermédiaires en outre-mer en 2017 avec engagement de location 9 ans"
+    # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 # section 8

--- a/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/plafond.yaml
@@ -1,0 +1,5 @@
+description: Plafond
+unit: currency
+values:
+  2014-01-01:
+    value: 300000.0

--- a/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/seuil.yaml
+++ b/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/seuil.yaml
@@ -1,5 +1,0 @@
-description: Plafond
-unit: currency
-values:
-  2014-01-01:
-    value: 300000.0

--- a/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/taux.yaml
@@ -3,16 +3,16 @@ outremer:
   description: Taux de la réduction Pinel en métropole selon la durée d'engagement de location
   6_ans:
     2014-01:
-      value: 0.12
+      value: 0.23
   9_ans:
     2014-01:
-      value: 0.18
+      value: 0.29
 metropole:
   reference: https://www.legifrance.gouv.fr/affichCodeArticle.do;3?idArticle=LEGIARTI000026876425&cidTexte=LEGITEXT000006069577
   description: Taux de la réduction Pinel en outre-mer selon la durée d'engagement de location
   6_ans:
     2014-01:
-      value: 0.23
+      value: 0.12
   9_ans:
     2014-01:
-      value: 0.29
+      value: 0.18

--- a/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/taux.yaml
@@ -1,0 +1,18 @@
+outremer:
+  reference: https://www.legifrance.gouv.fr/affichCodeArticle.do;3?idArticle=LEGIARTI000026876425&cidTexte=LEGITEXT000006069577
+  description: Taux de la réduction Pinel en métropole selon la durée d'engagement de location
+  6_ans:
+    2014-01:
+      value: 0.12
+  9_ans:
+    2014-01:
+      value: 0.18
+metropole:
+  reference: https://www.legifrance.gouv.fr/affichCodeArticle.do;3?idArticle=LEGIARTI000026876425&cidTexte=LEGITEXT000006069577
+  description: Taux de la réduction Pinel en outre-mer selon la durée d'engagement de location
+  6_ans:
+    2014-01:
+      value: 0.23
+  9_ans:
+    2014-01:
+      value: 0.29

--- a/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/taux12.yaml
+++ b/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/taux12.yaml
@@ -1,5 +1,0 @@
-description: Taux 12%
-unit: /1
-values:
-  2014-01-01:
-    value: 0.12

--- a/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/taux18.yaml
+++ b/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/taux18.yaml
@@ -1,5 +1,0 @@
-description: Taux 18%
-unit: /1
-values:
-  2014-01-01:
-    value: 0.18

--- a/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/taux23.yaml
+++ b/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/taux23.yaml
@@ -1,5 +1,0 @@
-description: Taux 23%
-unit: /1
-values:
-  2014-01-01:
-    value: 0.23

--- a/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/taux29.yaml
+++ b/openfisca_france/parameters/impot_revenu/reductions_impots/rpinel/taux29.yaml
@@ -1,5 +1,0 @@
-description: Taux 29%
-unit: /1
-values:
-  2014-01-01:
-    value: 0.29

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "42.5.1",
+    version = "43.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/calculateur_impots/yaml/reduc_malraux.yaml
+++ b/tests/calculateur_impots/yaml/reduc_malraux.yaml
@@ -12,10 +12,10 @@
       caseW: false
       declarants:
       - ind0
-      f7ra: 500
-      f7rb: 500
-      f7rc: 500
-      f7rd: 500
+      f7ra_2015: 500
+      f7rb_2015: 500
+      f7rc_2015: 500
+      f7rd_2015: 500
       f7re: 500
       f7rf: 500
       f7sx: 500
@@ -61,10 +61,10 @@
       caseW: false
       declarants:
       - ind0
-      f7ra: 500
-      f7rb: 500
-      f7rc: 500
-      f7rd: 500
+      f7ra_2015: 500
+      f7rb_2015: 500
+      f7rc_2015: 500
+      f7rd_2015: 500
       f7re: 500
       f7rf: 500
       f7sx: 500

--- a/tests/calculateur_impots/yaml/reduc_pinel_dom.yaml
+++ b/tests/calculateur_impots/yaml/reduc_pinel_dom.yaml
@@ -186,3 +186,60 @@
     patnat: 0.0
     rbg: 45000.0
     rfr: 45000.0
+- name: reduc_pinel_dom
+  period: 2018
+  absolute_error_margin: 0.1
+  input:
+    foyer_fiscal:
+      caseF: false
+      caseG: false
+      caseL: false
+      caseP: false
+      caseS: false
+      caseT: false
+      caseW: false
+      declarants:
+      - ind0
+      f7ci: 500
+      f7di: 500
+      f7dz: 500
+      f7ez: 500
+      f7rc: 200
+      f7rd: 200
+      f7qc: 0
+      f7qd: 0
+      f7qg: 0
+      f7qh: 10000
+      f7qk: 10000
+      f7ql: 10000
+      f7qo: 10000
+      f7qp: 10000
+      f7qu: 10000
+      f7qt: 20000
+      f7sz: 500
+      f7tz: 500
+      nbF: 0.0
+      nbG: 0.0
+      nbH: 0.0
+      nbI: 0.0
+      nbJ: 0
+      nbR: 0
+    individus:
+      ind0:
+        activite: actif
+        date_naissance: '1970-01-01'
+        salaire_imposable: 50000.0
+        statut_marital: celibataire
+    famille:
+      parents:
+      - ind0
+    menage:
+      personne_de_reference: ind0
+  output:
+    reductions: 6221.0
+    iai: 1481.0
+    irpp: -1481.0
+    nbptr: 1.0
+    patnat: 0.0
+    rbg: 45000.0
+    rfr: 45000.0

--- a/tests/calculateur_impots/yaml/reduc_pinel_dom.yaml
+++ b/tests/calculateur_impots/yaml/reduc_pinel_dom.yaml
@@ -86,7 +86,7 @@
     rni: 45000.0
 - name: reduc_pinel_dom
   period: 2016
-  absolute_error_margin: 0.1
+  absolute_error_margin: 2.0
   input:
     foyer_fiscal:
       caseF: false

--- a/tests/calculateur_impots/yaml/reduc_pinel_metro.yaml
+++ b/tests/calculateur_impots/yaml/reduc_pinel_metro.yaml
@@ -185,3 +185,59 @@
     rbg: 45000.0
     reductions: 4100.0
     rfr: 45000.0
+- name: reduc_pinel_metro
+  period: 2018
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      caseF: false
+      caseG: false
+      caseL: false
+      caseP: false
+      caseS: false
+      caseT: false
+      caseW: false
+      declarants:
+      - ind0
+      f7ai: 500
+      f7bi: 500
+      f7bz: 500
+      f7cz: 500
+      f7ra: 300
+      f7rb: 200
+      f7qa: 0
+      f7qb: 10000
+      f7qe: 10000
+      f7qf: 0
+      f7qi: 10000
+      f7qj: 10000
+      f7qm: 10000
+      f7qn: 10000
+      f7qr: 5000
+      f7qs: 15000
+      f7rz: 500
+      nbF: 0.0
+      nbG: 0.0
+      nbH: 0.0
+      nbI: 0.0
+      nbJ: 0
+      nbR: 0
+    individus:
+      ind0:
+        activite: actif
+        date_naissance: '1970-01-01'
+        salaire_imposable: 50000.0
+        statut_marital: celibataire
+    famille:
+      parents:
+      - ind0
+    menage:
+      personne_de_reference: ind0
+  output:
+    iai: 3102.0
+    irpp: -3102.0
+    nbptr: 1.0
+    patnat: 0.0
+    rbg: 45000.0
+    reductions: 4600.0
+    rfr: 45000.0


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2018.
* Zones impactées : `model/prelevements_obligatoires/impot_revenu/`.
* Détails :
  - Ajoute comme inputs variables les nouvelles cases de la déclaration IR 2018 liée à la réduction Pinel.
  - Renomme les anciennes inputs variables du même nom, selon la méthode habituelle 
  - Mets à jour la formule de calcul de la réduction (introduction des investissements réalisés en 2018 et ajout du report des investissements 2017)
  - Factorise les formules de la réduction Pinel
  - Renomme le paramètre `seuil`en `plafond`
  - Ajoute 2 tests issus des résultats du [calculateur en ligne du site impots.gouv](https://www3.impots.gouv.fr/simulateur/calcul_impot/2019/index.htm)

Cf. la [brochure pratique](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=2&cad=rja&uact=8&ved=2ahUKEwiKw6yDwq_iAhURyoUKHWk_ChsQFjABegQIBRAC&url=https%3A%2F%2Fwww.impots.gouv.fr%2Fportail%2Fwww2%2Ffichiers%2Fdocumentation%2Fbrochure%2Fir_2019%2Fpdf_integral%2Fbrochure_ir_2019.pdf&usg=AOvVaw0ykfoZqAyeo-fX0iMHpOyl) pour plus de détails sur le fonctionnement de cette réduction.

- - - -

Ces changements  :

- Modifient l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.
