### PR TITLE
Implémentation de l’abattement sur le revenu de substitution pour l’ASS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 42.5.0 [#1326](https://github.com/openfisca/openfisca-france/pull/1326)
+
+* Correction d'un calcul existant
+* Périodes concernées : toutes.
+* Zones impactées : `prestations/minima_sociaux/ass`.
+* Détails :
+  - Application de l’abattement sur les revenus de substitution pour l’allocation de solidarité spécifique (ASS).
+  - Factorise le calcul de l’abattement des ressources pour les variables ass_base_ressources_individu et ass_base_ressources_conjoint.
+
 ## 42.4.0 [#1328](https://github.com/openfisca/openfisca-france/pull/1328)
 
 * Revalorisation périodique.

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -73,24 +73,17 @@ class ass_base_ressources_individu(Variable):
         '''
                 N'intègre pas l'exception citée à l'article R5423-2 du Code du Travail sur les conjoints chefs d'entreprises entrant dans le champ d'application de l'article 50-0 du CGI
                 '''
-        last_month = period.start.period('month').offset(-1)
         # Rolling year
         previous_year = period.start.period('year').offset(-1)
         # N-1
         last_year = period.last_year
 
-        has_ressources_substitution = (
-            individu('chomage_net', last_month)
-            + individu('indemnites_journalieres', last_month)
-            + individu('retraite_nette', last_month)
-            ) > 0
-
-        salaire_imposable = calculateWithAbatement(individu, parameters, period, 'salaire_imposable', has_ressources_substitution)
-        revenus_stage_formation_pro = calculateWithAbatement(individu, parameters, period, 'revenus_stage_formation_pro', has_ressources_substitution)
-        aah = calculateWithAbatement(individu, parameters, period, 'aah', has_ressources_substitution)
-        retraite_nette = calculateWithAbatement(individu, parameters, period, 'retraite_nette', has_ressources_substitution)
-        pensions_alimentaires_percues = calculateWithAbatement(individu, parameters, period, 'pensions_alimentaires_percues', has_ressources_substitution)
-        indemnites_stage = calculateWithAbatement(individu, parameters, period, 'indemnites_stage', has_ressources_substitution)
+        salaire_imposable = calculateWithAbatement(individu, parameters, period, 'salaire_imposable')
+        revenus_stage_formation_pro = calculateWithAbatement(individu, parameters, period, 'revenus_stage_formation_pro')
+        aah = calculateWithAbatement(individu, parameters, period, 'aah')
+        retraite_nette = calculateWithAbatement(individu, parameters, period, 'retraite_nette')
+        pensions_alimentaires_percues = calculateWithAbatement(individu, parameters, period, 'pensions_alimentaires_percues')
+        indemnites_stage = calculateWithAbatement(individu, parameters, period, 'indemnites_stage')
 
         pensions_invalidite = individu('pensions_invalidite', previous_year, options=[ADD])
         revenus_locatifs = individu('revenus_locatifs', previous_year, options=[ADD])
@@ -132,15 +125,8 @@ class ass_base_ressources_conjoint(Variable):
 
     def formula(individu, period, parameters):
         ass_base_ressources_individu = individu('ass_base_ressources_individu', period)
-        last_month = period.start.period('month').offset(-1)
-        has_ressources_substitution = (
-            individu('chomage_net', last_month)
-            + individu('indemnites_journalieres', last_month)
-            + individu('retraite_nette', last_month)
-            ) > 0
-        chomage_net = calculateWithAbatement(individu, parameters, period, 'chomage_net', has_ressources_substitution)
-        indemnites_journalieres = calculateWithAbatement(individu, parameters, period, 'indemnites_journalieres',
-                                                         has_ressources_substitution)
+        chomage_net = calculateWithAbatement(individu, parameters, period, 'chomage_net')
+        indemnites_journalieres = calculateWithAbatement(individu, parameters, period, 'indemnites_journalieres')
 
         return (
                 ass_base_ressources_individu
@@ -149,8 +135,13 @@ class ass_base_ressources_conjoint(Variable):
         )
 
 
-def calculateWithAbatement(individu, parameters, period, ressourceName, has_ressources_substitution):
+def calculateWithAbatement(individu, parameters, period, ressourceName):
     last_month = period.start.period('month').offset(-1)
+    has_ressources_substitution = (
+        individu('chomage_net', last_month)
+        + individu('indemnites_journalieres', last_month)
+        + individu('retraite_nette', last_month)
+        ) > 0
     # Rolling year
     previous_year = period.start.period('year').offset(-1)
 

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -91,7 +91,6 @@ class ass_base_ressources_individu(Variable):
         retraite_nette = calculateWithAbatement(individu, parameters, period, 'retraite_nette', has_ressources_substitution)
         pensions_alimentaires_percues = calculateWithAbatement(individu, parameters, period, 'pensions_alimentaires_percues', has_ressources_substitution)
         indemnites_stage = calculateWithAbatement(individu, parameters, period, 'indemnites_stage', has_ressources_substitution)
-        indemnites_journalieres = calculateWithAbatement(individu, parameters, period, 'indemnites_journalieres', has_ressources_substitution)
 
         pensions_invalidite = individu('pensions_invalidite', previous_year, options=[ADD])
         revenus_locatifs = individu('revenus_locatifs', previous_year, options=[ADD])
@@ -122,7 +121,6 @@ class ass_base_ressources_individu(Variable):
             + revenus_tns()
             + revenus_locatifs
             + revenus_capital
-            + indemnites_journalieres
             )
 
 

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -131,10 +131,10 @@ class ass_base_ressources_conjoint(Variable):
         indemnites_journalieres = calculateWithAbatement(individu, parameters, period, 'indemnites_journalieres')
 
         return (
-                ass_base_ressources_individu
-                + chomage_net
-                + indemnites_journalieres
-        )
+            ass_base_ressources_individu
+            + chomage_net
+            + indemnites_journalieres
+            )
 
 
 def calculateWithAbatement(individu, parameters, period, ressourceName):
@@ -160,7 +160,7 @@ def calculateWithAbatement(individu, parameters, period, ressourceName):
 
     tx_abat_applique = where(has_ressources_substitution, tx_abat_partiel, tx_abat_total)
 
-    return where(ressource_interrompue,  (1 - tx_abat_applique) * ressource_year, ressource_year)
+    return where(ressource_interrompue, (1 - tx_abat_applique) * ressource_year, ressource_year)
 
 
 class ass_eligibilite_cumul_individu(Variable):
@@ -233,8 +233,8 @@ class ass_eligibilite_individu(Variable):
         eligible_cumul_ass = individu('ass_eligibilite_cumul_individu', period)
 
         demandeur_emploi_non_indemnise_et_cumul_accepte = (
-            (individu('chomage_net', period) == 0) *
-            ((individu('activite', period) == TypesActivite.chomeur) + eligible_cumul_ass)
+            (individu('chomage_net', period) == 0)
+            * ((individu('activite', period) == TypesActivite.chomeur) + eligible_cumul_ass)
             )
 
         # Indique que l'individu a travaillé 5 ans au cours des 10 dernieres années.

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -70,9 +70,6 @@ class ass_base_ressources_individu(Variable):
         ]
 
     def formula(individu, period, parameters):
-        '''
-                N'intègre pas l'exception citée à l'article R5423-2 du Code du Travail sur les conjoints chefs d'entreprises entrant dans le champ d'application de l'article 50-0 du CGI
-                '''
         # Rolling year
         previous_year = period.start.period('year').offset(-1)
         # N-1
@@ -90,17 +87,16 @@ class ass_base_ressources_individu(Variable):
         revenus_capital = individu('revenus_capital', period) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         def revenus_tns():
-            revenus_auto_entrepreneur = individu('tns_auto_entrepreneur_benefice', previous_year, options=[ADD])
+            revenus_auto_entrepreneur = individu('tns_auto_entrepreneur_benefice', previous_year, options= [ADD])
 
-            # Les revenus TNS hors AE sont estimés en se basant <sur le revenu N-1
+            # Les revenus TNS hors AE sont estimés en se basant sur le revenu N-1
             tns_micro_entreprise_benefice = individu('tns_micro_entreprise_benefice', last_year)
             tns_benefice_exploitant_agricole = individu('tns_benefice_exploitant_agricole', last_year)
-            tns_autres_revenus = individu('tns_autres_revenus', last_year, options=[ADD])
+            tns_autres_revenus = individu('tns_autres_revenus', last_year)
 
             return revenus_auto_entrepreneur + tns_micro_entreprise_benefice + tns_benefice_exploitant_agricole + tns_autres_revenus
 
-        pensions_alimentaires_versees_individu = individu('pensions_alimentaires_versees_individu', previous_year,
-                                                          options=[ADD])
+        pensions_alimentaires_versees_individu = individu('pensions_alimentaires_versees_individu', previous_year, options=[ADD])
 
         return (
             salaire_imposable

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -120,8 +120,14 @@ class ass_base_ressources_conjoint(Variable):
     definition_period = MONTH
 
     def formula(individu, period, parameters):
+        # Rolling year
+        previous_year = period.start.period('year').offset(-1)
+
+        last_month = period.start.period('month').offset(-1)
+
         ass_base_ressources_individu = individu('ass_base_ressources_individu', period)
-        chomage_net = calculateWithAbatement(individu, parameters, period, 'chomage_net')
+        chomage_net_interrompue = individu('chomage_net', last_month) == 0
+        chomage_net = individu('chomage_net', previous_year, options=[ADD]) * (1 - chomage_net_interrompue)
         indemnites_journalieres = calculateWithAbatement(individu, parameters, period, 'indemnites_journalieres')
 
         return (

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -87,7 +87,7 @@ class ass_base_ressources_individu(Variable):
         revenus_capital = individu('revenus_capital', period) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
 
         def revenus_tns():
-            revenus_auto_entrepreneur = individu('tns_auto_entrepreneur_benefice', previous_year, options= [ADD])
+            revenus_auto_entrepreneur = individu('tns_auto_entrepreneur_benefice', previous_year, options=[ADD])
 
             # Les revenus TNS hors AE sont estimés en se basant sur le revenu N-1
             tns_micro_entreprise_benefice = individu('tns_micro_entreprise_benefice', last_year)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "42.4.0",
+    version = "42.5.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/ass_abbattement.yaml
+++ b/tests/formulas/ass_abbattement.yaml
@@ -120,7 +120,7 @@
 
 - name: Abattement des revenus quand le revenu d'individu est interrompu
   description: Montant ASS pour personne seule avec ressources mensuelles inférieures à 941,70 et pris en compte à 70%
-  period: 2019-04
+  period: 2018-04
   absolute_error_margin: 0.02
   input:
     famille:
@@ -134,13 +134,13 @@
         ass_precondition_remplie: true
         activite: chomeur
         salaire_imposable:
-          2019-01: 940
-          2019-02: 940
-          2019-03: 0
-          year:2018-04: 940 * 12
+          2018-01: 940
+          2018-02: 940
+          2018-03: 0
+          year:2017-04: 940 * 12
         chomage_net:
-          2019-03: 200
-          year:2018-04: 2000
+          2018-03: 200
+          year:2017-04: 2000
   output:
     ass_base_ressources_individu: [7896]
     ass_base_ressources: 7896
@@ -148,7 +148,7 @@
 
 - name: Abattement des revenus quand le revenu d'individu est interrompu
   description: Montant ASS pour personne en couple avec ressources mensuelles inférieures à 1883.43 et pris en compte à 70%
-  period: 2019-04
+  period: 2018-04
   absolute_error_margin: 0.02
   input:
     famille:
@@ -163,13 +163,13 @@
         ass_precondition_remplie: true
         activite: chomeur
         salaire_imposable:
-          2019-01: 1880
-          2019-02: 1880
-          2019-03: 0
-          year:2018-04: 1880 * 12
+          2018-01: 1880
+          2018-02: 1880
+          2018-03: 0
+          year:2017-04: 1880 * 12
         chomage_net:
-          2019-03: 200
-          year:2018-04: 2000
+          2018-03: 200
+          year:2017-04: 2000
       parent2:
         ass_precondition_remplie: true
         activite: chomeur
@@ -181,7 +181,7 @@
 
 - name: Abattement des revenus quand le revenu d'individu et du conjoint sont interrompus
   description: Montant ASS pour personne en couple
-  period: 2019-04
+  period: 2018-04
   absolute_error_margin: 0.02
   input:
     famille:
@@ -196,24 +196,24 @@
         ass_precondition_remplie: true
         activite: chomeur
         salaire_imposable:
-          2019-01: 1000
-          2019-02: 1000
-          2019-03: 0
-          year:2018-04: 1000 * 12
+          2018-01: 1000
+          2018-02: 1000
+          2018-03: 0
+          year:2017-04: 1000 * 12
         chomage_net:
-          2019-03: 200
-          year:2018-04: 2000
+          2018-03: 200
+          year:2017-04: 2000
       parent2:
         ass_precondition_remplie: true
         activite: chomeur
         salaire_imposable:
-          2019-01: 1100
-          2019-02: 1100
-          2019-03: 0
-          year:2018-04: 1100 * 12
+          2018-01: 1100
+          2018-02: 1100
+          2018-03: 0
+          year:2017-04: 1100 * 12
         chomage_net:
-          2019-03: 140
-          year:2018-04: 140 * 12
+          2018-03: 140
+          year:2017-04: 140 * 12
   output:
     ass_base_ressources_individu: [8400, 9240]
     ass_base_ressources_conjoint: [10400, 10920]
@@ -222,7 +222,7 @@
 
 - name: Abattement des revenus quand le revenu d'individu et du conjoint sont interrompus
   description: Montant ASS pour personne en couple
-  period: 2019-04
+  period: 2018-04
   absolute_error_margin: 0.02
   input:
     famille:
@@ -237,34 +237,34 @@
         ass_precondition_remplie: true
         activite: chomeur
         revenus_locatifs:
-          2019-01: 400
-          2019-02: 400
-          2019-03: 0
-          year:2018-04: 400 * 12
+          2018-01: 400
+          2018-02: 400
+          2018-03: 0
+          year:2017-04: 400 * 12
         salaire_imposable:
-          2019-01: 400
-          2019-02: 400
-          2019-03: 0
-          year:2018-04: 400 * 12
+          2018-01: 400
+          2018-02: 400
+          2018-03: 0
+          year:2017-04: 400 * 12
         chomage_net:
-          2019-03: 200
-          year:2018-04: 2000
+          2018-03: 200
+          year:2017-04: 2000
       parent2:
         ass_precondition_remplie: true
         activite: chomeur
         revenus_locatifs:
-          2019-01: 500
-          2019-02: 500
-          2019-03: 0
-          year:2018-04: 500 * 12
+          2018-01: 500
+          2018-02: 500
+          2018-03: 0
+          year:2017-04: 500 * 12
         salaire_imposable:
-          2019-01: 200
-          2019-02: 200
-          2019-03: 0
-          year:2018-04: 200 * 12
+          2018-01: 200
+          2018-02: 200
+          2018-03: 0
+          year:2017-04: 200 * 12
         chomage_net:
-          2019-03: 140
-          year:2018-04: 140 * 12
+          2018-03: 140
+          year:2017-04: 140 * 12
   output:
     ass_base_ressources_individu: [8160, 7680]
     ass_base_ressources_conjoint: [10160, 9360]

--- a/tests/formulas/ass_abbattement.yaml
+++ b/tests/formulas/ass_abbattement.yaml
@@ -114,6 +114,159 @@
         - parent2
   output:
     ass_eligibilite_individu: [true, false]
-    ass_base_ressources_individu: [0, 1000]
+    ass_base_ressources_individu: [0, 8000]
     ass_base_ressources_conjoint: [0, 8000]
     ass_base_ressources: [8000]
+
+- name: Abattement des revenus quand le revenu d'individu est interrompu
+  description: Montant ASS pour personne seule avec ressources mensuelles inférieures à 941,70 et pris en compte à 70%
+  period: 2019-04
+  absolute_error_margin: 0.02
+  input:
+    famille:
+      parents: [parent1]
+    foyer_fiscal:
+      declarants: [parent1]
+    menage:
+      personne_de_reference: parent1
+    individus:
+      parent1:
+        ass_precondition_remplie: true
+        activite: chomeur
+        salaire_imposable:
+          2019-01: 940
+          2019-02: 940
+          2019-03: 0
+          year:2018-04: 940 * 12
+        chomage_net:
+          2019-03: 200
+          year:2018-04: 2000
+  output:
+    ass_base_ressources_individu: [7896]
+    ass_base_ressources: 7896
+    ass: 494.40
+
+- name: Abattement des revenus quand le revenu d'individu est interrompu
+  description: Montant ASS pour personne en couple avec ressources mensuelles inférieures à 1883.43 et pris en compte à 70%
+  period: 2019-04
+  absolute_error_margin: 0.02
+  input:
+    famille:
+      parents: [parent1, parent2]
+    foyer_fiscal:
+      declarants: [parent1, parent2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+    individus:
+      parent1:
+        ass_precondition_remplie: true
+        activite: chomeur
+        salaire_imposable:
+          2019-01: 1880
+          2019-02: 1880
+          2019-03: 0
+          year:2018-04: 1880 * 12
+        chomage_net:
+          2019-03: 200
+          year:2018-04: 2000
+      parent2:
+        ass_precondition_remplie: true
+        activite: chomeur
+  output:
+    ass_base_ressources_individu: [15792, 0]
+    ass_base_ressources_conjoint: [17792, 0]
+    ass_base_ressources: 15792
+    ass: 494.40
+
+- name: Abattement des revenus quand le revenu d'individu et du conjoint sont interrompus
+  description: Montant ASS pour personne en couple
+  period: 2019-04
+  absolute_error_margin: 0.02
+  input:
+    famille:
+      parents: [parent1, parent2]
+    foyer_fiscal:
+      declarants: [parent1, parent2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+    individus:
+      parent1:
+        ass_precondition_remplie: true
+        activite: chomeur
+        salaire_imposable:
+          2019-01: 1000
+          2019-02: 1000
+          2019-03: 0
+          year:2018-04: 1000 * 12
+        chomage_net:
+          2019-03: 200
+          year:2018-04: 2000
+      parent2:
+        ass_precondition_remplie: true
+        activite: chomeur
+        salaire_imposable:
+          2019-01: 1100
+          2019-02: 1100
+          2019-03: 0
+          year:2018-04: 1100 * 12
+        chomage_net:
+          2019-03: 140
+          year:2018-04: 140 * 12
+  output:
+    ass_base_ressources_individu: [8400, 9240]
+    ass_base_ressources_conjoint: [10400, 10920]
+    ass_base_ressources: 19320
+    ass: 202.80
+
+- name: Abattement des revenus quand le revenu d'individu et du conjoint sont interrompus
+  description: Montant ASS pour personne en couple
+  period: 2019-04
+  absolute_error_margin: 0.02
+  input:
+    famille:
+      parents: [parent1, parent2]
+    foyer_fiscal:
+      declarants: [parent1, parent2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+    individus:
+      parent1:
+        ass_precondition_remplie: true
+        activite: chomeur
+        revenus_locatifs:
+          2019-01: 400
+          2019-02: 400
+          2019-03: 0
+          year:2018-04: 400 * 12
+        salaire_imposable:
+          2019-01: 400
+          2019-02: 400
+          2019-03: 0
+          year:2018-04: 400 * 12
+        chomage_net:
+          2019-03: 200
+          year:2018-04: 2000
+      parent2:
+        ass_precondition_remplie: true
+        activite: chomeur
+        revenus_locatifs:
+          2019-01: 500
+          2019-02: 500
+          2019-03: 0
+          year:2018-04: 500 * 12
+        salaire_imposable:
+          2019-01: 200
+          2019-02: 200
+          2019-03: 0
+          year:2018-04: 200 * 12
+        chomage_net:
+          2019-03: 140
+          year:2018-04: 140 * 12
+  output:
+    ass_base_ressources_individu: [8160, 7680]
+    ass_base_ressources_conjoint: [10160, 9360]
+    ass_base_ressources: 17520
+    ass: 352.80

--- a/tests/mes-aides.gouv.fr/test_mes_aides_556ece2d1619d23d68b91e46.yaml
+++ b/tests/mes-aides.gouv.fr/test_mes_aides_556ece2d1619d23d68b91e46.yaml
@@ -268,4 +268,4 @@ input:
     personne_de_reference: 556ecc8cb601174568edcad1
     statut_occupation_logement: proprietaire
 output:
-  ass: 490
+  ass: 170.07


### PR DESCRIPTION
* Correction d'un calcul existant
* Périodes concernées : toutes.
* Zones impactées : `prestations/minima_sociaux/ass`.
* Détails :
  - Application de l’abattement sur les revenus de substitution pour l’allocation de solidarité spécifique (ASS).
  - Factorise le calcule de l’abattement des ressources pour les variables ass_base_ressources_individu et ass_base_ressources_conjoint.
