### PR TITLE
Passage du pourcentage de la décote en paramètre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-# 48.1.0 [#1354](https://github.com/openfisca/openfisca-france/pull/1354)
+## 48.2.0 [#1355](https://github.com/openfisca/openfisca-france/pull/1355)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2001.
+* Zones impactées : 
+  - `model\prelevements_obligatoires\impot_revenu\ir.py`
+  - `parameters\impot_revenu\decote`
+* Détails :
+  - Ajoute un paramètre `impot_revenu.decote.taux` pour permettre d'éventuelles réformes.
+  - Factorise les formules `2014` et `2015` de la `decote`.
+
+## 48.1.0 [#1354](https://github.com/openfisca/openfisca-france/pull/1354)
 
 * Évolution du système socio-fiscal
 * Périodes concernées : à partir du 01/01/2018

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1351,7 +1351,7 @@ class decote(Variable):
         ir_plaf_qf = foyer_fiscal('ir_plaf_qf', period)
         decote = parameters(period).impot_revenu.decote
 
-        return around(max_(0, decote.seuil - ir_plaf_qf) * 0.5)
+        return around(max_(0, decote.seuil - ir_plaf_qf) * decote.taux)
 
     def formula_2014_01_01(foyer_fiscal, period, parameters):
         ir_plaf_qf = foyer_fiscal("ir_plaf_qf", period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1351,25 +1351,19 @@ class decote(Variable):
         ir_plaf_qf = foyer_fiscal('ir_plaf_qf', period)
         decote = parameters(period).impot_revenu.decote
 
-        return around((ir_plaf_qf < decote.seuil) * (decote.seuil - ir_plaf_qf) * 0.5)
-
-    def formula_2015_01_01(foyer_fiscal, period, parameters):
-        ir_plaf_qf = foyer_fiscal('ir_plaf_qf', period)
-        nb_adult = foyer_fiscal('nb_adult', period)
-        decote_seuil_celib = parameters(period).impot_revenu.decote.seuil_celib
-        decote_seuil_couple = parameters(period).impot_revenu.decote.seuil_couple
-        decote_celib = (ir_plaf_qf < 4 / 3 * decote_seuil_celib) * (decote_seuil_celib - 3 / 4 * ir_plaf_qf)
-        decote_couple = (ir_plaf_qf < 4 / 3 * decote_seuil_couple) * (decote_seuil_couple - 3 / 4 * ir_plaf_qf)
-
-        return around((nb_adult == 1) * decote_celib + (nb_adult == 2) * decote_couple)
+        return around(max_(0,decote.seuil - ir_plaf_qf) * 0.5)
 
     def formula_2014_01_01(foyer_fiscal, period, parameters):
-        ir_plaf_qf = foyer_fiscal('ir_plaf_qf', period)
-        nb_adult = foyer_fiscal('nb_adult', period)
+        # Ca pourrait marcher aussi à partir de 2001-01-01, avec taux= 0.5
+        # mais ça serait peut être moins clair au regard du texte de loi, qui ne diff
+        #érentiait pas seuil_celib et seuil_couple
+        ir_plaf_qf = foyer_fiscal("ir_plaf_qf", period)
+        nb_adult = foyer_fiscal("nb_adult", period)
+        taux_decote = parameters(period).impot_revenu.decote.taux
         decote_seuil_celib = parameters(period).impot_revenu.decote.seuil_celib
         decote_seuil_couple = parameters(period).impot_revenu.decote.seuil_couple
-        decote_celib = (ir_plaf_qf < decote_seuil_celib) * (decote_seuil_celib - ir_plaf_qf)
-        decote_couple = (ir_plaf_qf < decote_seuil_couple) * (decote_seuil_couple - ir_plaf_qf)
+        decote_celib = max_(0, decote_seuil_celib - taux_decote * ir_plaf_qf)
+        decote_couple = max_(0, decote_seuil_couple - taux_decote * ir_plaf_qf)
 
         return around((nb_adult == 1) * decote_celib + (nb_adult == 2) * decote_couple)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1351,12 +1351,12 @@ class decote(Variable):
         ir_plaf_qf = foyer_fiscal('ir_plaf_qf', period)
         decote = parameters(period).impot_revenu.decote
 
-        return around(max_(0,decote.seuil - ir_plaf_qf) * 0.5)
+        return around(max_(0, decote.seuil - ir_plaf_qf) * 0.5)
 
     def formula_2014_01_01(foyer_fiscal, period, parameters):
         # Ca pourrait marcher aussi à partir de 2001-01-01, avec taux= 0.5
         # mais ça serait peut être moins clair au regard du texte de loi, qui ne diff
-        #érentiait pas seuil_celib et seuil_couple
+        # érentiait pas seuil_celib et seuil_couple
         ir_plaf_qf = foyer_fiscal("ir_plaf_qf", period)
         nb_adult = foyer_fiscal("nb_adult", period)
         taux_decote = parameters(period).impot_revenu.decote.taux

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1354,9 +1354,6 @@ class decote(Variable):
         return around(max_(0, decote.seuil - ir_plaf_qf) * 0.5)
 
     def formula_2014_01_01(foyer_fiscal, period, parameters):
-        # Ca pourrait marcher aussi à partir de 2001-01-01, avec taux= 0.5
-        # mais ça serait peut être moins clair au regard du texte de loi, qui ne diff
-        # érentiait pas seuil_celib et seuil_couple
         ir_plaf_qf = foyer_fiscal("ir_plaf_qf", period)
         nb_adult = foyer_fiscal("nb_adult", period)
         taux_decote = parameters(period).impot_revenu.decote.taux

--- a/openfisca_france/parameters/impot_revenu/decote/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/decote/taux.yaml
@@ -1,0 +1,11 @@
+description: Seuil de la décote pour un couple
+reference:
+  - https://www.ipp.eu/baremes-ipp/impot-sur-le-revenu/calcul_impot_revenu/plaf_qf/
+  - http://bofip.impots.gouv.fr/bofip/2495-PGP
+  - https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000037985566&cidTexte=LEGITEXT000006069577
+unit: currency
+values:
+  2014-01-01:
+    value: 1.0
+  2015-01-01:
+    value: 0.75

--- a/openfisca_france/parameters/impot_revenu/decote/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/decote/taux.yaml
@@ -1,4 +1,4 @@
-﻿description: Taux de la décote
+description: Taux de la décote
 reference:
   - http://bofip.impots.gouv.fr/bofip/2495-PGP
   - https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000037985566&cidTexte=LEGITEXT000006069577

--- a/openfisca_france/parameters/impot_revenu/decote/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/decote/taux.yaml
@@ -1,10 +1,11 @@
-description: Seuil de la décote pour un couple
+﻿description: Taux de la décote
 reference:
-  - https://www.ipp.eu/baremes-ipp/impot-sur-le-revenu/calcul_impot_revenu/plaf_qf/
   - http://bofip.impots.gouv.fr/bofip/2495-PGP
   - https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000037985566&cidTexte=LEGITEXT000006069577
-unit: currency
+unit: /1
 values:
+  2001-01-01:
+    value: 0.5
   2014-01-01:
     value: 1.0
   2015-01-01:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.1.0",
+    version = "48.2.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Amélioration technique. 
* Périodes concernées : Aucune (formule équivalente)
* Zones impactées : `model\prelevements_obligatoires\impot_revenu\ir.py`.
* Détails : 
    - passage du 0.75 en paramètre, pour permettre d'éventuelles réformes.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) : 
- Corrigent ou améliorent un calcul déjà existant.
