### PR TITLE
Corrige double comparaison incompatible avec Numpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 48.3.2 [#1365](https://github.com/openfisca/openfisca-france/pull/1365)
+
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `openfisca_france/model/prestations/autonomie.py`
+* Détails :
+  - Corrige erreur sur 'apa_domicile', 'apa_etablissement' et 'apa_urgence_domicile'
+  - Il s'agit d'une double comparaison, incompatible avec `numpy`
+
 ### 48.3.1 [#1366](https://github.com/openfisca/openfisca-france/pull/1366)
 
 * Changement mineur
@@ -27,8 +37,8 @@
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2001.
 * Zones impactées :
-  - `model\prelevements_obligatoires\impot_revenu\ir.py`
-  - `parameters\impot_revenu\decote`
+  - `model/prelevements_obligatoires/impot_revenu/ir.py`
+  - `parameters/impot_revenu/decote`
 * Détails :
   - Ajoute un paramètre `impot_revenu.decote.taux` pour permettre d'éventuelles réformes.
   - Factorise les formules `2014` et `2015` de la `decote`.
@@ -37,7 +47,7 @@
 
 * Évolution du système socio-fiscal
 * Périodes concernées : à partir du 01/01/2018
-* Zones impactées : `parameters\impot_revenu\plafond_qf\reduction_ss_condition_revenus`.
+* Zones impactées : `parameters/impot_revenu/plafond_qf/reduction_ss_condition_revenus`.
 * Détails :
   - Pour matcher les valeurs apparaissant dans les références législatives
   - Probablement, ces valeurs ont été réajustées

--- a/openfisca_france/model/prestations/autonomie.py
+++ b/openfisca_france/model/prestations/autonomie.py
@@ -50,7 +50,7 @@ class apa_domicile_participation(Variable):
 
         condition_ressources_domicile = [
             base_ressources_apa_domicile <= (seuil_inf * majoration_tierce_personne),
-            (seuil_inf * majoration_tierce_personne) < base_ressources_apa_domicile <= (seuil_sup * majoration_tierce_personne),
+            ((seuil_inf * majoration_tierce_personne) < base_ressources_apa_domicile) * (base_ressources_apa_domicile <= (seuil_sup * majoration_tierce_personne)),
             base_ressources_apa_domicile > (seuil_sup * majoration_tierce_personne),
             ]
 
@@ -83,7 +83,7 @@ class apa_domicile_participation(Variable):
         second_seuil = 0.498 * majoration_tierce_personne
         condlist = [
             dependance_plan_aide_domicile_accepte <= premier_seuil,
-            premier_seuil <= dependance_plan_aide_domicile_accepte <= second_seuil,
+            (premier_seuil <= dependance_plan_aide_domicile_accepte) * (dependance_plan_aide_domicile_accepte <= second_seuil),
             dependance_plan_aide_domicile_accepte >= second_seuil,
             ]
         choicelist_1 = [
@@ -213,7 +213,7 @@ class apa_etablissement(Variable):
 
         conditions_ressources = [
             base_ressources_apa_etablissement <= seuil_inf_inst * majoration_tierce_personne,
-            seuil_inf_inst * majoration_tierce_personne < base_ressources_apa_etablissement <= seuil_sup_inst * majoration_tierce_personne,
+            (seuil_inf_inst * majoration_tierce_personne < base_ressources_apa_etablissement) * (base_ressources_apa_etablissement <= seuil_sup_inst * majoration_tierce_personne),
             base_ressources_apa > seuil_sup_inst * majoration_tierce_personne
             ]
 
@@ -297,10 +297,10 @@ class apa_urgence_domicile(Variable):
 
     def formula(individu, period, parameters):
         period = period.first_month
-        parameters = parameters(period.start).autonomie
+        autonomie = parameters(period.start).autonomie
         majoration_tierce_personne = autonomie.mtp.mtp
-        plafond_gir1 = parameters.apa_domicile.plafond_de_l_apa_a_domicile_en_part_du_mtp.gir_1
-        part_urgence_domicile = parameters.apa_domicile.apa_d_urgence.part_du_plafond_de_l_apa_a_domicile
+        plafond_gir1 = autonomie.apa_domicile.plafond_de_l_apa_a_domicile_en_part_du_mtp.gir_1
+        part_urgence_domicile = autonomie.apa_domicile.apa_d_urgence.part_du_plafond_de_l_apa_a_domicile
         return part_urgence_domicile * plafond_gir1 * majoration_tierce_personne
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.3.1",
+    version = "48.3.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Fix #1363
Fix #1359

* Correction d'un crash
* Périodes concernées : toutes
* Zones impactées : `openfisca_france/model/prestations/autonomie.py`
* Détails :
  - Corrige erreur sur 'apa_domicile', 'apa_etablissement' et 'apa_urgence_domicile'
  - Il s'agit d'une double comparaison, incompatible avec `numpy`

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
