### PR TITLE
Corrige le calcul de la PAJE de base pour les naissances gémellaires

### DIFF
--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -5,6 +5,7 @@ from numpy import round, floor, datetime64, maximum
 from openfisca_france.model.base import *
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf
 from openfisca_core.periods import Instant
+import numpy as np
 
 
 # Prestations familiales
@@ -148,6 +149,13 @@ class paje_base(Variable):
 
         a_un_enfant_eligible = famille.any(famille.members('enfant_eligible_paje', period))
         date_plus_jeune = famille.reduce(famille.members('date_naissance', period), maximum, datetime64('1066-01-01'))
+        # On veut obtenir *pour chaque individu* la date du plus jeune membre de la famille de cet individu
+        # on va donc "rétro-projeter" date_plus_jeune vers un array de la taille des individus
+        date_plus_jeune_i = date_plus_jeune[famille.members_entity_id]
+        # Pour chaque individu, est-il né à la même date que l'enfant le plus jeune de sa famille ?
+        ne_a_date_plus_jeune_i = np.equal(date_plus_jeune_i, famille.members('date_naissance', period))
+        # Et donc famille.sum() de cette quantité nous donne le nombre de naissances à cette date
+        enfants_multiples = famille.sum(ne_a_date_plus_jeune_i)
         sujet_a_reforme_2014 = date_plus_jeune >= datetime64('2014-04-01')
         sujet_a_reforme_2018 = date_plus_jeune >= datetime64('2018-04-01')
         ne_avant_avril_2014 = True
@@ -171,7 +179,7 @@ class paje_base(Variable):
             * (ressources > plafond_taux_plein) * montant_taux_partiel
             )
 
-        return a_un_enfant_eligible * montant
+        return a_un_enfant_eligible * enfants_multiples * montant
 
 
 class enfant_eligible_paje(Variable):

--- a/tests/formulas/paje/paje.yaml
+++ b/tests/formulas/paje/paje.yaml
@@ -1,3 +1,7 @@
+# Dans ces tests on spécifie l'âge des parents mais la date de naissance des enfants
+# car la PAJE peut être attribuée à des enfants nés le même jour (jumeaux) et la date
+# de naissance précise est donc indispensable
+
 - name: Avant le 1er avril 2014, le montant de base de la PAJE est proprotionnel à la BMAF
   period: 2013-01
   relative_error_margin: 0.01
@@ -8,13 +12,13 @@
       parent2:
         age: 40
       enfant1:
-        age: 1
+        date_naissance: 2012-01-01
       parent3:
         age: 40
       parent4:
         age: 40
       enfant2:
-        age: 2
+        date_naissance: 2011-01-01
     familles:
       famille_0:
         parents: [parent1, parent2]
@@ -41,6 +45,36 @@
   output:
     paje_base: 0.4595 * 399.0
 
+- name: Grossesses gémellaires vs enfants successifs
+  period: 2013-01
+  relative_error_margin: 0.01
+  input:
+    individus:
+      parent1:
+        age: 40
+      parent2:
+        age: 40
+      enfant1:
+        date_naissance: 2012-01-01
+      enfant2:
+        date_naissance: 2012-01-01
+      parent3:
+        age: 40
+      parent4:
+        age: 40
+      enfant3:
+        date_naissance: 2012-01-01
+      enfant4:
+        date_naissance: 2011-01-01
+    familles:
+      famille_0:
+        parents: [parent1, parent2]
+        enfants: [enfant1, enfant2]
+      famille_1:
+        parents: [parent3, parent4]
+        enfants: [enfant3, enfant4]
+  output:
+    paje_base: [366.68, 183.34]
 
 - name: À partir du 1er avril 2013, le montant de base de la PAJE est gelé
   period: 2015-01
@@ -52,13 +86,13 @@
       parent2:
         age: 40
       enfant1:
-        age: 1
+        date_naissance: 2014-01-01
       parent3:
         age: 40
       parent4:
         age: 40
       enfant2:
-        age: 2
+        date_naissance: 2013-01-01
     familles:
       famille_0:
         parents: [parent1, parent2]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées : `paje.py`.
* Détails :
  - Tient compte des naissances gémellaires dans le calcul de la PAJE base

Fixes #1288 

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
