### PR TITLE
Vectorise la formule de l'ADA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 42.5.1 [#1334](https://github.com/openfisca/openfisca-france/pull/1334)
+
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées : `prestations/minima_sociaux/ada`.
+* Détails :
+  - Utilise numpy `not` à la place du `not` de Python qui ne gère pas les vecteurs
+
 ## 42.5.0 [#1326](https://github.com/openfisca/openfisca-france/pull/1326)
 
 * Correction d'un calcul existant

--- a/openfisca_france/model/prestations/minima_sociaux/ada.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ada.py
@@ -21,7 +21,7 @@ class ada(Variable):
             ada.montant_journalier_pour_une_personne
             + (nb_pers - 1) * ada.majoration_pers_supp
             + ada.supplement_non_hebergement
-            * (not place_hebergement)
+            * not_(place_hebergement)
             )
 
         montant_ada = period.days * ada_par_jour * asile_demandeur

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "42.5.0",
+    version = "42.5.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/ada.yaml
+++ b/tests/formulas/ada.yaml
@@ -38,26 +38,12 @@
   output:
     ada: 432.0 # (10.2 + 4.20) * 30
 
-- name: Aide Demandeur Asile - 2 parents, 2 enfants, avec hebergement
-  description: Montant ADA au niveau de la famille
-  period: 2015-12
+- period: 2015-12
   absolute_error_margin: 1
   input:
-    nb_parents: 2
-    af_nbenf: 2
-    asile_demandeur: true
-    place_hebergement: true
+    nb_parents: [2, 1]
+    af_nbenf: [2, 0]
+    asile_demandeur: [true, false]
+    place_hebergement: [true, false]
   output:
-    ada: 527 # 17.0 * 31
-
-- name: Aide Demandeur Asile - 1 parent, 0 enfant, non demandeur de l'aide
-  description: Montant ADA au niveau de la famille
-  period: 2015-12
-  absolute_error_margin: 1
-  input:
-    nb_parents: 1
-    af_nbenf: 0
-    asile_demandeur: false
-    place_hebergement: false
-  output:
-    ada: 0
+    ada: [527, 0] # 17.0 * 31


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `prestations/minima_sociaux/ada`.
* Détails :
  - Utilise numpy `not` à la place du `not` de Python qui ne gère pas les vecteurs
- - - -