### PR TITLE
Corrige la taxation des plus-values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 43.1.0 [#1336](https://github.com/openfisca/openfisca-france/pull/1336)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2018.
+* Zones impactées : `model/prelevements_obligatoires/`.
+* Détails :
+  - Affine et corrige [#1333](https://github.com/openfisca/openfisca-france/issues/1333) sur le PFU
+  - Le PFU a été codé avant la publication du nouveau formulaire de l'IR et des règles précises concernant son application. Désormais, le formulaire est disponible et les règles connues, cette PR vient les corriger
+  - Pour plus de détails voir [le descriptif](https://github.com/openfisca/openfisca-france/pull/1336) de la version
+
 ### 43.0.1 [#1342](https://github.com/openfisca/openfisca-france/pull/1342)
 
 * Correction technique

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -224,13 +224,11 @@ class plus_values_base_large(Variable):
         v1_assiette_csg_plus_values = foyer_fiscal('assiette_csg_plus_values', period)
         v2_rfr_plus_values_hors_rni = foyer_fiscal('rfr_plus_values_hors_rni', period)
 
-        f3sg = foyer_fiscal('f3sg', period)
-        f3sl = foyer_fiscal('f3sl', period)
         f3ua = foyer_fiscal('f3ua', period)
         f3vg = foyer_fiscal('f3vg', period)
         f3vz = foyer_fiscal('f3vz', period)
 
-        intersection_v1_v2 = f3vg + f3ua + f3vz + f3sg + f3sl
+        intersection_v1_v2 = f3vg + f3ua + f3vz
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1866,6 +1866,7 @@ class rfr_plus_values_hors_rni(Variable):
         """
         Plus-values 2016 et + entrant dans le calcul du revenu fiscal de référence
         """
+        f3sa = foyer_fiscal('f3sa', period)
         f3sj = foyer_fiscal('f3sj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3tz = foyer_fiscal('f3tz', period)
@@ -1891,7 +1892,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + f3wi + f3wj + rpns_pvce
+        return f3sa + f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + f3wi + f3wj + rpns_pvce
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
         """

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -603,7 +603,7 @@ class revenu_categoriel_plus_values(Variable):
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
         f3wb = foyer_fiscal('f3wb', period)
-        
+
         return f3wb
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1617,7 +1617,6 @@ class taxation_plus_values_hors_bareme(Variable):
     label = u"Taxation forfaitaire des plus-values"
     reference = "http://bofip.impots.gouv.fr/bofip/6957-PGP"
     definition_period = YEAR
-    end = '2017-12-31'
 
     def formula_2007_01_01(foyer_fiscal, period, parameters):  # f3sd is in f3vd holder
         """

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1900,7 +1900,6 @@ class rfr_plus_values_hors_rni(Variable):
         A partir de l'imposition des revenus 2018, il est supposé qu'aucune plus-values n'est taxée au barème.
         Toutes les plus-values entrant dans le calcul du RFR se retrouvent ici dans la variable 'rfr_plus_values_hors_rni'
         """
-        # Ici, plus-values spécifiques au PFU
         f3sa = foyer_fiscal('f3sa', period)
         f3vg = foyer_fiscal('f3vg', period)
         f3ua = foyer_fiscal('f3ua', period)
@@ -1908,7 +1907,6 @@ class rfr_plus_values_hors_rni(Variable):
         f3sl = foyer_fiscal('f3sl', period)
         f3wb = foyer_fiscal('f3wb', period)
         f3sj = foyer_fiscal('f3sj', period)
-        #
 
         f3sk = foyer_fiscal('f3sk', period)
         f3tz = foyer_fiscal('f3tz', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1903,8 +1903,6 @@ class rfr_plus_values_hors_rni(Variable):
         f3sa = foyer_fiscal('f3sa', period)
         f3vg = foyer_fiscal('f3vg', period)
         f3ua = foyer_fiscal('f3ua', period)
-        f3sg = foyer_fiscal('f3sg', period)
-        f3sl = foyer_fiscal('f3sl', period)
         f3wb = foyer_fiscal('f3wb', period)
         f3sj = foyer_fiscal('f3sj', period)
 
@@ -1930,7 +1928,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3sa + f3vg + f3ua + f3sg + f3sl + f3wb + f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce
+        return f3sa + f3vg + f3ua + f3wb + f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce
 
 
 class iai(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -577,7 +577,6 @@ class revenu_categoriel_plus_values(Variable):
     label = u"Revenu catégoriel - Plus-values"
     reference = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
     definition_period = YEAR
-    end = '2017-12-31'
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         f3sb = foyer_fiscal('f3sb', period)
@@ -601,6 +600,11 @@ class revenu_categoriel_plus_values(Variable):
         f3ua = foyer_fiscal('f3ua', period)  # Cette case existant avant, mais ses montants étaient inclus dans 3vg.
 
         return f3sb + f3vg + f3wb + f3ua
+
+    def formula_2018_01_01(foyer_fiscal, period, parameters):
+        f3wb = foyer_fiscal('f3wb', period)
+        
+        return f3wb
 
 
 class revenu_categoriel_tspr(Variable):
@@ -977,8 +981,9 @@ class revenu_categoriel(Variable):
         rev_cat_tspr = foyer_fiscal('revenu_categoriel_tspr', period)
         rev_cat_rfon = foyer_fiscal('revenu_categoriel_foncier', period)
         rev_cat_rpns = foyer_fiscal('revenu_categoriel_non_salarial', period)
+        rev_cat_pv = foyer_fiscal('revenu_categoriel_plus_values', period)
 
-        return rev_cat_tspr + rev_cat_rfon + rev_cat_rpns
+        return rev_cat_tspr + rev_cat_rfon + rev_cat_rpns + rev_cat_pv
 
 
 ###############################################################################
@@ -1897,13 +1902,10 @@ class rfr_plus_values_hors_rni(Variable):
     def formula_2018_01_01(foyer_fiscal, period, parameters):
         """
         Plus-values 2018 et + entrant dans le calcul du revenu fiscal de référence.
-        A partir de l'imposition des revenus 2018, il est supposé qu'aucune plus-values n'est taxée au barème.
-        Toutes les plus-values entrant dans le calcul du RFR se retrouvent ici dans la variable 'rfr_plus_values_hors_rni'
         """
         f3sa = foyer_fiscal('f3sa', period)
         f3vg = foyer_fiscal('f3vg', period)
         f3ua = foyer_fiscal('f3ua', period)
-        f3wb = foyer_fiscal('f3wb', period)
         f3sj = foyer_fiscal('f3sj', period)
 
         f3sk = foyer_fiscal('f3sk', period)
@@ -1928,7 +1930,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3sa + f3vg + f3ua + f3wb + f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce
+        return f3sa + f3vg + f3ua + f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce
 
 
 class iai(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1906,9 +1906,7 @@ class rfr_plus_values_hors_rni(Variable):
         f3vg = foyer_fiscal('f3vg', period)
         f3ua = foyer_fiscal('f3ua', period)
         f3sj = foyer_fiscal('f3sj', period)
-
         f3sk = foyer_fiscal('f3sk', period)
-        f3tz = foyer_fiscal('f3tz', period)
         f3vc = foyer_fiscal('f3vc', period)
         f3vd_i = foyer_fiscal.members('f3vd', period)
         f3vf_i = foyer_fiscal.members('f3vf', period)
@@ -1929,7 +1927,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3sa + f3vg + f3ua + f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce
+        return f3sa + f3vg + f3ua + f3sj + f3sk + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce
 
 
 class iai(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -148,30 +148,7 @@ class plus_values_prelevement_forfaitaire_unique_ir(Variable):
         f3vg = foyer_fiscal('f3vg', period)
         f3ua = foyer_fiscal('f3ua', period)
 
-        # Ici, on reprend le champ des plus-values de la variable taxation_plus_values_hors_bareme
-        f3sj = foyer_fiscal('f3sj', period)
-        f3sk = foyer_fiscal('f3sk', period)
-        f3vm = foyer_fiscal('f3vm', period)
-        f3vt = foyer_fiscal('f3vt', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
-        f3wi = foyer_fiscal('f3wi', period)
-        f3wj = foyer_fiscal('f3wj', period)
-        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
-        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-
-        # Notes :
-        # 3WE n'est pas compté, car normalement, il n'est pas dans la base du PFU... A checker ?
-        # 3WB : il s'agit des plus-values et créances sans sursis de paiement (pour transfert du domicile fiscal hors de France)
-        #       après abattements. Normalement, il faudrait prendre la mesure avant abattement. Les montants avant abattements sont case 3WD. Mais cette case
-        #       comprend, en plus des plus-values imposables avant abbattement, celles bénéficiant d'un report d'imposition. HYP : on prend les montants nets.
-        # 3WI et 3WJ : les conditions liées au report d'imposition de l'art. 150-0 B ter du CGI ont été remaniées à la marge.
-        #              On ne prend pas en compte ces remaniements. Situation résumée dans https://taj-strategie.fr/plf-2018-lecture-definitive-fiscalite-personnes
-        return f3sa + f3vg + f3ua + f3sj + f3sk + f3vm + f3vt + f3vd + f3vi + f3vf + f3wi + f3wj + rpns_pvce
+        return f3sa + f3vg + f3ua
 
 
 class prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -142,14 +142,11 @@ class plus_values_prelevement_forfaitaire_unique_ir(Variable):
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
         '''
-        Cette variable fusionne le périmètre des plus-values des anciennes variables de plus_values-values présentes
-        dans taxation_plus_values_hors_bareme et dans 'revenu_categoriel_plus_values', mais en adaptant les assiettes au PFU
-        (notamment, pour les revenus de 'revenu_categoriel_plus_values', passage des montants nets à bruts)
+        Les assiettes des plus-values du PFU doivent être brutes (et non nettes)
         '''
         f3sa = foyer_fiscal('f3sa', period)
         f3vg = foyer_fiscal('f3vg', period)
         f3ua = foyer_fiscal('f3ua', period)
-        f3wb = foyer_fiscal('f3wb', period)
 
         # Ici, on reprend le champ des plus-values de la variable taxation_plus_values_hors_bareme
         f3sj = foyer_fiscal('f3sj', period)
@@ -174,7 +171,7 @@ class plus_values_prelevement_forfaitaire_unique_ir(Variable):
         #       comprend, en plus des plus-values imposables avant abbattement, celles bénéficiant d'un report d'imposition. HYP : on prend les montants nets.
         # 3WI et 3WJ : les conditions liées au report d'imposition de l'art. 150-0 B ter du CGI ont été remaniées à la marge.
         #              On ne prend pas en compte ces remaniements. Situation résumée dans https://taj-strategie.fr/plf-2018-lecture-definitive-fiscalite-personnes
-        return f3sa + f3vg + f3ua + f3wb + f3sj + f3sk + f3vm + f3vt + f3vd + f3vi + f3vf + f3wi + f3wj + rpns_pvce
+        return f3sa + f3vg + f3ua + f3sj + f3sk + f3vm + f3vt + f3vd + f3vi + f3vf + f3wi + f3wj + rpns_pvce
 
 
 class prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -149,8 +149,6 @@ class plus_values_prelevement_forfaitaire_unique_ir(Variable):
         f3sa = foyer_fiscal('f3sa', period)
         f3vg = foyer_fiscal('f3vg', period)
         f3ua = foyer_fiscal('f3ua', period)
-        f3sg = foyer_fiscal('f3sg', period)
-        f3sl = foyer_fiscal('f3sl', period)
         f3wb = foyer_fiscal('f3wb', period)
 
         # Ici, on reprend le champ des plus-values de la variable taxation_plus_values_hors_bareme
@@ -170,16 +168,13 @@ class plus_values_prelevement_forfaitaire_unique_ir(Variable):
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
         # Notes :
-        # 3sg + 3sl : correspond aux abattements associés aux cases 3vg et 3ua (donc, on considère les montants bruts).
-        #             En revanche, on n'enlève pas l'abattement fixe en 3va, car il est maintenu, y compris si le contribuable
-        #             choisit le PFU. Les conditions on été légèrement modifiées, mais on ne va pas dans ce détail-là. Cf par exemple https://taj-strategie.fr/plf-2018-lecture-definitive-fiscalite-personnes
         # 3WE n'est pas compté, car normalement, il n'est pas dans la base du PFU... A checker ?
         # 3WB : il s'agit des plus-values et créances sans sursis de paiement (pour transfert du domicile fiscal hors de France)
         #       après abattements. Normalement, il faudrait prendre la mesure avant abattement. Les montants avant abattements sont case 3WD. Mais cette case
         #       comprend, en plus des plus-values imposables avant abbattement, celles bénéficiant d'un report d'imposition. HYP : on prend les montants nets.
         # 3WI et 3WJ : les conditions liées au report d'imposition de l'art. 150-0 B ter du CGI ont été remaniées à la marge.
         #              On ne prend pas en compte ces remaniements. Situation résumée dans https://taj-strategie.fr/plf-2018-lecture-definitive-fiscalite-personnes
-        return f3sa + f3vg + f3ua + f3sg + f3sl + f3wb + f3sj + f3sk + f3vm + f3vt + f3vd + f3vi + f3vf + f3wi + f3wj + rpns_pvce
+        return f3sa + f3vg + f3ua + f3wb + f3sj + f3sk + f3vm + f3vt + f3vd + f3vi + f3vf + f3wi + f3wj + rpns_pvce
 
 
 class prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -192,14 +192,13 @@ class assiette_csg_plus_values(Variable):
 
         # Plus-values mobilières brutes (avant abattement)
         f3vg = foyer_fiscal('f3vg', period)
-        f3va = foyer_fiscal('f3va', period)
         f3we = foyer_fiscal('f3we', period)
         f3ua = foyer_fiscal('f3ua', period)
 
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
 
-        return f3vg + f3va + f3ua + f3vz + f3we
+        return f3vg + f3va + f3vz + f3we
 
 
 class assiette_csg_revenus_capital(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -198,7 +198,7 @@ class assiette_csg_plus_values(Variable):
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
 
-        return f3vg + f3va + f3vz + f3we
+        return f3vg + f3ua + f3vz + f3we
 
 
 class assiette_csg_revenus_capital(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -188,6 +188,19 @@ class assiette_csg_plus_values(Variable):
 
         return f3vg + f3sg + f3sl + f3va + f3ua + f3vz + f3we
 
+    def formula_2018_01_01(foyer_fiscal, period, parameters):
+
+        # Plus-values mobilières brutes (avant abattement)
+        f3vg = foyer_fiscal('f3vg', period)
+        f3va = foyer_fiscal('f3va', period)
+        f3we = foyer_fiscal('f3we', period)
+        f3ua = foyer_fiscal('f3ua', period)
+
+        # Plus-values immobilières
+        f3vz = foyer_fiscal('f3vz', period)
+
+        return f3vg + f3va + f3ua + f3vz + f3we
+
 
 class assiette_csg_revenus_capital(Variable):
     value_type = float

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -389,6 +389,7 @@ class abattements_plus_values(Variable):
     reference = u"http://bofip.impots.gouv.fr/bofip/9540-PGP"
     label = u"Abattements sur plus-values notamment pour durée de détention de droit commun, renforcé, et abattement en cas de départ à la retraite d'un dirigeant de PME (abattement fixe et pour durée de détention)"
     definition_period = YEAR
+    end = '2017-12-31'
 
     def formula_2013_01_01(foyer_fiscal, period):
         f3sg = foyer_fiscal('f3sg', period)
@@ -414,11 +415,6 @@ class abattements_plus_values(Variable):
         f3va = foyer_fiscal('f3va', period)
 
         return f3sg + f3sl + f3va
-
-    def formula_2018_01_01(foyer_fiscal, period):
-        f3va = foyer_fiscal('f3va', period)
-
-        return f3va
 
 
 # Plus values et gains taxables à des taux forfaitaires

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -193,6 +193,7 @@ class f3tz(Variable):
     entity = FoyerFiscal
     label = u"Plus-values de cession de titres d'OPC monétaires en report d'imposition, plus-values réalisées du 1.1 au 31.3.2017, plus-values en report d'imposition"
     # start_date = date(2016, 1, 1)
+    end = '2017-12-31'
     definition_period = YEAR
 
 

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -414,6 +414,11 @@ class abattements_plus_values(Variable):
 
         return f3sg + f3sl + f3va
 
+    def formula_2018_01_01(foyer_fiscal, period):
+        f3va = foyer_fiscal('f3va', period)
+
+        return f3va
+
 
 # Plus values et gains taxables à des taux forfaitaires
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "43.0.1",
+    version = "43.1.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -280,8 +280,9 @@
     prelevements_sociaux_revenus_capital: -32680 # ATTENTION : f3sa et f3vd sont hors du champ des prélèvements sociaux par hypothèse du simulateur (cf. docstring de la variable assiette_csg_plus_values pour une explication). Donc : -190000*(0.045+0.02+0.003+0.005+0.099)
     revenus_nets_du_capital: 270000 - 32680
     prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs: -28160 #-(22000*0.128) 3VD est un gain taxé forfaitairement au taux de 18% et non au PFU
-    impots_directs: -34560
-    revenu_disponible: 270000 - 32680 - 34560
+    axation_plus_values_hors_bareme: 9000 #50000 * 0.18
+    impots_directs: -28160 - 9000
+    revenu_disponible: 270000 - 32680 - 28160 - 9000
 
 - name: plus_values_immobilières_2018
   description: Montant d'impôt et revenu disponible pour les plus-values immobilières (3VZ)

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -279,7 +279,7 @@
   output:
     prelevements_sociaux_revenus_capital: -32680 # ATTENTION : f3sa et f3vd sont hors du champ des prélèvements sociaux par hypothèse du simulateur (cf. docstring de la variable assiette_csg_plus_values pour une explication). Donc : -190000*(0.045+0.02+0.003+0.005+0.099)
     revenus_nets_du_capital: 270000 - 32680
-    prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs: -34560 #-(27000*0.128)
+    prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs: -28160 #-(22000*0.128) 3VD est un gain taxé forfaitairement au taux de 18% et non au PFU
     impots_directs: -34560
     revenu_disponible: 270000 - 32680 - 34560
 

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -280,7 +280,7 @@
     prelevements_sociaux_revenus_capital: -32680 # ATTENTION : f3sa et f3vd sont hors du champ des prélèvements sociaux par hypothèse du simulateur (cf. docstring de la variable assiette_csg_plus_values pour une explication). Donc : -190000*(0.045+0.02+0.003+0.005+0.099)
     revenus_nets_du_capital: 270000 - 32680
     prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs: -28160 #-(22000*0.128) 3VD est un gain taxé forfaitairement au taux de 18% et non au PFU
-    axation_plus_values_hors_bareme: 9000 #50000 * 0.18
+    taxation_plus_values_hors_bareme: 9000 #50000 * 0.18
     impots_directs: -28160 - 9000
     revenu_disponible: 270000 - 32680 - 28160 - 9000
 


### PR DESCRIPTION
**Contexte** : Le PFU a été codé avant la publication du nouveau formulaire de l'IR et des règles précises concernant son application. Désormais, le formulaire est disponible et les règles connues. Cette PR vient donc corriger la partie "taxation des plus-values". (Cf. #1083). 

Par ailleurs, elle s'appuie sur la disponibilité du [simulateur de l'IR 2019 sur revenus 2018](https://www3.impots.gouv.fr/simulateur/calcul_impot/2019/index.htm).

3 régimes de taxation possible :
- PFU : Une grande partie des plus-values est concernée par le PFU (et l'option au barème sur choix) : 3VG, 3UA
- Autres taxes forfaitaires : L'ancien système de taxe forfaitaire à des taux particuliers (différents du taux de 12,8% comme le PFU) perdure pour certaines plus-values : 3VM, 3VT, 3SK, 3SJ, 3WI, 3WJ, 3VI, 3VF, 3VD
- Barème : L'ancien système d'imposition au barème (obligatoire) pour certaines plus-values perdure également : 3VJ, 3VK, 3WB.

Corrections apportées : 
 - À partir de l'IR 2019 sur revenus 2018, les cases 3VG et 3UA sont brutes (avant application d'abattement) contrairement aux années précédentes où elles étaient nettes. Il faut donc corriger les calculs liés au PFU pour prendre en compte cela. Notamment, le PFU s'appliquant aux revenus bruts, on ajoutait les abattements dans la base, désormais c'est inutile.
- De nombreuses plus-values et autres gains restent taxables forfaitairement, on les sort donc de l'assiette du PFU.
- On corrige les tests relatifs au PFU.

----

* Évolution du système socio-fiscal. 
* Périodes concernées : à partir du 01/01/2018.
* Zones impactées : `model/prelevements_obligatoires/`.

- - - -

Ces changements 

- Modifient l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.

