### PR TITLE
Mets à jour le crédit d'impôt pour la transition energétique (IR 2019 sur revenus 2018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+# 44.0.0 [#1329](https://github.com/openfisca/openfisca-france/pull/1329)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2018.
+* Zones impactées : `model/prelevements_obligatoires/impot_revenu/`.
+* Détails :
+  - Ajoute comme inputs variables les nouvelles cases de la déclaration IR 2018 liée au crédit d'impôt pour la transition énergétique (CITE)
+  - Renomme les anciennes inputs variables du même nom, selon la méthode habituelle
+  - Mets à jour la formule pour l'impôt 2019 sur revenus 2018
+  - Factorise les formules 2016, 2017 et 2018.
+
+## Guide de migration
+
+- Si vous utilisiez les variables `f7bm`, `f7aa`, il faut les renommer en ajoutant le suffixe `_2016`
+
 ## 43.1.0 [#1336](https://github.com/openfisca/openfisca-france/pull/1336)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1961,7 +1961,7 @@ class quaenv(Variable):
             ]
         depenses_transition_energetique = sum([foyer_fiscal(case, period) for case in cases_depenses])
         cases_depense_taux_reduit = ['f7ao', 'f7ap']
-        depenses_transition_energetique_taux_reduit = sum([foyer_fiscal(case, period) for case in cases_depenses])
+        depenses_transition_energetique_taux_reduit = sum([foyer_fiscal(case, period) for case in cases_depenses_taux_reduit])
 
         plafond_depenses_energetiques = P.max * (1 + maries_ou_pacses) + P.pac1 * personnes_a_charge
         plafond_depenses_energetiques_taux_reduit = max_(0, plafond_depenses_energetiques - depenses_transition_energetique)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1956,8 +1956,8 @@ class quaenv(Variable):
         P = parameters(period).impot_revenu.credits_impot.quaenv
 
         cases_depenses = [
-            'f7aa', 'f7ad', 'f7af', 'f7ah', 'f7ak', 'f7al', 'f7am', 'f7an', 'f7aq', 'f7ar', 'f7av', 'f7ax', 'f7ay', 'f7az',
-            'f7bb', 'f7bc', 'f7bd', 'f7be', 'f7bf', 'f7bh', 'f7bk', 'f7bl', 'f7cb',
+            'f7aa', 'f7ad', 'f7af', 'f7ah', 'f7ak', 'f7al', 'f7am', 'f7an', 'f7aq', 'f7ar', 'f7as', 'f7av', 'f7ax', 'f7ay', 'f7az',
+            'f7bb', 'f7bc', 'f7bd', 'f7be', 'f7bf', 'f7bh', 'f7bk', 'f7bl', 'f7bm', 'f7cb',
             ]
         depenses_transition_energetique = sum([foyer_fiscal(case, period) for case in cases_depenses])
         cases_depense_taux_reduit = ['f7ao', 'f7ap']

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1958,7 +1958,6 @@ class quaenv(Variable):
 
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
         personnes_a_charge = foyer_fiscal('nb_pac2', period)
-        rfr = foyer_fiscal('rfr', period)  # noqa F841
         P = parameters(period).impot_revenu.credits_impot.quaenv
 
         depenses_transition_energetique = (
@@ -2005,7 +2004,6 @@ class quaenv(Variable):
 
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
         personnes_a_charge = foyer_fiscal('nb_pac2', period)
-        rfr = foyer_fiscal('rfr', period)  # noqa F841
         P = parameters(period).impot_revenu.credits_impot.quaenv
 
         depenses_transition_energetique = (

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1961,7 +1961,7 @@ class quaenv(Variable):
             ]
         depenses_transition_energetique = sum([foyer_fiscal(case, period) for case in cases_depenses])
         cases_depense_taux_reduit = ['f7ao', 'f7ap']
-        depenses_transition_energetique_taux_reduit = sum([foyer_fiscal(case, period) for case in cases_depenses_taux_reduit])
+        depenses_transition_energetique_taux_reduit = sum([foyer_fiscal(case, period) for case in cases_depense_taux_reduit])
 
         plafond_depenses_energetiques = P.max * (1 + maries_ou_pacses) + P.pac1 * personnes_a_charge
         plafond_depenses_energetiques_taux_reduit = max_(0, plafond_depenses_energetiques - depenses_transition_energetique)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1933,38 +1933,15 @@ class quaenv(Variable):
         Crédits d’impôt pour dépenses en faveur de la transition energétique
         2017
         '''
-        f7ad = foyer_fiscal('f7ad', period)
-        f7af = foyer_fiscal('f7af', period)
-        f7ah = foyer_fiscal('f7ah', period)
-        f7ak = foyer_fiscal('f7ak', period)
-        f7al = foyer_fiscal('f7al', period)
-        f7am = foyer_fiscal('f7am', period)
-        f7an = foyer_fiscal('f7an', period)
-        f7aq = foyer_fiscal('f7aq', period)
-        f7ar = foyer_fiscal('f7ar', period)
-        f7av = foyer_fiscal('f7av', period)
-        f7ax = foyer_fiscal('f7ax', period)
-        f7ay = foyer_fiscal('f7ay', period)
-        f7az = foyer_fiscal('f7az', period)
-        f7bb = foyer_fiscal('f7bb', period)
-        f7bc = foyer_fiscal('f7bc', period)
-        f7bd = foyer_fiscal('f7bd', period)
-        f7be = foyer_fiscal('f7be', period)
-        f7bf = foyer_fiscal('f7bf', period)
-        f7bh = foyer_fiscal('f7bh', period)
-        f7bk = foyer_fiscal('f7bk', period)
-        f7bl = foyer_fiscal('f7bl', period)
-        f7cb = foyer_fiscal('f7cb', period)
-
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
         personnes_a_charge = foyer_fiscal('nb_pac2', period)
         P = parameters(period).impot_revenu.credits_impot.quaenv
 
-        depenses_transition_energetique = (
-            f7ad + f7af + f7ah + f7ak + f7al + f7am + f7an + f7aq + f7ar + f7av + f7ax
-            + f7ay + f7az + f7bb + f7bc + f7bd + f7be + f7bf + f7bh + f7bk + f7bl + f7cb
-            )
-
+        cases_depenses = [
+            'f7ad', 'f7af', 'f7ah', 'f7ak', 'f7al', 'f7am', 'f7an', 'f7aq', 'f7ar', 'f7av', 'f7ax', 'f7ay', 'f7az',
+            'f7bb', 'f7bc', 'f7bd', 'f7be', 'f7bf', 'f7bh', 'f7bk', 'f7bl', 'f7cb',
+            ]
+        depenses_transition_energetique = sum([foyer_fiscal(case, period) for case in cases_depenses])
         plafond_depenses_energetiques = P.max * (1 + maries_ou_pacses) + P.pac1 * personnes_a_charge
 
         return P.taux30 * min_(plafond_depenses_energetiques, depenses_transition_energetique)
@@ -1974,43 +1951,17 @@ class quaenv(Variable):
         Crédits d’impôt pour dépenses en faveur de la transition energétique
         2018
         '''
-        f7aa = foyer_fiscal('f7aa', period)
-        f7ad = foyer_fiscal('f7ad', period)
-        f7af = foyer_fiscal('f7af', period)
-        f7ah = foyer_fiscal('f7ah', period)
-        f7ak = foyer_fiscal('f7ak', period)
-        f7al = foyer_fiscal('f7al', period)
-        f7am = foyer_fiscal('f7am', period)
-        f7an = foyer_fiscal('f7an', period)
-        f7ao = foyer_fiscal('f7ao', period)
-        f7ap = foyer_fiscal('f7ap', period)
-        f7aq = foyer_fiscal('f7aq', period)
-        f7ar = foyer_fiscal('f7ar', period)
-        f7as = foyer_fiscal('f7as', period)
-        f7av = foyer_fiscal('f7av', period)
-        f7ax = foyer_fiscal('f7ax', period)
-        f7ay = foyer_fiscal('f7ay', period)
-        f7az = foyer_fiscal('f7az', period)
-        f7bb = foyer_fiscal('f7bb', period)
-        f7bc = foyer_fiscal('f7bc', period)
-        f7bd = foyer_fiscal('f7bd', period)
-        f7be = foyer_fiscal('f7be', period)
-        f7bf = foyer_fiscal('f7bf', period)
-        f7bh = foyer_fiscal('f7bh', period)
-        f7bk = foyer_fiscal('f7bk', period)
-        f7bl = foyer_fiscal('f7bl', period)
-        f7bm = foyer_fiscal('f7bm', period)
-        f7cb = foyer_fiscal('f7cb', period)
-
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
         personnes_a_charge = foyer_fiscal('nb_pac2', period)
         P = parameters(period).impot_revenu.credits_impot.quaenv
 
-        depenses_transition_energetique = (
-            f7aa + f7ad + f7af + f7ah + f7ak + f7al + f7am + f7an + f7aq + f7ar + f7as + f7av + f7ax
-            + f7ay + f7az + f7bb + f7bc + f7bd + f7be + f7bf + f7bh + f7bk + f7bl + f7bm + f7cb
-            )
-        depenses_transition_energetique_taux_reduit = f7ao + f7ap
+        cases_depenses = [
+            'f7aa', 'f7ad', 'f7af', 'f7ah', 'f7ak', 'f7al', 'f7am', 'f7an', 'f7aq', 'f7ar', 'f7av', 'f7ax', 'f7ay', 'f7az',
+            'f7bb', 'f7bc', 'f7bd', 'f7be', 'f7bf', 'f7bh', 'f7bk', 'f7bl', 'f7cb',
+            ]
+        depenses_transition_energetique = sum([foyer_fiscal(case, period) for case in cases_depenses])
+        cases_depense_taux_reduit = ['f7ao', 'f7ap']
+        depenses_transition_energetique_taux_reduit = sum([foyer_fiscal(case, period) for case in cases_depenses])
 
         plafond_depenses_energetiques = P.max * (1 + maries_ou_pacses) + P.pac1 * personnes_a_charge
         plafond_depenses_energetiques_taux_reduit = max_(0, plafond_depenses_energetiques - depenses_transition_energetique)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1743,7 +1743,7 @@ class quaenv(Variable):
         Crédits d’impôt pour dépenses en faveur de la qualité environnementale (1.1-31.8.2014) et transition energétique (1.9.2014-31.12.2015)
         2015
         '''
-        f7aa = foyer_fiscal('f7aa', period)
+        f7aa = foyer_fiscal('f7aa_2016', period)
         f7ad = foyer_fiscal('f7ad', period)
         f7af = foyer_fiscal('f7af', period)
         f7ah = foyer_fiscal('f7ah', period)
@@ -1885,7 +1885,7 @@ class quaenv(Variable):
         Crédits d’impôt pour dépenses en faveur de la transition energétique
         2016
         '''
-        f7aa = foyer_fiscal('f7aa', period)
+        f7aa = foyer_fiscal('f7aa_2016', period)
         f7ad = foyer_fiscal('f7ad', period)
         f7af = foyer_fiscal('f7af', period)
         f7ah = foyer_fiscal('f7ah', period)
@@ -1907,7 +1907,7 @@ class quaenv(Variable):
         f7bh = foyer_fiscal('f7bh', period)
         f7bk = foyer_fiscal('f7bk', period)
         f7bl = foyer_fiscal('f7bl', period)
-        f7bm = foyer_fiscal('f7bm', period)
+        f7bm = foyer_fiscal('f7bm_2016', period)
         f7cb = foyer_fiscal('f7cb', period)
         f7we = foyer_fiscal('f7we', period)  # noqa F841
         f7wg = foyer_fiscal('f7wg', period)  # noqa F841
@@ -1969,6 +1969,58 @@ class quaenv(Variable):
         plafond_depenses_energetiques = P.max * (1 + maries_ou_pacses) + P.pac1 * personnes_a_charge
 
         return P.taux30 * min_(plafond_depenses_energetiques, depenses_transition_energetique)
+
+    def formula_2018_01_01(foyer_fiscal, period, parameters):
+        '''
+        Crédits d’impôt pour dépenses en faveur de la transition energétique
+        2018
+        '''
+        f7aa = foyer_fiscal('f7aa', period)
+        f7ad = foyer_fiscal('f7ad', period)
+        f7af = foyer_fiscal('f7af', period)
+        f7ah = foyer_fiscal('f7ah', period)
+        f7ak = foyer_fiscal('f7ak', period)
+        f7al = foyer_fiscal('f7al', period)
+        f7am = foyer_fiscal('f7am', period)
+        f7an = foyer_fiscal('f7an', period)
+        f7ao = foyer_fiscal('f7ao', period)
+        f7ap = foyer_fiscal('f7ap', period)
+        f7aq = foyer_fiscal('f7aq', period)
+        f7ar = foyer_fiscal('f7ar', period)
+        f7as = foyer_fiscal('f7as', period)
+        f7av = foyer_fiscal('f7av', period)
+        f7ax = foyer_fiscal('f7ax', period)
+        f7ay = foyer_fiscal('f7ay', period)
+        f7az = foyer_fiscal('f7az', period)
+        f7bb = foyer_fiscal('f7bb', period)
+        f7bc = foyer_fiscal('f7bc', period)
+        f7bd = foyer_fiscal('f7bd', period)
+        f7be = foyer_fiscal('f7be', period)
+        f7bf = foyer_fiscal('f7bf', period)
+        f7bh = foyer_fiscal('f7bh', period)
+        f7bk = foyer_fiscal('f7bk', period)
+        f7bl = foyer_fiscal('f7bl', period)
+        f7bm = foyer_fiscal('f7bm', period)
+        f7cb = foyer_fiscal('f7cb', period)
+
+        maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        personnes_a_charge = foyer_fiscal('nb_pac2', period)
+        rfr = foyer_fiscal('rfr', period)  # noqa F841
+        P = parameters(period).impot_revenu.credits_impot.quaenv
+
+        depenses_transition_energetique = (
+            f7aa + f7ad + f7af + f7ah + f7ak + f7al + f7am + f7an + f7aq + f7ar + f7as + f7av + f7ax
+            + f7ay + f7az + f7bb + f7bc + f7bd + f7be + f7bf + f7bh + f7bk + f7bl + f7bm + f7cb
+            )
+        depenses_transition_energetique_taux_reduit = f7ao + f7ap
+
+        plafond_depenses_energetiques = P.max * (1 + maries_ou_pacses) + P.pac1 * personnes_a_charge
+        plafond_depenses_energetiques_taux_reduit = max_(0, plafond_depenses_energetiques - depenses_transition_energetique)
+
+        return (
+            P.taux30 * min_(plafond_depenses_energetiques, depenses_transition_energetique)
+            + P.taux15 * min_(plafond_depenses_energetiques_taux_reduit, depenses_transition_energetique_taux_reduit)
+            )
 
 
 class quaenv_bouquet(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1885,46 +1885,16 @@ class quaenv(Variable):
         Crédits d’impôt pour dépenses en faveur de la transition energétique
         2016
         '''
-        f7aa = foyer_fiscal('f7aa_2016', period)
-        f7ad = foyer_fiscal('f7ad', period)
-        f7af = foyer_fiscal('f7af', period)
-        f7ah = foyer_fiscal('f7ah', period)
-        f7ak = foyer_fiscal('f7ak', period)
-        f7al = foyer_fiscal('f7al', period)
-        f7am = foyer_fiscal('f7am', period)
-        f7an = foyer_fiscal('f7an', period)
-        f7aq = foyer_fiscal('f7aq', period)
-        f7ar = foyer_fiscal('f7ar', period)
-        f7av = foyer_fiscal('f7av', period)
-        f7ax = foyer_fiscal('f7ax', period)
-        f7ay = foyer_fiscal('f7ay', period)
-        f7az = foyer_fiscal('f7az', period)
-        f7bb = foyer_fiscal('f7bb', period)
-        f7bc = foyer_fiscal('f7bc', period)
-        f7bd = foyer_fiscal('f7bd', period)
-        f7be = foyer_fiscal('f7be', period)
-        f7bf = foyer_fiscal('f7bf', period)
-        f7bh = foyer_fiscal('f7bh', period)
-        f7bk = foyer_fiscal('f7bk', period)
-        f7bl = foyer_fiscal('f7bl', period)
-        f7bm = foyer_fiscal('f7bm_2016', period)
-        f7cb = foyer_fiscal('f7cb', period)
-        f7we = foyer_fiscal('f7we', period)  # noqa F841
-        f7wg = foyer_fiscal('f7wg', period)  # noqa F841
-
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
         nb_pac2 = foyer_fiscal('nb_pac2', period)
-        rfr = foyer_fiscal('rfr', period)  # noqa F841
         P = parameters(period).impot_revenu.credits_impot.quaenv
-
-        depenses_transition_energetique = (
-            f7aa + f7ad + f7af + f7ah + f7ak + f7al + f7am + f7an + f7aq + f7ar + f7av + f7ax
-            + f7ay + f7az + f7bb + f7bc + f7bd + f7be + f7bf + f7bh + f7bk + f7bl + f7bm + f7cb
-            )
-
         max0 = P.max * (1 + maries_ou_pacses) + P.pac1 * nb_pac2
 
-        # TODO: inclure la condition de non cumul éco-prêt / crédit quaenv si RFR > ... (condition complexifiée à partir de 2014)
+        cases_depenses = [
+            'f7aa_2016', 'f7ad', 'f7af', 'f7ah', 'f7ak', 'f7al', 'f7am', 'f7an', 'f7aq', 'f7ar', 'f7av', 'f7ax',
+            'f7ay', 'f7az', 'f7bb', 'f7bc', 'f7bd', 'f7be', 'f7bf', 'f7bh', 'f7bk', 'f7bl', 'f7bm_2016', 'f7cb',
+            ]
+        depenses_transition_energetique = sum([foyer_fiscal(case, period) for case in cases_depenses])
 
         return P.taux30 * min_(max0, depenses_transition_energetique)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -834,7 +834,7 @@ class f7bb(Variable):
     definition_period = YEAR
 
 
-class f7bm(Variable):
+class f7bm_2016(Variable):
     cerfa_field = u"7BM"
     value_type = int
     entity = FoyerFiscal
@@ -7840,7 +7840,7 @@ class f7cb(Variable):
     definition_period = YEAR
 
 
-class f7aa(Variable):
+class f7aa_2016(Variable):
     cerfa_field = u"7AA"
     value_type = int
     unit = 'currency'
@@ -7848,6 +7848,16 @@ class f7aa(Variable):
     label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 (hors bouquet sur 2 ans) : chaudières à condensation "
     # start_date = date(2015, 1, 1)
     end = '2016-12-31'
+    definition_period = YEAR
+
+
+class f7aa(Variable):
+    cerfa_field = u"7AA"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location : Chaudières à haute performance énergétique utilisant le fioul : dépenses payées en 2018 avec acceptation d’un devis et versement d’un acompte au plus tard le 31.12.2017 "
+    # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 
@@ -7870,6 +7880,45 @@ class f7af(Variable):
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
+
+class f7ao(Variable):
+    cerfa_field = u"7AO"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location : Chaudières à très haute performance énergétique utilisant le fioul : dépenses payées du 1.1.2018 au 30.6.2018 et dépenses payées du 1.7.2018 au 31.12.2018 avec acceptation d’un devis et versement d’un acompte au plus tard le 30.6.2018."
+    # start_date = date(2018, 1, 1)
+    definition_period = YEAR
+
+
+class f7ap(Variable):
+    cerfa_field = u"7AP"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location : Matériaux d’isolation thermique des parois vitrées (fenêtres, portes-fenêtres…) venant en remplacement de simples vitrages."
+    # start_date = date(2018, 1, 1)
+    definition_period = YEAR
+
+
+class f7as(Variable):
+    cerfa_field = u"7AS"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location : Pompes à chaleur (autres que air/air) dédiées à la production d’eau chaude sanitaire (chauffe-eaux thermodynamiques); dépenses payées en 2018 avec acceptation d’un devis et versement d’un acompte au plus tard le 31.12.2017"
+    # start_date = date(2018, 1, 1)
+    definition_period = YEAR
+
+
+class f7bm(Variable):
+    cerfa_field = u"7BM"
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location : Audit énergétique"
+    # start_date = date(2018, 1, 1)
+    definition_period = YEAR
 
 # """
 # réutilisation de case pour 2013

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -7924,6 +7924,7 @@ class f7bm(Variable):
 # réutilisation de case pour 2013
 # """
 
+
 class f7sd(Variable):
     cerfa_field = u"7SD"
     value_type = int

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "43.1.0",
+    version = "44.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/calculateur_impots/yaml/credit_quaenv.yaml
+++ b/tests/calculateur_impots/yaml/credit_quaenv.yaml
@@ -59,7 +59,7 @@
   output:
     credits_impot: 2400.0
     iai: 7702.0
-    irpp: 5302.0
+    irpp: -5302.0
     nbptr: 1.0
     quaenv: 2400.0
     rbg: 45000.0

--- a/tests/calculateur_impots/yaml/credit_quaenv.yaml
+++ b/tests/calculateur_impots/yaml/credit_quaenv.yaml
@@ -1,0 +1,66 @@
+- name: credit_quaenv
+  period: 2018
+  absolute_error_margin: 0.1
+  input:
+    foyer_fiscal:
+      caseF: false
+      caseG: false
+      caseL: false
+      caseP: false
+      caseS: false
+      caseT: false
+      caseW: false
+      declarants:
+      - ind0
+      f7aa: 100.0
+      f7ad: 200.0
+      f7af: 300.0
+      f7ah: 200.0
+      f7ak: 100.0
+      f7al: 1000.0
+      f7am: 100.0
+      f7an: 200.0
+      f7ao: 300.0
+      f7ap: 200.0
+      f7aq: 100.0
+      f7ar: 2000.0
+      f7as: 100.0
+      f7av: 200.0
+      f7ax: 300.0
+      f7ay: 200.0
+      f7az: 100.0
+      f7bb: 1500.0
+      f7bc: 100.0
+      f7bd: 200.0
+      f7be: 300.0
+      f7bf: 200.0
+      f7bh: 100.0
+      f7bk: 200.0
+      f7bl: 300.0
+      f7bm: 200.0
+      f7cb: 100.0
+      nbF: 0.0
+      nbG: 0.0
+      nbH: 0.0
+      nbI: 0.0
+      nbJ: 0
+      nbR: 0
+    individus:
+      ind0:
+        activite: actif
+        date_naissance: '1970-01-01'
+        salaire_imposable: 50000.0
+        statut_marital: celibataire
+    famille:
+      parents:
+      - ind0
+    menage:
+      personne_de_reference: ind0
+  output:
+    credits_impot: 2400.0
+    iai: 7702.0
+    irpp: 5302.0
+    nbptr: 1.0
+    quaenv: 2400.0
+    rbg: 45000.0
+    rfr: 45000.0


### PR DESCRIPTION

* Évolution du système socio-fiscal. 
* Périodes concernées : à partir du 01/01/2018
* Zones impactées : `model/prelevements_obligatoires/impot_revenu/`.
* Détails :
  - Ajoute comme inputs variables les nouvelles cases de la déclaration IR 2018 liée au CITE.
  - Renomme les anciennes inputs variables du même nom, selon la méthode habituelle
  - Mets à jour la formule de calcul du crédit (2 types de dépenses sont désormais éligibles seulement au taux réduit de 15)

- - - -

Ces changements  :

- Modifient l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.
