### PR TITLE
Limite l'âge à 100 ans pour rentrer dans le barème rente AT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 42.3.2 [#1327](https://github.com/openfisca/openfisca-france/pull/1327)
+
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées : `revenus/remplacement/rente_accident_travail`.
+* Détails :
+  - Corrige une erreur lors du calcul de la rente accident du travail pour les personnes de plus de 100 ans
+
 ### 42.3.1 [#1324](https://github.com/openfisca/openfisca-france/pull/1324)
 
 * Évolution du système socio-fiscal

--- a/openfisca_france/model/revenus/remplacement/rente_accident_travail.py
+++ b/openfisca_france/model/revenus/remplacement/rente_accident_travail.py
@@ -112,7 +112,7 @@ class rente_accident_travail_apres_rachat(Variable):
 
     def formula(individu, period, parameters):
         rente_at = parameters(period).accident_travail.rente.taux
-        age = max_(individu('age', period), 16)
+        age = min_(max_(individu('age', period), 16), 100)
         rente_accident_travail_rachat = individu('rente_accident_travail_rachat', period)
         conversion_rente_capital = rente_at.capital_representatif[age]
         rente_accident_travail_base = individu('rente_accident_travail_base', period)
@@ -131,7 +131,7 @@ class rente_accident_travail_rachat(Variable):
     def formula(individu, period, parameters):
         rente_at = parameters(period).accident_travail.rente.taux
         demande_rachat = individu('demande_rachat', period)
-        age = max_(individu('age', period), 16)
+        age = min_(max_(individu('age', period), 16), 100)
         conversion_rente_capital = rente_at.capital_representatif[age]
         rente_accident_travail_base = individu('rente_accident_travail_base', period)
         rachat = (rente_accident_travail_base * conversion_rente_capital) / 4

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "42.3.1",
+    version = "42.3.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/rente_at.yaml
+++ b/tests/formulas/rente_at.yaml
@@ -187,6 +187,7 @@
       parents: [parent1]
     individus:
       parent1:
+        age_en_mois: 1224
         taux_accident_travail: 0.90
         tns_benefice_exploitant_agricole:
           2017: 20000


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `revenus/remplacement/rente_accident_travaill`.
* Détails :
  - Les formules de la rente accident du travail fonctionne pour des personnes de plus de 100 ans
