### PR TITLE
Fusion des aides des compléments de ressources à l’AAH au 1er Décembre 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-### 48.4.0 [#1368](https://github.com/openfisca/openfisca-france/pull/1368)
+## 48.5.0 [#1362](https://github.com/openfisca/openfisca-france/pull/1362)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/12/2019.
+* Zones impactées : `model/prestations/minima_sociaux/aah`.
+* Détails :
+  - Neutralise le complément de ressources AAH
+  - Ne prends plus en compte le complément de ressources dans le calcul du CAAH
+
+## 48.4.0 [#1368](https://github.com/openfisca/openfisca-france/pull/1368)
 
 * Correction d'un crash.
 * Périodes concernées : toutes.
@@ -8,7 +17,7 @@
 * Détails :
   - Change l'entité associée à `ppa_plancher_revenu_activite_etudiant`
 
-### ~48.3.3 [#1361](https://github.com/openfisca/openfisca-france/pull/1361)~ Version dé-publiée
+### 48.3.3 [#1361](https://github.com/openfisca/openfisca-france/pull/1361)
 
 > Cette version a été dé-publiée pour éviter un changement majeur pour le correctif apporté par la 48.4.0
 

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -372,6 +372,11 @@ class caah(Variable):
     set_input = set_input_divide_by_period
     definition_period = MONTH
 
+    def formula_2019_12_01(individu, period, parameters):
+        eligibilite_caah = individu('eligibilite_caah', period)
+        mva = individu('mva', period)
+        return mva * eligibilite_caah
+
     def formula_2015_07_01(individu, period, parameters):
         eligibilite_caah = individu('eligibilite_caah', period)
         complement_ressources_aah = individu('complement_ressources_aah', period)

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -441,6 +441,7 @@ class complement_ressources_aah(Variable):
     label = "Le complément de ressources"
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006745305&dateTexte=&categorieLien=cid"
     definition_period = MONTH
+    end = "2019-11-30"
 
     def formula_2015_07_01(individu, period, parameters):
         prestations = parameters(period).prestations

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.4.0",
+    version = "48.5.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/complement_aah.yaml
+++ b/tests/formulas/complement_aah.yaml
@@ -2,23 +2,11 @@
   period: 2019-01
   absolute_error_margin: 1
   input:
-    famille:
-      parents: parent1
-    individus:
-      parent1:
-        age: 58
-        taux_incapacite: 0.8
-        taux_capacite_travail: 0.04
-        aah: 261.56
-        asi: 230.32
-    foyers_fiscaux:
-      foyer_fiscal_0:
-        declarants:
-        - parent1
-    menages:
-      menage_0:
-        personne_de_reference:
-        - parent1
+    aah: 261.56
+    age: 58
+    asi: 230.32
+    taux_capacite_travail: 0.04
+    taux_incapacite: 0.8
   output:
     complement_ressources_aah: 179.31
     caah: 179.31
@@ -27,23 +15,11 @@
   period: 2019-01
   absolute_error_margin: 1
   input:
-    famille:
-      parents: parent1
-      aide_logement_montant: 254.27
-    individus:
-      parent1:
-        age: 58
-        taux_incapacite: 0.8
-        aah: 261.56
-        asi: 200.71
-    foyers_fiscaux:
-      foyer_fiscal_0:
-        declarants:
-        - parent1
-    menages:
-      menage_0:
-        personne_de_reference:
-        - parent1
+    aide_logement_montant: 254.27
+    age: 58
+    taux_incapacite: 0.8
+    aah: 261.56
+    asi: 200.71
   output:
     mva: 104.77
     caah: 104.77
@@ -52,21 +28,9 @@
   period: 2019-01
   absolute_error_margin: 1
   input:
-    famille:
-      parents: parent1
-    individus:
-      parent1:
-        age: 55
-        aah_date_debut_hospitalisation: 2018-10-15
-        taux_incapacite: 0.8
-    foyers_fiscaux:
-      foyer_fiscal_0:
-        declarants:
-        - parent1
-    menages:
-      menage_0:
-        personne_de_reference:
-        - parent1
+    age: 55
+    aah_date_debut_hospitalisation: 2018-10-15
+    taux_incapacite: 0.8
   output:
     aah: 258.00
 
@@ -74,21 +38,9 @@
   period: 2018-09
   absolute_error_margin: 1
   input:
-    famille:
-      parents: parent1
-    individus:
-      parent1:
-        age: 55
-        aah_date_debut_incarceration: 2018-06-17
-        taux_incapacite: 0.8
-    foyers_fiscaux:
-      foyer_fiscal_0:
-        declarants:
-        - parent1
-    menages:
-      menage_0:
-        personne_de_reference:
-        - parent1
+    age: 55
+    aah_date_debut_incarceration: 2018-06-17
+    taux_incapacite: 0.8
   output:
     aah: 245.70
 
@@ -96,20 +48,25 @@
   period: 2019-01
   absolute_error_margin: 1
   input:
-    famille:
-      parents: parent1
-    individus:
-      parent1:
-        age: 55
-        aah_date_debut_incarceration: 2018-06-17
-        taux_incapacite: 0.8
-    foyers_fiscaux:
-      foyer_fiscal_0:
-        declarants:
-        - parent1
-    menages:
-      menage_0:
-        personne_de_reference:
-        - parent1
+    age: 55
+    aah_date_debut_incarceration: 2018-06-17
+    taux_incapacite: 0.8
   output:
     aah: 258.00
+
+- name: 'Réforme 01-12-2019 : suppression du complément de ressources au profit de la Majoration pour Vie Autonome'
+  absolute_error_margin: 1
+  input:
+    aide_logement_montant:
+      2019-11: 254.27
+      2019-12: 254.27
+    taux_capacite_travail:
+      2019-11: 0.04
+      2019-12: 0.04
+  output:
+    complement_ressources_aah:
+      2019-11: 139.31
+      2019-12: 0
+    mva:
+      2019-11: 104.77
+      2019-12: 104.77


### PR DESCRIPTION
* Évolution du système socio-fiscal. 
* Périodes concernées : à partir du 01/12/2019.
* Zones impactées : `model/prestations/minima_sociaux/aah`.
* Détails :
  - Supprime le complément de ressources au profit de la MVA à compter du 1er décembre 2019.