### PR TITLE
Ajoute une variable pour la nationalité des individus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## 48.2.1 [#1357](https://github.com/openfisca/openfisca-france/pull/1357)
+##  48.3.0 [#1358](https://github.com/openfisca/openfisca-france/pull/1358)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : `caracteristiques_socio_demographiques/demographie.py`.
+* Détails :
+  - Ajoute une variable pour la nationalité des individus
+  - Rend `ressortissant_eee` calculable à partir de la `nationalite`
+
+### 48.2.1 [#1357](https://github.com/openfisca/openfisca-france/pull/1357)
 
 * Changement mineur
 * Détails :
@@ -10,7 +19,7 @@
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2001.
-* Zones impactées : 
+* Zones impactées :
   - `model\prelevements_obligatoires\impot_revenu\ir.py`
   - `parameters\impot_revenu\decote`
 * Détails :

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -2,6 +2,40 @@
 
 from openfisca_france.model.base import *
 
+EEE_COUNTRY_CODES = [
+    b'AT',
+    b'BE',
+    b'BG',
+    b'CY',
+    b'CZ',
+    b'DE',
+    b'DK',
+    b'EE',
+    b'ES',
+    b'FI',
+    b'FR',
+    b'GR',
+    b'HR',
+    b'HU',
+    b'IE',
+    b'IS',
+    b'IT',
+    b'LI',
+    b'LU',
+    b'LV',
+    b'MT',
+    b'NL',
+    b'NO',
+    b'PL',
+    b'PT',
+    b'RO',
+    b'SE',
+    b'SI',
+    b'SK',
+    b'UK',
+    b'CH',  # Suisse hors EEE
+    ]
+
 
 class date_naissance(Variable):
     value_type = date
@@ -267,12 +301,25 @@ class rempli_obligation_scolaire(Variable):
     definition_period = MONTH
 
 
+class nationalite(Variable):
+    value_type = str
+    entity = Individu
+    default_value = 'FR'
+    max_length = 2
+    label = "Code ISO de la nationalité de l'individu"
+    definition_period = MONTH
+
+
 class ressortissant_eee(Variable):
     value_type = bool
     default_value = True
     entity = Individu
-    label = u"Ressortissant de l'EEE ou de la Suisse."
+    label = "Ressortissant de l'EEE ou de la Suisse."
     definition_period = MONTH
+
+    def formula(individu, period):
+        nationalite = individu('nationalite', period)
+        return sum([nationalite == code_iso for code_iso in EEE_COUNTRY_CODES])
 
 
 class duree_possession_titre_sejour(Variable):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.2.1",
+    version = "48.3.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/nationalite.yaml
+++ b/tests/formulas/nationalite.yaml
@@ -1,0 +1,5 @@
+period: 2019-08
+input:
+  nationalite: [FR, IT, AG]
+output:
+  ressortissant_eee: [true, true, false]

--- a/tests/formulas/nationalite.yaml
+++ b/tests/formulas/nationalite.yaml
@@ -1,5 +1,9 @@
-period: 2019-08
-input:
-  nationalite: [FR, IT, AG]
-output:
-  ressortissant_eee: [true, true, false]
+- period: 2019-08
+  input:
+    nationalite: [FR, IT, AG]
+  output:
+    ressortissant_eee: [true, true, false]
+
+- period: 2019-08
+  output:
+    ressortissant_eee: true


### PR DESCRIPTION
##  48.3.0 [#1358](https://github.com/openfisca/openfisca-france/pull/1358)

* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées : `caracteristiques_socio_demographiques/demographie.py`.
* Détails :
  - Ajoute une variable pour la nationalité des individus
  - Rend `ressortissant_eee` calculable à partir de la `nationalite`