### PR TITLE
Remove unicode keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2366,8 +2366,8 @@ Par exemple pour :
 
 ```
 class TypesAAHNonCalculable(Enum):
-calculable = u"Calculable"
-intervention_CDAPH_necessaire = u"intervention_CDAPH_necessaire"
+calculable = "Calculable"
+intervention_CDAPH_necessaire = "intervention_CDAPH_necessaire"
 ```
 
 - `False`, ancien index 0, devient `TypesAAHNonCalculable.calculable`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 48.3.1 [#1366](https://github.com/openfisca/openfisca-france/pull/1366)
+
+* Changement mineur
+* Zones impactées : `**/*`.
+* Détails :
+  - Supprime le keyword unicode `u`, qui n'est plus nécessaire depuis Python 3
+
 ##  48.3.0 [#1358](https://github.com/openfisca/openfisca-france/pull/1358)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/assets/apl/extract_subcommunes.py
+++ b/openfisca_france/assets/apl/extract_subcommunes.py
@@ -21,8 +21,8 @@ logger = logging.getLogger(app_name)
 
 def main():
     parser = argparse.ArgumentParser(description = __doc__)
-    parser.add_argument('insee_communes_file', help = u"INSEE communes file")
-    parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = u"increase output verbosity")
+    parser.add_argument('insee_communes_file', help = "INSEE communes file")
+    parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = "increase output verbosity")
     args = parser.parse_args()
     logging.basicConfig(level = logging.DEBUG if args.verbose else logging.WARNING)
 

--- a/openfisca_france/entities.py
+++ b/openfisca_france/entities.py
@@ -5,18 +5,18 @@ from openfisca_core.entities import build_entity
 Famille = build_entity(
     key = "famille",
     plural = "familles",
-    label = u'Famille',
+    label = 'Famille',
     roles = [
         {
             'key': 'parent',
             'plural': 'parents',
-            'label': u'Parents',
+            'label': 'Parents',
             'subroles': ['demandeur', 'conjoint']
             },
         {
             'key': 'enfant',
             'plural': 'enfants',
-            'label': u'Enfants'
+            'label': 'Enfants'
             }
         ]
     )
@@ -24,15 +24,15 @@ Famille = build_entity(
 Individu = build_entity(
     key = "individu",
     plural = "individus",
-    label = u'Individu',
+    label = 'Individu',
     is_person = True
     )
 
 FoyerFiscal = build_entity(
     key = "foyer_fiscal",
     plural = "foyers_fiscaux",
-    label = u'Déclaration d’impôts',
-    doc = u'''
+    label = 'Déclaration d’impôts',
+    doc = '''
     Le foyer fiscal désigne l'ensemble des personnes inscrites sur une même déclaration de revenus.
     Il peut y avoir plusieurs foyers fiscaux dans un seul ménage : par exemple, un couple non marié où chacun remplit
     sa propre déclaration de revenus compte pour deux foyers fiscaux.
@@ -42,13 +42,13 @@ FoyerFiscal = build_entity(
         {
             'key': 'declarant',
             'plural': 'declarants',
-            'label': u'Déclarants',
+            'label': 'Déclarants',
             'subroles': ['declarant_principal', 'conjoint'],
             },
         {
             'key': 'personne_a_charge',
             'plural': 'personnes_a_charge',
-            'label': u'Personnes à charge'
+            'label': 'Personnes à charge'
             },
         ]
     )
@@ -56,8 +56,8 @@ FoyerFiscal = build_entity(
 Menage = build_entity(
     key = "menage",
     plural = "menages",
-    label = u'Logement principal',
-    doc = u'''
+    label = 'Logement principal',
+    doc = '''
     Un ménage, au sens statistique du terme, désigne l'ensemble des occupants d'un même logement sans que ces personnes
     soient nécessairement unies par des liens de parenté (en cas de cohabitation, par exemple).
     Un ménage peut être composé d'une seule personne.
@@ -67,23 +67,23 @@ Menage = build_entity(
     roles = [
         {
             'key': 'personne_de_reference',
-            'label': u'Personne de référence',
+            'label': 'Personne de référence',
             'max': 1
             },
         {
             'key': 'conjoint',
-            'label': u'Conjoint',
+            'label': 'Conjoint',
             'max': 1
             },
         {
             'key': 'enfant',
             'plural': 'enfants',
-            'label': u'Enfants',
+            'label': 'Enfants',
             },
         {
             'key': 'autre',
             'plural': 'autres',
-            'label': u'Autres'
+            'label': 'Autres'
             }
         ]
     )

--- a/openfisca_france/france_taxbenefitsystem.py
+++ b/openfisca_france/france_taxbenefitsystem.py
@@ -15,7 +15,7 @@ COUNTRY_DIR = os.path.dirname(os.path.abspath(__file__))
 
 class FranceTaxBenefitSystem(TaxBenefitSystem):
     """French tax benefit system"""
-    CURRENCY = u"€"
+    CURRENCY = "€"
     DATA_SOURCES_DIR = os.path.join(COUNTRY_DIR, 'data', 'sources')
     preprocess_parameters = staticmethod(preprocessing.preprocess_parameters)
 

--- a/openfisca_france/model/base.py
+++ b/openfisca_france/model/base.py
@@ -8,55 +8,55 @@ from openfisca_france.entities import Famille, FoyerFiscal, Individu, Menage  # 
 
 class TypesActivite(Enum):
     __order__ = 'actif chomeur etudiant retraite inactif'  # Needed to preserve the enum order in Python 2
-    actif = u'Actif occupé'
-    chomeur = u'Chômeur'
-    etudiant = u'Étudiant, élève'
-    retraite = u'Retraité'
-    inactif = u'Autre, inactif'
+    actif = 'Actif occupé'
+    chomeur = 'Chômeur'
+    etudiant = 'Étudiant, élève'
+    retraite = 'Retraité'
+    inactif = 'Autre, inactif'
 
 
 class TypesCategorieNonSalarie(Enum):
     __order__ = 'non_pertinent artisan commercant profession_liberale'  # Needed to preserve the enum order in Python 2
-    non_pertinent = u"Non pertinent (l'individu n'est pas un travailleur indépendant)"
-    artisan = u'Artisant'
-    commercant = u'Commercant'
-    profession_liberale = u'Profession libérale'
+    non_pertinent = "Non pertinent (l'individu n'est pas un travailleur indépendant)"
+    artisan = 'Artisant'
+    commercant = 'Commercant'
+    profession_liberale = 'Profession libérale'
 
 
 class TypesCategorieSalarie(Enum):
     __order__ = 'prive_non_cadre prive_cadre public_titulaire_etat public_titulaire_militaire public_titulaire_territoriale public_titulaire_hospitaliere public_non_titulaire non_pertinent'  # Needed to preserve the enum order in Python 2
-    prive_non_cadre = u'prive_non_cadre'
-    prive_cadre = u'prive_cadre'
-    public_titulaire_etat = u'public_titulaire_etat'
-    public_titulaire_militaire = u'public_titulaire_militaire'
-    public_titulaire_territoriale = u'public_titulaire_territoriale'
-    public_titulaire_hospitaliere = u'public_titulaire_hospitaliere'
-    public_non_titulaire = u'public_non_titulaire'
-    non_pertinent = u'non_pertinent'
+    prive_non_cadre = 'prive_non_cadre'
+    prive_cadre = 'prive_cadre'
+    public_titulaire_etat = 'public_titulaire_etat'
+    public_titulaire_militaire = 'public_titulaire_militaire'
+    public_titulaire_territoriale = 'public_titulaire_territoriale'
+    public_titulaire_hospitaliere = 'public_titulaire_hospitaliere'
+    public_non_titulaire = 'public_non_titulaire'
+    non_pertinent = 'non_pertinent'
 
 
 class TypesStatutMarital(Enum):
     __order__ = 'non_renseigne marie celibataire divorce veuf pacse jeune_veuf'  # Needed to preserve the enum order in Python 2
-    non_renseigne = u'Non renseigné'
-    marie = u'Marié'
-    celibataire = u'Celibataire'
-    divorce = u'Divorcé'
-    veuf = u'Veuf'
-    pacse = u'Pacsé'
-    jeune_veuf = u'Jeune veuf'
+    non_renseigne = 'Non renseigné'
+    marie = 'Marié'
+    celibataire = 'Celibataire'
+    divorce = 'Divorcé'
+    veuf = 'Veuf'
+    pacse = 'Pacsé'
+    jeune_veuf = 'Jeune veuf'
 
 
 class TypesStatutOccupationLogement(Enum):
     __order__ = 'non_renseigne primo_accedant proprietaire locataire_hlm locataire_vide locataire_meuble loge_gratuitement locataire_foyer sans_domicile'  # Needed to preserve the enum order in Python 2
-    non_renseigne = u"Non renseigné"
-    primo_accedant = u"Accédant à la propriété"
-    proprietaire = u"Propriétaire (non accédant) du logement"
-    locataire_hlm = u"Locataire d'un logement HLM"
-    locataire_vide = u"Locataire ou sous-locataire d'un logement loué vide non-HLM"
-    locataire_meuble = u"Locataire ou sous-locataire d'un logement loué meublé ou d'une chambre d'hôtel"
-    loge_gratuitement = u"Logé gratuitement par des parents, des amis ou l'employeur"
-    locataire_foyer = u"Locataire d'un foyer (résidence universitaire, maison de retraite, foyer de jeune travailleur, résidence sociale...)"
-    sans_domicile = u"Sans domicile stable"
+    non_renseigne = "Non renseigné"
+    primo_accedant = "Accédant à la propriété"
+    proprietaire = "Propriétaire (non accédant) du logement"
+    locataire_hlm = "Locataire d'un logement HLM"
+    locataire_vide = "Locataire ou sous-locataire d'un logement loué vide non-HLM"
+    locataire_meuble = "Locataire ou sous-locataire d'un logement loué meublé ou d'une chambre d'hôtel"
+    loge_gratuitement = "Logé gratuitement par des parents, des amis ou l'employeur"
+    locataire_foyer = "Locataire d'un foyer (résidence universitaire, maison de retraite, foyer de jeune travailleur, résidence sociale...)"
+    sans_domicile = "Sans domicile stable"
 
 
 # Taux de prime moyen de la fonction publique

--- a/openfisca_france/model/caracteristiques_socio_demographiques/capacite_travail.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/capacite_travail.py
@@ -7,14 +7,14 @@ class taux_capacite_travail(Variable):
     value_type = float
     default_value = 1.0
     entity = Individu
-    label = u"Taux de capacité de travail, appréciée par la commission des droits et de l'autonomie des personnes handicapées (CDAPH)"
+    label = "Taux de capacité de travail, appréciée par la commission des droits et de l'autonomie des personnes handicapées (CDAPH)"
     definition_period = MONTH
 
 
 class taux_incapacite(Variable):
     value_type = float
     entity = Individu
-    label = u"Taux d'incapacité"
+    label = "Taux d'incapacité"
     definition_period = MONTH
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=BD54F4B28313142C87FC8B96013E0441.tplgfr44s_1?idArticle=LEGIARTI000023097719&cidTexte=LEGITEXT000006073189&dateTexte=20190312"
     documentation = "Taux d'incapacité retenu pour l'Allocation Adulte Handicapé (AAH)."

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -41,21 +41,21 @@ class date_naissance(Variable):
     value_type = date
     default_value = date(1970, 1, 1)
     entity = Individu
-    label = u"Date de naissance"
+    label = "Date de naissance"
     definition_period = ETERNITY
 
 
 class adoption(Variable):
     value_type = bool
     entity = Individu
-    label = u"Enfant adopté"
+    label = "Enfant adopté"
     definition_period = MONTH
 
 
 class garde_alternee(Variable):
     value_type = bool
     entity = Individu
-    label = u'Enfant en garde alternée'
+    label = 'Enfant en garde alternée'
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -65,7 +65,7 @@ class activite(Variable):
     default_value = TypesActivite.inactif
     possible_values = TypesActivite  # defined in model/base.py
     entity = Individu
-    label = u"Activité"
+    label = "Activité"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -73,7 +73,7 @@ class activite(Variable):
 class enceinte(Variable):
     value_type = bool
     entity = Individu
-    label = u"Est enceinte"
+    label = "Est enceinte"
     definition_period = MONTH
 
 
@@ -82,7 +82,7 @@ class statut_marital(Variable):
     possible_values = TypesStatutMarital  # defined in model/base.py
     default_value = TypesStatutMarital.celibataire
     entity = Individu
-    label = u"Statut marital"
+    label = "Statut marital"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -93,135 +93,135 @@ class statut_marital(Variable):
 
 
 class nbN(Variable):
-    cerfa_field = u"N"
+    cerfa_field = "N"
     value_type = int
     is_period_size_independent = True
     entity = FoyerFiscal
-    label = u"Nombre d'enfants mariés/pacsés et d'enfants non mariés chargés de famille"
+    label = "Nombre d'enfants mariés/pacsés et d'enfants non mariés chargés de famille"
     definition_period = YEAR
 
 
 class nbR(Variable):
-    cerfa_field = u"R"
+    cerfa_field = "R"
     value_type = int
     is_period_size_independent = True
     entity = FoyerFiscal
-    label = u"Nombre de titulaires (autres que les enfants) de la carte invalidité d'au moins 80 %"
+    label = "Nombre de titulaires (autres que les enfants) de la carte invalidité d'au moins 80 %"
     definition_period = YEAR
 
 
 class caseE(Variable):
-    cerfa_field = u"E"
+    cerfa_field = "E"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Situation pouvant donner droit à une demi-part supplémentaire : vous vivez seul au 1er janvier de l'année de perception des revenus et vous avez élevé un enfant pendant moins de 5 ans durant la période où vous viviez seul"
+    label = "Situation pouvant donner droit à une demi-part supplémentaire : vous vivez seul au 1er janvier de l'année de perception des revenus et vous avez élevé un enfant pendant moins de 5 ans durant la période où vous viviez seul"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class caseF(Variable):
-    cerfa_field = u"F"
+    cerfa_field = "F"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Situation pouvant donner droit à une demi-part supplémentaire : conjoint titulaire d'une pension ou d'une carte d'invalidité (vivant ou décédé l'année de perception des revenus)"
+    label = "Situation pouvant donner droit à une demi-part supplémentaire : conjoint titulaire d'une pension ou d'une carte d'invalidité (vivant ou décédé l'année de perception des revenus)"
     definition_period = YEAR
 
 
 class caseG(Variable):
-    cerfa_field = u"G"
+    cerfa_field = "G"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Titulaire d'une pension de veuve de guerre"
+    label = "Titulaire d'une pension de veuve de guerre"
     definition_period = YEAR
     # attention, ne pas confondre caseG et nbG qui se rapportent toutes les 2 à une "case" G, l'une étant une vraie case
     # que l'on remplt et l'autre une case que l'on coche
 
 
 class caseH(Variable):
-    cerfa_field = u"H"
+    cerfa_field = "H"
     value_type = int
     is_period_size_independent = True
     entity = FoyerFiscal
-    label = u"Année de naissance des enfants à charge en garde alternée"
+    label = "Année de naissance des enfants à charge en garde alternée"
     definition_period = YEAR
 
 
 # il ne s'agit pas à proprement parlé de la case H, les cases permettant d'indiquer l'année de naissance
-#    se rapportent bien à nbH mais ne sont pas nommées, choisissons nous de laisser cerfa_field = u'H' pour caseH ?
+#    se rapportent bien à nbH mais ne sont pas nommées, choisissons nous de laisser cerfa_field = 'H' pour caseH ?
 #    De plus les caseH peuvent être multiples puisqu'il peut y avoir plusieurs enfants? donc faut-il les nommer caseH1, caseH2...caseH6 (les 6 présentes dans la déclaration) ?
 #    il faut aussi créer les cases F, G, R et I qui donnent également les années de naissances des PAC
 
 
 class caseK(Variable):
-    cerfa_field = u"K"
+    cerfa_field = "K"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Situation pouvant donner droit à une demi-part supplémentaire: vous avez eu un enfant décédé après l’âge de 16 ans ou par suite de faits de guerre"
+    label = "Situation pouvant donner droit à une demi-part supplémentaire: vous avez eu un enfant décédé après l’âge de 16 ans ou par suite de faits de guerre"
     end = '2011-12-31'
     definition_period = YEAR
 
 
 class caseL(Variable):
-    cerfa_field = u"L"
+    cerfa_field = "L"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Situation pouvant donner droit à une demi-part supplémentaire: vous vivez seul au 1er janvier de l'année de perception des revenus et vous avez élevé un enfant pendant au moins 5 ans durant la période où vous viviez seul (définition depuis 2009) - Un au moins de vos enfants à charge ou rattaché est issu du mariage avec votre conjoint décédé (définition avant 2008)"
+    label = "Situation pouvant donner droit à une demi-part supplémentaire: vous vivez seul au 1er janvier de l'année de perception des revenus et vous avez élevé un enfant pendant au moins 5 ans durant la période où vous viviez seul (définition depuis 2009) - Un au moins de vos enfants à charge ou rattaché est issu du mariage avec votre conjoint décédé (définition avant 2008)"
     definition_period = YEAR
 
 
 class caseN(Variable):
-    cerfa_field = u"N"
+    cerfa_field = "N"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Vous ne viviez pas seul au 1er janvier de l'année de perception des revenus"
+    label = "Vous ne viviez pas seul au 1er janvier de l'année de perception des revenus"
     definition_period = YEAR
 
 
 class caseP(Variable):
-    cerfa_field = u"P"
+    cerfa_field = "P"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Titulaire d'une pension pour une invalidité d'au moins 40 % ou d'une carte d'invalidité d'au moins 80%"
+    label = "Titulaire d'une pension pour une invalidité d'au moins 40 % ou d'une carte d'invalidité d'au moins 80%"
     definition_period = YEAR
 
 
 class caseS(Variable):
-    cerfa_field = u"S"
+    cerfa_field = "S"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Vous êtes mariés/pacsés et l'un des deux déclarants âgé de plus de 75 ans est titulaire de la carte du combattant ou d'une pension militaire d'invalidité ou de victime de guerre"
+    label = "Vous êtes mariés/pacsés et l'un des deux déclarants âgé de plus de 75 ans est titulaire de la carte du combattant ou d'une pension militaire d'invalidité ou de victime de guerre"
     definition_period = YEAR
 
 
 class caseT(Variable):
-    cerfa_field = u"T"
+    cerfa_field = "T"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Vous êtes parent isolé au 1er janvier de l'année de perception des revenus"
+    label = "Vous êtes parent isolé au 1er janvier de l'année de perception des revenus"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
     # TODO: Set definition_period as YEAR and change the suggestion process (scenarios.py)
 
 
 class caseW(Variable):
-    cerfa_field = u"W"
+    cerfa_field = "W"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Vous ou votre conjoint (même s'il est décédé), âgés de plus de 75 ans, êtes titulaire de la carte du combattant ou d'une pension militaire d'invalidité ou de victime de guerre"
+    label = "Vous ou votre conjoint (même s'il est décédé), âgés de plus de 75 ans, êtes titulaire de la carte du combattant ou d'une pension militaire d'invalidité ou de victime de guerre"
     definition_period = YEAR
 
 
 class handicap(Variable):
     value_type = bool
     entity = Individu
-    label = u"Individu en situation de handicap"
+    label = "Individu en situation de handicap"
     definition_period = MONTH
 
 
 class invalidite(Variable):
     value_type = bool
     entity = Individu
-    label = u"Individu titulaire d'une carte d'invalidité"
+    label = "Individu titulaire d'une carte d'invalidité"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -230,7 +230,7 @@ class nb_parents(Variable):
     value_type = int
     is_period_size_independent = True
     entity = Famille
-    label = u"Nombre d'adultes (parents) dans la famille"
+    label = "Nombre d'adultes (parents) dans la famille"
     definition_period = MONTH
 
     def formula(famille, period):
@@ -243,7 +243,7 @@ class nb_parents(Variable):
 class maries(Variable):
     value_type = bool
     entity = Famille
-    label = u"maries"
+    label = "maries"
     definition_period = MONTH
 
     def formula(famille, period):
@@ -258,7 +258,7 @@ class maries(Variable):
 class en_couple(Variable):
     value_type = bool
     entity = Famille
-    label = u"Indicatrice de vie en couple"
+    label = "Indicatrice de vie en couple"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -272,7 +272,7 @@ class en_couple(Variable):
 class est_enfant_dans_famille(Variable):
     value_type = bool
     entity = Individu
-    label = u"Indique que l'individu est un enfant dans une famille"
+    label = "Indique que l'individu est un enfant dans une famille"
     definition_period = ETERNITY
 
     def formula(individu, period):
@@ -282,7 +282,7 @@ class est_enfant_dans_famille(Variable):
 class etudiant(Variable):
     value_type = bool
     entity = Individu
-    label = u"Indicatrice individuelle étudiant"
+    label = "Indicatrice individuelle étudiant"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -297,7 +297,7 @@ class rempli_obligation_scolaire(Variable):
     value_type = bool
     default_value = True
     entity = Individu
-    label = u"Rempli l'obligation scolaire"
+    label = "Rempli l'obligation scolaire"
     definition_period = MONTH
 
 
@@ -325,12 +325,12 @@ class ressortissant_eee(Variable):
 class duree_possession_titre_sejour(Variable):
     value_type = int
     entity = Individu
-    label = u"Durée depuis laquelle l'individu possède un titre de séjour (en années)"
+    label = "Durée depuis laquelle l'individu possède un titre de séjour (en années)"
     definition_period = MONTH
 
 
 class enfant_place(Variable):
     value_type = bool
     entity = Individu
-    label = u"Enfant placé en structure spécialisée ou famille d'accueil"
+    label = "Enfant placé en structure spécialisée ou famille d'accueil"
     definition_period = MONTH

--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -9,21 +9,21 @@ from openfisca_france.model.base import *
 class coloc(Variable):
     value_type = bool
     entity = Menage
-    label = u"Vie en colocation"
+    label = "Vie en colocation"
     definition_period = MONTH
 
 
 class logement_crous(Variable):
     value_type = bool
     entity = Menage
-    label = u"Le logement est gérée par les CROUS "
+    label = "Le logement est gérée par les CROUS "
     definition_period = MONTH
 
 
 class logement_chambre(Variable):
     value_type = bool
     entity = Menage
-    label = u"Le logement est considéré comme une chambre"
+    label = "Le logement est considéré comme une chambre"
     definition_period = MONTH
 
 
@@ -31,7 +31,7 @@ class loyer(Variable):
     value_type = float
     entity = Menage
     set_input = set_input_divide_by_period
-    label = u"Loyer ou mensualité d'emprunt pour un primo-accédant"
+    label = "Loyer ou mensualité d'emprunt pour un primo-accédant"
     definition_period = MONTH
 
 
@@ -39,7 +39,7 @@ class depcom(Variable):
     value_type = str
     max_length = 5
     entity = Menage
-    label = u"Code INSEE (depcom) du lieu de résidence"
+    label = "Code INSEE (depcom) du lieu de résidence"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -48,21 +48,21 @@ class charges_locatives(Variable):
     value_type = float
     entity = Menage
     set_input = set_input_divide_by_period
-    label = u'Charges locatives'
+    label = 'Charges locatives'
     definition_period = MONTH
 
 
 class proprietaire_proche_famille(Variable):
     value_type = bool
     entity = Famille
-    label = u"Le propriétaire du logement a un lien de parenté avec la personne de référence ou son conjoint"
+    label = "Le propriétaire du logement a un lien de parenté avec la personne de référence ou son conjoint"
     definition_period = MONTH
 
 
 class habite_chez_parents(Variable):
     value_type = bool
     entity = Individu
-    label = u"L'individu habite chez ses parents"
+    label = "L'individu habite chez ses parents"
     definition_period = MONTH
 
 
@@ -71,7 +71,7 @@ class statut_occupation_logement(Variable):
     possible_values = TypesStatutOccupationLogement  # defined in model/base.py
     entity = Menage
     default_value = TypesStatutOccupationLogement.non_renseigne
-    label = u"Statut d'occupation du logement"
+    label = "Statut d'occupation du logement"
     set_input = set_input_dispatch_by_period
     definition_period = MONTH
 
@@ -172,16 +172,16 @@ class residence_saint_martin(Variable):
 
 
 class TypesLieuResidence(Enum):
-    non_renseigne = u"Non renseigné"
-    metropole = u"Métropole"
-    guadeloupe = u"Guadeloupe"
-    martinique = u"Martinique"
-    guyane = u"Guyane"
-    la_reunion = u"La réunion"
-    saint_pierre_et_miquelon = u"Saint Pierre et Miquelon"
-    mayotte = u"Mayotte"
-    saint_bartelemy = u"Saint Bartelemy"
-    saint_martin = u"Saint Martin"
+    non_renseigne = "Non renseigné"
+    metropole = "Métropole"
+    guadeloupe = "Guadeloupe"
+    martinique = "Martinique"
+    guyane = "Guyane"
+    la_reunion = "La réunion"
+    saint_pierre_et_miquelon = "Saint Pierre et Miquelon"
+    mayotte = "Mayotte"
+    saint_bartelemy = "Saint Bartelemy"
+    saint_martin = "Saint Martin"
 
 
 class residence(Variable):
@@ -189,7 +189,7 @@ class residence(Variable):
     possible_values = TypesLieuResidence
     default_value = TypesLieuResidence.non_renseigne
     entity = Menage
-    label = u"Zone de résidence"
+    label = "Zone de résidence"
     definition_period = MONTH
 
     def formula(menage, period, parameters):

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -6,8 +6,8 @@ from openfisca_france.model.base import *
 class unites_consommation(Variable):
     value_type = float
     entity = Menage
-    label = u"Unités de consommation du ménage, selon l'échelle de l'INSEE"
-    reference = u"https://insee.fr/fr/metadonnees/definition/c1802"
+    label = "Unités de consommation du ménage, selon l'échelle de l'INSEE"
+    reference = "https://insee.fr/fr/metadonnees/definition/c1802"
     definition_period = YEAR
 
     def formula(menage, period, parameters):
@@ -20,7 +20,7 @@ class type_menage(Variable):
     value_type = int
     is_period_size_independent = True
     entity = Menage
-    label = u"Type de ménage"
+    label = "Type de ménage"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -48,7 +48,7 @@ class type_menage(Variable):
 class revenu_disponible(Variable):
     value_type = float
     entity = Menage
-    label = u"Revenu disponible du ménage"
+    label = "Revenu disponible du ménage"
     reference = "http://fr.wikipedia.org/wiki/Revenu_disponible"
     definition_period = YEAR
 
@@ -83,7 +83,7 @@ class revenu_disponible(Variable):
 class niveau_de_vie(Variable):
     value_type = float
     entity = Menage
-    label = u"Niveau de vie du ménage"
+    label = "Niveau de vie du ménage"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -95,7 +95,7 @@ class niveau_de_vie(Variable):
 class revenus_nets_du_travail(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenus nets du travail (salariés et non salariés)"
+    label = "Revenus nets du travail (salariés et non salariés)"
     reference = "http://fr.wikipedia.org/wiki/Revenu_du_travail"
     definition_period = YEAR
 
@@ -124,7 +124,7 @@ class revenus_nets_du_travail(Variable):
 class pensions_nettes(Variable):
     value_type = float
     entity = Individu
-    label = u"Pensions et revenus de remplacement"
+    label = "Pensions et revenus de remplacement"
     reference = "http://fr.wikipedia.org/wiki/Rente"
     definition_period = YEAR
 
@@ -153,7 +153,7 @@ class pensions_nettes(Variable):
 class plus_values_base_large(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Montant des plus-values utilisé pour le montant total de revenus du capital"
+    label = "Montant des plus-values utilisé pour le montant total de revenus du capital"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period):
@@ -236,7 +236,7 @@ class plus_values_base_large(Variable):
 class revenus_nets_du_capital(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenus du capital nets de prélèvements sociaux"
+    label = "Revenus du capital nets de prélèvements sociaux"
     reference = "http://fr.wikipedia.org/wiki/Revenu#Revenu_du_Capital"
     definition_period = YEAR
 
@@ -285,7 +285,7 @@ class revenus_nets_du_capital(Variable):
 class revenus_fonciers_bruts_menage(Variable):
     value_type = float
     entity = Menage
-    label = u"Revenus fonciers du ménage après déficits mais avant abattements"
+    label = "Revenus fonciers du ménage après déficits mais avant abattements"
     definition_period = YEAR
 
     def formula_2013_01_01(menage, period):
@@ -315,7 +315,7 @@ class revenus_fonciers_bruts_menage(Variable):
 class revenus_travail_super_bruts_menage(Variable):
     value_type = float
     entity = Menage
-    label = u"Revenus du travail super bruts du ménage"
+    label = "Revenus du travail super bruts du ménage"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -356,7 +356,7 @@ class revenus_travail_super_bruts_menage(Variable):
 class revenus_remplacement_pensions_bruts_menage(Variable):
     value_type = float
     entity = Menage
-    label = u"Revenus de remplacement et pensions bruts du ménage"
+    label = "Revenus de remplacement et pensions bruts du ménage"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -396,7 +396,7 @@ class revenus_remplacement_pensions_bruts_menage(Variable):
 class revenus_capitaux_mobiliers_plus_values_bruts_menage(Variable):
     value_type = float
     entity = Menage
-    label = u"Revenus bruts des capitaux mobiliers et plus-values du ménage"
+    label = "Revenus bruts des capitaux mobiliers et plus-values du ménage"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -433,7 +433,7 @@ class revenus_capitaux_mobiliers_plus_values_bruts_menage(Variable):
 class revenus_super_bruts_menage(Variable):
     value_type = float
     entity = Menage
-    label = u"Revenus super bruts du ménage"
+    label = "Revenus super bruts du ménage"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -454,7 +454,7 @@ class revenus_super_bruts_menage(Variable):
 class prelevements_sociaux_menage(Variable):
     value_type = float
     entity = Menage
-    label = u"Prélèvements sociaux du ménage (tous revenus, hors prestations)"
+    label = "Prélèvements sociaux du ménage (tous revenus, hors prestations)"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -476,7 +476,7 @@ class prelevements_sociaux_menage(Variable):
 class prestations_sociales(Variable):
     value_type = float
     entity = Famille
-    label = u"Prestations sociales"
+    label = "Prestations sociales"
     reference = "http://fr.wikipedia.org/wiki/Prestation_sociale"
     definition_period = YEAR
 
@@ -495,7 +495,7 @@ class prestations_sociales(Variable):
 class prestations_familiales(Variable):
     value_type = float
     entity = Famille
-    label = u"Prestations familiales"
+    label = "Prestations familiales"
     reference = "http://www.social-sante.gouv.fr/informations-pratiques,89/fiches-pratiques,91/prestations-familiales,1885/les-prestations-familiales,12626.html"
     definition_period = YEAR
 
@@ -515,7 +515,7 @@ class minimum_vieillesse(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"Minimum vieillesse (ASI + ASPA)"
+    label = "Minimum vieillesse (ASI + ASPA)"
     definition_period = YEAR
 
     def formula(famille, period):
@@ -525,7 +525,7 @@ class minimum_vieillesse(Variable):
 class minima_sociaux(Variable):
     value_type = float
     entity = Famille
-    label = u"Minima sociaux"
+    label = "Minima sociaux"
     reference = "http://fr.wikipedia.org/wiki/Minima_sociaux"
     definition_period = YEAR
 
@@ -551,7 +551,7 @@ class minima_sociaux(Variable):
 class aides_logement(Variable):
     value_type = float
     entity = Famille
-    label = u"Aides logement nettes"
+    label = "Aides logement nettes"
     reference = "http://vosdroits.service-public.fr/particuliers/N20360.xhtml"
     definition_period = YEAR
 
@@ -562,7 +562,7 @@ class aides_logement(Variable):
 class irpp_economique(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Notion économique de l'IRPP"
+    label = "Notion économique de l'IRPP"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -587,7 +587,7 @@ class irpp_economique(Variable):
 class impots_directs(Variable):
     value_type = float
     entity = Menage
-    label = u"Impôts directs"
+    label = "Impôts directs"
     reference = "http://fr.wikipedia.org/wiki/Imp%C3%B4t_direct"
     definition_period = YEAR
 

--- a/openfisca_france/model/patrimoine/livret_epargne_populaire.py
+++ b/openfisca_france/model/patrimoine/livret_epargne_populaire.py
@@ -32,7 +32,7 @@ class livret_epargne_populaire_plafond(Variable):
 class livret_epargne_populaire_eligibilite(Variable):
     value_type = bool
     entity = Individu
-    label = u"Eligibilité au livret d'épargne populaire"
+    label = "Eligibilité au livret d'épargne populaire"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -45,7 +45,7 @@ class livret_epargne_populaire_eligibilite(Variable):
 class livret_epargne_populaire_taux(Variable):
     value_type = float
     entity = Individu
-    label = u"Eligibilité au livret d'épargne populaire"
+    label = "Eligibilité au livret d'épargne populaire"
     definition_period = MONTH
 
     def formula(individu, period, parameters):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
@@ -10,149 +10,149 @@ log = logging.getLogger(__name__)
 
 # Csg déductible
 class f6de(Variable):
-    cerfa_field = u"6DE"
+    cerfa_field = "6DE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"CSG déductible calculée sur les revenus du patrimoine"
+    label = "CSG déductible calculée sur les revenus du patrimoine"
     definition_period = YEAR
 
 
 # Pensions alimentaires
 class f6gi(Variable):
-    cerfa_field = u"6GI"
+    cerfa_field = "6GI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Pensions alimentaires versées à des enfants majeurs (décision de justice définitive avant 2006): 1er enfant"
+    label = "Pensions alimentaires versées à des enfants majeurs (décision de justice définitive avant 2006): 1er enfant"
     definition_period = YEAR
 
 
 class f6gj(Variable):
-    cerfa_field = u"6GJ"
+    cerfa_field = "6GJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Pensions alimentaires versées à des enfants majeurs (décision de justice définitive avant 2006): 2eme enfant"
+    label = "Pensions alimentaires versées à des enfants majeurs (décision de justice définitive avant 2006): 2eme enfant"
     definition_period = YEAR
 
 
 class f6el(Variable):
-    cerfa_field = u"6EL"
+    cerfa_field = "6EL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Autres pensions alimentaires versées à des enfants majeurs: 1er enfant"
+    label = "Autres pensions alimentaires versées à des enfants majeurs: 1er enfant"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 class f6em(Variable):
-    cerfa_field = u"6EM"
+    cerfa_field = "6EM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Autres pensions alimentaires versées à des enfants majeurs: 2eme enfant"
+    label = "Autres pensions alimentaires versées à des enfants majeurs: 2eme enfant"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 class f6gp(Variable):
-    cerfa_field = u"6GP"
+    cerfa_field = "6GP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Autres pensions alimentaires versées décision de justice définitive avant 2006 (mineurs, ascendants)"
+    label = "Autres pensions alimentaires versées décision de justice définitive avant 2006 (mineurs, ascendants)"
     definition_period = YEAR
 
 
 class f6gu(Variable):
-    cerfa_field = u"6GU"
+    cerfa_field = "6GU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Autres pensions alimentaires versées (mineurs, ascendants)"
+    label = "Autres pensions alimentaires versées (mineurs, ascendants)"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 # Frais d'accueil d'une personne de plus de 75 ans dans le besoin
 class f6eu(Variable):
-    cerfa_field = u"6EU"
+    cerfa_field = "6EU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Frais d'accueil de personnes de plus de 75 ans dans le besoin"
+    label = "Frais d'accueil de personnes de plus de 75 ans dans le besoin"
     definition_period = YEAR
 
 
 class f6ev(Variable):
-    cerfa_field = u"6EV"
+    cerfa_field = "6EV"
     value_type = int
     is_period_size_independent = True
     entity = FoyerFiscal
-    label = u"Nombre de personnes de plus de 75 ans dans le besoin accueillies sous votre toit"
+    label = "Nombre de personnes de plus de 75 ans dans le besoin accueillies sous votre toit"
     definition_period = YEAR
 
 
 # Déductions diverses
 class f6dd(Variable):
-    cerfa_field = u"6DD"
+    cerfa_field = "6DD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déductions diverses"
+    label = "Déductions diverses"
     definition_period = YEAR
 
 
 # Épargne retraite - PERP, PRÉFON, COREM et CGOS
 class f6ps(Variable):
     cerfa_field = {
-        0: u"6PS",
-        1: u"6PT",
-        2: u"6PU",
+        0: "6PS",
+        1: "6PT",
+        2: "6PU",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plafond de déduction épargne retraite (plafond calculé sur les revenus perçus en n-1)"
+    label = "Plafond de déduction épargne retraite (plafond calculé sur les revenus perçus en n-1)"
     definition_period = YEAR
 
 
 class f6rs(Variable):
     cerfa_field = {
-        0: u"6RS",
-        1: u"6RT",
-        2: u"6RU",
+        0: "6RS",
+        1: "6RT",
+        2: "6RU",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Cotisations d'épargne retraite versées au titre d'un PERP, PREFON, COREM et C.G.O.S"
+    label = "Cotisations d'épargne retraite versées au titre d'un PERP, PREFON, COREM et C.G.O.S"
     definition_period = YEAR
 
 
 class f6ss(Variable):
     cerfa_field = {
-        0: u"6SS",
-        1: u"6ST",
-        2: u"6SU",
+        0: "6SS",
+        1: "6ST",
+        2: "6SU",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Rachat de cotisations PERP, PREFON, COREM et C.G.O.S"
+    label = "Rachat de cotisations PERP, PREFON, COREM et C.G.O.S"
     definition_period = YEAR
 
 
 # Souscriptions en faveur du cinéma ou de l’audiovisuel
 # TODO: ancien numéro de case, antérieur à 2008 ....au moins! vérifier pour 07-06-05 ect...probablement avant 2005 (autre nom en 12 et 13)
 class f6aa(Variable):
-    cerfa_field = u"6AA"
+    cerfa_field = "6AA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions en faveur du cinéma ou de l’audiovisuel"
+    label = "Souscriptions en faveur du cinéma ou de l’audiovisuel"
     # start_date = date(2005, 1, 1)
     end = '2006-12-31'
     definition_period = YEAR
@@ -163,11 +163,11 @@ class f6aa(Variable):
 
 # ancien numéro de case, antérieur à 2008 ....au moins vérifier pour 07-06-05 ect...probablement avant 2005 (autre nom en  12 et13)
 class f6cc(Variable):
-    cerfa_field = u"CC"
+    cerfa_field = "CC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des SOFIPÊCHE"
+    label = "Souscriptions au capital des SOFIPÊCHE"
     # start_date = date(2005, 1, 1)
     end = '2005-12-31'
     definition_period = YEAR
@@ -176,7 +176,7 @@ class f6cc(Variable):
 # Investissements DOM-TOM dans le cadre d’une entreprise < = 2005
 # ou Versements sur un compte épargne codéveloppement
 class f6eh(Variable):
-    cerfa_field = u"EH"
+    cerfa_field = "EH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -187,11 +187,11 @@ class f6eh(Variable):
 
 
 class f6da(Variable):
-    cerfa_field = u"DA"
+    cerfa_field = "DA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Pertes en capital consécutives à la souscription au capital de sociétés nouvelles ou de sociétés en difficulté"
+    label = "Pertes en capital consécutives à la souscription au capital de sociétés nouvelles ou de sociétés en difficulté"
     # start_date = date(2005, 1, 1)
     end = '2005-12-31'
     definition_period = YEAR
@@ -199,11 +199,11 @@ class f6da(Variable):
 
 # Dépenses de grosses réparations effectuées par les nus propriétaires
 class f6cb(Variable):
-    cerfa_field = u"6CB"
+    cerfa_field = "6CB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires (dépenses réalisées au cours de l'année de perception des revenus)"
+    label = "Dépenses de grosses réparations effectuées par les nus-propriétaires (dépenses réalisées au cours de l'année de perception des revenus)"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
@@ -211,154 +211,154 @@ class f6cb(Variable):
 # TODO: before 2006 was Pertes en capital consécutives à la souscription au capital de sociétés nouvelles ou de sociétés en difficulté (cases CB et DA de la déclaration complémentaire)
 
 class f6hj(Variable):
-    cerfa_field = u"6HJ"
+    cerfa_field = "6HJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2009"
+    label = "Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2009"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f6hk(Variable):
-    cerfa_field = u"6HK"
+    cerfa_field = "6HK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2010"
+    label = "Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2010"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f6hl(Variable):
-    cerfa_field = u"6HL"
+    cerfa_field = "6HL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2011"
+    label = "Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2011"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f6hm(Variable):
-    cerfa_field = u"6HM"
+    cerfa_field = "6HM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2012"
+    label = "Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f6hn(Variable):
-    cerfa_field = u"6HN"
+    cerfa_field = "6HN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2013"
+    label = "Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f6ho(Variable):
-    cerfa_field = u"6HO"
+    cerfa_field = "6HO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2014"
+    label = "Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2014"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f6hp(Variable):
-    cerfa_field = u"6HP"
+    cerfa_field = "6HP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2015"
+    label = "Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2015"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f6hq(Variable):
-    cerfa_field = u"6HQ"
+    cerfa_field = "6HQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2016"
+    label = "Dépenses de grosses réparations effectuées par les nus-propriétaires: report des dépenses de l'année 2016"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 # Sommes à rajouter au revenu imposable
 class f6gh(Variable):
-    cerfa_field = u"6GH"
+    cerfa_field = "6GH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Sommes à ajouter au revenu imposable"
+    label = "Sommes à ajouter au revenu imposable"
     definition_period = YEAR
 
 
 # Deficits antérieurs
 class f6fa(Variable):
-    cerfa_field = u"6FA"
+    cerfa_field = "6FA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Deficits globaux des années antérieures non encore déduits les années précédentes: année de perception des revenus -6"
+    label = "Deficits globaux des années antérieures non encore déduits les années précédentes: année de perception des revenus -6"
     definition_period = YEAR
 
 
 class f6fb(Variable):
-    cerfa_field = u"6FB"
+    cerfa_field = "6FB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -5"
+    label = "Deficits globaux des années antérieures non encore déduits: année de perception des revenus -5"
     definition_period = YEAR
 
 
 class f6fc(Variable):
-    cerfa_field = u"6FC"
+    cerfa_field = "6FC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -4"
+    label = "Deficits globaux des années antérieures non encore déduits: année de perception des revenus -4"
     definition_period = YEAR
 
 
 class f6fd(Variable):
-    cerfa_field = u"6FD"
+    cerfa_field = "6FD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -3"
+    label = "Deficits globaux des années antérieures non encore déduits: année de perception des revenus -3"
     definition_period = YEAR
 
 
 class f6fe(Variable):
-    cerfa_field = u"6FE"
+    cerfa_field = "6FE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -2"
+    label = "Deficits globaux des années antérieures non encore déduits: année de perception des revenus -2"
     definition_period = YEAR
 
 
 class f6fl(Variable):
-    cerfa_field = u"6FL"
+    cerfa_field = "6FL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Deficits globaux des années antérieures non encore déduits: année de perception des revenus -1"
+    label = "Deficits globaux des années antérieures non encore déduits: année de perception des revenus -1"
     definition_period = YEAR
 
 
 class rfr_cd(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Charges déductibles entrant dans le revenus fiscal de référence"
+    label = "Charges déductibles entrant dans le revenus fiscal de référence"
     reference = "Article 1417 du Code Général des Impôts - IV-1°-a)"
     definition_period = YEAR
 
@@ -377,7 +377,7 @@ class rfr_cd(Variable):
 class cd1(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Charges déductibles non plafonnées"
+    label = "Charges déductibles non plafonnées"
     reference = "http://impotsurlerevenu.org/definitions/215-charge-deductible.php"
     definition_period = YEAR
 
@@ -472,7 +472,7 @@ class cd1(Variable):
 class cd2(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Charges déductibles plafonnées"
+    label = "Charges déductibles plafonnées"
     reference = "http://impotsurlerevenu.org/definitions/215-charge-deductible.php"
     definition_period = YEAR
     end = '2008-12-31'
@@ -509,7 +509,7 @@ class cd2(Variable):
 class rbg_int(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenu brut global intermédiaire"
+    label = "Revenu brut global intermédiaire"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -522,7 +522,7 @@ class rbg_int(Variable):
 class charges_deduc(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Charges déductibles"
+    label = "Charges déductibles"
     reference = "http://impotsurlerevenu.org/definitions/215-charge-deductible.php"
     definition_period = YEAR
 
@@ -536,7 +536,7 @@ class charges_deduc(Variable):
 class pensions_alimentaires_deduites(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Pensions alimentaires"
+    label = "Pensions alimentaires"
     reference = "http://frederic.anne.free.fr/Cours/ITV.htm"
     definition_period = YEAR
 
@@ -568,7 +568,7 @@ class pensions_alimentaires_deduites(Variable):
 class cd_acc75a(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Frais d’accueil sous votre toit d’une personne de plus de 75 ans"
+    label = "Frais d’accueil sous votre toit d’une personne de plus de 75 ans"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -582,7 +582,7 @@ class cd_acc75a(Variable):
 class pertes_capital_societes_nouvelles(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Pertes en capital consécutives à la souscription au capital de sociétés nouvelles ou de sociétés en difficulté"
+    label = "Pertes en capital consécutives à la souscription au capital de sociétés nouvelles ou de sociétés en difficulté"
     definition_period = YEAR
     end = '2006-12-31'
 
@@ -616,7 +616,7 @@ class pertes_capital_societes_nouvelles(Variable):
 class cd_deddiv(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Déductions diverses"
+    label = "Déductions diverses"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -628,7 +628,7 @@ class cd_deddiv(Variable):
 class cd_doment(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Investissements DOM-TOM dans le cadre d’une entreprise"
+    label = "Investissements DOM-TOM dans le cadre d’une entreprise"
     end = '2005-12-31'
     definition_period = YEAR
 
@@ -645,7 +645,7 @@ class cd_doment(Variable):
 class cd_eparet(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Charge déductible au titre de l'épargne retraite (PERP, PRÉFON, COREM et CGOS)"
+    label = "Charge déductible au titre de l'épargne retraite (PERP, PRÉFON, COREM et CGOS)"
     definition_period = YEAR
 
     def formula_2004(foyer_fiscal, period, parameters):
@@ -667,7 +667,7 @@ class cd_eparet(Variable):
 class cd_sofipe(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des SOFIPÊCHE"
+    label = "Souscriptions au capital des SOFIPÊCHE"
     end = '2006-12-31'
     definition_period = YEAR
 
@@ -688,7 +688,7 @@ class cd_sofipe(Variable):
 class souscriptions_cinema_audiovisuel(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Souscriptions en faveur du cinéma ou de l’audiovisuel"
+    label = "Souscriptions en faveur du cinéma ou de l’audiovisuel"
     end = '2005-12-31'
     definition_period = YEAR
 
@@ -708,7 +708,7 @@ class souscriptions_cinema_audiovisuel(Variable):
 class epargne_codeveloppement(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Versements sur un compte épargne codéveloppement"
+    label = "Versements sur un compte épargne codéveloppement"
     end = '2008-12-31'
     definition_period = YEAR
 
@@ -728,8 +728,8 @@ class epargne_codeveloppement(Variable):
 class grosses_reparations(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Dépenses de grosses réparations des nus-propriétaires"
-    reference = u"http://bofip.impots.gouv.fr/bofip/1852-PGP"
+    label = "Dépenses de grosses réparations des nus-propriétaires"
+    reference = "http://bofip.impots.gouv.fr/bofip/1852-PGP"
     definition_period = YEAR
 
     def formula_2009(foyer_fiscal, period, parameters):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 class credits_impot(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédits d'impôt pour l'impôt sur les revenus"
+    label = "Crédits d'impôt pour l'impôt sur les revenus"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -58,7 +58,7 @@ class credits_impot(Variable):
 class nb_pac2(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Nombre de personnes à charges (en comptant les enfants en résidence alternée comme une demi personne à charge)"
+    label = "Nombre de personnes à charges (en comptant les enfants en résidence alternée comme une demi personne à charge)"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -73,7 +73,7 @@ class nb_pac2(Variable):
 class acqgpl(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédit d'impôt pour dépense d'acquisition ou de transformation d'un véhicule GPL ou mixte"
+    label = "Crédit d'impôt pour dépense d'acquisition ou de transformation d'un véhicule GPL ou mixte"
     end = '2007-12-31'
     definition_period = YEAR
 
@@ -92,7 +92,7 @@ class acqgpl(Variable):
 class aidmob(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédit d'impôt aide à la mobilité"
+    label = "Crédit d'impôt aide à la mobilité"
     end = '2008-12-31'
     definition_period = YEAR
 
@@ -114,7 +114,7 @@ class aidmob(Variable):
 class aidper(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédits d’impôt pour dépenses en faveur de l’aide aux personnes"
+    label = "Crédits d’impôt pour dépenses en faveur de l’aide aux personnes"
     reference = "http://bofip.impots.gouv.fr/bofip/3859-PGP"
     definition_period = YEAR
 
@@ -301,7 +301,7 @@ class aidper(Variable):
 class assloy(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédit d’impôt primes d’assurance pour loyers impayés"
+    label = "Crédit d’impôt primes d’assurance pour loyers impayés"
     reference = "http://bofip.impots.gouv.fr/bofip/844-PGP.html?identifiant=BOI-IR-RICI-320-20120912"
     definition_period = YEAR
     end = '2016-12-31'
@@ -320,7 +320,7 @@ class assloy(Variable):
 class autent(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"autent"
+    label = "autent"
     definition_period = YEAR
 
     def formula_2009(foyer_fiscal, period, parameters):
@@ -336,7 +336,7 @@ class autent(Variable):
 class ci_garext(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Frais de garde des enfants à l’extérieur du domicile"
+    label = "Frais de garde des enfants à l’extérieur du domicile"
     reference = "http://bofip.impots.gouv.fr/bofip/865-PGP?datePubl=13/04/2013"
     definition_period = YEAR
 
@@ -367,8 +367,8 @@ class ci_garext(Variable):
 class credit_cotisations_syndicales(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédit d'impôt pour cotisations syndicales"
-    reference = u"http://bofip.impots.gouv.fr/bofip/1605-PGP"
+    label = "Crédit d'impôt pour cotisations syndicales"
+    reference = "http://bofip.impots.gouv.fr/bofip/1605-PGP"
     definition_period = YEAR
 
     def formula_2012_01_01(foyer_fiscal, period, parameters):
@@ -381,7 +381,7 @@ class credit_cotisations_syndicales(Variable):
 class creimp_exc_2008(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédit d'impôt exceptionnel sur les revenus 2008"
+    label = "Crédit d'impôt exceptionnel sur les revenus 2008"
     definition_period = YEAR
     end = '2008-12-31'
 
@@ -416,7 +416,7 @@ class creimp_exc_2008(Variable):
 class creimp(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Ensemble de crédits d'impôt"
+    label = "Ensemble de crédits d'impôt"
     definition_period = YEAR
 
     def formula_2002_01_01(foyer_fiscal, period, parameters):
@@ -752,7 +752,7 @@ class creimp(Variable):
 class acompte_ir_elus_locaux(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Acompte d'impôt associé au prélèvement à la source des indemnités des élus locaux"
+    label = "Acompte d'impôt associé au prélèvement à la source des indemnités des élus locaux"
     definition_period = YEAR
     end = '2017-12-31'  # On neutralise cette variable à partir de 2018 car cette variable n'est pas un montant de revenu, mais un montant d'impôt, versé en acompte. Or, pour le moment, à partir de 2018, on ne dispose pas de cet acompte.
 
@@ -772,7 +772,7 @@ class acompte_ir_elus_locaux(Variable):
 class prelevement_forfaitaire_non_liberatoire(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Prélèvement forfaitaire non libératoire sur les revenus du capital"
+    label = "Prélèvement forfaitaire non libératoire sur les revenus du capital"
     definition_period = YEAR
 
     def formula_2013_01_01(foyer_fiscal, period):
@@ -792,7 +792,7 @@ class prelevement_forfaitaire_non_liberatoire(Variable):
 class acomptes_ir(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Ensemble des acomptes de l'IR"
+    label = "Ensemble des acomptes de l'IR"
     definition_period = YEAR
 
     def formula_2013_01_01(foyer_fiscal, period):
@@ -812,7 +812,7 @@ class acomptes_ir(Variable):
 class direpa(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédit d’impôt directive « épargne »"
+    label = "Crédit d’impôt directive « épargne »"
     definition_period = YEAR
 
     def formula_2006(foyer_fiscal, period, parameters):
@@ -828,7 +828,7 @@ class direpa(Variable):
 class divide(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédit d'impôt dividendes"
+    label = "Crédit d'impôt dividendes"
     end = '2009-12-31'
     definition_period = YEAR
 
@@ -849,7 +849,7 @@ class divide(Variable):
 class drbail(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédit d’impôt représentatif de la taxe additionnelle au droit de bail"
+    label = "Crédit d’impôt représentatif de la taxe additionnelle au droit de bail"
     definition_period = YEAR
 
     def formula_2002(foyer_fiscal, period, parameters):
@@ -866,8 +866,8 @@ class drbail(Variable):
 class inthab(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédit d’impôt intérêts des emprunts pour l’habitation principale"
-    reference = u"http://bofip.impots.gouv.fr/bofip/3863-PGP.html?identifiant=BOI-IR-RICI-350-20120912"
+    label = "Crédit d’impôt intérêts des emprunts pour l’habitation principale"
+    reference = "http://bofip.impots.gouv.fr/bofip/3863-PGP.html?identifiant=BOI-IR-RICI-350-20120912"
     definition_period = YEAR
 
     def formula_2007_01_01(foyer_fiscal, period, parameters):
@@ -1182,7 +1182,7 @@ class inthab(Variable):
 class jeunes(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"jeunes"
+    label = "jeunes"
     end = '2008-12-31'
     definition_period = YEAR
 
@@ -1195,7 +1195,7 @@ class jeunes(Variable):
 class jeunes_ind(Variable):
     value_type = float
     entity = Individu
-    label = u"Crédit d'impôt en faveur des jeunes"
+    label = "Crédit d'impôt en faveur des jeunes"
     end = '2008-12-31'
     definition_period = YEAR
 
@@ -1244,7 +1244,7 @@ class jeunes_ind(Variable):
 class percvm(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédit d’impôt pertes sur cessions de valeurs mobilières"
+    label = "Crédit d’impôt pertes sur cessions de valeurs mobilières"
     end = '2010-12-31'
     definition_period = YEAR
 
@@ -1262,7 +1262,7 @@ class percvm(Variable):
 class preetu(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédit d’impôt pour souscription de prêts étudiants"
+    label = "Crédit d’impôt pour souscription de prêts étudiants"
     definition_period = YEAR
 
     def formula_2005_01_01(foyer_fiscal, period, parameters):
@@ -1304,7 +1304,7 @@ class preetu(Variable):
 class prlire(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Prélèvement libératoire à restituer (case 2DH)"
+    label = "Prélèvement libératoire à restituer (case 2DH)"
     definition_period = YEAR
 
     def formula_2002(foyer_fiscal, period, parameters):
@@ -1320,7 +1320,7 @@ class prlire(Variable):
 class quaenv(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédits d’impôt pour dépenses en faveur de la qualité environnementale (2005 - 2014) / de la transition energétique (2014 - ) "
+    label = "Crédits d’impôt pour dépenses en faveur de la qualité environnementale (2005 - 2014) / de la transition energétique (2014 - ) "
     definition_period = YEAR
 
     def formula_2005_01_01(foyer_fiscal, period, parameters):
@@ -1937,7 +1937,7 @@ class quaenv(Variable):
 class quaenv_bouquet(Variable):
     value_type = bool
     entity = FoyerFiscal
-    label = u"Indicateur de réalisation d'un bouquet de travaux, dans le cadre du crédit d'impôt en faveur de la qualité environnementale"
+    label = "Indicateur de réalisation d'un bouquet de travaux, dans le cadre du crédit d'impôt en faveur de la qualité environnementale"
     definition_period = YEAR
     reference = "http://bofip.impots.gouv.fr/bofip/3883-PGP.html?identifiant=BOI-IR-RICI-280-20170807"
     end = '2015-12-31'
@@ -2132,7 +2132,7 @@ class quaenv_bouquet(Variable):
 class saldom2(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Crédit d’impôt emploi d’un salarié à domicile"
+    label = "Crédit d’impôt emploi d’un salarié à domicile"
     definition_period = YEAR
 
     def formula_2007_01_01(foyer_fiscal, period, parameters):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -45,7 +45,7 @@ class jour_xyz(Variable):
     value_type = int
     default_value = 360
     entity = FoyerFiscal
-    label = u"Jours décomptés au titre de cette déclaration"
+    label = "Jours décomptés au titre de cette déclaration"
     definition_period = YEAR
 
 
@@ -59,7 +59,7 @@ class age(Variable):
     value_type = int
     default_value = -9999
     entity = Individu
-    label = u"Âge (en années) au premier jour du mois"
+    label = "Âge (en années) au premier jour du mois"
     definition_period = MONTH
     is_period_size_independent = True
     set_input = set_input_dispatch_by_period
@@ -99,7 +99,7 @@ class age_en_mois(Variable):
     default_value = -9999
     unit = 'months'
     entity = Individu
-    label = u"Âge (en mois)"
+    label = "Âge (en mois)"
     is_period_size_independent = True
     definition_period = MONTH
 
@@ -130,7 +130,7 @@ class depcom_foyer(Variable):
     max_length = 5
     entity = FoyerFiscal
     default_value = "00000"
-    label = u"Code AFT du lieu de domicile fiscal"
+    label = "Code AFT du lieu de domicile fiscal"
     definition_period = YEAR
     set_input = set_input_dispatch_by_period
     # Cette variable est similaire à la variable "depcom" qui est le lieu de domicile du ménage tandis que "depcom_foyer" est le lieu de résidence fiscale du foyer fiscal.
@@ -189,7 +189,7 @@ class residence_fiscale_mayotte(Variable):
 class nb_adult(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Nombre d'adulte(s) déclarants dans le foyer fiscal"
+    label = "Nombre d'adulte(s) déclarants dans le foyer fiscal"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -203,7 +203,7 @@ class nb_adult(Variable):
 class nb_pac(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Nombre de personnes à charge dans le foyer fiscal"
+    label = "Nombre de personnes à charge dans le foyer fiscal"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -217,8 +217,8 @@ class nb_pac(Variable):
 class enfant_a_charge(Variable):
     value_type = bool
     entity = Individu
-    label = u"Enfant à charge non marié, de moins de 18 ans au 1er janvier de l'année de perception des" \
-        u" revenus, ou né durant la même année, ou handicapés quel que soit son âge"
+    label = "Enfant à charge non marié, de moins de 18 ans au 1er janvier de l'année de perception des" \
+        " revenus, ou né durant la même année, ou handicapés quel que soit son âge"
     definition_period = YEAR
 
     def formula(individu, period):
@@ -232,11 +232,11 @@ class enfant_a_charge(Variable):
 
 
 class nbF(Variable):
-    cerfa_field = u'F'
+    cerfa_field = 'F'
     entity = FoyerFiscal
     value_type = float
-    label = u"Nombre d'enfants à charge non mariés, qui ne sont pas en résidence alternée, de moins de 18 ans au 1er janvier de l'année de perception des" \
-        u" revenus, ou nés durant la même année ou handicapés quel que soit leur âge"
+    label = "Nombre d'enfants à charge non mariés, qui ne sont pas en résidence alternée, de moins de 18 ans au 1er janvier de l'année de perception des" \
+        " revenus, ou nés durant la même année ou handicapés quel que soit leur âge"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -248,10 +248,10 @@ class nbF(Variable):
 
 
 class nbG(Variable):
-    cerfa_field = u'G'
+    cerfa_field = 'G'
     entity = FoyerFiscal
     value_type = float
-    label = u"Nombre d'enfants qui ne sont pas en résidence alternée à charge titulaires de la carte d'invalidité."
+    label = "Nombre d'enfants qui ne sont pas en résidence alternée à charge titulaires de la carte d'invalidité."
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -264,10 +264,10 @@ class nbG(Variable):
 
 
 class nbH(Variable):
-    cerfa_field = u'H'
+    cerfa_field = 'H'
     entity = FoyerFiscal
     value_type = float
-    label = u"Nombre d'enfants à charge en résidence alternée, non mariés de moins de 18 ans au 1er janvier de l'année de perception des revenus, ou nés durant la même année ou handicapés quel que soit leur âge"
+    label = "Nombre d'enfants à charge en résidence alternée, non mariés de moins de 18 ans au 1er janvier de l'année de perception des revenus, ou nés durant la même année ou handicapés quel que soit leur âge"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -279,10 +279,10 @@ class nbH(Variable):
 
 
 class nbI(Variable):
-    cerfa_field = u'I'
+    cerfa_field = 'I'
     entity = FoyerFiscal
     value_type = float
-    label = u"Nombre d'enfants à charge en résidence alternée titulaires de la carte d'invalidité"
+    label = "Nombre d'enfants à charge en résidence alternée titulaires de la carte d'invalidité"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -297,7 +297,7 @@ class nbI(Variable):
 class enfant_majeur_celibataire_sans_enfant(Variable):
     value_type = bool
     entity = Individu
-    label = u"Enfant majeur célibataire sans enfant"
+    label = "Enfant majeur célibataire sans enfant"
     definition_period = YEAR
 
     def formula(individu, period):
@@ -311,9 +311,9 @@ class enfant_majeur_celibataire_sans_enfant(Variable):
 
 
 class nbJ(Variable):
-    cerfa_field = u'J'
+    cerfa_field = 'J'
     entity = FoyerFiscal
-    label = u"Nombre d'enfants majeurs célibataires sans enfant"
+    label = "Nombre d'enfants majeurs célibataires sans enfant"
     value_type = int
     definition_period = YEAR
 
@@ -324,7 +324,7 @@ class nbJ(Variable):
 
 class nombre_enfants_majeurs_celibataires_sans_enfant(Variable):
     entity = Menage
-    label = u"Nombre d'enfants majeurs célibataires sans enfant"
+    label = "Nombre d'enfants majeurs célibataires sans enfant"
     value_type = int
     definition_period = YEAR
 
@@ -336,7 +336,7 @@ class nombre_enfants_majeurs_celibataires_sans_enfant(Variable):
 class maries_ou_pacses(Variable):
     value_type = bool
     entity = FoyerFiscal
-    label = u"Déclarants mariés ou pacsés"
+    label = "Déclarants mariés ou pacsés"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period):
@@ -349,7 +349,7 @@ class maries_ou_pacses(Variable):
 class celibataire_ou_divorce(Variable):
     value_type = bool
     entity = FoyerFiscal
-    label = u"Déclarant célibataire ou divorcé"
+    label = "Déclarant célibataire ou divorcé"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period):
@@ -364,7 +364,7 @@ class celibataire_ou_divorce(Variable):
 class veuf(Variable):
     value_type = bool
     entity = FoyerFiscal
-    label = u"Déclarant veuf"
+    label = "Déclarant veuf"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period):
@@ -377,7 +377,7 @@ class veuf(Variable):
 class jeune_veuf(Variable):
     value_type = bool
     entity = FoyerFiscal
-    label = u"Déclarant jeune veuf"
+    label = "Déclarant jeune veuf"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period):
@@ -395,7 +395,7 @@ class jeune_veuf(Variable):
 class revenu_assimile_salaire(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenu imposé comme des salaires (salaires, mais aussi 3vj, 3vk)"
+    label = "Revenu imposé comme des salaires (salaires, mais aussi 3vj, 3vk)"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -410,7 +410,7 @@ class revenu_assimile_salaire(Variable):
 class revenu_assimile_salaire_apres_abattements(Variable):
     value_type = float
     entity = Individu
-    label = u"Salaires et chômage imposables après abattements"
+    label = "Salaires et chômage imposables après abattements"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -432,7 +432,7 @@ class revenu_assimile_salaire_apres_abattements(Variable):
 class revenu_assimile_pension(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenu imposé comme des pensions (retraites, pensions alimentaires, etc.)"
+    label = "Revenu imposé comme des pensions (retraites, pensions alimentaires, etc.)"
     definition_period = YEAR
 
     def formula(individu, period):
@@ -447,7 +447,7 @@ class revenu_assimile_pension(Variable):
 class revenu_assimile_pension_apres_abattements(Variable):
     value_type = float
     entity = Individu
-    label = u"Pensions après abattements"
+    label = "Pensions après abattements"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -467,7 +467,7 @@ class revenu_assimile_pension_apres_abattements(Variable):
 class indu_plaf_abat_pen(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Plafonnement de l'abattement de 10% sur les pensions du foyer"
+    label = "Plafonnement de l'abattement de 10% sur les pensions du foyer"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -485,7 +485,7 @@ class indu_plaf_abat_pen(Variable):
 class abattement_salaires_pensions(Variable):
     value_type = float
     entity = Individu
-    label = u"Abattement de 20% sur les salaires et pensions, en vigueur jusqu'à 2006"
+    label = "Abattement de 20% sur les salaires et pensions, en vigueur jusqu'à 2006"
     end = '2005-12-31'
     definition_period = YEAR
 
@@ -505,9 +505,9 @@ class rente_viagere_titre_onereux(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = FoyerFiscal
-    label = u"Rentes viagères (rentes à titre onéreux)"
+    label = "Rentes viagères (rentes à titre onéreux)"
     set_input = set_input_divide_by_period
-    reference = u"http://fr.wikipedia.org/wiki/Rente_viagère"
+    reference = "http://fr.wikipedia.org/wiki/Rente_viagère"
     definition_period = MONTH
 
     def formula(foyer_fiscal, period, parameters):
@@ -523,8 +523,8 @@ class rente_viagere_titre_onereux(Variable):
 class rente_viagere_titre_onereux_net(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Rentes viagères après abattements"
-    reference = u"http://www.lafinancepourtous.fr/Vie-professionnelle-et-retraite/Retraite/Epargne-retraite/La-rente-viagere/La-fiscalite-de-la-rente-viagere"
+    label = "Rentes viagères après abattements"
+    reference = "http://www.lafinancepourtous.fr/Vie-professionnelle-et-retraite/Retraite/Epargne-retraite/La-rente-viagere/La-fiscalite-de-la-rente-viagere"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -550,7 +550,7 @@ class rente_viagere_titre_onereux_net(Variable):
 class traitements_salaires_pensions_rentes(Variable):
     value_type = float
     entity = Individu
-    label = u"Traitements salaires pensions et rentes individuelles"
+    label = "Traitements salaires pensions et rentes individuelles"
     definition_period = YEAR
 
     def formula(individu, period):
@@ -574,7 +574,7 @@ class traitements_salaires_pensions_rentes(Variable):
 class revenu_categoriel_plus_values(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenu catégoriel - Plus-values"
+    label = "Revenu catégoriel - Plus-values"
     reference = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
     definition_period = YEAR
 
@@ -610,7 +610,7 @@ class revenu_categoriel_plus_values(Variable):
 class revenu_categoriel_tspr(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenu catégoriel - Traitements, salaires, pensions et rentes"
+    label = "Revenu catégoriel - Traitements, salaires, pensions et rentes"
     reference = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
     definition_period = YEAR
 
@@ -626,7 +626,7 @@ class revenu_categoriel_tspr(Variable):
 class deficit_rcm(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Deficit capitaux mobiliers"
+    label = "Deficit capitaux mobiliers"
     reference = "http://www.lefigaro.fr/impots/2008/04/25/05003-20080425ARTFIG00254-les-subtilites-des-revenus-de-capitaux-mobiliers-.php"
     definition_period = YEAR
 
@@ -644,7 +644,7 @@ class deficit_rcm(Variable):
 class revenu_categoriel_capital(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenu catégoriel - Capitaux"
+    label = "Revenu catégoriel - Capitaux"
     reference = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
     definition_period = YEAR
 
@@ -854,7 +854,7 @@ class revenu_categoriel_capital(Variable):
 class rfr_rvcm_abattements_a_reintegrer(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Abattement sur revenus des valeurs et capitaux mobiliers à réintégrer dans le calcul du revenu fiscal de référence"
+    label = "Abattement sur revenus des valeurs et capitaux mobiliers à réintégrer dans le calcul du revenu fiscal de référence"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -917,7 +917,7 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
 class revenu_categoriel_foncier(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenu catégoriel - Foncier"
+    label = "Revenu catégoriel - Foncier"
     reference = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
     definition_period = YEAR
 
@@ -958,7 +958,7 @@ class revenu_categoriel_foncier(Variable):
 class revenu_categoriel_non_salarial(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenu catégoriel - Revenus personnels non salariés"
+    label = "Revenu catégoriel - Revenus personnels non salariés"
     reference = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
     definition_period = YEAR
 
@@ -986,7 +986,7 @@ class revenu_categoriel_non_salarial(Variable):
 class revenu_categoriel(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenus catégoriels"
+    label = "Revenus catégoriels"
     reference = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/revenus-categoriesl.htm"
     definition_period = YEAR
 
@@ -1011,7 +1011,7 @@ class revenu_categoriel(Variable):
 class deficit_ante(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Déficit global antérieur"
+    label = "Déficit global antérieur"
     reference = "http://impotsurlerevenu.org/declaration-de-revenus-fonciers-2044/796-deficits-anterieurs-restant-a-imputer-cadre-450.php"
     definition_period = YEAR
 
@@ -1032,7 +1032,7 @@ class deficit_ante(Variable):
 class rbg(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenu brut global"
+    label = "Revenu brut global"
     reference = "http://www.documentissime.fr/dossiers-droit-pratique/dossier-19-l-impot-sur-le-revenu-les-modalites-generales-d-imposition/la-determination-du-revenu-imposable/le-revenu-brut-global.html"
     definition_period = YEAR
 
@@ -1056,7 +1056,7 @@ class rbg(Variable):
 class csg_patrimoine_deductible_ir(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Csg déductible sur le patrimoine"
+    label = "Csg déductible sur le patrimoine"
     reference = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_ctrb_soc&typePage=cpr02&sfid=503&espId=1&communaute=1&impot=CS"
     definition_period = YEAR
 
@@ -1073,7 +1073,7 @@ class csg_patrimoine_deductible_ir(Variable):
 class rng(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenu net global"
+    label = "Revenu net global"
     reference = "http://impotsurlerevenu.org/definitions/114-revenu-net-global.php"
     definition_period = YEAR
 
@@ -1088,7 +1088,7 @@ class rng(Variable):
 class rni(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenu net imposable"
+    label = "Revenu net imposable"
     reference = "http://impotsurlerevenu.org/definitions/115-revenu-net-imposable.php"
     definition_period = YEAR
 
@@ -1102,7 +1102,7 @@ class rni(Variable):
 class ir_brut(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Impôt sur le revenu brut avant non imposabilité et plafonnement du quotient"
+    label = "Impôt sur le revenu brut avant non imposabilité et plafonnement du quotient"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -1117,7 +1117,7 @@ class ir_brut(Variable):
 class ir_ss_qf(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Impôt sans quotient familial"
+    label = "Impôt sans quotient familial"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -1135,7 +1135,7 @@ class ir_ss_qf(Variable):
 class ir_plaf_qf(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Impôt après plafonnement du quotient familial et réduction complémentaire"
+    label = "Impôt après plafonnement du quotient familial et réduction complémentaire"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -1331,7 +1331,7 @@ class ir_plaf_qf(Variable):
 class avantage_qf(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Avantage quotient familial"
+    label = "Avantage quotient familial"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -1344,7 +1344,7 @@ class avantage_qf(Variable):
 class decote(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"décote"
+    label = "décote"
     definition_period = YEAR
 
     def formula_2001_01_01(foyer_fiscal, period, parameters):
@@ -1368,7 +1368,7 @@ class decote(Variable):
 class decote_gain_fiscal(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Gain fiscal de la décote/Décote au sens Dgfip tel que sur la feuille d'impôt"
+    label = "Gain fiscal de la décote/Décote au sens Dgfip tel que sur la feuille d'impôt"
     definition_period = YEAR
 
     def formula_1982_01_01(foyer_fiscal, period, parameters):
@@ -1384,7 +1384,7 @@ class decote_gain_fiscal(Variable):
 class reduction_ss_condition_revenus(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt sous condition de revenus, s'imputant avant toutes autres réductions"
+    label = "Réduction d'impôt sous condition de revenus, s'imputant avant toutes autres réductions"
     definition_period = YEAR
 
     def formula_2016_01_01(foyer_fiscal, period, parameters):
@@ -1418,7 +1418,7 @@ class reduction_ss_condition_revenus(Variable):
 class nat_imp(Variable):
     value_type = bool
     entity = FoyerFiscal
-    label = u"nat_imp"
+    label = "nat_imp"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -1437,7 +1437,7 @@ class nat_imp(Variable):
 class ip_net(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Impôt sur le revenu après décote et réduction sous condition de revenus, avant réductions"
+    label = "Impôt sur le revenu après décote et réduction sous condition de revenus, avant réductions"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -1457,7 +1457,7 @@ class ip_net(Variable):
 class iaidrdi(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Impôt après imputation des réductions d'impôt"
+    label = "Impôt après imputation des réductions d'impôt"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -1473,7 +1473,7 @@ class iaidrdi(Variable):
 class cont_rev_loc(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Contribution sur les revenus locatifs"
+    label = "Contribution sur les revenus locatifs"
     definition_period = YEAR
 
     def formula_2001_01_01(foyer_fiscal, period, parameters):
@@ -1489,7 +1489,7 @@ class cont_rev_loc(Variable):
 class teicaa(Variable):  # f5rm
     value_type = float
     entity = FoyerFiscal
-    label = u"Taxe exceptionelle sur l'indemnité compensatrice des agents d'assurance"
+    label = "Taxe exceptionelle sur l'indemnité compensatrice des agents d'assurance"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -1507,7 +1507,7 @@ class teicaa(Variable):  # f5rm
 class assiette_vente(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Assiette régime microsociale pour les ventes"
+    label = "Assiette régime microsociale pour les ventes"
     definition_period = YEAR
 
     def formula_2009_01_01(foyer_fiscal, period, parameters):
@@ -1522,7 +1522,7 @@ class assiette_vente(Variable):
 class assiette_service(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Assiette régime microsociale pour les prestations et services"
+    label = "Assiette régime microsociale pour les prestations et services"
     definition_period = YEAR
 
     def formula_2009_01_01(foyer_fiscal, period, parameters):
@@ -1540,7 +1540,7 @@ class assiette_service(Variable):
 class assiette_proflib(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Assiette régime microsociale pour les professions libérales"
+    label = "Assiette régime microsociale pour les professions libérales"
     definition_period = YEAR
 
     def formula_2009_01_01(foyer_fiscal, period, parameters):
@@ -1560,7 +1560,7 @@ class assiette_proflib(Variable):
 class microsocial(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Assiette régime microsociale totale"
+    label = "Assiette régime microsociale totale"
     reference = "http://fr.wikipedia.org/wiki/R%C3%A9gime_micro-social"
     definition_period = YEAR
 
@@ -1580,7 +1580,7 @@ class microsocial(Variable):
 class microentreprise(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"microentreprise"
+    label = "microentreprise"
     definition_period = YEAR
 
     def formula_2009_01_01(foyer_fiscal, period, parameters):
@@ -1601,7 +1601,7 @@ class microentreprise(Variable):
 class tax_rvcm_forfaitaire(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Taxation forfaitaire des revenus des valeurs et capitaux mobiliers"
+    label = "Taxation forfaitaire des revenus des valeurs et capitaux mobiliers"
     reference = "http://bofip.impots.gouv.fr/bofip/3727-PGP.html"
     definition_period = YEAR
     end = '2017-12-31'
@@ -1619,7 +1619,7 @@ class tax_rvcm_forfaitaire(Variable):
 class taxation_plus_values_hors_bareme(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Taxation forfaitaire des plus-values"
+    label = "Taxation forfaitaire des plus-values"
     reference = "http://bofip.impots.gouv.fr/bofip/6957-PGP"
     definition_period = YEAR
 
@@ -1789,7 +1789,7 @@ class taxation_plus_values_hors_bareme(Variable):
 class rfr_plus_values_hors_rni(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Plus-values hors RNI entrant dans le calcul du revenu fiscal de référence (PV au barème, PV éxonérées ..)"
+    label = "Plus-values hors RNI entrant dans le calcul du revenu fiscal de référence (PV au barème, PV éxonérées ..)"
     definition_period = YEAR
 
     def formula_2011_01_01(foyer_fiscal, period, parameters):
@@ -1938,7 +1938,7 @@ class rfr_plus_values_hors_rni(Variable):
 class iai(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Impôt avant imputations de l'impôt sur le revenu"
+    label = "Impôt avant imputations de l'impôt sur le revenu"
     reference = "http://forum-juridique.net-iris.fr/finances-fiscalite-assurance/43963-declaration-impots.html"
     definition_period = YEAR
 
@@ -1969,7 +1969,7 @@ class iai(Variable):
 class cehr(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Contribution exceptionnelle sur les hauts revenus"
+    label = "Contribution exceptionnelle sur les hauts revenus"
     reference = "http://www.legifrance.gouv.fr/affichCode.do?cidTexte=LEGITEXT000006069577&idSectionTA=LEGISCTA000025049019"
     definition_period = YEAR
 
@@ -1989,7 +1989,7 @@ class cehr(Variable):
 class irpp(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Impôt sur le revenu des personnes physiques restant à payer, après prise en compte des éventuels acomptes"
+    label = "Impôt sur le revenu des personnes physiques restant à payer, après prise en compte des éventuels acomptes"
     reference = "http://www.impots.gouv.fr/portal/dgi/public/particuliers.impot?pageId=part_impot_revenu&espId=1&impot=IR&sfid=50"
     definition_period = YEAR
 
@@ -2031,7 +2031,7 @@ class irpp(Variable):
 class foyer_impose(Variable):
     value_type = bool
     entity = FoyerFiscal
-    label = u"Le foyer fiscal est imposé"
+    label = "Le foyer fiscal est imposé"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -2046,8 +2046,8 @@ class foyer_impose(Variable):
 class pensions_alimentaires_versees(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Pensions alimentaires versées"
-    reference = u"http://vosdroits.service-public.fr/particuliers/F2.xhtml"
+    label = "Pensions alimentaires versées"
+    reference = "http://vosdroits.service-public.fr/particuliers/F2.xhtml"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -2064,7 +2064,7 @@ class pensions_alimentaires_versees(Variable):
 class rfr(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenu fiscal de référence"
+    label = "Revenu fiscal de référence"
     reference = "http://bofip.impots.gouv.fr/bofip/5934-PGP.html?identifiant=BOI-IF-TH-10-50-30-20-20121127#5934-PGP_Calcul_du_revenu_fiscal_de__40"
     definition_period = YEAR
 
@@ -2099,7 +2099,7 @@ class rfr(Variable):
 class glo(Variable):
     value_type = float
     entity = Individu
-    label = u"Gain de levée d'options"
+    label = "Gain de levée d'options"
     reference = "http://www.officeo.fr/imposition-au-bareme-progressif-de-l-impot-sur-le-revenu-des-gains-de-levee-d-options-sur-actions-et-attributions-d-actions-gratuites"
     definition_period = YEAR
 
@@ -2141,7 +2141,7 @@ class glo(Variable):
 class credits_impot_sur_valeurs_etrangeres(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Avoir fiscal et crédits d'impôt"
+    label = "Avoir fiscal et crédits d'impôt"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -2153,7 +2153,7 @@ class credits_impot_sur_valeurs_etrangeres(Variable):
 class rpns_pvce(Variable):
     value_type = float
     entity = Individu
-    label = u"Plus values de cession - Revenu des professions non salariées"
+    label = "Plus values de cession - Revenu des professions non salariées"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -2188,7 +2188,7 @@ class rpns_pvce(Variable):
 class rpns_exon(Variable):
     value_type = float
     entity = Individu
-    label = u"Plus values de cession exonérées -Revenu des professions non salariées"
+    label = "Plus values de cession exonérées -Revenu des professions non salariées"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -2227,7 +2227,7 @@ class rpns_exon(Variable):
 class defrag(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Déficit agricole des années antérieures"
+    label = "Déficit agricole des années antérieures"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -2256,7 +2256,7 @@ class defrag(Variable):
 class defacc(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Déficit industriels et commerciaux non professionnels des années antérieures"
+    label = "Déficit industriels et commerciaux non professionnels des années antérieures"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -2291,7 +2291,7 @@ class defacc(Variable):
 class defncn(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Déficit non commerciaux non professionnels des années antérieures"
+    label = "Déficit non commerciaux non professionnels des années antérieures"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -2323,7 +2323,7 @@ class defncn(Variable):
 class defmeu(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Déficit des locations meublées non professionnelles des années antérieures"
+    label = "Déficit des locations meublées non professionnelles des années antérieures"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -2348,7 +2348,7 @@ class defmeu(Variable):
 class rag(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenus agricoles"
+    label = "Revenus agricoles"
     reference = "http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&impot=BA&pageId=prof_ba&sfid=50"
     definition_period = YEAR
 
@@ -2377,7 +2377,7 @@ class rag(Variable):
 class ric(Variable):
     value_type = float
     entity = Individu
-    label = u"Bénéfices industriels et commerciaux"
+    label = "Bénéfices industriels et commerciaux"
     reference = "http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?pageId=prof_bic&espId=2&impot=BIC&sfid=50"
     definition_period = YEAR
 
@@ -2429,7 +2429,7 @@ class ric(Variable):
 class rac(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenus accessoires individuels"
+    label = "Revenus accessoires individuels"
     reference = "http://vosdroits.service-public.fr/particuliers/F1225.xhtml"
     definition_period = YEAR
 
@@ -2476,7 +2476,7 @@ class rac(Variable):
 class rnc(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenus non commerciaux individuels"
+    label = "Revenus non commerciaux individuels"
     reference = "http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&pageId=prof_bnc&impot=BNC&sfid=50"
     definition_period = YEAR
 
@@ -2515,7 +2515,7 @@ class rnc(Variable):
 class rpns(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenus individuels des professions non salariées"
+    label = "Revenus individuels des professions non salariées"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -2530,7 +2530,7 @@ class rpns(Variable):
 class rpns_pvct(Variable):
     value_type = float
     entity = Individu
-    label = u"Plus values de court terme -Revenu des professions non salariées"
+    label = "Plus values de court terme -Revenu des professions non salariées"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -2549,7 +2549,7 @@ class rpns_pvct(Variable):
 class moins_values_court_terme_nonpro(Variable):
     value_type = float
     entity = Individu
-    label = u"Moins values de court terme - Revenu des professions non salariées non profesionnelles"
+    label = "Moins values de court terme - Revenu des professions non salariées non profesionnelles"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -2562,7 +2562,7 @@ class moins_values_court_terme_nonpro(Variable):
 class moins_values_court_terme_pro(Variable):
     value_type = float
     entity = Individu
-    label = u"Moins values de court terme - Revenu des professions non salariées profesionnelles"
+    label = "Moins values de court terme - Revenu des professions non salariées profesionnelles"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -2581,7 +2581,7 @@ class moins_values_court_terme_pro(Variable):
 class moins_values_court_terme_non_salaries(Variable):
     value_type = float
     entity = Individu
-    label = u"Moins values de court terme - Revenu des professions non salariées (toutes)"
+    label = "Moins values de court terme - Revenu des professions non salariées (toutes)"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -2594,7 +2594,7 @@ class moins_values_court_terme_non_salaries(Variable):
 class moins_values_long_terme_non_salaries(Variable):
     value_type = float
     entity = Individu
-    label = u"Moins values de long terme - Revenu des professions non salariées"
+    label = "Moins values de long terme - Revenu des professions non salariées"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -2609,7 +2609,7 @@ class moins_values_long_terme_non_salaries(Variable):
 class rpns_revenus_forfait_agricole(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenus du forfait agricole - Revenus des professions non salariées"
+    label = "Revenus du forfait agricole - Revenus des professions non salariées"
     definition_period = YEAR
     end = '2015-12-31'  # TODO : le forfait agricole est remplaçé par le régime micro-bénéfices agricoles à partir de 2016
 
@@ -2623,7 +2623,7 @@ class rpns_revenus_forfait_agricole(Variable):
 class rpns_individu(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenus des professions non salariées individuels"
+    label = "Revenus des professions non salariées individuels"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -2787,7 +2787,7 @@ class rpns_individu(Variable):
 class abat_spe(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Abattements spéciaux"
+    label = "Abattements spéciaux"
     reference = "http://bofip.impots.gouv.fr/bofip/2036-PGP"
     definition_period = YEAR
 
@@ -2866,7 +2866,7 @@ class abat_spe(Variable):
 class taux_effectif(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"taux_effectif"
+    label = "taux_effectif"
     definition_period = YEAR
 
     def formula_2009_01_01(foyer_fiscal, period, parameters):
@@ -2887,7 +2887,7 @@ class taux_effectif(Variable):
 class taux_moyen_imposition(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Taux moyen d'imposition"
+    label = "Taux moyen d'imposition"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -2906,7 +2906,7 @@ class taux_moyen_imposition(Variable):
 class nbptr(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Nombre de parts"
+    label = "Nombre de parts"
     reference = "http://vosdroits.service-public.fr/particuliers/F2705.xhtml"
     definition_period = YEAR
 
@@ -3019,7 +3019,7 @@ class nbptr(Variable):
 class ppe_coef(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Coefficient de conversion - Prime pour l'emploi"
+    label = "Coefficient de conversion - Prime pour l'emploi"
     end = '2015-12-31'
     definition_period = YEAR
 
@@ -3036,7 +3036,7 @@ class ppe_coef(Variable):
 class ppe_elig(Variable):
     value_type = bool
     entity = FoyerFiscal
-    label = u"PPE: eligibilité à la ppe, condition sur le revenu fiscal de référence"
+    label = "PPE: eligibilité à la ppe, condition sur le revenu fiscal de référence"
     end = '2015-12-31'
     definition_period = YEAR
 
@@ -3064,7 +3064,7 @@ class ppe_elig(Variable):
 class ppe_rev(Variable):
     value_type = float
     entity = Individu
-    label = u"Base ressource de la ppe"
+    label = "Base ressource de la ppe"
     end = '2015-12-31'
     definition_period = YEAR
 
@@ -3085,7 +3085,7 @@ class ppe_rev(Variable):
 class ppe_coef_tp(Variable):
     value_type = float
     entity = Individu
-    label = u"PPE: coefficient de conversion temps partiel"
+    label = "PPE: coefficient de conversion temps partiel"
     end = '2015-12-31'
     definition_period = YEAR
 
@@ -3105,7 +3105,7 @@ class ppe_coef_tp(Variable):
 class ppe_base(Variable):
     value_type = float
     entity = Individu
-    label = u"Montant de base de la PPE"
+    label = "Montant de base de la PPE"
     end = '2015-12-31'
     definition_period = YEAR
 
@@ -3120,7 +3120,7 @@ class ppe_base(Variable):
 class ppe_elig_individu(Variable):
     value_type = bool
     entity = Individu
-    label = u"Eligibilité individuelle à la ppe"
+    label = "Eligibilité individuelle à la ppe"
     end = '2015-12-31'
     definition_period = YEAR
 
@@ -3139,7 +3139,7 @@ class ppe_elig_individu(Variable):
 class ppe_brute(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Prime pour l'emploi brute"
+    label = "Prime pour l'emploi brute"
     end = '2015-12-31'
     definition_period = YEAR
 
@@ -3245,7 +3245,7 @@ class ppe_brute(Variable):
 class ppe(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Prime pour l'emploi"
+    label = "Prime pour l'emploi"
     end = '2015-12-31'
     reference = "http://vosdroits.service-public.fr/particuliers/F2882.xhtml"
     definition_period = YEAR

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/plus_values_immobilieres.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/plus_values_immobilieres.py
@@ -73,7 +73,7 @@ from openfisca_france.model.base import *
 class ir_pv_immo(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Impôt sur le revenu afférent à la plus-value immobilière"
+    label = "Impôt sur le revenu afférent à la plus-value immobilière"
     reference = "http://www.impots.gouv.fr/portal/dgi/public/popup?espId=1&typePage=cpr02&docOid=documentstandard_2157"
     definition_period = YEAR
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -12,57 +12,57 @@ log = logging.getLogger(__name__)
 class assurance_vie_pfu_ir_plus8ans_1990_19970926(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée d'au moins 8 ans pour les contrats souscrits entre le 1er janvier 1990 et le 26 septembre 1997, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée d'au moins 8 ans pour les contrats souscrits entre le 1er janvier 1990 et le 26 septembre 1997, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
     definition_period = YEAR
 
 
 class assurance_vie_pfu_ir_plus6ans_avant1990(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée d'au moins 6 ans pour les contrats souscrits avant le 1er janvier 1990, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée d'au moins 6 ans pour les contrats souscrits avant le 1er janvier 1990, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
     definition_period = YEAR
 
 
 class assurance_vie_pfu_ir_moins4ans_1990_19970926(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée de moins de 4 ans pour les contrats souscrits entre le 1er janvier 1990 et le 26 septembre 1997, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée de moins de 4 ans pour les contrats souscrits entre le 1er janvier 1990 et le 26 septembre 1997, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
     definition_period = YEAR
 
 
 class assurance_vie_pfu_ir_4_8_ans_1990_19970926(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée entre 4 et 8 ans pour les contrats souscrits entre le 1er janvier 1990 et le 26 septembre 1997, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée entre 4 et 8 ans pour les contrats souscrits entre le 1er janvier 1990 et le 26 septembre 1997, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
     definition_period = YEAR
 
 
 class assurance_vie_pfu_ir_plus8ans_19970926_primes_avant_20170927(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie de plus de 8 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées avant le 27 septembre 2017, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie de plus de 8 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées avant le 27 septembre 2017, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
     definition_period = YEAR
 
 
 class assurance_vie_pfu_ir_4_8_ans_19970926_primes_avant_20170927(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie entre 4 et 8 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées avant le 27 septembre 2017, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie entre 4 et 8 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées avant le 27 septembre 2017, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
     definition_period = YEAR
 
 
 class assurance_vie_pfu_ir_moins4ans_19970926_primes_avant_20170927(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie de moins de 4 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées avant le 27 septembre 2017, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie de moins de 4 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées avant le 27 septembre 2017, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
     definition_period = YEAR
 
 
 class f2zz(Variable):
-    cerfa_field = u"2ZZ"
+    cerfa_field = "2ZZ"
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie de moins de 8 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées après le 27 septembre 2017, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie de moins de 8 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées après le 27 septembre 2017, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
     definition_period = YEAR
     # start_date = date(2018, 1, 1)
 
@@ -70,7 +70,7 @@ class f2zz(Variable):
 class f2vv(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie de plus de 8 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées après le 27 septembre 2017, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu; produit correspondant aux primes n'excédant pas 150 000 euros."
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie de plus de 8 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées après le 27 septembre 2017, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu; produit correspondant aux primes n'excédant pas 150 000 euros."
     definition_period = YEAR
     # start_date = date(2018, 1, 1)
 
@@ -78,7 +78,7 @@ class f2vv(Variable):
 class f2ww(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie de plus de 8 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées après le 27 septembre 2017, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu; produit correspondant aux primes excédant pas 150 000 euros."
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie de plus de 8 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées après le 27 septembre 2017, et que le bénéficiaire décide de soumettre au prélèvement forfaitaire unique au titre de l'impôt sur le revenu; produit correspondant aux primes excédant pas 150 000 euros."
     definition_period = YEAR
     # start_date = date(2018, 1, 1)
 
@@ -86,7 +86,7 @@ class f2ww(Variable):
 class assurance_vie_pfu_ir(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie soumis au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie soumis au prélèvement forfaitaire unique au titre de l'impôt sur le revenu"
     definition_period = YEAR
 
     def formula_2018_01_01(foyer_fiscal, period):
@@ -100,7 +100,7 @@ class assurance_vie_pfu_ir(Variable):
 class revenus_capitaux_prelevement_forfaitaire_unique_ir(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenus des valeurs et capitaux mobiliers soumis au prélèvement forfaitaire unique (partie impôt sur le revenu)"
+    label = "Revenus des valeurs et capitaux mobiliers soumis au prélèvement forfaitaire unique (partie impôt sur le revenu)"
     definition_period = MONTH
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
@@ -123,7 +123,7 @@ class revenus_capitaux_prelevement_forfaitaire_unique_ir(Variable):
 class plus_values_prelevement_forfaitaire_unique_ir(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Plus-values soumises au prélèvement forfaitaire unique (partie impôt sur le revenu)"
+    label = "Plus-values soumises au prélèvement forfaitaire unique (partie impôt sur le revenu)"
     definition_period = YEAR
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
@@ -140,7 +140,7 @@ class plus_values_prelevement_forfaitaire_unique_ir(Variable):
 class prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Partie du prélèvement forfaitaire unique associée à l'impôt sur le revenu (hors assurance-vie, épargne solidaire et produits venant des états non-coopératifs)"
+    label = "Partie du prélèvement forfaitaire unique associée à l'impôt sur le revenu (hors assurance-vie, épargne solidaire et produits venant des états non-coopératifs)"
     definition_period = YEAR
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
@@ -182,7 +182,7 @@ class prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_eta
 class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Partie du prélèvement forfaitaire unique associée à l'impôt sur le revenu sur l'assurance-vie"
+    label = "Partie du prélèvement forfaitaire unique associée à l'impôt sur le revenu sur l'assurance-vie"
     definition_period = YEAR
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
@@ -209,7 +209,7 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
 class prelevement_forfaitaire_unique_ir(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Partie du prélèvement forfaitaire unique associée à l'impôt sur le revenu"
+    label = "Partie du prélèvement forfaitaire unique associée à l'impôt sur le revenu"
     definition_period = YEAR
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/prelevement_forfaitaire_liberatoire.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/prelevement_forfaitaire_liberatoire.py
@@ -9,42 +9,42 @@ log = logging.getLogger(__name__)
 class assurance_vie_pl_non_anonyme_plus8ans_depuis1990(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée d'au moins 8 ans pour les contrats souscrits depuis le 1er janvier 1990, et que le bénéficiaire décide de soumettre au prélèvement libératoire"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée d'au moins 8 ans pour les contrats souscrits depuis le 1er janvier 1990, et que le bénéficiaire décide de soumettre au prélèvement libératoire"
     definition_period = YEAR
 
 
 class assurance_vie_pl_non_anonyme_plus6ans_avant1990(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée d'au moins 6 ans pour les contrats souscrits précédemment, et que le bénéficiaire décide de soumettre au prélèvement libératoire"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée d'au moins 6 ans pour les contrats souscrits précédemment, et que le bénéficiaire décide de soumettre au prélèvement libératoire"
     definition_period = YEAR
 
 
 class assurance_vie_pl_non_anonyme_moins4ans_depuis1990(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée de moins de 4 ans, pour les contrats souscrits depuis le 1er janvier 1990, et que le bénéficiaire décide de soumettre au prélèvement libératoire"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée de moins de 4 ans, pour les contrats souscrits depuis le 1er janvier 1990, et que le bénéficiaire décide de soumettre au prélèvement libératoire"
     definition_period = YEAR
 
 
 class assurance_vie_pl_non_anonyme_4_8_ans_depuis1990(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée de 4 à 8 ans, pour les contrats souscrits depuis le 1er janvier 1990, et que le bénéficiaire décide de soumettre au prélèvement libératoire"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie d'une durée de 4 à 8 ans, pour les contrats souscrits depuis le 1er janvier 1990, et que le bénéficiaire décide de soumettre au prélèvement libératoire"
     definition_period = YEAR
 
 
 class assurance_vie_pl_anonyme(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie lorsque le bénéficiaire ne révèle pas son identité et son domicile fiscal, et qu'il décide de soumettre ces produits au prélèvement libératoire"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie lorsque le bénéficiaire ne révèle pas son identité et son domicile fiscal, et qu'il décide de soumettre ces produits au prélèvement libératoire"
     definition_period = YEAR
 
 
 class prelevement_forfaitaire_liberatoire(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Prelèvement forfaitaire libératoire sur les revenus du capital"
+    label = "Prelèvement forfaitaire libératoire sur les revenus du capital"
     reference = "art. 125-0 A du Code Général des Impôts"
     definition_period = YEAR
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/variables_communes.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/variables_communes.py
@@ -11,12 +11,12 @@ log = logging.getLogger(__name__)
 class produit_epargne_solidaire(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produit d'épargne solidaire"
+    label = "Produit d'épargne solidaire"
     definition_period = YEAR
 
 
 class produit_etats_non_cooperatif(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits de placement à revenus fixe ou de contrats de capitalisation et d'assurance-vie versés à un bénéficiaire résidant dans un état non-coopératif"
+    label = "Produits de placement à revenus fixe ou de contrats de capitalisation et d'assurance-vie versés à un bénéficiaire résidant dans un état non-coopératif"
     definition_period = YEAR

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 class reductions(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réductions d'impôt sur le revenu"
+    label = "Réductions d'impôt sur le revenu"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -59,7 +59,7 @@ class reductions(Variable):
 class accult(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Acquisition de biens culturels"
+    label = "Acquisition de biens culturels"
     definition_period = YEAR
 
     def formula_2002(foyer_fiscal, period, parameters):
@@ -76,7 +76,7 @@ class accult(Variable):
 class adhcga(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"adhcga"
+    label = "adhcga"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -94,7 +94,7 @@ class adhcga(Variable):
 class assvie(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"assvie"
+    label = "assvie"
     end = '2004-12-31'
     definition_period = YEAR
 
@@ -116,7 +116,7 @@ class assvie(Variable):
 class cappme(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt au titre des souscriptions en numéraire au capital de PME non côtées"
+    label = "Réduction d'impôt au titre des souscriptions en numéraire au capital de PME non côtées"
     reference = "http://bofip.impots.gouv.fr/bofip/4374-PGP"
     definition_period = YEAR
 
@@ -495,7 +495,7 @@ class cappme(Variable):
 class reduction_cotisations_syndicales(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt pour cotisations syndicales"
+    label = "Réduction d'impôt pour cotisations syndicales"
     definition_period = YEAR
     end = '2011-12-31'
 
@@ -509,7 +509,7 @@ class reduction_cotisations_syndicales(Variable):
 class cotsyn(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Montant de la réduction ou crédit d'impôt pour cotisations syndicales"
+    label = "Montant de la réduction ou crédit d'impôt pour cotisations syndicales"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -527,7 +527,7 @@ class cotsyn(Variable):
 class creaen(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"creaen"
+    label = "creaen"
     definition_period = YEAR
     end = '2014-12-31'
 
@@ -598,7 +598,7 @@ class creaen(Variable):
 class deffor(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"deffor"
+    label = "deffor"
     definition_period = YEAR
 
     def formula_2006_01_01(foyer_fiscal, period, parameters):
@@ -615,7 +615,7 @@ class deffor(Variable):
 class daepad(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"daepad"
+    label = "daepad"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -633,7 +633,7 @@ class daepad(Variable):
 class dfppce(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Dons à des organismes d'intérêt général et dons pour le financement des partis politiques"
+    label = "Dons à des organismes d'intérêt général et dons pour le financement des partis politiques"
     reference = "http://bofip.impots.gouv.fr/bofip/5823-PGP"
     definition_period = YEAR
 
@@ -799,7 +799,7 @@ class dfppce(Variable):
 class doment(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"doment"
+    label = "doment"
     definition_period = YEAR
 
     def formula_2005_01_01(foyer_fiscal, period, parameters):
@@ -1659,7 +1659,7 @@ class doment(Variable):
 class domlog(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt au titre des investissements outre-mer réalisés par des personnes physiques"
+    label = "Réduction d'impôt au titre des investissements outre-mer réalisés par des personnes physiques"
     reference = "http://bofip.impots.gouv.fr/bofip/6716-PGP"
     definition_period = YEAR
 
@@ -2124,7 +2124,7 @@ class domlog(Variable):
 class domsoc(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt au titre de l'acquisition ou de la souscription de logements sociaux outre-mer"
+    label = "Réduction d'impôt au titre de l'acquisition ou de la souscription de logements sociaux outre-mer"
     reference = "http://bofip.impots.gouv.fr/bofip/9398-PGP"
     definition_period = YEAR
 
@@ -2396,7 +2396,7 @@ class domsoc(Variable):
 class donapd(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"donapd"
+    label = "donapd"
     reference = "http://bofip.impots.gouv.fr/bofip/5873-PGP?datePubl=vig#5873-PGP_Cas_particulier_des_dons_fa_21"
     definition_period = YEAR
 
@@ -2423,7 +2423,7 @@ class donapd(Variable):
 class duflot(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt en faveur de l'investissement locatif intermédiaire - Dispositif Duflot"
+    label = "Réduction d'impôt en faveur de l'investissement locatif intermédiaire - Dispositif Duflot"
     reference = "http://bofip.impots.gouv.fr/bofip/8425-PGP"
     definition_period = YEAR
 
@@ -2554,7 +2554,7 @@ class duflot(Variable):
 class ecodev(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"ecodev"
+    label = "ecodev"
     end = '2009-12-31'
     definition_period = YEAR
 
@@ -2573,7 +2573,7 @@ class ecodev(Variable):
 class ecpess(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"ecpess"
+    label = "ecpess"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -2598,7 +2598,7 @@ class ecpess(Variable):
 class garext(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt en faveur des dépenses de frais de garde des jeunes enfants"
+    label = "Réduction d'impôt en faveur des dépenses de frais de garde des jeunes enfants"
     reference = "http://bofip.impots.gouv.fr/bofip/865-PGP?datePubl=13/04/2013#"
     definition_period = YEAR
     end = '2004-12-31'
@@ -2647,7 +2647,7 @@ class garext(Variable):
 class intagr(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"intagr"
+    label = "intagr"
     definition_period = YEAR
 
     def formula_2005_01_01(foyer_fiscal, period, parameters):
@@ -2666,7 +2666,7 @@ class intagr(Variable):
 class intcon(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"intcon"
+    label = "intcon"
     end = '2005-12-31'
     definition_period = YEAR
 
@@ -2685,7 +2685,7 @@ class intcon(Variable):
 class intemp(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"intemp"
+    label = "intemp"
     end = '2003-12-31'
     definition_period = YEAR
 
@@ -2705,7 +2705,7 @@ class intemp(Variable):
 class invfor(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt au titre des investissements forestiers"
+    label = "Réduction d'impôt au titre des investissements forestiers"
     reference = "http://bofip.impots.gouv.fr/bofip/5537-PGP"
     definition_period = YEAR
 
@@ -3011,7 +3011,7 @@ class invfor(Variable):
 class invlst(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt en faveur des investissements dans le secteur touristique"
+    label = "Réduction d'impôt en faveur des investissements dans le secteur touristique"
     reference = "http://bofip.impots.gouv.fr/bofip/6265-PGP"
     definition_period = YEAR
 
@@ -3345,7 +3345,7 @@ class invlst(Variable):
 class invrev(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt en faveur des investissements dans les résidences de tourisme"
+    label = "Réduction d'impôt en faveur des investissements dans les résidences de tourisme"
     reference = "http://bofip.impots.gouv.fr/bofip/6266-PGP"
     end = '2003-12-31'
     definition_period = YEAR
@@ -3376,7 +3376,7 @@ class invrev(Variable):
 class locmeu(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt en faveur de l'acquisition de logements destinés à la location meublée non professionnelle - Dispositif Censi-Bouvard"
+    label = "Réduction d'impôt en faveur de l'acquisition de logements destinés à la location meublée non professionnelle - Dispositif Censi-Bouvard"
     reference = "http://bofip.impots.gouv.fr/bofip/4885-PGP"
     definition_period = YEAR
 
@@ -3989,7 +3989,7 @@ class locmeu(Variable):
 class mecena(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Mécénat d'entreprise"
+    label = "Mécénat d'entreprise"
     definition_period = YEAR
 
     def formula_2003_01_01(foyer_fiscal, period, parameters):
@@ -4005,7 +4005,7 @@ class mecena(Variable):
 class mohist(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"mohist"
+    label = "mohist"
     definition_period = YEAR
 
     def formula_2008_01_01(foyer_fiscal, period, parameters):
@@ -4022,7 +4022,7 @@ class mohist(Variable):
 class patnat(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt en faveur des dépenses de préservation du patrimoine naturel"
+    label = "Réduction d'impôt en faveur des dépenses de préservation du patrimoine naturel"
     reference = "http://bofip.impots.gouv.fr/bofip/6240-PGP"
     definition_period = YEAR
 
@@ -4103,7 +4103,7 @@ class patnat(Variable):
 class prcomp(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Prestations compensatoires"
+    label = "Prestations compensatoires"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -4137,7 +4137,7 @@ class prcomp(Variable):
 class reduction_impot_exceptionnelle(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt exceptionnelle"
+    label = "Réduction d'impôt exceptionnelle"
     end = '2013-12-31'
     definition_period = YEAR
 
@@ -4154,7 +4154,7 @@ class reduction_impot_exceptionnelle(Variable):
 class rehab(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt pour travaux de réhabilitation des résidences de tourisme"
+    label = "Réduction d'impôt pour travaux de réhabilitation des résidences de tourisme"
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000033781921&cidTexte=LEGITEXT000006069577&categorieLien=id&dateTexte=20170101"
     definition_period = YEAR
 
@@ -4172,7 +4172,7 @@ class rehab(Variable):
 class repsoc(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"repsoc"
+    label = "repsoc"
     definition_period = YEAR
 
     def formula_2003_01_01(foyer_fiscal, period, parameters):
@@ -4191,7 +4191,7 @@ class repsoc(Variable):
 class resimm(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt au titre des dépenses de restauration immobilière - Dispositif Malraux"
+    label = "Réduction d'impôt au titre des dépenses de restauration immobilière - Dispositif Malraux"
     reference = "http://bofip.impots.gouv.fr/bofip/1372-PGP"
     definition_period = YEAR
 
@@ -4343,7 +4343,7 @@ class resimm(Variable):
 class rpinel(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt en faveur de l'investissement locatif intermédiaire - Dispositif Pinel"
+    label = "Réduction d'impôt en faveur de l'investissement locatif intermédiaire - Dispositif Pinel"
     reference = "http://bofip.impots.gouv.fr/bofip/8425-PGP"
     definition_period = YEAR
 
@@ -4450,7 +4450,7 @@ class rpinel(Variable):
 class rsceha(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"rsceha"
+    label = "rsceha"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -4470,7 +4470,7 @@ class rsceha(Variable):
 class saldom(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt au titre des sommes versées pour l'emploi d'un salarié à domicile"
+    label = "Réduction d'impôt au titre des sommes versées pour l'emploi d'un salarié à domicile"
     reference = "http://bofip.impots.gouv.fr/bofip/3968-PGP.html?identifiant=BOI-IR-RICI-150-20-20150515#"
     definition_period = YEAR
     end = '2016-12-31'
@@ -4576,7 +4576,7 @@ class saldom(Variable):
 class scelli(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Réduction d'impôt au titre des investissements locatifs - Dispositif Scellier"
+    label = "Réduction d'impôt au titre des investissements locatifs - Dispositif Scellier"
     reference = "http://bofip.impots.gouv.fr/bofip/4951-PGP"
     definition_period = YEAR
 
@@ -5365,7 +5365,7 @@ class scelli(Variable):
 class sofica(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"sofica"
+    label = "sofica"
     definition_period = YEAR
 
     def formula_2006_01_01(foyer_fiscal, period, parameters):
@@ -5408,7 +5408,7 @@ class sofica(Variable):
 class sofipe(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"sofipe"
+    label = "sofipe"
     end = '2011-01-01'
     definition_period = YEAR
 
@@ -5429,7 +5429,7 @@ class sofipe(Variable):
 class spfcpi(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"spfcpi"
+    label = "spfcpi"
     reference = "http://bofip.impots.gouv.fr/bofip/5321-PGP"
     definition_period = YEAR
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -5,89 +5,89 @@ from openfisca_france.model.base import *
 
 # Dons à des organismes établis en France
 class f7ud(Variable):
-    cerfa_field = u"7UD"
+    cerfa_field = "7UD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dons à des organismes d'aide aux personnes en difficulté"
+    label = "Dons à des organismes d'aide aux personnes en difficulté"
     definition_period = YEAR
 
 
 # début/fin ?
 class f7uf(Variable):
-    cerfa_field = u"7UF"
+    cerfa_field = "7UF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dons à d'autres oeuvres d'utilité publique ou fiscalement assimilables aux oeuvres d'intérêt général"
+    label = "Dons à d'autres oeuvres d'utilité publique ou fiscalement assimilables aux oeuvres d'intérêt général"
     definition_period = YEAR
 
 
 class f7xs(Variable):
-    cerfa_field = u"7XS"
+    cerfa_field = "7XS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -5"
+    label = "Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -5"
     definition_period = YEAR
 
 
 class f7xt(Variable):
-    cerfa_field = u"7XT"
+    cerfa_field = "7XT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -4"
+    label = "Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -4"
     definition_period = YEAR
 
 
 class f7xu(Variable):
-    cerfa_field = u"7XU"
+    cerfa_field = "7XU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -3"
+    label = "Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -3"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 class f7xw(Variable):
-    cerfa_field = u"7XW"
+    cerfa_field = "7XW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -2"
+    label = "Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -2"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f7xy(Variable):
-    cerfa_field = u"7XY"
+    cerfa_field = "7XY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -1"
+    label = "Report des années antérieures des dons (report des réductions et crédits d'impôt): année de perception des revenus -1"
     # start_date = date(2008, 1, 1)
     definition_period = YEAR
 
 
 class f7va(Variable):
-    cerfa_field = u"7VA"
+    cerfa_field = "7VA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dons à des organismes d'aides aux personnes établis dans un Etat européen"
+    label = "Dons à des organismes d'aides aux personnes établis dans un Etat européen"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 # f7va, f7vc 2011 ou 2013 ?
 class f7vc(Variable):
-    cerfa_field = u"7VC"
+    cerfa_field = "7VC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dons à des autres organismes établis dans un Etat européen"
+    label = "Dons à des autres organismes établis dans un Etat européen"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
@@ -98,14 +98,14 @@ class f7vc(Variable):
 # f7ac, f7ae, f7ag
 class f7ac(Variable):
     cerfa_field = {
-        0: u"7AC",
-        1: u"7AE",
-        2: u"7AG",
+        0: "7AC",
+        1: "7AE",
+        2: "7AG",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Cotisations syndicales des salariées et pensionnés"
+    label = "Cotisations syndicales des salariées et pensionnés"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
@@ -114,110 +114,110 @@ class f7ac(Variable):
 
 
 class f7db(Variable):
-    cerfa_field = u"7DB"
+    cerfa_field = "7DB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Sommes versées pour l'emploi d'un salarié à domicile par les personnes ayant excercé une activité professionnelle ou ayant été demandeur d'emploi l'année de perception des revenus déclarés"
+    label = "Sommes versées pour l'emploi d'un salarié à domicile par les personnes ayant excercé une activité professionnelle ou ayant été demandeur d'emploi l'année de perception des revenus déclarés"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f7dd(Variable):
-    cerfa_field = u"7DD"
+    cerfa_field = "7DD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Sommes versées pour l'emploi d'un salarié à domicile pour un ascendant bénéficiaire de l'APA "
+    label = "Sommes versées pour l'emploi d'un salarié à domicile pour un ascendant bénéficiaire de l'APA "
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7df(Variable):
-    cerfa_field = u"7DF"
+    cerfa_field = "7DF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Sommes versées pour l'emploi d'un salarié à domicile par les personnes retraités, ou inactives l'année de perception des revenus déclarés"
+    label = "Sommes versées pour l'emploi d'un salarié à domicile par les personnes retraités, ou inactives l'année de perception des revenus déclarés"
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7dq(Variable):
-    cerfa_field = u"7DQ"
+    cerfa_field = "7DQ"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Emploi direct pour la première fois d'un salarié à domicile durant l'année de perception des revenus déclarés"
+    label = "Emploi direct pour la première fois d'un salarié à domicile durant l'année de perception des revenus déclarés"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class f7dg(Variable):
-    cerfa_field = u"7DG"
+    cerfa_field = "7DG"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Vous, votre conjoint ou une personne à votre charge à une carte d'invalidité d'au moins 80 % l'année de perception des revenus déclarés"
+    label = "Vous, votre conjoint ou une personne à votre charge à une carte d'invalidité d'au moins 80 % l'année de perception des revenus déclarés"
     definition_period = YEAR
 
 
 class f7dl(Variable):
-    cerfa_field = u"7DL"
+    cerfa_field = "7DL"
     value_type = int
     entity = FoyerFiscal
-    label = u"Nombre d'ascendants bénéficiaires de l'APA, âgés de plus de 65 ans, pour lesquels des dépenses ont été engagées l'année de perception des revenus déclarés"
+    label = "Nombre d'ascendants bénéficiaires de l'APA, âgés de plus de 65 ans, pour lesquels des dépenses ont été engagées l'année de perception des revenus déclarés"
     definition_period = YEAR
 
 
 # Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale
 class f7uh_2007(Variable):
-    cerfa_field = u"7UH"
+    cerfa_field = "7UH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêts payés la première année de remboursement du prêt pour l'habitation principale"
+    label = "Intérêts payés la première année de remboursement du prêt pour l'habitation principale"
     # start_date = date(2007, 1, 1)
     end = '2007-12-31'
     definition_period = YEAR
 
 
 class f7vy(Variable):
-    cerfa_field = u"7VY"
+    cerfa_field = "7VY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements anciens (acquis entre le 06/05/2007 et le 30/09/2011) ou neufs (acquis entre le 06/05/2007 et le 31/12/2009): Première annuité"
+    label = "Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements anciens (acquis entre le 06/05/2007 et le 30/09/2011) ou neufs (acquis entre le 06/05/2007 et le 31/12/2009): Première annuité"
     # start_date = date(2008, 1, 1)
     end = '2013-12-31'
     definition_period = YEAR
 
 
 class f7vz(Variable):
-    cerfa_field = u"7VZ"
+    cerfa_field = "7VZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements anciens (acquis entre le 06/05/2007 et le 30/09/2011) ou neufs (acquis entre le 06/05/2007 et le 31/12/2009): annuités suivantes"
+    label = "Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements anciens (acquis entre le 06/05/2007 et le 30/09/2011) ou neufs (acquis entre le 06/05/2007 et le 31/12/2009): annuités suivantes"
     # start_date = date(2008, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7vx(Variable):
-    cerfa_field = u"7VX"
+    cerfa_field = "7VX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs BBC acquis ou construits du 01/01/2009 au 30/09/2011"
+    label = "Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs BBC acquis ou construits du 01/01/2009 au 30/09/2011"
     definition_period = YEAR
 
 
 class f7vw(Variable):
-    cerfa_field = u"7VW"
+    cerfa_field = "7VW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2010 au 31/12/2010: première annuité"
+    label = "Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2010 au 31/12/2010: première annuité"
     # start_date = date(2010, 1, 1)
     end = '2013-12-31'
     definition_period = YEAR
@@ -225,22 +225,22 @@ class f7vw(Variable):
 
 # TODO: variable non présente dans OF, à intégrer partout où c'est nécessaire
 class f7vv(Variable):
-    cerfa_field = u"7VV"
+    cerfa_field = "7VV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2010 au 31/12/2010: annuités suivantes"
+    label = "Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2010 au 31/12/2010: annuités suivantes"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 # TODO: variable non présente dans OF, à intégrer partout où c'est nécessaire
 class f7vu(Variable):
-    cerfa_field = u"7VU"
+    cerfa_field = "7VU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2011 au 30/09/2011: première annuité"
+    label = "Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2011 au 30/09/2011: première annuité"
     # start_date = date(2011, 1, 1)
     end = '2014-12-31'
     definition_period = YEAR
@@ -248,11 +248,11 @@ class f7vu(Variable):
 
 # TODO: variable non présente dans OF, à intégrer partout où c'est nécessaire
 class f7vt(Variable):
-    cerfa_field = u"7VT"
+    cerfa_field = "7VT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2011 au 30/09/2011: annuités suivantes"
+    label = "Intérêt des emprunts contractés pour l'acquisition ou la construction de l'habitation principale: logements neufs non-BBC acquis ou construits du 01/01/2011 au 30/09/2011: annuités suivantes"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
@@ -261,675 +261,675 @@ class f7vt(Variable):
 
 
 class f7cd(Variable):
-    cerfa_field = u"7CD"
+    cerfa_field = "7CD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses d'accueil dans un établissement pour personnes âgées dépendantes: 1ere personne"
+    label = "Dépenses d'accueil dans un établissement pour personnes âgées dépendantes: 1ere personne"
     definition_period = YEAR
 
 
 class f7ce(Variable):
-    cerfa_field = u"7CE"
+    cerfa_field = "7CE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses d'accueil dans un établissement pour personnes âgées dépendantes: 2éme personne"
+    label = "Dépenses d'accueil dans un établissement pour personnes âgées dépendantes: 2éme personne"
     definition_period = YEAR
 
 
 # Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus
 class f7ga(Variable):
-    cerfa_field = u"7GA"
+    cerfa_field = "7GA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 1er enfant à charge"
+    label = "Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 1er enfant à charge"
     definition_period = YEAR
 
 
 class f7gb(Variable):
-    cerfa_field = u"7GB"
+    cerfa_field = "7GB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 2ème enfant à charge"
+    label = "Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 2ème enfant à charge"
     definition_period = YEAR
 
 
 class f7gc(Variable):
-    cerfa_field = u"7GC"
+    cerfa_field = "7GC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 3ème enfant à charge"
+    label = "Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 3ème enfant à charge"
     definition_period = YEAR
 
 
 class f7ge(Variable):
-    cerfa_field = u"7GE"
+    cerfa_field = "7GE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 1er enfant à charge en résidence alternée"
+    label = "Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 1er enfant à charge en résidence alternée"
     definition_period = YEAR
 
 
 class f7gf(Variable):
-    cerfa_field = u"7GF"
+    cerfa_field = "7GF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 2ème enfant à charge en résidence alternée"
+    label = "Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 2ème enfant à charge en résidence alternée"
     definition_period = YEAR
 
 
 class f7gg(Variable):
-    cerfa_field = u"7GG"
+    cerfa_field = "7GG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 3ème enfant à charge en résidence alternée"
+    label = "Frais de garde des enfants de moins de 6 ans au 01/01 de l'année de perception des revenus: 3ème enfant à charge en résidence alternée"
     definition_period = YEAR
 
 
 # Nombre d'enfants à charge poursuivant leurs études
 class f7ea(Variable):
-    cerfa_field = u"7EA"
+    cerfa_field = "7EA"
     value_type = int
     is_period_size_independent = True
     entity = FoyerFiscal
-    label = u"Nombre d'enfants à charge poursuivant leurs études au collège"
+    label = "Nombre d'enfants à charge poursuivant leurs études au collège"
     definition_period = YEAR
 
 
 class f7eb(Variable):
-    cerfa_field = u"7EB"
+    cerfa_field = "7EB"
     value_type = int
     is_period_size_independent = True
     entity = FoyerFiscal
-    label = u"Nombre d'enfants à charge en résidence alternée poursuivant leurs études au collège"
+    label = "Nombre d'enfants à charge en résidence alternée poursuivant leurs études au collège"
     definition_period = YEAR
 
 
 class f7ec(Variable):
-    cerfa_field = u"7EC"
+    cerfa_field = "7EC"
     value_type = int
     is_period_size_independent = True
     entity = FoyerFiscal
-    label = u"Nombre d'enfants à charge poursuivant leurs études au lycée"
+    label = "Nombre d'enfants à charge poursuivant leurs études au lycée"
     definition_period = YEAR
 
 
 class f7ed(Variable):
-    cerfa_field = u"7ED"
+    cerfa_field = "7ED"
     value_type = int
     is_period_size_independent = True
     entity = FoyerFiscal
-    label = u"Nombre d'enfants à charge en résidence alternée poursuivant leurs études au lycée"
+    label = "Nombre d'enfants à charge en résidence alternée poursuivant leurs études au lycée"
     definition_period = YEAR
 
 
 class f7ef(Variable):
-    cerfa_field = u"7EF"
+    cerfa_field = "7EF"
     value_type = int
     is_period_size_independent = True
     entity = FoyerFiscal
-    label = u"Nombre d'enfants à charge poursuivant leurs études dans l'enseignement supérieur"
+    label = "Nombre d'enfants à charge poursuivant leurs études dans l'enseignement supérieur"
     definition_period = YEAR
 
 
 class f7eg(Variable):
-    cerfa_field = u"7EG"
+    cerfa_field = "7EG"
     value_type = int
     is_period_size_independent = True
     entity = FoyerFiscal
-    label = u"Nombre d'enfants à charge en résidence alternée poursuivant leurs études dans l'enseignement supérieur"
+    label = "Nombre d'enfants à charge en résidence alternée poursuivant leurs études dans l'enseignement supérieur"
     definition_period = YEAR
 
 
 # Intérêts des prêts étudiants
 class f7td(Variable):
-    cerfa_field = u"7TD"
+    cerfa_field = "7TD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêts des prêts étudiants versés avant l'année de perception des revenus déclarés"
+    label = "Intérêts des prêts étudiants versés avant l'année de perception des revenus déclarés"
     # start_date = date(2008, 1, 1)
     definition_period = YEAR
 
 
 class f7vo(Variable):
-    cerfa_field = u"7VO"
+    cerfa_field = "7VO"
     value_type = int
     is_period_size_independent = True
     entity = FoyerFiscal
-    label = u"Nombre d'années de remboursement du prêt étudiant avant l'année de perception des revenus déclarés"
+    label = "Nombre d'années de remboursement du prêt étudiant avant l'année de perception des revenus déclarés"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 class f7uk(Variable):
-    cerfa_field = u"7UK"
+    cerfa_field = "7UK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêts des prêts étudiants versés durant l'année de perception des revenus déclarés"
+    label = "Intérêts des prêts étudiants versés durant l'année de perception des revenus déclarés"
     definition_period = YEAR
 
 
 # Primes de rente survie, contrats d'épargne handicap
 class f7gz(Variable):
-    cerfa_field = u"7GZ"
+    cerfa_field = "7GZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Primes de rente survie, contrats d'épargne handicap"
+    label = "Primes de rente survie, contrats d'épargne handicap"
     definition_period = YEAR
 
 
 # Prestations compensatoires
 class f7wm(Variable):
-    cerfa_field = u"7WM"
+    cerfa_field = "7WM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Prestations compensatoires: Capital fixé en substitution de rente"
+    label = "Prestations compensatoires: Capital fixé en substitution de rente"
     definition_period = YEAR
 
 
 class f7wn(Variable):
-    cerfa_field = u"7WN"
+    cerfa_field = "7WN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Prestations compensatoires: Sommes versées l'année de perception des revenus déclarés"
+    label = "Prestations compensatoires: Sommes versées l'année de perception des revenus déclarés"
     definition_period = YEAR
 
 
 class f7wo(Variable):
-    cerfa_field = u"7WO"
+    cerfa_field = "7WO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Prestations compensatoires: Sommes totales décidées par jugement l'année de perception des revenus déclarés ou capital reconstitué"
+    label = "Prestations compensatoires: Sommes totales décidées par jugement l'année de perception des revenus déclarés ou capital reconstitué"
     definition_period = YEAR
 
 
 class f7wp(Variable):
-    cerfa_field = u"7WP"
+    cerfa_field = "7WP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Prestations compensatoires: Report des sommes décidées l'année de perception des revenus -1"
+    label = "Prestations compensatoires: Report des sommes décidées l'année de perception des revenus -1"
     definition_period = YEAR
 
 
 # Dépenses en faveur de la qualité environnementale de l'habitation principale
 class f7we(Variable):
-    cerfa_field = u"7WE"
+    cerfa_field = "7WE"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: éco-prêt à taux zéro avec offre de prêt émise l'année de perception des revenus déclarés"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: éco-prêt à taux zéro avec offre de prêt émise l'année de perception des revenus déclarés"
     # start_date = date(2009, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7wg(Variable):
-    cerfa_field = u"7WG"
+    cerfa_field = "7WG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: éco-prêt à taux zéro avec offre de prêt émise l'année de perception des revenus déclarés -1"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: éco-prêt à taux zéro avec offre de prêt émise l'année de perception des revenus déclarés -1"
     # start_date = date(2012, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7wa(Variable):
-    cerfa_field = u"7WA"
+    cerfa_field = "7WA"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique des murs avant le 03/04/2012"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique des murs avant le 03/04/2012"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7wb(Variable):
-    cerfa_field = u"7WB"
+    cerfa_field = "7WB"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique des murs à compter du 04/04/2012"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique des murs à compter du 04/04/2012"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7wc(Variable):
-    cerfa_field = u"7WC"
+    cerfa_field = "7WC"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique sur plus de la moitié de la surface des murs extérieurs"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique sur plus de la moitié de la surface des murs extérieurs"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ve(Variable):
-    cerfa_field = u"7VE"
+    cerfa_field = "7VE"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de la toiture avant le 04/04/2012"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de la toiture avant le 04/04/2012"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7vf(Variable):
-    cerfa_field = u"7VF"
+    cerfa_field = "7VF"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de la toiture à compter du 04/04/2012"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de la toiture à compter du 04/04/2012"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7vg(Variable):
-    cerfa_field = u"7VG"
+    cerfa_field = "7VG"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de toute la toiture"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de toute la toiture"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7vh(Variable):
-    cerfa_field = u"7VH"
+    cerfa_field = "7VH"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de toute la toiture du 1.9 au 31.12.2014"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: travaux d'isolation thermique de toute la toiture du 1.9 au 31.12.2014"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7sg(Variable):
-    cerfa_field = u"7SG"
+    cerfa_field = "7SG"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Matériaux d'isolation thermique des murs (acquisitionn et pose)"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Matériaux d'isolation thermique des murs (acquisitionn et pose)"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7sj(Variable):
-    cerfa_field = u"7SJ"
+    cerfa_field = "7SJ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Matériaux d'isolation thermique des parois vitrées"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Matériaux d'isolation thermique des parois vitrées"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7sk(Variable):
-    cerfa_field = u"7SK"
+    cerfa_field = "7SK"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Volets isolants"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Volets isolants"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7sl(Variable):
-    cerfa_field = u"7SL"
+    cerfa_field = "7SL"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Portes d'entrées donnant sur l'extérieur"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Portes d'entrées donnant sur l'extérieur"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ah(Variable):
-    cerfa_field = u"7AH"
+    cerfa_field = "7AH"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Matériaux d'isolation thermique des murs (acquisitionn et pose)"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Matériaux d'isolation thermique des murs (acquisitionn et pose)"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7ak(Variable):
-    cerfa_field = u"7AK"
+    cerfa_field = "7AK"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : travaux d'isolation thermique de toute la toiture"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : travaux d'isolation thermique de toute la toiture"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7al(Variable):
-    cerfa_field = u"7AL"
+    cerfa_field = "7AL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Matériaux d’isolation des planchers bas sur sous-sol, sur vide sanitaire ou sur passage couvert (acquisition et pose)"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Matériaux d’isolation des planchers bas sur sous-sol, sur vide sanitaire ou sur passage couvert (acquisition et pose)"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7am(Variable):
-    cerfa_field = u"7AM"
+    cerfa_field = "7AM"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Matériaux d'isolation thermique des parois vitrées"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Matériaux d'isolation thermique des parois vitrées"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7an(Variable):
-    cerfa_field = u"7AN"
+    cerfa_field = "7AN"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Volets isolants"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Volets isolants"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7aq(Variable):
-    cerfa_field = u"7AQ"
+    cerfa_field = "7AQ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Portes d'entrées donnant sur l'extérieur"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Portes d'entrées donnant sur l'extérieur"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7vk(Variable):
-    cerfa_field = u"7VK"
+    cerfa_field = "7VK"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Volets isolants 2015"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Volets isolants 2015"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7vl(Variable):
-    cerfa_field = u"7VL"
+    cerfa_field = "7VL"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Portes d'entrées donnant sur l'extérieur 2015"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Portes d'entrées donnant sur l'extérieur 2015"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7sm(Variable):
-    cerfa_field = u"7SM"
+    cerfa_field = "7SM"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de production d'électricité utilisant l'énergie radiative du soleil"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de production d'électricité utilisant l'énergie radiative du soleil"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7sn(Variable):
-    cerfa_field = u"7SN"
+    cerfa_field = "7SN"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Appareils de chauffage au bois ou autres biomasses remplaçant un appareil équivalent"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Appareils de chauffage au bois ou autres biomasses remplaçant un appareil équivalent"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7so(Variable):
-    cerfa_field = u"7SO"
+    cerfa_field = "7SO"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Appareils de chauffage au bois ou autres biomasses ne remplaçant pas un appareil équivalent"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Appareils de chauffage au bois ou autres biomasses ne remplaçant pas un appareil équivalent"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7sp(Variable):
-    cerfa_field = u"7SP"
+    cerfa_field = "7SP"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Pompes à chaleur autres que air/air et autres que géothermiques dont la finalité essentielle est la production de chaleur"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Pompes à chaleur autres que air/air et autres que géothermiques dont la finalité essentielle est la production de chaleur"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7sq(Variable):
-    cerfa_field = u"7SQ"
+    cerfa_field = "7SQ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Pompes à chaleur géothermiques dont la finalité essentielle est la production de chaleur"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Pompes à chaleur géothermiques dont la finalité essentielle est la production de chaleur"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7sr(Variable):
-    cerfa_field = u"7SR"
+    cerfa_field = "7SR"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Pompes à chaleur (autres que air/air) dédiées à la production d'eau chaude sanitaire (chauffe-eaux thermodynamiques)"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Pompes à chaleur (autres que air/air) dédiées à la production d'eau chaude sanitaire (chauffe-eaux thermodynamiques)"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ss(Variable):
-    cerfa_field = u"7SS"
+    cerfa_field = "7SS"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de fourniture d'eau chaude sanitaire fonctionnant à l'énergie solaire et dotés de capteurs solaires"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de fourniture d'eau chaude sanitaire fonctionnant à l'énergie solaire et dotés de capteurs solaires"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7st(Variable):
-    cerfa_field = u"7ST"
+    cerfa_field = "7ST"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Autres équipements de production d'énergie utilisant une source d'énergie renouvelable (éolien, hydraulique)"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Autres équipements de production d'énergie utilisant une source d'énergie renouvelable (éolien, hydraulique)"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7tn(Variable):
-    cerfa_field = u"7TN"
+    cerfa_field = "7TN"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale en 2015: Appareils de chauffage au bois ou autres biomasses remplaçant un appareil équivalent"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale en 2015: Appareils de chauffage au bois ou autres biomasses remplaçant un appareil équivalent"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7tp(Variable):
-    cerfa_field = u"7TP"
+    cerfa_field = "7TP"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale 2015: Pompes à chaleur autres que air/air et autres que géothermiques dont la finalité essentielle est la production de chaleur"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale 2015: Pompes à chaleur autres que air/air et autres que géothermiques dont la finalité essentielle est la production de chaleur"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7tq(Variable):
-    cerfa_field = u"7TQ"
+    cerfa_field = "7TQ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale 2015: Pompes à chaleur géothermiques dont la finalité essentielle est la production de chaleur"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale 2015: Pompes à chaleur géothermiques dont la finalité essentielle est la production de chaleur"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7tr(Variable):
-    cerfa_field = u"7TR"
+    cerfa_field = "7TR"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale 2015: Pompes à chaleur (autres que air/air) dédiées à la production d'eau chaude sanitaire (chauffe-eaux thermodynamiques)"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale 2015: Pompes à chaleur (autres que air/air) dédiées à la production d'eau chaude sanitaire (chauffe-eaux thermodynamiques)"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7ts(Variable):
-    cerfa_field = u"7TS"
+    cerfa_field = "7TS"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale 2015: Équipements de fourniture d'eau chaude sanitaire fonctionnant à l'énergie solaire et dotés de capteurs solaires"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale 2015: Équipements de fourniture d'eau chaude sanitaire fonctionnant à l'énergie solaire et dotés de capteurs solaires"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7ar(Variable):
-    cerfa_field = u"7AR"
+    cerfa_field = "7AR"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale en 2015 (hors bouquet sur 2 ans) : Appareils de chauffage au bois ou autres biomasses "
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale en 2015 (hors bouquet sur 2 ans) : Appareils de chauffage au bois ou autres biomasses "
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7av(Variable):
-    cerfa_field = u"7AV"
+    cerfa_field = "7AV"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale 2015 (hors bouquet sur 2 ans) : Pompes à chaleur autres que air/air dont la finalité essentielle est la production de chaleur"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale 2015 (hors bouquet sur 2 ans) : Pompes à chaleur autres que air/air dont la finalité essentielle est la production de chaleur"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7ax(Variable):
-    cerfa_field = u"7AX"
+    cerfa_field = "7AX"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale 2015 (hors bouquet sur 2 ans) : Pompes à chaleur (autres que air/air) dédiées à la production d'eau chaude sanitaire (chauffe-eaux thermodynamiques)"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale 2015 (hors bouquet sur 2 ans) : Pompes à chaleur (autres que air/air) dédiées à la production d'eau chaude sanitaire (chauffe-eaux thermodynamiques)"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7ay(Variable):
-    cerfa_field = u"7AY"
+    cerfa_field = "7AY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale 2015 (hors bouquet sur 2 ans) : Équipements de fourniture d'eau chaude sanitaire fonctionnant à l'énergie solaire et dotés de capteurs solaires"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale 2015 (hors bouquet sur 2 ans) : Équipements de fourniture d'eau chaude sanitaire fonctionnant à l'énergie solaire et dotés de capteurs solaires"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7az(Variable):
-    cerfa_field = u"7AZ"
+    cerfa_field = "7AZ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale 2015 (hors bouquet sur 2 ans) : Équipements de fourniture d'eau chaude sanitaire fonctionnant à l'énergie hydraulique"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale 2015 (hors bouquet sur 2 ans) : Équipements de fourniture d'eau chaude sanitaire fonctionnant à l'énergie hydraulique"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7bb(Variable):
-    cerfa_field = u"7BB"
+    cerfa_field = "7BB"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Systèmes de production d'électricité utilisant une source d'énergie renouvelable (éolien, hydraulique)"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Systèmes de production d'électricité utilisant une source d'énergie renouvelable (éolien, hydraulique)"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7bm_2016(Variable):
-    cerfa_field = u"7BM"
+    cerfa_field = "7BM"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale : Systèmes de production d'électricité utilisant une source d'énergie renouvelable (éolien, hydraulique) avec signature d'un devis et versement d'un acompte avant le 1.1.2016"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale : Systèmes de production d'électricité utilisant une source d'énergie renouvelable (éolien, hydraulique) avec signature d'un devis et versement d'un acompte avant le 1.1.2016"
     # start_date = date(2016, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7st(Variable):  # noqa 728
-    cerfa_field = u"7ST"
+    cerfa_field = "7ST"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Autres équipements de production d'énergie utilisant une source d'énergie renouvelable (éolien, hydraulique)"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Autres équipements de production d'énergie utilisant une source d'énergie renouvelable (éolien, hydraulique)"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7su(Variable):
-    cerfa_field = u"7SU"
+    cerfa_field = "7SU"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de récupération et de traitement des eaux pluviales"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de récupération et de traitement des eaux pluviales"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7sv(Variable):
-    cerfa_field = u"7SV"
+    cerfa_field = "7SV"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Diagnostic de performance énergétique"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Diagnostic de performance énergétique"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7sw(Variable):
-    cerfa_field = u"7SW"
+    cerfa_field = "7SW"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de raccordement à un réseau de chaleur"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: Équipements de raccordement à un réseau de chaleur"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7bc(Variable):
-    cerfa_field = u"7BC"
+    cerfa_field = "7BC"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Diagnostic de performance énergétique"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Diagnostic de performance énergétique"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7bd(Variable):
-    cerfa_field = u"7BD"
+    cerfa_field = "7BD"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Équipements de raccordement à un réseau de chaleur"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Équipements de raccordement à un réseau de chaleur"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7be(Variable):
-    cerfa_field = u"7BE"
+    cerfa_field = "7BE"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Compteurs individuels de chauffage ou d'eau chaude sanitaire dans immeuble collectif"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Compteurs individuels de chauffage ou d'eau chaude sanitaire dans immeuble collectif"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7bf(Variable):
-    cerfa_field = u"7BF"
+    cerfa_field = "7BF"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Système de charge pour véhicules électriques "
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Système de charge pour véhicules électriques "
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7bh(Variable):
-    cerfa_field = u"7BH"
+    cerfa_field = "7BH"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Equipements installés dans les DOM (raccordement à un réseau de froid) "
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Equipements installés dans les DOM (raccordement à un réseau de froid) "
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7bk(Variable):
-    cerfa_field = u"7BK"
+    cerfa_field = "7BK"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Equipements installés dans les DOM (protection des parois vitrés)"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Equipements installés dans les DOM (protection des parois vitrés)"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
@@ -937,183 +937,183 @@ class f7bk(Variable):
 # TODO, nouvelle variable à intégrer dans OF (cf ancien nom déjà utilisé)
 # TODO vérifier pour les années précédentes
 class f7bl(Variable):
-    cerfa_field = u"7BL"
+    cerfa_field = "7BL"
     value_type = int
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Equipements installés dans les DOM (optimisation de la ventilation naturelle)"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (hors bouquet sur 2 ans) : Equipements installés dans les DOM (optimisation de la ventilation naturelle)"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 # TODO: CHECK
 # Intérêts d'emprunts
-#     build_column('f7wg', IntCol(entity = 'foy', label = u"Intérêts d'emprunts", val_type = "monetary", cerfa_field = u'7')) # cf pour quelle année
+#     build_column('f7wg', IntCol(entity = 'foy', label = "Intérêts d'emprunts", val_type = "monetary", cerfa_field = '7')) # cf pour quelle année
 #
 
 
 class f7wq(Variable):
-    cerfa_field = u"7WQ"
+    cerfa_field = "7WQ"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolation thermique des parois vitrées du 01/01/2012 au 03/04/2012"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolation thermique des parois vitrées du 01/01/2012 au 03/04/2012"
     # start_date = date(2010, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7ws(Variable):
-    cerfa_field = u"7WS"
+    cerfa_field = "7WS"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolations des parois vitrées à compter du 04/04/2012"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolations des parois vitrées à compter du 04/04/2012"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7wt(Variable):
-    cerfa_field = u"7WT"
+    cerfa_field = "7WT"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolation thermique des parois vitrées réalisées sur au moins la moitié des fenêtres du logement "
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolation thermique des parois vitrées réalisées sur au moins la moitié des fenêtres du logement "
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7wu(Variable):
-    cerfa_field = u"7WU"
+    cerfa_field = "7WU"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de volets avant 2012"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de volets avant 2012"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7wv_2012(Variable):
-    cerfa_field = u"7WV"
+    cerfa_field = "7WV"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de volets en 2012"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de volets en 2012"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7wv(Variable):
-    cerfa_field = u"7WV"
+    cerfa_field = "7WV"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat en 2015 de matériaux d'isolation thermique des parois vitrées concernant au moins la moitié des fenêtres"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: achat en 2015 de matériaux d'isolation thermique des parois vitrées concernant au moins la moitié des fenêtres"
     # start_date = date(2015, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class f7ww_2012(Variable):
-    cerfa_field = u"7WW"
+    cerfa_field = "7WW"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: vous avez réalisé des dépenses d'acquisitions de portes d'entrées donnant sur l'extérieur, avant le 1.1.2012"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: vous avez réalisé des dépenses d'acquisitions de portes d'entrées donnant sur l'extérieur, avant le 1.1.2012"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7ww(Variable):
-    cerfa_field = u"7WW"
+    cerfa_field = "7WW"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat en 2015 de matériaux d'isolation thermique des parois vitrées concernant moins de la moitié des fenêtres"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: achat en 2015 de matériaux d'isolation thermique des parois vitrées concernant moins de la moitié des fenêtres"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7wx(Variable):
-    cerfa_field = u"7WX"
+    cerfa_field = "7WX"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de portes en 2012"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: achat de portes en 2012"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7wh(Variable):
-    cerfa_field = u"7WH"
+    cerfa_field = "7WH"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale (logement achevé depuis plus de 2 ans): bouquet de travaux réalisé pendant l'année de perception des revenus"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale (logement achevé depuis plus de 2 ans): bouquet de travaux réalisé pendant l'année de perception des revenus"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7wk(Variable):
-    cerfa_field = u"7WK"
+    cerfa_field = "7WK"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Votre habitation principale est une maison individuelle"
+    label = "Votre habitation principale est une maison individuelle"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class f7wf(Variable):
-    cerfa_field = u"7WF"
+    cerfa_field = "7WF"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolation thermique des parois vitrées avant le 01/01/n-1"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: dépenses d'isolation thermique des parois vitrées avant le 01/01/n-1"
     end = '2013-12-31'
     definition_period = YEAR
 
 
 # Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale
 class f7wi_2012(Variable):
-    cerfa_field = u"7WI"
+    cerfa_field = "7WI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: Ascenseurs électriques à traction"
+    label = "Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: Ascenseurs électriques à traction"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7wi(Variable):
-    cerfa_field = u"7WI"
+    cerfa_field = "7WI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: dépenses payées en 2015 de matériaux d'isolation des toitures, posés sur une partie de la toiture"
+    label = "Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: dépenses payées en 2015 de matériaux d'isolation des toitures, posés sur une partie de la toiture"
     # start_date = date(2015, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class f7wj(Variable):
-    cerfa_field = u"7WJ"
+    cerfa_field = "7WJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: équipements spécialement conçus pour les personnes âgées ou handicapées"
+    label = "Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: équipements spécialement conçus pour les personnes âgées ou handicapées"
     definition_period = YEAR
 
 
 class f7wl(Variable):
-    cerfa_field = u"7WL"
+    cerfa_field = "7WL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: travaux de prévention des risques technologiques"
+    label = "Dépenses en faveur de l'aide aux personnes réalisées dans l'habitation principale: travaux de prévention des risques technologiques"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7wr(Variable):
-    cerfa_field = u"7WR"
+    cerfa_field = "7WR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de l'aide aux personnes réalisées dans des habitations données en location : travaux de prévention des risques technologiques"
+    label = "Dépenses en faveur de l'aide aux personnes réalisées dans des habitations données en location : travaux de prévention des risques technologiques"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
@@ -1121,2458 +1121,2458 @@ class f7wr(Variable):
 # Investissements dans les DOM-TOM dans le cadre d'une entreprise
 
 class f7ur(Variable):
-    cerfa_field = u"7UR"
+    cerfa_field = "7UR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements réalisés en n-1, total réduction d’impôt"
+    label = "Investissements réalisés en n-1, total réduction d’impôt"
     end = '2008-12-31'
     definition_period = YEAR
 
 
 # TODO: vérifier les années antérieures
 class f7oz(Variable):
-    cerfa_field = u"7OZ"
+    cerfa_field = "7OZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer: report de réduction d'impôt non imputée les années antérieures année n-6"
+    label = "Investissements outre-mer: report de réduction d'impôt non imputée les années antérieures année n-6"
     end = '2011-12-31'
     definition_period = YEAR
 
 
 class f7pz(Variable):
-    cerfa_field = u"7PZ"
+    cerfa_field = "7PZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer réalisés en 2007 dans le cadre d'une entreprise: report de réduction d'impôt non imputée les années antérieures"
+    label = "Investissements outre-mer réalisés en 2007 dans le cadre d'une entreprise: report de réduction d'impôt non imputée les années antérieures"
     end = '2013-12-31'
     definition_period = YEAR
 
 
 class f7qz_2012(Variable):
-    cerfa_field = u"7QZ"
+    cerfa_field = "7QZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer réalisés en 2008 dans le casdre d'une entreprise: report de réduction d'impôt non imputée les années antérieures"
+    label = "Investissements outre-mer réalisés en 2008 dans le casdre d'une entreprise: report de réduction d'impôt non imputée les années antérieures"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class fhqz(Variable):
-    cerfa_field = u"HQZ"
+    cerfa_field = "HQZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer réalisés en 2008 dans le casdre d'une entreprise: report de réduction d'impôt non imputée les années antérieures"
+    label = "Investissements outre-mer réalisés en 2008 dans le casdre d'une entreprise: report de réduction d'impôt non imputée les années antérieures"
     definition_period = YEAR
     end = '2013-12-31'
 
 
 class f7rz_2010(Variable):
-    cerfa_field = u"7RZ"
+    cerfa_field = "7RZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer: report de réduction d'impôt non imputée les années antérieures année n-3"
+    label = "Investissements outre-mer: report de réduction d'impôt non imputée les années antérieures année n-3"
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f7rz_2015(Variable):
-    cerfa_field = u"7RZ"
+    cerfa_field = "7RZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location : Dans les logements situés dans les départements d’outre-mer : équipements de raccordement à un réseau de froid ;  équipements ou matériaux de protection des parois vitrées ou opaques contre les rayonnements solaires ;  équipements visant à l’optimisation de la ventilation naturelle "
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location : Dans les logements situés dans les départements d’outre-mer : équipements de raccordement à un réseau de froid ;  équipements ou matériaux de protection des parois vitrées ou opaques contre les rayonnements solaires ;  équipements visant à l’optimisation de la ventilation naturelle "
     # start_date = date(2014, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class f7qv(Variable):
-    cerfa_field = u"7QV"
+    cerfa_field = "7QV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010, nvestissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010, nvestissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class fhqv(Variable):
-    cerfa_field = u"HQV"
+    cerfa_field = "HQV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010, nvestissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010, nvestissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
     definition_period = YEAR
 
 
 class f7qo_2012(Variable):
-    cerfa_field = u"7QO"
+    cerfa_field = "7QO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010 à hauteur de 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010 à hauteur de 50%"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7qp_2012(Variable):
-    cerfa_field = u"7QP"
+    cerfa_field = "7QP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010 à hauteur de 60%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010 à hauteur de 60%"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class fhqo(Variable):
-    cerfa_field = u"HQO"
+    cerfa_field = "HQO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010 à hauteur de 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010 à hauteur de 50%"
     definition_period = YEAR
 
 
 class fhqp(Variable):
-    cerfa_field = u"HQP"
+    cerfa_field = "HQP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010 à hauteur de 60%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements immobliliers engagés avant le 1.1.2011 et investissements ayant reçu un agrément avant le 5.12.2010 à hauteur de 60%"
     definition_period = YEAR
 
 
 class f7pa_2012(Variable):
-    cerfa_field = u"7PA"
+    cerfa_field = "7PA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7pa(Variable):
-    cerfa_field = u"7PA"
+    cerfa_field = "7PA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2013"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhpa(Variable):
-    cerfa_field = u"HPA"
+    cerfa_field = "HPA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
     definition_period = YEAR
 
 
 class f7pb_2012(Variable):
-    cerfa_field = u"7PB"
+    cerfa_field = "7PB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class fhpb(Variable):
-    cerfa_field = u"HPB"
+    cerfa_field = "HPB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
     definition_period = YEAR
 
 
 class f7pb(Variable):
-    cerfa_field = u"7PB"
+    cerfa_field = "7PB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2013"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7pc_2011(Variable):
-    cerfa_field = u"7PC"
+    cerfa_field = "7PC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
     end = '2011-12-31'
     definition_period = YEAR
 
 
 class f7pc(Variable):
-    cerfa_field = u"7PC"
+    cerfa_field = "7PC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2013"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7pd_2012(Variable):
-    cerfa_field = u"7PD"
+    cerfa_field = "7PD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7pd(Variable):
-    cerfa_field = u"7PD"
+    cerfa_field = "7PD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2013"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhpd(Variable):
-    cerfa_field = u"HPD"
+    cerfa_field = "HPD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
     definition_period = YEAR
 
 
 class f7qe(Variable):
-    cerfa_field = u"7QE"
+    cerfa_field = "7QE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet avant 1.1.2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet avant 1.1.2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
     # end = '2012-12-31' changes meaning in 2014
     definition_period = YEAR
 
 
 class fhqe(Variable):
-    cerfa_field = u"HQE"
+    cerfa_field = "HQE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet avant 1.1.2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet avant 1.1.2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
     definition_period = YEAR
 
 
 class f7pe_2012(Variable):
-    cerfa_field = u"7PE"
+    cerfa_field = "7PE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7pe(Variable):
-    cerfa_field = u"7PE"
+    cerfa_field = "7PE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2013 (investissements réalisés et achevés en 2013)"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2013 (investissements réalisés et achevés en 2013)"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7pf_2012(Variable):
-    cerfa_field = u"7PF"
+    cerfa_field = "7PF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7pf(Variable):
-    cerfa_field = u"7PF"
+    cerfa_field = "7PF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2014 (investissements réalisés en 2009 et achevés de 2010 à 2015)"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2014 (investissements réalisés en 2009 et achevés de 2010 à 2015)"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhpe(Variable):
-    cerfa_field = u"HPE"
+    cerfa_field = "HPE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
     definition_period = YEAR
 
 
 class fhpf(Variable):
-    cerfa_field = u"HPF"
+    cerfa_field = "HPF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
     definition_period = YEAR
 
 
 class f7pg(Variable):
-    cerfa_field = u"7PG"
+    cerfa_field = "7PG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
     # end = '2011-12-31' changes meaning in 2015
     definition_period = YEAR
 
 
 class f7ph(Variable):
-    cerfa_field = u"7PH"
+    cerfa_field = "7PH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
     # end = '2011-12-31' changes meaning in 2015
     definition_period = YEAR
 
 
 class fhph(Variable):
-    cerfa_field = u"HPH"
+    cerfa_field = "HPH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
     definition_period = YEAR
 
 
 class f7pi_2012(Variable):
-    cerfa_field = u"7PI"
+    cerfa_field = "7PI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7pi(Variable):
-    cerfa_field = u"7PI"
+    cerfa_field = "7PI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2014 (investissements réalisés en 2012 et achevés de 2012 à 2015)"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2014 (investissements réalisés en 2012 et achevés de 2012 à 2015)"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhpi(Variable):
-    cerfa_field = u"HPI"
+    cerfa_field = "HPI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63%"
     definition_period = YEAR
 
 
 class f7pj_2012(Variable):
-    cerfa_field = u"7PJ"
+    cerfa_field = "7PJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7pj(Variable):
-    cerfa_field = u"7PJ"
+    cerfa_field = "7PJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2014 (investissements réalisés et achevés de 2013 à 2015)"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé 2014 (investissements réalisés et achevés de 2013 à 2015)"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhpj(Variable):
-    cerfa_field = u"HPJ"
+    cerfa_field = "HPJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5%"
     definition_period = YEAR
 
 
 class f7pk(Variable):
-    cerfa_field = u"7PK"
+    cerfa_field = "7PK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise, montant de la réduction d' impôt calculée"
     # end = '2011-12-31' changes meaning in 2016
     definition_period = YEAR
 
 
 class f7pl(Variable):
-    cerfa_field = u"7PL"
+    cerfa_field = "7PL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
     # end = '2011-12-31' changes meaning in 2016
     definition_period = YEAR
 
 
 class f7pm(Variable):
-    cerfa_field = u"7PM"
+    cerfa_field = "7PM"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%"
     # end = '2013-12-31' changes meaning in 2016
     definition_period = YEAR
 
 
 class f7pn(Variable):
-    cerfa_field = u"7PN"
+    cerfa_field = "7PN"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50 %"
     # end = '2013-12-31' changes meaning in 2016
     definition_period = YEAR
 
 
 class fhpl(Variable):
-    cerfa_field = u"HPL"
+    cerfa_field = "HPL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise, montant de la réduction d' impôt dont vous demandez l'imputation en 2011"
     definition_period = YEAR
 
 
 class fhpm(Variable):
-    cerfa_field = u"HPM"
+    cerfa_field = "HPM"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%"
     definition_period = YEAR
 
 
 class fhpn(Variable):
-    cerfa_field = u"HPN"
+    cerfa_field = "HPN"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50 %"
     definition_period = YEAR
 
 
 class f7po(Variable):
-    cerfa_field = u"7PO"
+    cerfa_field = "7PO"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60 %"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class fhpo(Variable):
-    cerfa_field = u"HPO"
+    cerfa_field = "HPO"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60 %"
     definition_period = YEAR
 
 
 class f7pp_2012(Variable):
-    cerfa_field = u"7PP"
+    cerfa_field = "7PP"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7pq_2012(Variable):
-    cerfa_field = u"7PQ"
+    cerfa_field = "7PQ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7pr_2012(Variable):
-    cerfa_field = u"7PR"
+    cerfa_field = "7PR"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7ps_2012(Variable):
-    cerfa_field = u"7PS"
+    cerfa_field = "7PS"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50 %"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7pt_2012(Variable):
-    cerfa_field = u"7PT"
+    cerfa_field = "7PT"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60 %"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7pu(Variable):
-    cerfa_field = u"7PU"
+    cerfa_field = "7PU"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
     end = '2013-12-31'
     definition_period = YEAR
 
 
 class f7pv(Variable):
-    cerfa_field = u"7PV"
+    cerfa_field = "7PV"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     end = '2013-12-31'
     definition_period = YEAR
 
 
 class f7pw(Variable):
-    cerfa_field = u"7PW"
+    cerfa_field = "7PW"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     end = '2013-12-31'
     definition_period = YEAR
 
 
 class f7px(Variable):
-    cerfa_field = u"7PX"
+    cerfa_field = "7PX"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt  à hauteur de 52,63 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt  à hauteur de 52,63 %"
     end = '2013-12-31'
     definition_period = YEAR
 
 
 class f7py(Variable):
-    cerfa_field = u"7PY"
+    cerfa_field = "7PY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhpp(Variable):
-    cerfa_field = u"HPP"
+    cerfa_field = "HPP"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
     definition_period = YEAR
 
 
 class fhpq(Variable):
-    cerfa_field = u"HPQ"
+    cerfa_field = "HPQ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     definition_period = YEAR
 
 
 class fhpr(Variable):
-    cerfa_field = u"HPR"
+    cerfa_field = "HPR"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     definition_period = YEAR
 
 
 class fhps(Variable):
-    cerfa_field = u"HPS"
+    cerfa_field = "HPS"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50 %"
     definition_period = YEAR
 
 
 class fhpt(Variable):
-    cerfa_field = u"HPT"
+    cerfa_field = "HPT"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60 %"
     definition_period = YEAR
 
 
 class fhpu(Variable):
-    cerfa_field = u"HPU"
+    cerfa_field = "HPU"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
     definition_period = YEAR
 
 
 class fhpv(Variable):
-    cerfa_field = u"HPV"
+    cerfa_field = "HPV"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     definition_period = YEAR
 
 
 class fhpw(Variable):
-    cerfa_field = u"7HW"
+    cerfa_field = "7HW"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     definition_period = YEAR
 
 
 class fhpx(Variable):
-    cerfa_field = u"HPX"
+    cerfa_field = "HPX"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt  à hauteur de 52,63 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt  à hauteur de 52,63 %"
     definition_period = YEAR
 
 
 class fhpy(Variable):
-    cerfa_field = u"HPY"
+    cerfa_field = "HPY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     definition_period = YEAR
 
 
 class f7rg(Variable):
-    cerfa_field = u"7RG"
+    cerfa_field = "7RG"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7rh(Variable):
-    cerfa_field = u"7RH"
+    cerfa_field = "7RH"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ri(Variable):
-    cerfa_field = u"7RI"
+    cerfa_field = "7RI"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7rj(Variable):
-    cerfa_field = u"7RJ"
+    cerfa_field = "7RJ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhrg(Variable):
-    cerfa_field = u"HRG"
+    cerfa_field = "HRG"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrh(Variable):
-    cerfa_field = u"HRH"
+    cerfa_field = "HRH"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhri(Variable):
-    cerfa_field = u"HRI"
+    cerfa_field = "HRI"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50%, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrj(Variable):
-    cerfa_field = u"HRJ"
+    cerfa_field = "HRJ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7rk(Variable):
-    cerfa_field = u"7RK"
+    cerfa_field = "7RK"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7rl(Variable):
-    cerfa_field = u"7RL"
+    cerfa_field = "7RL"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7rm(Variable):
-    cerfa_field = u"7RM"
+    cerfa_field = "7RM"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7rn(Variable):
-    cerfa_field = u"7RN"
+    cerfa_field = "7RN"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ro(Variable):
-    cerfa_field = u"7RO"
+    cerfa_field = "7RO"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7rp(Variable):
-    cerfa_field = u"7RP"
+    cerfa_field = "7RP"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7rq(Variable):
-    cerfa_field = u"7RQ"
+    cerfa_field = "7RQ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7rr(Variable):
-    cerfa_field = u"7RR"
+    cerfa_field = "7RR"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhlh(Variable):
-    cerfa_field = u"HLH"
+    cerfa_field = "HLH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7rs(Variable):
-    cerfa_field = u"7RS"
+    cerfa_field = "7RS"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhmb(Variable):
-    cerfa_field = u"HMB"
+    cerfa_field = "HMB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7rt(Variable):
-    cerfa_field = u"7RT"
+    cerfa_field = "7RT"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhkt(Variable):
-    cerfa_field = u"7KT"
+    cerfa_field = "7KT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt, Investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt, Investissements dans votre entreprise"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7ru(Variable):
-    cerfa_field = u"7RU"
+    cerfa_field = "7RU"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7rv(Variable):
-    cerfa_field = u"7RV"
+    cerfa_field = "7RV"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhmc(Variable):
-    cerfa_field = u"HMC"
+    cerfa_field = "HMC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Autres investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Autres investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7rw(Variable):
-    cerfa_field = u"7RW"
+    cerfa_field = "7RW"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7rx(Variable):
-    cerfa_field = u"7RX"
+    cerfa_field = "7RX"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ry(Variable):
-    cerfa_field = u"7RY"
+    cerfa_field = "7RY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhrk(Variable):
-    cerfa_field = u"HRK"
+    cerfa_field = "HRK"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrl(Variable):
-    cerfa_field = u"HRL"
+    cerfa_field = "HRL"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrm(Variable):
-    cerfa_field = u"HRM"
+    cerfa_field = "HRM"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrn(Variable):
-    cerfa_field = u"HRN"
+    cerfa_field = "HRN"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhro(Variable):
-    cerfa_field = u"HRO"
+    cerfa_field = "HRO"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrp(Variable):
-    cerfa_field = u"HRP"
+    cerfa_field = "HRP"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrq(Variable):
-    cerfa_field = u"HRQ"
+    cerfa_field = "HRQ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrr(Variable):
-    cerfa_field = u"HRR"
+    cerfa_field = "HRR"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrs(Variable):
-    cerfa_field = u"HRS"
+    cerfa_field = "HRS"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrt(Variable):
-    cerfa_field = u"HRT"
+    cerfa_field = "HRT"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2010 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhru(Variable):
-    cerfa_field = u"HRU"
+    cerfa_field = "HRU"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrv(Variable):
-    cerfa_field = u"HRV"
+    cerfa_field = "HRV"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrw(Variable):
-    cerfa_field = u"HRW"
+    cerfa_field = "HRW"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrx(Variable):
-    cerfa_field = u"HRX"
+    cerfa_field = "HRX"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhry(Variable):
-    cerfa_field = u"HRY"
+    cerfa_field = "HRY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements ayant fait l'objet en 2011 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 %, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7nu(Variable):
-    cerfa_field = u"7NU"
+    cerfa_field = "7NU"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhnu(Variable):
-    cerfa_field = u"HNU"
+    cerfa_field = "HNU"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 52,63 %"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7nv(Variable):
-    cerfa_field = u"7NV"
+    cerfa_field = "7NV"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7nw(Variable):
-    cerfa_field = u"7NW"
+    cerfa_field = "7NW"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhnv(Variable):
-    cerfa_field = u"HNV"
+    cerfa_field = "HNV"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 62,5 %"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhnw(Variable):
-    cerfa_field = u"HNW"
+    cerfa_field = "HNW"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7nx(Variable):
-    cerfa_field = u"7NX"
+    cerfa_field = "7NX"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt calculée"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ny(Variable):
-    cerfa_field = u"7NY"
+    cerfa_field = "7NY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 # TODO: 7N* : end ?
 class fhny(Variable):
-    cerfa_field = u"HNY"
+    cerfa_field = "HNY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, investissements dans votre entreprise avec exploitation directe, montant de la réduction d'impôt dont vous demandez l'imputation en 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7mn(Variable):
-    cerfa_field = u"7MN"
+    cerfa_field = "7MN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
     # start_date = date(2011, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class fhmn(Variable):
-    cerfa_field = u"HMN"
+    cerfa_field = "HMN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet avant 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7lh_2012(Variable):
-    cerfa_field = u"7LH"
+    cerfa_field = "7LH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7lh(Variable):
-    cerfa_field = u"7LH"
+    cerfa_field = "7LH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report de l'année 2014"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report de l'année 2014"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhlh(Variable):  # noqa 728
-    cerfa_field = u"HLH"
+    cerfa_field = "HLH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7mb(Variable):
-    cerfa_field = u"7MB"
+    cerfa_field = "7MB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements ayant fait l'objet en 2009 d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un accompte d'au moins 50%, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60%"
     # start_date = date(2011, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7kt(Variable):
-    cerfa_field = u"7KT"
+    cerfa_field = "7KT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt, Investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt, Investissements dans votre entreprise"
     # start_date = date(2011, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7li(Variable):
-    cerfa_field = u"7LI"
+    cerfa_field = "7LI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Autres investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Autres investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
     # start_date = date(2011, 1, 1) changes meaningin 2015
     definition_period = YEAR
 
 
 class fhli(Variable):
-    cerfa_field = u"HLI"
+    cerfa_field = "HLI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Autres investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Autres investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 50%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7mc(Variable):
-    cerfa_field = u"7MC"
+    cerfa_field = "7MC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Autres investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Autres investissements réalisés en 2010, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt à hauteur de 60%"
     # start_date = date(2011, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7ku(Variable):
-    cerfa_field = u"7KU"
+    cerfa_field = "7KU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements dans votre entreprise"
     # start_date = date(2011, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class fhku(Variable):
-    cerfa_field = u"7HU"
+    cerfa_field = "7HU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise REPORT : Investissements réalisés en 2010, Investissements dans votre entreprise"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7sz_2009(Variable):
-    cerfa_field = u"7SZ"
+    cerfa_field = "7SZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements Outre-Mer; Report de la réduction N-1"
+    label = "Investissements Outre-Mer; Report de la réduction N-1"
     # start_date = date(2006, 1, 1)
     end = '2009-12-31'
     definition_period = YEAR
 
 
 class f7sz_2015(Variable):
-    cerfa_field = u"7SZ"
+    cerfa_field = "7SZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location"
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location"
     # start_date = date(2012, 1, 1) # disparait provisoirement en 2014
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class fhaa(Variable):
-    cerfa_field = u"HAA"
+    cerfa_field = "HAA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 52,63%"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhab(Variable):
-    cerfa_field = u"HAB"
+    cerfa_field = "HAB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2012, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 62,5%"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhaf(Variable):
-    cerfa_field = u"HAF"
+    cerfa_field = "HAF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 52,63%"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhag(Variable):
-    cerfa_field = u"HAG"
+    cerfa_field = "HAG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 62,5%"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhac(Variable):
-    cerfa_field = u"HAC"
+    cerfa_field = "HAC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements dans votre entreprise en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements dans votre entreprise en 2010"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhah(Variable):
-    cerfa_field = u"HAH"
+    cerfa_field = "HAH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements dans votre entreprise en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements dans votre entreprise en 2011"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhad(Variable):
-    cerfa_field = u"HAD"
+    cerfa_field = "HAD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2010"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhai(Variable):
-    cerfa_field = u"HAI"
+    cerfa_field = "HAI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2011"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhae(Variable):
-    cerfa_field = u"HAE"
+    cerfa_field = "HAE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements dans votre entreprise avec exploitation directe montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements dans votre entreprise avec exploitation directe montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhaj(Variable):
-    cerfa_field = u"HAJ"
+    cerfa_field = "HAJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2014, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhak(Variable):
-    cerfa_field = u"HAK"
+    cerfa_field = "HAK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2010 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2010 à hauteur de 52,63%"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhal(Variable):
-    cerfa_field = u"HAL"
+    cerfa_field = "HAL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2010 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2010 à hauteur de 62,5%"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhap(Variable):
-    cerfa_field = u"HAP"
+    cerfa_field = "HAP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2011 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2011 à hauteur de 52,63%"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhaq(Variable):
-    cerfa_field = u"HAQ"
+    cerfa_field = "HAQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2011 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2011 à hauteur de 62,5%"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fham(Variable):
-    cerfa_field = u"HAM"
+    cerfa_field = "HAM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2010"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhar(Variable):
-    cerfa_field = u"HAR"
+    cerfa_field = "HAR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2011"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhan(Variable):
-    cerfa_field = u"HAN"
+    cerfa_field = "HAN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2010"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhas(Variable):
-    cerfa_field = u"HAS"
+    cerfa_field = "HAS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2011"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhao(Variable):
-    cerfa_field = u"HAO"
+    cerfa_field = "HAO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhat(Variable):
-    cerfa_field = u"HAT"
+    cerfa_field = "HAT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhau(Variable):
-    cerfa_field = u"HAU"
+    cerfa_field = "HAU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 52,63%"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhav(Variable):
-    cerfa_field = u"HAV"
+    cerfa_field = "HAV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 62,5%"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhaw(Variable):
-    cerfa_field = u"HAW"
+    cerfa_field = "HAW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhax(Variable):
-    cerfa_field = u"HAX"
+    cerfa_field = "HAX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhay(Variable):
-    cerfa_field = u"HAY"
+    cerfa_field = "HAY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhbi(Variable):
-    cerfa_field = u"HBI"
+    cerfa_field = "HBI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 52,63%"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbj(Variable):
-    cerfa_field = u"HBJ"
+    cerfa_field = "HBJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 62,5%"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbn(Variable):
-    cerfa_field = u"HBN"
+    cerfa_field = "HBN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 52,63%"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbo(Variable):
-    cerfa_field = u"HBO"
+    cerfa_field = "HBO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 62,5%"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbk(Variable):
-    cerfa_field = u"HBK"
+    cerfa_field = "HBK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements dans votre entreprise en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements dans votre entreprise en 2010"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbp(Variable):
-    cerfa_field = u"HBP"
+    cerfa_field = "HBP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements dans votre entreprise en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements dans votre entreprise en 2011"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbl(Variable):
-    cerfa_field = u"HBL"
+    cerfa_field = "HBL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2010"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbq(Variable):
-    cerfa_field = u"HBQ"
+    cerfa_field = "HBQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2011"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbm(Variable):
-    cerfa_field = u"HBM"
+    cerfa_field = "HBM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements dans votre entreprise avec exploitation directe montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements dans votre entreprise avec exploitation directe montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbr(Variable):
-    cerfa_field = u"HBR"
+    cerfa_field = "HBR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2015, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbs(Variable):
-    cerfa_field = u"HBS"
+    cerfa_field = "HBS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2012 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2012 à hauteur de 52,63%"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbt(Variable):
-    cerfa_field = u"HBT"
+    cerfa_field = "HBT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2012 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2012 à hauteur de 62,5%"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbx(Variable):
-    cerfa_field = u"HBX"
+    cerfa_field = "HBX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2013 ou 2014 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2013 ou 2014 à hauteur de 52,63%"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhby(Variable):
-    cerfa_field = u"HBY"
+    cerfa_field = "HBY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2013 ou 2014 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2013 ou 2014 à hauteur de 62,5%"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbu(Variable):
-    cerfa_field = u"HBU"
+    cerfa_field = "HBU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2012"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbz(Variable):
-    cerfa_field = u"HBZ"
+    cerfa_field = "HBZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2013 ou 2014"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2013 ou 2014"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbv(Variable):
-    cerfa_field = u"HBV"
+    cerfa_field = "HBV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2012"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhca(Variable):
-    cerfa_field = u"HCA"
+    cerfa_field = "HCA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2013 ou 2014"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2013 ou 2014"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhbw(Variable):
-    cerfa_field = u"HBW"
+    cerfa_field = "HBW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2015, en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2015, en 2012"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhcb(Variable):
-    cerfa_field = u"HCB"
+    cerfa_field = "HCB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2015, en 2013 ou 2014"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2015, en 2013 ou 2014"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhci(Variable):
-    cerfa_field = u"HCI"
+    cerfa_field = "HCI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2012 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2012 à hauteur de 52,63%"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhcj(Variable):
-    cerfa_field = u"HCJ"
+    cerfa_field = "HCJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2012 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2012 à hauteur de 62,5%"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhcn(Variable):
-    cerfa_field = u"HCN"
+    cerfa_field = "HCN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2013 ou 2014 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2013 ou 2014 à hauteur de 52,63%"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhco(Variable):
-    cerfa_field = u"HCO"
+    cerfa_field = "HCO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2013 ou 2014 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012, 2013 ou 2014 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2013 ou 2014 à hauteur de 62,5%"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhck(Variable):
-    cerfa_field = u"HCK"
+    cerfa_field = "HCK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2012"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhcp(Variable):
-    cerfa_field = u"HCP"
+    cerfa_field = "HCP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2013 ou 2014"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2013 ou 2014"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhcl(Variable):
-    cerfa_field = u"HCL"
+    cerfa_field = "HCL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2012"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhcq(Variable):
-    cerfa_field = u"HCQ"
+    cerfa_field = "HCQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2013 ou 2014"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2013 ou 2014"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhcm(Variable):
-    cerfa_field = u"HCM"
+    cerfa_field = "HCM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2015, en 2012"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2015, en 2012"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhcr(Variable):
-    cerfa_field = u"HCR"
+    cerfa_field = "HCR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2015, en 2013 ou 2014"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2015, en 2013 ou 2014"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhdi(Variable):
-    cerfa_field = u"HDI"
+    cerfa_field = "HDI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdj(Variable):
-    cerfa_field = u"HDJ"
+    cerfa_field = "HDJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdk(Variable):
-    cerfa_field = u"HDK"
+    cerfa_field = "HDK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdl(Variable):
-    cerfa_field = u"HDL"
+    cerfa_field = "HDL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdm(Variable):
-    cerfa_field = u"HDM"
+    cerfa_field = "HDM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdn(Variable):
-    cerfa_field = u"HDN"
+    cerfa_field = "HDN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdo(Variable):
-    cerfa_field = u"HDO"
+    cerfa_field = "HDO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdp(Variable):
-    cerfa_field = u"HDP"
+    cerfa_field = "HDP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdq(Variable):
-    cerfa_field = u"HDQ"
+    cerfa_field = "HDQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdr(Variable):
-    cerfa_field = u"HDR"
+    cerfa_field = "HDR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhds(Variable):
-    cerfa_field = u"HDS"
+    cerfa_field = "HDS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdt(Variable):
-    cerfa_field = u"HDT"
+    cerfa_field = "HDT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdu(Variable):
-    cerfa_field = u"HDU"
+    cerfa_field = "HDU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdv(Variable):
-    cerfa_field = u"HDV"
+    cerfa_field = "HDV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhdw(Variable):
-    cerfa_field = u"HDW"
+    cerfa_field = "HDW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhsa(Variable):
-    cerfa_field = u"HSA"
+    cerfa_field = "HSA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 52,63%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsb(Variable):
-    cerfa_field = u"HSB"
+    cerfa_field = "HSB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2010 à hauteur de 62,5%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsf(Variable):
-    cerfa_field = u"HSF"
+    cerfa_field = "HSF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 52,63%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsg(Variable):
-    cerfa_field = u"HSG"
+    cerfa_field = "HSG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d'impôt en 2011 à hauteur de 62,5%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsc(Variable):
-    cerfa_field = u"HSC"
+    cerfa_field = "HSC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise en 2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsh(Variable):
-    cerfa_field = u"HSH"
+    cerfa_field = "HSH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise en 2011"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsd(Variable):
-    cerfa_field = u"HSD"
+    cerfa_field = "HSD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsi(Variable):
-    cerfa_field = u"HSI"
+    cerfa_field = "HSI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculée en 2011"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhse(Variable):
-    cerfa_field = u"HSE"
+    cerfa_field = "HSE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsj(Variable):
-    cerfa_field = u"HSJ"
+    cerfa_field = "HSJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements réalisés en 2013, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsk(Variable):
-    cerfa_field = u"HSK"
+    cerfa_field = "HSK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2010 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2010 à hauteur de 52,63%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsl(Variable):
-    cerfa_field = u"HSL"
+    cerfa_field = "HSL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2010 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2010 à hauteur de 62,5%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsp(Variable):
-    cerfa_field = u"HSP"
+    cerfa_field = "HSP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2011 à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2011 à hauteur de 52,63%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsq(Variable):
-    cerfa_field = u"HSQ"
+    cerfa_field = "HSQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2011 à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2010 ou 2011 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt en 2011 à hauteur de 62,5%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsm(Variable):
-    cerfa_field = u"HSM"
+    cerfa_field = "HSM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsr(Variable):
-    cerfa_field = u"HSR"
+    cerfa_field = "HSR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise en 2011"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsn(Variable):
-    cerfa_field = u"HSN"
+    cerfa_field = "HSN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhss(Variable):
-    cerfa_field = u"HSS"
+    cerfa_field = "HSS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe en 2011"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhso(Variable):
-    cerfa_field = u"HSO"
+    cerfa_field = "HSO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhst(Variable):
-    cerfa_field = u"HST"
+    cerfa_field = "HST"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013, en 2011"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsu(Variable):
-    cerfa_field = u"HSU"
+    cerfa_field = "HSU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 52,63%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsv(Variable):
-    cerfa_field = u"HSV"
+    cerfa_field = "HSV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 62,5%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsw(Variable):
-    cerfa_field = u"HSW"
+    cerfa_field = "HSW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsx(Variable):
-    cerfa_field = u"HSX"
+    cerfa_field = "HSX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsy(Variable):
-    cerfa_field = u"HS"
+    cerfa_field = "HS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Autres investissements, Investissements ayant fait l’objet en 2012 d’une demande d’agrément, d’une déclaration d’ouverture de chantier ou d’un acompte d’au moins 50 %, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhsz(Variable):
-    cerfa_field = u"HSZ"
+    cerfa_field = "HSZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 52,63%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhba(Variable):
-    cerfa_field = u"HBA"
+    cerfa_field = "HBA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 52,63%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 52,63%"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhcc(Variable):
-    cerfa_field = u"HCC"
+    cerfa_field = "HCC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 56%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 56%"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhcs(Variable):
-    cerfa_field = u"HCS"
+    cerfa_field = "HCS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 56%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 56%"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhta(Variable):
-    cerfa_field = u"HTA"
+    cerfa_field = "HTA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 62,5%"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhbb(Variable):
-    cerfa_field = u"HBB"
+    cerfa_field = "HBB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 62,5%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 62,5%"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhcd(Variable):
-    cerfa_field = u"HCD"
+    cerfa_field = "HCD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 66%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 66%"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhct(Variable):
-    cerfa_field = u"HCT"
+    cerfa_field = "HCT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 66%"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements donnés en location à une entreprise exploitante à laquelle vous rétrocédez la réduction d’impôt à hauteur de 66%"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhtb(Variable):
-    cerfa_field = u"HTB"
+    cerfa_field = "HTB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhbe(Variable):
-    cerfa_field = u"HBE"
+    cerfa_field = "HBE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhce(Variable):
-    cerfa_field = u"HCE"
+    cerfa_field = "HCE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhcu(Variable):
-    cerfa_field = u"HCU"
+    cerfa_field = "HCU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhtc(Variable):
-    cerfa_field = u"HTC"
+    cerfa_field = "HTC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhbf(Variable):
-    cerfa_field = u"HBF"
+    cerfa_field = "HBF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhcf(Variable):
-    cerfa_field = u"HCF"
+    cerfa_field = "HCF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhcv(Variable):
-    cerfa_field = u"HCV"
+    cerfa_field = "HCV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt calculé"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhtd(Variable):
-    cerfa_field = u"HTD"
+    cerfa_field = "HTD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhbg(Variable):
-    cerfa_field = u"HBG"
+    cerfa_field = "HBG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhcg(Variable):
-    cerfa_field = u"HCG"
+    cerfa_field = "HCG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhcw(Variable):
-    cerfa_field = u"HCW"
+    cerfa_field = "HCW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
+    label = "Investissements outre-mer dans le cadre de l'entreprise : Investissements autres que ceux des lignes précédentes, Investissements dans votre entreprise avec exploitation directe, montant de la réduction d’impôt dont vous demandez l’imputation en 2013"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 # Aide aux créateurs et repreneurs d'entreprises
 class f7fy_2011(Variable):
-    cerfa_field = u"7FY"
+    cerfa_field = "7FY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés: conventions signées avant l'année n-1 et ayant pris fin en année n-1"
+    label = "Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés: conventions signées avant l'année n-1 et ayant pris fin en année n-1"
     end = '2011-12-31'
     definition_period = YEAR
 
 
 class f7gy(Variable):
-    cerfa_field = u"7GY"
+    cerfa_field = "7GY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés dont handicapés: conventions signées avant l'année n-1 et ayant pris fin en année n-1"
+    label = "Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés dont handicapés: conventions signées avant l'année n-1 et ayant pris fin en année n-1"
     # start_date = date(2006, 1, 1)
     end = '2011-12-31'
     definition_period = YEAR
 
 
 class f7hy(Variable):
-    cerfa_field = u"7HY"
+    cerfa_field = "7HY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés: conventions signées en n-1 et n'ayant pas pris fin en n-1"
+    label = "Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés: conventions signées en n-1 et n'ayant pas pris fin en n-1"
     # start_date = date(2009, 1, 1)
     end = '2011-12-31'
     definition_period = YEAR
 
 
 class f7ky(Variable):
-    cerfa_field = u"7KY"
+    cerfa_field = "7KY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés dont handicapés: conventions signées en n-1 et ayant pris fin en n-1"
+    label = "Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés dont handicapés: conventions signées en n-1 et ayant pris fin en n-1"
     # start_date = date(2009, 1, 1)
     end = '2011-12-31'
     definition_period = YEAR
 
 
 class f7iy(Variable):
-    cerfa_field = u"7IY"
+    cerfa_field = "7IY"
     value_type = int
     entity = FoyerFiscal
     # end = '2009-12-31' changes meaning in 2014
@@ -3581,20 +3581,20 @@ class f7iy(Variable):
 
 # 2012 et 2013 ok
 class f7ly(Variable):
-    cerfa_field = u"7LY"
+    cerfa_field = "7LY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés: conventions ayant pas pris fin l'année de perception des revenus déclarés"
+    label = "Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés: conventions ayant pas pris fin l'année de perception des revenus déclarés"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 # 2012 et 2013 ok
 class f7my(Variable):
-    cerfa_field = u"7MY"
+    cerfa_field = "7MY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés dont handicapés: conventions ayant pas pris fin l'année de perception des revenus déclarés"
+    label = "Aide aux créateurs et repreneurs d'entreprises, nombre de créateurs aidés dont handicapés: conventions ayant pas pris fin l'année de perception des revenus déclarés"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
@@ -3604,126 +3604,126 @@ class f7my(Variable):
 
 # 2012 et 2013 ok
 class f7ra_2015(Variable):
-    cerfa_field = u"7RA"
+    cerfa_field = "7RA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Travaux de restauration immobilière dans une zone de protection du patrimoine architectural, urbain et paysager"
+    label = "Travaux de restauration immobilière dans une zone de protection du patrimoine architectural, urbain et paysager"
     # start_date = date(2009, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class f7rb_2015(Variable):
-    cerfa_field = u"7RB"
+    cerfa_field = "7RB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé : dépenses payées en 2014 sur opérations engagées en 2011"
+    label = "Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé : dépenses payées en 2014 sur opérations engagées en 2011"
     # end = '2012-12-31' changes meaning in 2014
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class f7rc_2015(Variable):
-    cerfa_field = u"7RC"
+    cerfa_field = "7RC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
+    label = "Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     # start_date = date(2011, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class f7rd_2015(Variable):
-    cerfa_field = u"7RD"
+    cerfa_field = "7RD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
+    label = "Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     # start_date = date(2011, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class f7re(Variable):
-    cerfa_field = u"7RE"
+    cerfa_field = "7RE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
+    label = "Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     # start_date = date(2012, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7rf(Variable):
-    cerfa_field = u"7RF"
+    cerfa_field = "7RF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
+    label = "Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     # start_date = date(2012, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7sx(Variable):
-    cerfa_field = u"7SX"
+    cerfa_field = "7SX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
+    label = "Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7sy(Variable):
-    cerfa_field = u"7SY"
+    cerfa_field = "7SY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
+    label = "Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7tx(Variable):
-    cerfa_field = u"7TX"
+    cerfa_field = "7TX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé; Opérations engagées en 2017 dans un site patrimonial remarquable couvert par un PSMV"
+    label = "Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé; Opérations engagées en 2017 dans un site patrimonial remarquable couvert par un PSMV"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7ty(Variable):
-    cerfa_field = u"7TY"
+    cerfa_field = "7TY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé; Opérations engagées en 2017 dans un site patrimonial remarquable non couvert par un PSMV"
+    label = "Travaux de restauration immobilière dans un secteur sauvegardé ou assimilé; Opérations engagées en 2017 dans un site patrimonial remarquable non couvert par un PSMV"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7gw(Variable):
-    cerfa_field = u"7GW"
+    cerfa_field = "7GW"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements achevés en n-2 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna : report de 1/5 de la réduction d'impôt"
+    label = "Investissements achevés en n-2 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna : report de 1/5 de la réduction d'impôt"
     # start_date = date(2013, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7gx(Variable):
-    cerfa_field = u"7GX"
+    cerfa_field = "7GX"
     value_type = int
     entity = FoyerFiscal
-    label = u"Investissements achevés en n-2 avec promesse d'achat en n-3 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna : report de 1/5 de la réduction d'impôt"
+    label = "Investissements achevés en n-2 avec promesse d'achat en n-3 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna : report de 1/5 de la réduction d'impôt"
     # start_date = date(2013, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
@@ -3731,321 +3731,321 @@ class f7gx(Variable):
 
 # Investissements locatifs dans le secteur de touristique
 class f7xa(Variable):
-    cerfa_field = u"7XA"
+    cerfa_field = "7XA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: travaux engagés avant 2011 dans un village résidentiel de tourisme"
+    label = "Investissements locatifs dans le secteur de touristique: travaux engagés avant 2011 dans un village résidentiel de tourisme"
     # start_date = date(2011, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7xb_2012(Variable):
-    cerfa_field = u"7XB"
+    cerfa_field = "7XB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: travaux engagés avant 2011 dans une résidence de tourisme classée ou meublée"
+    label = "Investissements locatifs dans le secteur de touristique: travaux engagés avant 2011 dans une résidence de tourisme classée ou meublée"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7xb(Variable):
-    cerfa_field = u"7XB"
+    cerfa_field = "7XB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat en 2015 de matériaux d'isolation des murs concernant au moins la moitié de la surface des murs"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: achat en 2015 de matériaux d'isolation des murs concernant au moins la moitié de la surface des murs"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7xc_2012(Variable):
-    cerfa_field = u"7XC"
+    cerfa_field = "7XC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: prix d'acquisition ou de revient d'un logement neuf acquis ou achevé en n-1"
+    label = "Investissements locatifs dans le secteur de touristique: prix d'acquisition ou de revient d'un logement neuf acquis ou achevé en n-1"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7xc(Variable):
-    cerfa_field = u"7XC"
+    cerfa_field = "7XC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale: achat en 2015 de matériaux d'isolation des murs concernant moins de la moitié de la surface des murs"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale: achat en 2015 de matériaux d'isolation des murs concernant moins de la moitié de la surface des murs"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7xd(Variable):
-    cerfa_field = u"7XD"
+    cerfa_field = "7XD"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: logement neuf, demande d'étalement du solde de la réduction d'impôt sur 6 ans"
+    label = "Investissements locatifs dans le secteur de touristique: logement neuf, demande d'étalement du solde de la réduction d'impôt sur 6 ans"
     # start_date = date(2009, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7xe(Variable):
-    cerfa_field = u"7XE"
+    cerfa_field = "7XE"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, demande d'étalement du solde de la réduction d'impôt sur 6 ans"
+    label = "Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, demande d'étalement du solde de la réduction d'impôt sur 6 ans"
     # start_date = date(2009, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7xf(Variable):
-    cerfa_field = u"7XF"
+    cerfa_field = "7XF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique, logement neuf: report des dépenses d'investissement des années antérieures"
+    label = "Investissements locatifs dans le secteur de touristique, logement neuf: report des dépenses d'investissement des années antérieures"
     definition_period = YEAR
 
 
 class f7xh(Variable):
-    cerfa_field = u"7XH"
+    cerfa_field = "7XH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: travaux de reconstruction, agrandissement, réparation dans une résidence de tourisme classée ou un meublé de tourisme"
+    label = "Investissements locatifs dans le secteur de touristique: travaux de reconstruction, agrandissement, réparation dans une résidence de tourisme classée ou un meublé de tourisme"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7xi(Variable):
-    cerfa_field = u"7XI"
+    cerfa_field = "7XI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique, logement neuf: report des dépenses d'investissement des années antérieures"
+    label = "Investissements locatifs dans le secteur de touristique, logement neuf: report des dépenses d'investissement des années antérieures"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7xj(Variable):
-    cerfa_field = u"7XJ"
+    cerfa_field = "7XJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, report des dépenses d'investissement des années antérieures"
+    label = "Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, report des dépenses d'investissement des années antérieures"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7xk(Variable):
-    cerfa_field = u"7XK"
+    cerfa_field = "7XK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
+    label = "Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7xl(Variable):
-    cerfa_field = u"7XL"
+    cerfa_field = "7XL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, prix de revient d'un logement réhabilité en n-1 et achevé depuis moins de 15 ans"
+    label = "Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, prix de revient d'un logement réhabilité en n-1 et achevé depuis moins de 15 ans"
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7xm(Variable):
-    cerfa_field = u"7XM"
+    cerfa_field = "7XM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, report de dépenses des travaux de réhabilitation achevés les années antérieures"
+    label = "Investissements locatifs dans le secteur de touristique: réhabilitation d'un logement, report de dépenses des travaux de réhabilitation achevés les années antérieures"
     definition_period = YEAR
 
 
 # TODO: f7xn cf années < à 2011 (possible erreur dans le label pour ces dates, à vérifier)
 class f7xn(Variable):
-    cerfa_field = u"7XN"
+    cerfa_field = "7XN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique, logement neuf: report des dépenses d'investissement des années antérieures"
+    label = "Investissements locatifs dans le secteur de touristique, logement neuf: report des dépenses d'investissement des années antérieures"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7xo(Variable):
-    cerfa_field = u"7XO"
+    cerfa_field = "7XO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
+    label = "Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     # start_date = date(2008, 1, 1)
     definition_period = YEAR
 
 
 class f7xp(Variable):
-    cerfa_field = u"7XP"
+    cerfa_field = "7XP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
+    label = "Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7xq(Variable):
-    cerfa_field = u"7XQ"
+    cerfa_field = "7XQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
+    label = "Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7xr(Variable):
-    cerfa_field = u"7XR"
+    cerfa_field = "7XR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
+    label = "Investissements locatifs dans une résidence hôtelière à vocation sociale: report des dépenses d'investissement des années antérieures"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7xv(Variable):
-    cerfa_field = u"7XV"
+    cerfa_field = "7XV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: Report des dépenses d'investissement des années antérieures"
+    label = "Investissements locatifs dans le secteur de touristique: Report des dépenses d'investissement des années antérieures"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7xx_2012(Variable):
-    cerfa_field = u"7XX"
+    cerfa_field = "7XX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: travaux engagés après 2012 dans un village résidentiel de tourisme"
+    label = "Investissements locatifs dans le secteur de touristique: travaux engagés après 2012 dans un village résidentiel de tourisme"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7xx(Variable):
-    cerfa_field = u"7XX"
+    cerfa_field = "7XX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Travaux de réhabilitation des résidences de tourisme : dépenses payées en 2017"
+    label = "Travaux de réhabilitation des résidences de tourisme : dépenses payées en 2017"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7xz(Variable):
-    cerfa_field = u"7XZ"
+    cerfa_field = "7XZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: travaux engagés après 2012 dans une résidence de tourisme classée ou un meublé tourisme"
+    label = "Investissements locatifs dans le secteur de touristique: travaux engagés après 2012 dans une résidence de tourisme classée ou un meublé tourisme"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7uy(Variable):
-    cerfa_field = u"7UY"
+    cerfa_field = "7UY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: Report des dépenses d'investissement des années antérieures"
+    label = "Investissements locatifs dans le secteur de touristique: Report des dépenses d'investissement des années antérieures"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7uz(Variable):
-    cerfa_field = u"7UZ"
+    cerfa_field = "7UZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs dans le secteur de touristique: Report des dépenses d'investissement des années antérieures"
+    label = "Investissements locatifs dans le secteur de touristique: Report des dépenses d'investissement des années antérieures"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 # Souscriptions au capital des PME
 class f7cf(Variable):
-    cerfa_field = u"7CF"
+    cerfa_field = "7CF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, petites entreprises en phase de démarrage, ou d'expansion"
+    label = "Souscriptions au capital des PME non cotées, petites entreprises en phase de démarrage, ou d'expansion"
     definition_period = YEAR
 
 
 class f7cl(Variable):
-    cerfa_field = u"7CL"
+    cerfa_field = "7CL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -4"
+    label = "Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -4"
     definition_period = YEAR
 
 
 class f7cm(Variable):
-    cerfa_field = u"7CM"
+    cerfa_field = "7CM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -3"
+    label = "Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -3"
     definition_period = YEAR
 
 
 class f7cn(Variable):
-    cerfa_field = u"7CN"
+    cerfa_field = "7CN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -2"
+    label = "Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -2"
     definition_period = YEAR
 
 
 class f7cc(Variable):
-    cerfa_field = u"7CC"
+    cerfa_field = "7CC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1"
+    label = "Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7cq(Variable):
-    cerfa_field = u"7CQ"
+    cerfa_field = "7CQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1pour les start-up"
+    label = "Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1pour les start-up"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7cu(Variable):
-    cerfa_field = u"7CU"
+    cerfa_field = "7CU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, montant versé au titre de souscriptions antérieures"
+    label = "Souscriptions au capital des PME non cotées, montant versé au titre de souscriptions antérieures"
     end = '2016-12-31'
     definition_period = YEAR
 
@@ -4053,71 +4053,71 @@ class f7cu(Variable):
 # TODO: en 2013 et 2012 plus de sofipêche (pourtant présent dans param à ces dates...), case 7gs réutilisée
 
 class f7gs(Variable):
-    cerfa_field = u"7GS"
+    cerfa_field = "7GS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Reports concernant les investissements achevés ou acquis au cours des années antérieures: Investissements réalisés en n-3 en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Reports concernant les investissements achevés ou acquis au cours des années antérieures: Investissements réalisés en n-3 en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 # Investissements OUTRE-MER dans le secteur du logement et autres secteurs d’activité
 class f7ua_2007(Variable):
-    cerfa_field = u"7UA"
+    cerfa_field = "7UA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le secteur du logement et autres secteurs d'activité : dans le secteur du logement du 01-01-2002 au 20-07-2003"
+    label = "Investissements outre-mer dans le secteur du logement et autres secteurs d'activité : dans le secteur du logement du 01-01-2002 au 20-07-2003"
     end = '2007-12-31'
     definition_period = YEAR
 
 
 class f7ua(Variable):
-    cerfa_field = u"7UA"
+    cerfa_field = "7UA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : travaux avec adhésion à une organisation de producteurs"
+    label = "Investissements forestiers : travaux avec adhésion à une organisation de producteurs"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7ub_2007(Variable):
-    cerfa_field = u"7UB"
+    cerfa_field = "7UB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le secteur du logement et autres secteurs d'activité : dans les autres secteurs d'activité du 01-01-2002 au 20-07-2003"
+    label = "Investissements outre-mer dans le secteur du logement et autres secteurs d'activité : dans les autres secteurs d'activité du 01-01-2002 au 20-07-2003"
     end = '2007-12-31'
     definition_period = YEAR
 
 
 class f7ub(Variable):
-    cerfa_field = u"7UB"
+    cerfa_field = "7UB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : travaux consécutifs à un sinistre, avec adhésion à une organisation de producteurs"
+    label = "Investissements forestiers : travaux consécutifs à un sinistre, avec adhésion à une organisation de producteurs"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 # En 2013 les "7" sont remplacés par des "H" dans les CERFA-FIELDS
 # en 2013 et 2012, 7uc se rapporte à autre chose, réutilisation de la case
-#    build_column('f7uc', IntCol(entity = 'foy', label = u"", val_type = "monetary", cerfa_field = u'7UC', end = date(2011,12,31)))  # vérifier <=2011
+#    build_column('f7uc', IntCol(entity = 'foy', label = "", val_type = "monetary", cerfa_field = '7UC', end = date(2011,12,31)))  # vérifier <=2011
 
 class f7uc(Variable):
-    cerfa_field = u"7UC"
+    cerfa_field = "7UC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Cotisations pour la défense des forêts contre l'incendie "
+    label = "Cotisations pour la défense des forêts contre l'incendie "
     definition_period = YEAR
 
 
 class f7ui_2008(Variable):
-    cerfa_field = u"7UI"
+    cerfa_field = "7UI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4126,17 +4126,17 @@ class f7ui_2008(Variable):
 
 
 class f7ui(Variable):
-    cerfa_field = u"7UI"
+    cerfa_field = "7UI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : contrat de gestion avec adhésion à une organisation de producteurs "
+    label = "Investissements forestiers : contrat de gestion avec adhésion à une organisation de producteurs "
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7uj(Variable):
-    cerfa_field = u"7UJ"
+    cerfa_field = "7UJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4145,7 +4145,7 @@ class f7uj(Variable):
 
 
 class f7qb(Variable):
-    cerfa_field = u"7QB"
+    cerfa_field = "7QB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4154,7 +4154,7 @@ class f7qb(Variable):
 
 
 class fhqb(Variable):
-    cerfa_field = u"HQB"
+    cerfa_field = "HQB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4162,7 +4162,7 @@ class fhqb(Variable):
 
 
 class f7qc(Variable):
-    cerfa_field = u"7QC"
+    cerfa_field = "7QC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4171,7 +4171,7 @@ class f7qc(Variable):
 
 
 class fhqc(Variable):
-    cerfa_field = u"HQC"
+    cerfa_field = "HQC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4179,7 +4179,7 @@ class fhqc(Variable):
 
 
 class f7qd(Variable):
-    cerfa_field = u"7QD"
+    cerfa_field = "7QD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4188,7 +4188,7 @@ class f7qd(Variable):
 
 
 class fhqd(Variable):
-    cerfa_field = u"HQD"
+    cerfa_field = "HQD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4197,7 +4197,7 @@ class fhqd(Variable):
 
 
 class f7qk(Variable):
-    cerfa_field = u"7QK"
+    cerfa_field = "7QK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4206,7 +4206,7 @@ class f7qk(Variable):
 
 
 class f7qn_2012(Variable):
-    cerfa_field = u"7QN"
+    cerfa_field = "7QN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4215,7 +4215,7 @@ class f7qn_2012(Variable):
 
 
 class f7kg(Variable):
-    cerfa_field = u"7KG"
+    cerfa_field = "7KG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4224,7 +4224,7 @@ class f7kg(Variable):
 
 
 class fhql(Variable):
-    cerfa_field = u"7HL"
+    cerfa_field = "7HL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4232,7 +4232,7 @@ class fhql(Variable):
 
 
 class f7ql(Variable):
-    cerfa_field = u"7QL"
+    cerfa_field = "7QL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4241,7 +4241,7 @@ class f7ql(Variable):
 
 
 class f7qt_2012(Variable):
-    cerfa_field = u"7QT"
+    cerfa_field = "7QT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4250,7 +4250,7 @@ class f7qt_2012(Variable):
 
 
 class f7qm_2012(Variable):
-    cerfa_field = u"7QM"
+    cerfa_field = "7QM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4259,7 +4259,7 @@ class f7qm_2012(Variable):
 
 
 class fhqt(Variable):
-    cerfa_field = u"HQT"
+    cerfa_field = "HQT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4267,7 +4267,7 @@ class fhqt(Variable):
 
 
 class fhqm(Variable):
-    cerfa_field = u"HQM"
+    cerfa_field = "HQM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4275,7 +4275,7 @@ class fhqm(Variable):
 
 
 class f7qu_2012(Variable):
-    cerfa_field = u"7QU"
+    cerfa_field = "7QU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4284,7 +4284,7 @@ class f7qu_2012(Variable):
 
 
 class f7ki(Variable):
-    cerfa_field = u"7KI"
+    cerfa_field = "7KI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4292,7 +4292,7 @@ class f7ki(Variable):
 
 
 class f7qj(Variable):
-    cerfa_field = u"7QJ"
+    cerfa_field = "7QJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4300,7 +4300,7 @@ class f7qj(Variable):
 
 
 class f7qw(Variable):
-    cerfa_field = u"7QW"
+    cerfa_field = "7QW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4308,7 +4308,7 @@ class f7qw(Variable):
 
 
 class f7qx(Variable):
-    cerfa_field = u"7QX"
+    cerfa_field = "7QX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4316,7 +4316,7 @@ class f7qx(Variable):
 
 
 class f7qf(Variable):
-    cerfa_field = u"7QF"
+    cerfa_field = "7QF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4324,7 +4324,7 @@ class f7qf(Variable):
 
 
 class fhqf(Variable):
-    cerfa_field = u"HQF"
+    cerfa_field = "HQF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4332,7 +4332,7 @@ class fhqf(Variable):
 
 
 class f7qg(Variable):
-    cerfa_field = u"7QG"
+    cerfa_field = "7QG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4340,7 +4340,7 @@ class f7qg(Variable):
 
 
 class fhqg(Variable):
-    cerfa_field = u"HQG"
+    cerfa_field = "HQG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4348,7 +4348,7 @@ class fhqg(Variable):
 
 
 class f7qh(Variable):
-    cerfa_field = u"7QH"
+    cerfa_field = "7QH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4356,7 +4356,7 @@ class f7qh(Variable):
 
 
 class f7qi(Variable):
-    cerfa_field = u"7QI"
+    cerfa_field = "7QI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4364,7 +4364,7 @@ class f7qi(Variable):
 
 
 class fhqi(Variable):
-    cerfa_field = u"HQI"
+    cerfa_field = "HQI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4372,7 +4372,7 @@ class fhqi(Variable):
 
 
 class f7qq(Variable):
-    cerfa_field = u"7QQ"
+    cerfa_field = "7QQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4380,7 +4380,7 @@ class f7qq(Variable):
 
 
 class f7qr_2012(Variable):
-    cerfa_field = u"7QR"
+    cerfa_field = "7QR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4389,7 +4389,7 @@ class f7qr_2012(Variable):
 
 
 class fhqr(Variable):
-    cerfa_field = u"HQR"
+    cerfa_field = "HQR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4397,7 +4397,7 @@ class fhqr(Variable):
 
 
 class f7qs_2012(Variable):
-    cerfa_field = u"7QS"
+    cerfa_field = "7QS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4406,7 +4406,7 @@ class f7qs_2012(Variable):
 
 
 class f7mm(Variable):
-    cerfa_field = u"7MM"
+    cerfa_field = "7MM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4416,7 +4416,7 @@ class f7mm(Variable):
 
 
 class fhmm(Variable):
-    cerfa_field = u"HMM"
+    cerfa_field = "HMM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4425,7 +4425,7 @@ class fhmm(Variable):
 
 
 class f7lg(Variable):
-    cerfa_field = u"7LG"
+    cerfa_field = "7LG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4434,7 +4434,7 @@ class f7lg(Variable):
 
 
 class fhlg(Variable):
-    cerfa_field = u"HLG"
+    cerfa_field = "HLG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4443,7 +4443,7 @@ class fhlg(Variable):
 
 
 class f7lk(Variable):
-    cerfa_field = u"7LK"
+    cerfa_field = "7LK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4452,7 +4452,7 @@ class f7lk(Variable):
 
 
 class f7ll(Variable):
-    cerfa_field = u"7LL"
+    cerfa_field = "7LL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4461,7 +4461,7 @@ class f7ll(Variable):
 
 
 class f7lo(Variable):
-    cerfa_field = u"7LO"
+    cerfa_field = "7LO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4470,7 +4470,7 @@ class f7lo(Variable):
 
 
 class f7ma(Variable):
-    cerfa_field = u"7MA"
+    cerfa_field = "7MA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4479,7 +4479,7 @@ class f7ma(Variable):
 
 
 class fhma(Variable):
-    cerfa_field = u"HMA"
+    cerfa_field = "HMA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4488,7 +4488,7 @@ class fhma(Variable):
 
 
 class f7ks(Variable):
-    cerfa_field = u"7KS"
+    cerfa_field = "7KS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4496,7 +4496,7 @@ class f7ks(Variable):
 
 
 class fhks(Variable):
-    cerfa_field = u"HKS"
+    cerfa_field = "HKS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4504,7 +4504,7 @@ class fhks(Variable):
 
 
 class f7kh(Variable):
-    cerfa_field = u"7KH"
+    cerfa_field = "7KH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
@@ -4512,131 +4512,131 @@ class f7kh(Variable):
 
 
 class f7oa(Variable):
-    cerfa_field = u"7OA"
+    cerfa_field = "7OA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% avant 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% avant 2009"
     # start_date = date(2011, 1, 1) changes meaning in 2014
     definition_period = YEAR
 
 
 class f7ob(Variable):
-    cerfa_field = u"7OB"
+    cerfa_field = "7OB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2009"
     # start_date = date(2011, 1, 1) changes meaning
     definition_period = YEAR
 
 
 class f7oc(Variable):
-    cerfa_field = u"7OC"
+    cerfa_field = "7OC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     # start_date = date(2011, 1, 1) changes meaning in 2014
     definition_period = YEAR
 
 
 class f7oh(Variable):
-    cerfa_field = u"7OH"
+    cerfa_field = "7OH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% avant 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% avant 2009"
     # start_date = date(2011, 1, 1) changes meaning in 2015
     definition_period = YEAR
 
 
 class f7oi(Variable):
-    cerfa_field = u"7OI"
+    cerfa_field = "7OI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2009"
     # start_date = date(2011, 1, 1) changes meaning in 2015
     definition_period = YEAR
 
 
 class f7oj(Variable):
-    cerfa_field = u"7OJ"
+    cerfa_field = "7OJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     # start_date = date(2011, 1, 1) changes meaning in 2015
     definition_period = YEAR
 
 
 class f7cr(Variable):
-    cerfa_field = u"7CR"
+    cerfa_field = "7CR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de versement de l'année 2013 pour les start-up"
+    label = "Souscriptions au capital des PME non cotées, report de versement de l'année 2013 pour les start-up"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7cv(Variable):
-    cerfa_field = u"7CV"
+    cerfa_field = "7CV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de versement de l'année 2014 pour les start-up"
+    label = "Souscriptions au capital des PME non cotées, report de versement de l'année 2014 pour les start-up"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7cx(Variable):
-    cerfa_field = u"7CX"
+    cerfa_field = "7CX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de versement de l'année 2015 pour les start-up"
+    label = "Souscriptions au capital des PME non cotées, report de versement de l'année 2015 pour les start-up"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7cy(Variable):
-    cerfa_field = u"7CY"
+    cerfa_field = "7CY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de réduction d'impôt au titre du plafonnement global de l'année 2013"
+    label = "Souscriptions au capital des PME non cotées, report de réduction d'impôt au titre du plafonnement global de l'année 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7dy(Variable):
-    cerfa_field = u"7DY"
+    cerfa_field = "7DY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de réduction d'impôt au titre du plafonnement global de l'année 2014"
+    label = "Souscriptions au capital des PME non cotées, report de réduction d'impôt au titre du plafonnement global de l'année 2014"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7ey(Variable):
-    cerfa_field = u"7CY"
+    cerfa_field = "7CY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de réduction d'impôt au titre du plafonnement global de l'année 2015"
+    label = "Souscriptions au capital des PME non cotées, report de réduction d'impôt au titre du plafonnement global de l'année 2015"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7fy(Variable):
-    cerfa_field = u"7FY"
+    cerfa_field = "7FY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de réduction d'impôt au titre du plafonnement global de l'année 2016"
+    label = "Souscriptions au capital des PME non cotées, report de réduction d'impôt au titre du plafonnement global de l'année 2016"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
@@ -4645,696 +4645,696 @@ class f7fy(Variable):
 
 
 class f7gs(Variable):  # noqa 728
-    cerfa_field = u"7GS"
+    cerfa_field = "7GS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1 pour les start-up"
+    label = "Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1 pour les start-up"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7ok(Variable):
-    cerfa_field = u"7OK"
+    cerfa_field = "7OK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Autres investissements"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Autres investissements"
     # start_date = date(2011, 1, 1) + changes meaning in 2016
     definition_period = YEAR
 
 
 class f7ol(Variable):
-    cerfa_field = u"7OL"
+    cerfa_field = "7OL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
     # start_date = date(2012, 1, 1) + changes meaning in 2016
     definition_period = YEAR
 
 
 class f7om(Variable):
-    cerfa_field = u"7OM"
+    cerfa_field = "7OM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
     # start_date = date(2012, 1, 1) + changes meaning in 2016
     definition_period = YEAR
 
 
 class f7on(Variable):
-    cerfa_field = u"7ON"
+    cerfa_field = "7ON"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     # start_date = date(2012, 1, 1) + changes meaning in 2016
     definition_period = YEAR
 
 
 class f7oo(Variable):
-    cerfa_field = u"7OO"
+    cerfa_field = "7OO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
     # start_date = date(2012, 1, 1) + changes meaning in 2016
     definition_period = YEAR
 
 
 class f7op_2012(Variable):
-    cerfa_field = u"7OP"
+    cerfa_field = "7OP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7oq_2012(Variable):
-    cerfa_field = u"7OQ"
+    cerfa_field = "7OQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7or_2012(Variable):
-    cerfa_field = u"7OR"
+    cerfa_field = "7OR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7os_2012(Variable):
-    cerfa_field = u"7OS"
+    cerfa_field = "7OS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7ot(Variable):
-    cerfa_field = u"7OT"
+    cerfa_field = "7OT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ou(Variable):
-    cerfa_field = u"7OU"
+    cerfa_field = "7OU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ov(Variable):
-    cerfa_field = u"7OV"
+    cerfa_field = "7OV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     # start_date = date(2012, 1, 1) + changes meaning in 2015
     definition_period = YEAR
 
 
 class f7ow(Variable):
-    cerfa_field = u"7OW"
+    cerfa_field = "7OW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, "
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, "
     # start_date = date(2012, 1, 1) + changes meaning in 2016
     definition_period = YEAR
 
 
 class f7ox(Variable):
-    cerfa_field = u"7OX"
+    cerfa_field = "7OX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2017"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2017"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhoa(Variable):
-    cerfa_field = u"HOA"
+    cerfa_field = "HOA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% avant 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% avant 2009"
     # start_date = date(2011, 1, 1) changes meaning in 2014
     definition_period = YEAR
 
 
 class fhob(Variable):
-    cerfa_field = u"HOB"
+    cerfa_field = "HOB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2009"
     # start_date = date(2011, 1, 1) changes meaning
     definition_period = YEAR
 
 
 class fhoc(Variable):
-    cerfa_field = u"HOC"
+    cerfa_field = "HOC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     # start_date = date(2011, 1, 1) changes meaning in 2014
     definition_period = YEAR
 
 
 class fhoh(Variable):
-    cerfa_field = u"HOH"
+    cerfa_field = "HOH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% avant 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% avant 2009"
     # start_date = date(2011, 1, 1) changes meaning in 2015
     definition_period = YEAR
 
 
 class fhoi(Variable):
-    cerfa_field = u"HOI"
+    cerfa_field = "HOI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2009"
     # start_date = date(2011, 1, 1) changes meaning in 2015
     definition_period = YEAR
 
 
 class fhoj(Variable):
-    cerfa_field = u"HOJ"
+    cerfa_field = "HOJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Investissements immobiliers engagés en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     # start_date = date(2011, 1, 1) changes meaning in 2015
     definition_period = YEAR
 
 
 class fhok(Variable):
-    cerfa_field = u"HOK"
+    cerfa_field = "HOK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2011, Autres investissements"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2011, Autres investissements"
     # start_date = date(2011, 1, 1) + changes meaning in 2016
     definition_period = YEAR
 
 
 class fhol(Variable):
-    cerfa_field = u"HOL"
+    cerfa_field = "HOL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
     # start_date = date(2012, 1, 1) + changes meaning in 2016
     definition_period = YEAR
 
 
 class fhom(Variable):
-    cerfa_field = u"HOM"
+    cerfa_field = "HOM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
     # start_date = date(2012, 1, 1) + changes meaning in 2016
     definition_period = YEAR
 
 
 class fhon(Variable):
-    cerfa_field = u"HON"
+    cerfa_field = "HON"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé avant le 1.1.2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     # start_date = date(2012, 1, 1) + changes meaning in 2016
     definition_period = YEAR
 
 
 class fhoo(Variable):
-    cerfa_field = u"HOO"
+    cerfa_field = "HOO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
     # start_date = date(2012, 1, 1) + changes meaning in 2016
     definition_period = YEAR
 
 
 class fhop(Variable):
-    cerfa_field = u"HOP"
+    cerfa_field = "HOP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhoq(Variable):
-    cerfa_field = u"HOQ"
+    cerfa_field = "HOQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhor(Variable):
-    cerfa_field = u"HOR"
+    cerfa_field = "HOR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2011, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhos(Variable):
-    cerfa_field = u"HOS"
+    cerfa_field = "HOS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % avant 2009"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhot(Variable):
-    cerfa_field = u"HOT"
+    cerfa_field = "HOT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2009"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhou(Variable):
-    cerfa_field = u"HOU"
+    cerfa_field = "HOU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class fhov(Variable):
-    cerfa_field = u"HOV"
+    cerfa_field = "HOV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     # start_date = date(2012, 1, 1) + changes meaning in 2015
     definition_period = YEAR
 
 
 # TODO: 7O* : end ?
 class fhow(Variable):
-    cerfa_field = u"HOW"
+    cerfa_field = "HOW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2012, "
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2012, "
     # start_date = date(2012, 1, 1) + changes meaning in 2016
     definition_period = YEAR
 
 
 class fhod(Variable):
-    cerfa_field = u"HOD"
+    cerfa_field = "HOD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés avant le 1.1.2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés avant le 1.1.2011"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhoe(Variable):
-    cerfa_field = u"HOE"
+    cerfa_field = "HOE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhof(Variable):
-    cerfa_field = u"HOF"
+    cerfa_field = "HOF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhog(Variable):
-    cerfa_field = u"HOG"
+    cerfa_field = "HOG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhox(Variable):
-    cerfa_field = u"HOX"
+    cerfa_field = "HOX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2011"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhoy(Variable):
-    cerfa_field = u"HOY"
+    cerfa_field = "HOY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2012"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2013, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhoz(Variable):
-    cerfa_field = u"HOZ"
+    cerfa_field = "HOZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2013, Autres investissements"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2013, Autres investissements"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhua(Variable):
-    cerfa_field = u"HUA"
+    cerfa_field = "HUA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2014, Investissements immobiliers engagés avant le 1.1.2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2014, Investissements immobiliers engagés avant le 1.1.2011"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhub(Variable):
-    cerfa_field = u"HUB"
+    cerfa_field = "HUB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2014, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2014, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhuc(Variable):
-    cerfa_field = u"HUC"
+    cerfa_field = "HUC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2014, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2014, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhud(Variable):
-    cerfa_field = u"HUD"
+    cerfa_field = "HUD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2014, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2014, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhue(Variable):
-    cerfa_field = u"HUE"
+    cerfa_field = "HUE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2014, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2014, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2011"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhuf(Variable):
-    cerfa_field = u"HUF"
+    cerfa_field = "HUF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2014, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2012"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2014, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2012"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhug(Variable):
-    cerfa_field = u"HUG"
+    cerfa_field = "HUG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2014, Autres investissements"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2014, Autres investissements"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhuh(Variable):
-    cerfa_field = u"HUH"
+    cerfa_field = "HUH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2015, Investissements immobiliers engagés avant le 1.1.2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2015, Investissements immobiliers engagés avant le 1.1.2011"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhui(Variable):
-    cerfa_field = u"HUI"
+    cerfa_field = "HUI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2015, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2015, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhuj(Variable):
-    cerfa_field = u"HUJ"
+    cerfa_field = "HUJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2015, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2015, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhuk(Variable):
-    cerfa_field = u"HUK"
+    cerfa_field = "HUK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2015, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2015, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhul(Variable):
-    cerfa_field = u"HUL"
+    cerfa_field = "HUL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2015, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2015, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2011"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhum(Variable):
-    cerfa_field = u"HUM"
+    cerfa_field = "HUM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2015, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2012"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2015, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2012"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhun(Variable):
-    cerfa_field = u"HUN"
+    cerfa_field = "HUN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2015, Autres investissements"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2015, Autres investissements"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhuo(Variable):
-    cerfa_field = u"HUO"
+    cerfa_field = "HUO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2016, Investissements immobiliers engagés avant le 1.1.2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2016, Investissements immobiliers engagés avant le 1.1.2011"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhup(Variable):
-    cerfa_field = u"HUP"
+    cerfa_field = "HUP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2016, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2016, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhuq(Variable):
-    cerfa_field = u"HUQ"
+    cerfa_field = "HUQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2016, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2016, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhur(Variable):
-    cerfa_field = u"HUR"
+    cerfa_field = "HUR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2016, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2016, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhus(Variable):
-    cerfa_field = u"HUS"
+    cerfa_field = "HUS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2016, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2016, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2011"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhut(Variable):
-    cerfa_field = u"HUT"
+    cerfa_field = "HUT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2016, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2012"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2016, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2012"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhuu(Variable):
-    cerfa_field = u"HUU"
+    cerfa_field = "HUU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2016, Autres investissements"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2016, Autres investissements"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhva(Variable):
-    cerfa_field = u"HVA"
+    cerfa_field = "HVA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2017, Investissements immobiliers engagés avant le 1.1.2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2017, Investissements immobiliers engagés avant le 1.1.2011"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhvb(Variable):
-    cerfa_field = u"HVB"
+    cerfa_field = "HVB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2017, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2017, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhvc(Variable):
-    cerfa_field = u"HVC"
+    cerfa_field = "HVC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2017, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2017, Investissements immobiliers  que vous avez engagé en 2012, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhvd(Variable):
-    cerfa_field = u"HVD"
+    cerfa_field = "HVD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2017, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2017, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2010"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhve(Variable):
-    cerfa_field = u"HVE"
+    cerfa_field = "HVE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2017, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2011"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2017, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2011"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhvf(Variable):
-    cerfa_field = u"HVF"
+    cerfa_field = "HVF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2017, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2012"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2017, Investissements immobiliers engagés en 2012 ou 2013, ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50% en 2012"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhvg(Variable):
-    cerfa_field = u"HVG"
+    cerfa_field = "HVG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement : Investissements réalisés en 2017, Autres investissements"
+    label = "Investissements outre-mer dans le logement : Investissements réalisés en 2017, Autres investissements"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
@@ -5342,337 +5342,337 @@ class fhvg(Variable):
 # Investissements outre-mer dans le logement social
 
 class fhra(Variable):
-    cerfa_field = u"HRA"
+    cerfa_field = "HRA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Investissements ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Investissements ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrb(Variable):
-    cerfa_field = u"HRB"
+    cerfa_field = "HRB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Investissements ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Investissements ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2011"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrc(Variable):
-    cerfa_field = u"HRC"
+    cerfa_field = "HRC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Investissements ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2012"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Investissements ayant fait l'objet d'une demande d'agrément, d'une déclaration d'ouverture de chantier ou d'un acompte d'au moins 50 % en 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhrd(Variable):
-    cerfa_field = u"HRD"
+    cerfa_field = "HRD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Autres investissements"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2013, Autres investissements"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhkg(Variable):
-    cerfa_field = u"HKG"
+    cerfa_field = "HKG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2009"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2009"
     # start_date = date(2013, 1, 1)
     end = '2014-12-31'
     definition_period = YEAR
 
 
 class fhkh(Variable):
-    cerfa_field = u"HKH"
+    cerfa_field = "HKH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2010"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2010"
     # start_date = date(2013, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class fhki(Variable):
-    cerfa_field = u"HKI"
+    cerfa_field = "HKI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2010"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2010"
     # start_date = date(2013, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class fhqn(Variable):
-    cerfa_field = u"HQN"
+    cerfa_field = "HQN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2011"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2011"
     # start_date = date(2013, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class fhqu(Variable):
-    cerfa_field = u"HQU"
+    cerfa_field = "HQU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2011"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2011"
     # start_date = date(2013, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class fhqk(Variable):
-    cerfa_field = u"HQK"
+    cerfa_field = "HQK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2011"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2011"
     # start_date = date(2013, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class fhqj(Variable):
-    cerfa_field = u"HQJ"
+    cerfa_field = "HQJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2012"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhqs(Variable):
-    cerfa_field = u"HQS"
+    cerfa_field = "HQS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2012"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhqw(Variable):
-    cerfa_field = u"HQW"
+    cerfa_field = "HQW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2012"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhqx(Variable):
-    cerfa_field = u"HQX"
+    cerfa_field = "HQX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2012"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class fhxa(Variable):
-    cerfa_field = u"HXA"
+    cerfa_field = "HXA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2014"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2014"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhxb(Variable):
-    cerfa_field = u"HXB"
+    cerfa_field = "HXB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2014"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2014"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhxc(Variable):
-    cerfa_field = u"HXC"
+    cerfa_field = "HXC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2014"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2014"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhxe(Variable):
-    cerfa_field = u"HXE"
+    cerfa_field = "HXE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2014"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2014"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class fhxf(Variable):
-    cerfa_field = u"HXF"
+    cerfa_field = "HXF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2015"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2015"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhxg(Variable):
-    cerfa_field = u"HXG"
+    cerfa_field = "HXG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2015"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2015"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhxh(Variable):
-    cerfa_field = u"HXH"
+    cerfa_field = "HXH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2015"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2015"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhxi(Variable):
-    cerfa_field = u"HXI"
+    cerfa_field = "HXI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2015"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2015"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhxk(Variable):
-    cerfa_field = u"HXK"
+    cerfa_field = "HXK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2015"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2015"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class fhxl(Variable):
-    cerfa_field = u"HXL"
+    cerfa_field = "HXL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2016"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2016"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhxm(Variable):
-    cerfa_field = u"HXM"
+    cerfa_field = "HXM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2016"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2016"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhxn(Variable):
-    cerfa_field = u"HXN"
+    cerfa_field = "HXN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2016"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2016"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhxo(Variable):
-    cerfa_field = u"HXO"
+    cerfa_field = "HXO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2016"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2016"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhxp(Variable):
-    cerfa_field = u"HXP"
+    cerfa_field = "HXP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2016"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2016"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class fhxq(Variable):
-    cerfa_field = u"HXQ"
+    cerfa_field = "HXQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2017"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2017"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhxr(Variable):
-    cerfa_field = u"HXR"
+    cerfa_field = "HXR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2017"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2017"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhxs(Variable):
-    cerfa_field = u"HXS"
+    cerfa_field = "HXS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2017"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2017"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhxt(Variable):
-    cerfa_field = u"HXT"
+    cerfa_field = "HXT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2017"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2017"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class fhxu(Variable):
-    cerfa_field = u"HXU"
+    cerfa_field = "HXU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements outre-mer dans le logement social : Investissements réalisés en 2017"
+    label = "Investissements outre-mer dans le logement social : Investissements réalisés en 2017"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
@@ -5681,39 +5681,39 @@ class fhxu(Variable):
 # de fonds d'investissement de proximité
 
 class f7gq(Variable):
-    cerfa_field = u"7GQ"
+    cerfa_field = "7GQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscription de parts de fonds communs de placement dans l'innovation"
+    label = "Souscription de parts de fonds communs de placement dans l'innovation"
     definition_period = YEAR
 
 
 class f7fq(Variable):
-    cerfa_field = u"7FQ"
+    cerfa_field = "7FQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscription de parts de fonds d'investissement de proximité"
+    label = "Souscription de parts de fonds d'investissement de proximité"
     definition_period = YEAR
 
 
 class f7fm(Variable):
-    cerfa_field = u"7FM"
+    cerfa_field = "7FM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscription de parts de fonds d'investissement de proximité investis en Corse"
+    label = "Souscription de parts de fonds d'investissement de proximité investis en Corse"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f7fl(Variable):
-    cerfa_field = u"7FL"
+    cerfa_field = "7FL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscription de parts de fonds d'investissement de proximité investis outre-mer par des personnes domiciliées outre-mer"
+    label = "Souscription de parts de fonds d'investissement de proximité investis outre-mer par des personnes domiciliées outre-mer"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
@@ -5721,134 +5721,134 @@ class f7fl(Variable):
 # Souscriptions au capital de SOFICA
 
 class f7en(Variable):
-    cerfa_field = u"7EN"
+    cerfa_field = "7EN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital de SOFICA 48 %"
+    label = "Souscriptions au capital de SOFICA 48 %"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7gn(Variable):
-    cerfa_field = u"7GN"
+    cerfa_field = "7GN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital de SOFICA 36 %"
+    label = "Souscriptions au capital de SOFICA 36 %"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 class f7fn(Variable):
-    cerfa_field = u"7FN"
+    cerfa_field = "7FN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Souscriptions au capital de SOFICA 30 %"
+    label = "Souscriptions au capital de SOFICA 30 %"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 # Intérêts d'emprunt pour reprise de société
 class f7fh(Variable):
-    cerfa_field = u"7FH"
+    cerfa_field = "7FH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêts d'emprunt pour reprise de société"
+    label = "Intérêts d'emprunt pour reprise de société"
     definition_period = YEAR
 
 
 # Frais de comptabilité et d'adhésion à un CGA (centre de gestion agréée) ou à une AA (association agréée))
 class f7ff(Variable):
-    cerfa_field = u"7FF"
+    cerfa_field = "7FF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Frais de comptabilité et d'adhésion à un CGA (centre de gestion agréée) ou à une AA (association agréée)"
+    label = "Frais de comptabilité et d'adhésion à un CGA (centre de gestion agréée) ou à une AA (association agréée)"
     definition_period = YEAR
 
 
 class f7fg(Variable):
-    cerfa_field = u"7FG"
+    cerfa_field = "7FG"
     value_type = int
     entity = FoyerFiscal
-    label = u"Frais de comptabilité et d'adhésion à un CGA ou à une AA: nombre d'exploitations"
+    label = "Frais de comptabilité et d'adhésion à un CGA ou à une AA: nombre d'exploitations"
     definition_period = YEAR
 
 
 # Travaux de conservation et de restauration d’objets classés monuments historiques
 class f7nz(Variable):
-    cerfa_field = u"7NZ"
+    cerfa_field = "7NZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Travaux de conservation et de restauration d’objets classés monuments historiques"
+    label = "Travaux de conservation et de restauration d’objets classés monuments historiques"
     # start_date = date(2008, 1, 1)
     definition_period = YEAR
 
 
 # Dépenses de protection du patrimoine naturel
 class f7ka(Variable):
-    cerfa_field = u"7KA"
+    cerfa_field = "7KA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de protection du patrimoine naturel"
+    label = "Dépenses de protection du patrimoine naturel"
     end = '2013-12-31'
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7kb(Variable):
-    cerfa_field = u"7KB"
+    cerfa_field = "7KB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
+    label = "Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7kc(Variable):
-    cerfa_field = u"7KC"
+    cerfa_field = "7KC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
+    label = "Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7kd(Variable):
-    cerfa_field = u"7KD"
+    cerfa_field = "7KD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
+    label = "Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7ke(Variable):
-    cerfa_field = u"7KE"
+    cerfa_field = "7KE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
+    label = "Dépenses de protection du patrimoine naturel (excédent de réduction d’impôt d’années antérieures qui n’a pu être imputé)"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 # TODO: séparer en plusieurs variables (même case pour plusieurs variables selon les années)
 class f7uh(Variable):
-    cerfa_field = u"7UH"
+    cerfa_field = "7UH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dons et cotisations versés aux partis politiques"
+    label = "Dons et cotisations versés aux partis politiques"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
@@ -5857,1260 +5857,1260 @@ class f7uh(Variable):
 
 
 class f7un(Variable):
-    cerfa_field = u"7UN"
+    cerfa_field = "7UN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers: frais d'acquisition"
+    label = "Investissements forestiers: frais d'acquisition"
     definition_period = YEAR
 
 
 class f7ul(Variable):
-    cerfa_field = u"7UL"
+    cerfa_field = "7UL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : frais d'assurance"
+    label = "Investissements forestiers : frais d'assurance"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7uu(Variable):
-    cerfa_field = u"7UU"
+    cerfa_field = "7UU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report N-4, hors sinistre"
+    label = "Investissements forestiers : report N-4, hors sinistre"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7uv(Variable):
-    cerfa_field = u"7UV"
+    cerfa_field = "7UV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report N-3, hors sinistre"
+    label = "Investissements forestiers : report N-3, hors sinistre"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7uw(Variable):
-    cerfa_field = u"7UW"
+    cerfa_field = "7UW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report N-2, hors sinistre"
+    label = "Investissements forestiers : report N-2, hors sinistre"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7th(Variable):
-    cerfa_field = u"7TH"
+    cerfa_field = "7TH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report N-3, après sinistre"
+    label = "Investissements forestiers : report N-3, après sinistre"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7ti(Variable):
-    cerfa_field = u"7TI"
+    cerfa_field = "7TI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report N-2, après sinistre"
+    label = "Investissements forestiers : report N-2, après sinistre"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7tj(Variable):
-    cerfa_field = u"7TJ"
+    cerfa_field = "7TJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report N-1, après sinistre"
+    label = "Investissements forestiers : report N-1, après sinistre"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7tk(Variable):
-    cerfa_field = u"7TK"
+    cerfa_field = "7TK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report N-1, après sinistre,  avec adhésion à une organisation de producteurs"
+    label = "Investissements forestiers : report N-1, après sinistre,  avec adhésion à une organisation de producteurs"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7tm(Variable):
-    cerfa_field = u"7TM"
+    cerfa_field = "7TM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report 2015, après sinistre"
+    label = "Investissements forestiers : report 2015, après sinistre"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7to(Variable):
-    cerfa_field = u"7TO"
+    cerfa_field = "7TO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report 2015, après sinistre, avec adhésion à une association de producteurs"
+    label = "Investissements forestiers : report 2015, après sinistre, avec adhésion à une association de producteurs"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7ux(Variable):
-    cerfa_field = u"7UX"
+    cerfa_field = "7UX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report N-1, hors sinistre"
+    label = "Investissements forestiers : report N-1, hors sinistre"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7vm(Variable):
-    cerfa_field = u"7VM"
+    cerfa_field = "7VM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report 2015, hors sinistre"
+    label = "Investissements forestiers : report 2015, hors sinistre"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7vn(Variable):
-    cerfa_field = u"7VN"
+    cerfa_field = "7VN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report 2015, hors sinistre, avec adhésion à une association de producteurs"
+    label = "Investissements forestiers : report 2015, hors sinistre, avec adhésion à une association de producteurs"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7vp(Variable):
-    cerfa_field = u"7VP"
+    cerfa_field = "7VP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report 2014, hors sinistre, avec adhésion à une association de producteurs"
+    label = "Investissements forestiers : report 2014, hors sinistre, avec adhésion à une association de producteurs"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7tg(Variable):
-    cerfa_field = u"7TG"
+    cerfa_field = "7TG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report 2011, après sinistre"
+    label = "Investissements forestiers : report 2011, après sinistre"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7tf(Variable):
-    cerfa_field = u"7TF"
+    cerfa_field = "7TF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : report 2010, après sinistre"
+    label = "Investissements forestiers : report 2010, après sinistre"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7ut(Variable):
-    cerfa_field = u"7UT"
+    cerfa_field = "7UT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements forestiers : indicatrice travaux consécutifs à un sinistre"
+    label = "Investissements forestiers : indicatrice travaux consécutifs à un sinistre"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 # Intérêts pour paiement différé accordé aux agriculteurs
 class f7um(Variable):
-    cerfa_field = u"7UM"
+    cerfa_field = "7UM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêts pour paiement différé accordé aux agriculteurs"
+    label = "Intérêts pour paiement différé accordé aux agriculteurs"
     definition_period = YEAR
 
 
 # Investissements locatifs neufs : Dispositif Scellier:
 class f7hj(Variable):
-    cerfa_field = u"7HJ"
+    cerfa_field = "7HJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 en métropole"
+    label = "Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 en métropole"
     # start_date = date(2009, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7hk(Variable):
-    cerfa_field = u"7HK"
+    cerfa_field = "7HK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 dans les DOM-COM"
+    label = "Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 dans les DOM-COM"
     # start_date = date(2009, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7hn(Variable):
-    cerfa_field = u"7HN"
+    cerfa_field = "7HN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 en métropole avec promesse d'achat avant le 1er janvier 2010"
+    label = "Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 en métropole avec promesse d'achat avant le 1er janvier 2010"
     # start_date = date(2010, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7ho(Variable):
-    cerfa_field = u"7HO"
+    cerfa_field = "7HO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 dans les DOM-COM avec promesse d'achat avant le 1er janvier 2010"
+    label = "Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2010 dans les DOM-COM avec promesse d'achat avant le 1er janvier 2010"
     # start_date = date(2010, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7hl(Variable):
-    cerfa_field = u"7HL"
+    cerfa_field = "7HL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2009 (métropole et DOM ne respectant pas les plafonds)"
+    label = "Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2009 (métropole et DOM ne respectant pas les plafonds)"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7hm(Variable):
-    cerfa_field = u"7HM"
+    cerfa_field = "7HM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2009 dans les DOM et respectant les plafonds"
+    label = "Investissements locatifs neufs dispositif Scellier: investissements réalisés en 2009 dans les DOM et respectant les plafonds"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7hr(Variable):
-    cerfa_field = u"7HR"
+    cerfa_field = "7HR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés et achevés en 2009, en métropole en 2009; dans les DOM du 1.1.2009 au 26.5.2009 ; dans les DOM du 27.5.2009 au 30.12.2009 lorsqu'ils ne respectent pas les plafonds spécifiques"
+    label = "Investissements locatifs neufs dispositif Scellier: investissements réalisés et achevés en 2009, en métropole en 2009; dans les DOM du 1.1.2009 au 26.5.2009 ; dans les DOM du 27.5.2009 au 30.12.2009 lorsqu'ils ne respectent pas les plafonds spécifiques"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7hs(Variable):
-    cerfa_field = u"7HS"
+    cerfa_field = "7HS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: investissements réalisés et achevés en 2009 dans les DOM COM du 27.5.2009 au 31.12.2009 respectant les plafonds spécifiques"
+    label = "Investissements locatifs neufs dispositif Scellier: investissements réalisés et achevés en 2009 dans les DOM COM du 27.5.2009 au 31.12.2009 respectant les plafonds spécifiques"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7la(Variable):
-    cerfa_field = u"7LA"
+    cerfa_field = "7LA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2009"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2009"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7lb(Variable):
-    cerfa_field = u"7LB"
+    cerfa_field = "7LB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2010"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2010"
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7lc(Variable):
-    cerfa_field = u"7LC"
+    cerfa_field = "7LC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report de l'année 2010"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report de l'année 2010"
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7ld(Variable):
-    cerfa_field = u"7LD"
+    cerfa_field = "7LD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report de l'année 2011"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report de l'année 2011"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7le(Variable):
-    cerfa_field = u"7LE"
+    cerfa_field = "7LE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2011"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2011"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7lf(Variable):
-    cerfa_field = u"7LF"
+    cerfa_field = "7LF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2011 : report du solde de réduction d'impôt de l'année 2011"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2011 : report du solde de réduction d'impôt de l'année 2011"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ls(Variable):
-    cerfa_field = u"7LS"
+    cerfa_field = "7LS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7lt(Variable):
-    cerfa_field = u"7LT"
+    cerfa_field = "7LT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report de l'année 2013"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report de l'année 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7lm(Variable):
-    cerfa_field = u"7LM"
+    cerfa_field = "7LM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7ln(Variable):
-    cerfa_field = u"7LN"
+    cerfa_field = "7LN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2013"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2009 ou 2010 ou réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report de l'année 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7lz(Variable):
-    cerfa_field = u"7LZ"
+    cerfa_field = "7LZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Report du solde de réduction d'impôt de l'année 2012"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Report du solde de réduction d'impôt de l'année 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7lx(Variable):
-    cerfa_field = u"7LX"
+    cerfa_field = "7LX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Report du solde de réduction d'impôt de l'année 2013"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Report du solde de réduction d'impôt de l'année 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7mg(Variable):
-    cerfa_field = u"7MG"
+    cerfa_field = "7MG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2012 : report du solde de réduction d'impôt de l'année 2012"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2012 : report du solde de réduction d'impôt de l'année 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7mh(Variable):
-    cerfa_field = u"7MH"
+    cerfa_field = "7MH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2012 : report du solde de réduction d'impôt de l'année 2013"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés et achevés en 2012 : report du solde de réduction d'impôt de l'année 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7lj(Variable):
-    cerfa_field = u"7LJ"
+    cerfa_field = "7LJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés en 2012 et achevés de 2012 à 2014 : report du solde de réduction d'impôt de l'année 2014"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés en 2012 et achevés de 2012 à 2014 : report du solde de réduction d'impôt de l'année 2014"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7lp(Variable):
-    cerfa_field = u"7LP"
+    cerfa_field = "7LP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés en 2012 et achevés de 2012 à 2015 : report du solde de réduction d'impôt de l'année 2015"
+    label = "Investissements locatifs neufs dispositif Scellier: Report du solde des réductions d'impôts non encore imputé, Investissements réalisés en 2012 et achevés de 2012 à 2015 : report du solde de réduction d'impôt de l'année 2015"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7na(Variable):
-    cerfa_field = u"7NA"
+    cerfa_field = "7NA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, métropole, BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, métropole, BBC"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7nb(Variable):
-    cerfa_field = u"7NB"
+    cerfa_field = "7NB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, "
+    label = "Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, "
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7nc(Variable):
-    cerfa_field = u"7NC"
+    cerfa_field = "7NC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, métropole, BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, métropole, BBC"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7nd(Variable):
-    cerfa_field = u"7ND"
+    cerfa_field = "7ND"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, métropole, BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, métropole, BBC"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7ne(Variable):
-    cerfa_field = u"7NE"
+    cerfa_field = "7NE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, métropole, BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, métropole, BBC"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7nf(Variable):
-    cerfa_field = u"7NF"
+    cerfa_field = "7NF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, "
+    label = "Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, "
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7ng(Variable):
-    cerfa_field = u"7NG"
+    cerfa_field = "7NG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, "
+    label = "Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, "
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7nh(Variable):
-    cerfa_field = u"7NH"
+    cerfa_field = "7NH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, Investissement réalisé du 1.1.2011 au 31.1.2011, métropole, non-BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, Investissement réalisé du 1.1.2011 au 31.1.2011, métropole, non-BBC"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7ni(Variable):
-    cerfa_field = u"7NI"
+    cerfa_field = "7NI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, métropole, non-BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, métropole, non-BBC"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7nj(Variable):
-    cerfa_field = u"7NJ"
+    cerfa_field = "7NJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, métropole, non-BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, métropole, non-BBC"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7nk(Variable):
-    cerfa_field = u"7NK"
+    cerfa_field = "7NK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7nl(Variable):
-    cerfa_field = u"7NL"
+    cerfa_field = "7NL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7nm(Variable):
-    cerfa_field = u"7NM"
+    cerfa_field = "7NM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, Investissement réalisé du 1.1.2011 au 31.1.2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, Investissement réalisé du 1.1.2011 au 31.1.2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7nn(Variable):
-    cerfa_field = u"7NN"
+    cerfa_field = "7NN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7no(Variable):
-    cerfa_field = u"7NO"
+    cerfa_field = "7NO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7np(Variable):
-    cerfa_field = u"7NP"
+    cerfa_field = "7NP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7nq(Variable):
-    cerfa_field = u"7NQ"
+    cerfa_field = "7NQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements engagés en 2010, réalisés en 2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7nr(Variable):
-    cerfa_field = u"7NR"
+    cerfa_field = "7NR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, Investissement réalisé du 1.1.2011 au 31.1.2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.1.2011 au 31.1.2011, Investissement réalisé du 1.1.2011 au 31.1.2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7ns(Variable):
-    cerfa_field = u"7NS"
+    cerfa_field = "7NS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.2.2011 au 31.3.2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7nt(Variable):
-    cerfa_field = u"7NT"
+    cerfa_field = "7NT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, Investissement réalisé du 1.4.2011 au 31.12.2011, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7hv(Variable):
-    cerfa_field = u"7HV"
+    cerfa_field = "7HV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 en métropole"
+    label = "Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 en métropole"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7hw(Variable):
-    cerfa_field = u"7HW"
+    cerfa_field = "7HW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 dans les DOM COM"
+    label = "Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 dans les DOM COM"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7hx(Variable):
-    cerfa_field = u"7HX"
+    cerfa_field = "7HX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 en métropole avec promesse d'achat avant le 1.1.2010"
+    label = "Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 en métropole avec promesse d'achat avant le 1.1.2010"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7hz(Variable):
-    cerfa_field = u"7HZ"
+    cerfa_field = "7HZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 dans les DOM COM avec promesse d'achat avant le 1.1.2010"
+    label = "Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2010 dans les DOM COM avec promesse d'achat avant le 1.1.2010"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7ht(Variable):
-    cerfa_field = u"7HT"
+    cerfa_field = "7HT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2009, Investissements réalisés en 2009 et achevés en 2010, en métropole en 2009; dans les DOM du 1.1.2009 au 26.5.2009 ; dans les DOM du 27.5.2009 au 30.12.2009 lorsqu'ils ne respectent pas les plafonds spécifiques"
+    label = "Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2009, Investissements réalisés en 2009 et achevés en 2010, en métropole en 2009; dans les DOM du 1.1.2009 au 26.5.2009 ; dans les DOM du 27.5.2009 au 30.12.2009 lorsqu'ils ne respectent pas les plafonds spécifiques"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7hu(Variable):
-    cerfa_field = u"7HU"
+    cerfa_field = "7HU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2009, Investissements réalisés en 2009 et achevés en 2010, dans les DOM COM du 27.5.2009 au 31.12.2009 respectant les plafonds spécifiques"
+    label = "Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2009, Investissements réalisés en 2009 et achevés en 2010, dans les DOM COM du 27.5.2009 au 31.12.2009 respectant les plafonds spécifiques"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7ha(Variable):
-    cerfa_field = u"7HA"
+    cerfa_field = "7HA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés et réalisés en 2011"
+    label = "Investissements locatifs neufs dispositif Scellier: Investissements achevés et réalisés en 2011"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7hb(Variable):
-    cerfa_field = u"7HB"
+    cerfa_field = "7HB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés et réalisés en 2011, avec promesse d'achat en 2010"
+    label = "Investissements locatifs neufs dispositif Scellier: Investissements achevés et réalisés en 2011, avec promesse d'achat en 2010"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7hg(Variable):
-    cerfa_field = u"7HG"
+    cerfa_field = "7HG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2011 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna"
+    label = "Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2011 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7hh(Variable):
-    cerfa_field = u"7HH"
+    cerfa_field = "7HH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2011 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna avec promesse d'achat en 2010"
+    label = "Investissements locatifs neufs dispositif Scellier: réductions investissements réalisés et achevés en 2011 en Polynésie française, Nouvelle Calédonie, dans les îles Walllis et Futuna avec promesse d'achat en 2010"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7hd(Variable):
-    cerfa_field = u"7HD"
+    cerfa_field = "7HD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés en 2011, réalisés en 2010, en métropole et dans les DOM-COM"
+    label = "Investissements locatifs neufs dispositif Scellier: Investissements achevés en 2011, réalisés en 2010, en métropole et dans les DOM-COM"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7he(Variable):
-    cerfa_field = u"7HE"
+    cerfa_field = "7HE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés en 2011, en métropole et dans les DOM-COM avec promesse d'achat avant le 1.1.2010"
+    label = "Investissements locatifs neufs dispositif Scellier: Investissements achevés en 2011, en métropole et dans les DOM-COM avec promesse d'achat avant le 1.1.2010"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7hf(Variable):
-    cerfa_field = u"7HF"
+    cerfa_field = "7HF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier: Investissements achevés en 2011, Investissements réalisés en 2009 en métropole et dans les DOM-COM"
+    label = "Investissements locatifs neufs dispositif Scellier: Investissements achevés en 2011, Investissements réalisés en 2009 en métropole et dans les DOM-COM"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ja(Variable):
-    cerfa_field = u"7JA"
+    cerfa_field = "7JA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2012, métropole, BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2012, métropole, BBC"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7jb(Variable):
-    cerfa_field = u"7JB"
+    cerfa_field = "7JB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, métropole, BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, métropole, BBC"
     # start_date = date(2012, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7jd(Variable):
-    cerfa_field = u"7JD"
+    cerfa_field = "7JD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, métropole, BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, métropole, BBC"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7je(Variable):
-    cerfa_field = u"7JE"
+    cerfa_field = "7JE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, métropole, BBC "
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, métropole, BBC "
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7jf(Variable):
-    cerfa_field = u"7JF"
+    cerfa_field = "7JF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2012, métropole, non-BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements réalisés et engagés en 2012, métropole, non-BBC"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7jg(Variable):
-    cerfa_field = u"7JG"
+    cerfa_field = "7JG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, métropole, non-BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, métropole, non-BBC"
     # start_date = date(2012, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7jh(Variable):
-    cerfa_field = u"7JH"
+    cerfa_field = "7JH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, métropole, non-BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, métropole, non-BBC"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7jj(Variable):
-    cerfa_field = u"7JJ"
+    cerfa_field = "7JJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, métropole, non-BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, métropole, non-BBC"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7jk(Variable):
-    cerfa_field = u"7JK"
+    cerfa_field = "7JK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7jl(Variable):
-    cerfa_field = u"7JL"
+    cerfa_field = "7JL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2012, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7jm(Variable):
-    cerfa_field = u"7JM"
+    cerfa_field = "7JM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7jn(Variable):
-    cerfa_field = u"7JN"
+    cerfa_field = "7JN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, DOM, Saint-Barthélémy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7jo(Variable):
-    cerfa_field = u"7JO"
+    cerfa_field = "7JO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7jp(Variable):
-    cerfa_field = u"7JP"
+    cerfa_field = "7JP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
+    label = "Investissements locatifs neufs dispositif Scellier : investissements engagés en 2011, réalisés en 2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     # start_date = date(2012, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7jq(Variable):
-    cerfa_field = u"7JQ"
+    cerfa_field = "7JQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.1.2012 au 31.3.2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7jr(Variable):
-    cerfa_field = u"7JR"
+    cerfa_field = "7JR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
+    label = "Investissements locatifs neufs dispositif Scellier : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, Investissement réalisé du 1.4.2012 au 31.12.2012, Polynésie Française, Nouvelle Calédonie, Wallis et Futuna"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7gj(Variable):
-    cerfa_field = u"7GJ"
+    cerfa_field = "7GJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés et réalisés en 2012, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés et réalisés en 2012, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7gk(Variable):
-    cerfa_field = u"7GK"
+    cerfa_field = "7GK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés et réalisés en 2012, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon, avec promesse d'achat en 2011"
+    label = "Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés et réalisés en 2012, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon, avec promesse d'achat en 2011"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7gl(Variable):
-    cerfa_field = u"7GL"
+    cerfa_field = "7GL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2012 et réalisés en 2011, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2012 et réalisés en 2011, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7gp(Variable):
-    cerfa_field = u"7GP"
+    cerfa_field = "7GP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2012 et réalisés en 2011, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon, avec promesse d'achat en 2010s"
+    label = "Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2012 et réalisés en 2011, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon, avec promesse d'achat en 2010s"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7fa(Variable):
-    cerfa_field = u"7FA"
+    cerfa_field = "7FA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013, métropole, BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013, métropole, BBC"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7fb(Variable):
-    cerfa_field = u"7FB"
+    cerfa_field = "7FB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013, métropole, non-BBC"
+    label = "Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013, métropole, non-BBC"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7fc(Variable):
-    cerfa_field = u"7FC"
+    cerfa_field = "7FC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013, DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013, DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7fd(Variable):
-    cerfa_field = u"7FD"
+    cerfa_field = "7FD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna"
+    label = "Investissements locatifs neufs dispositif Scellier : Investissements achevés ou acquis en 2013, réalisés du 1.1.2013 au 31.3.2013 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7ya(Variable):
-    cerfa_field = u"7YA"
+    cerfa_field = "7YA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés du 1.1.2013 au 31.3.2013 avec promesse d'achat en 2012, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés du 1.1.2013 au 31.3.2013 avec promesse d'achat en 2012, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7yb(Variable):
-    cerfa_field = u"7YB"
+    cerfa_field = "7YB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2012, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2012, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7yc(Variable):
-    cerfa_field = u"7YC"
+    cerfa_field = "7YC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2012 avec promesse d'achat en 2011, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2012 avec promesse d'achat en 2011, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7yd(Variable):
-    cerfa_field = u"7YD"
+    cerfa_field = "7YD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2011, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2011, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7ye(Variable):
-    cerfa_field = u"7YE"
+    cerfa_field = "7YE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2011 avec promesse d'achat en 2010, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2011 avec promesse d'achat en 2010, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7yf(Variable):
-    cerfa_field = u"7YF"
+    cerfa_field = "7YF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2010, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2010, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7yg(Variable):
-    cerfa_field = u"7YG"
+    cerfa_field = "7YG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2010 avec promesse d'achat avant le 1.1.2010, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2010 avec promesse d'achat avant le 1.1.2010, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2014, 1, 1)
     end = '2014-12-31'
     definition_period = YEAR
 
 
 class f7yh(Variable):
-    cerfa_field = u"7YH"
+    cerfa_field = "7YH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Report concernant les investissements réalisés en 2009 et achevés en 2013 en métropole et dans les DOM-COM "
+    label = "Investissements locatifs neufs dispositif Scellier : Report concernant les investissements réalisés en 2009 et achevés en 2013 en métropole et dans les DOM-COM "
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7yi(Variable):
-    cerfa_field = u"7YI"
+    cerfa_field = "7YI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2009, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
+    label = "Investissements locatifs neufs dispositif Scellier : Reports concernant les investissements achevés ou acquis au cours des années antérieures, Investissements achevés en 2013 et réalisés en 2009, en métropole, dans les DOM, à Saint-Barthélemy, Saint-Martin, Saint-Pierre-et-Miquelon"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7yj(Variable):
-    cerfa_field = u"7YJ"
+    cerfa_field = "7YJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2012 et achevés en 2013 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
+    label = "Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2012 et achevés en 2013 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7yk(Variable):
-    cerfa_field = u"7YK"
+    cerfa_field = "7YK"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2013 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
+    label = "Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2013 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7yl(Variable):
-    cerfa_field = u"7YL"
+    cerfa_field = "7YL"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2013 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
+    label = "Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2013 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7ym(Variable):
-    cerfa_field = u"7YM"
+    cerfa_field = "7YM"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2012 ou réalisés du 1.1.2013 au 31.3.2013 avec promesse d'achat en 2012 et achevés en 2014 en métropole et dans les DOM-COM"
+    label = "Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2012 ou réalisés du 1.1.2013 au 31.3.2013 avec promesse d'achat en 2012 et achevés en 2014 en métropole et dans les DOM-COM"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7yt(Variable):
-    cerfa_field = u"7YT"
+    cerfa_field = "7YT"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2012 ou réalisés du 1.1.2013 au 31.3.2013 avec promesse d'achat en 2012 et achevés en 2015 en métropole et dans les DOM-COM"
+    label = "Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2012 ou réalisés du 1.1.2013 au 31.3.2013 avec promesse d'achat en 2012 et achevés en 2015 en métropole et dans les DOM-COM"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7yn(Variable):
-    cerfa_field = u"7YN"
+    cerfa_field = "7YN"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2014 en métropole et dans les DOM-COM"
+    label = "Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2014 en métropole et dans les DOM-COM"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7yu(Variable):
-    cerfa_field = u"7YU"
+    cerfa_field = "7YU"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2015 en métropole et dans les DOM-COM"
+    label = "Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2015 en métropole et dans les DOM-COM"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7yo(Variable):
-    cerfa_field = u"7YO"
+    cerfa_field = "7YO"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2010 ou réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2014 en métropole et dans les DOM-COM"
+    label = "Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2010 ou réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2014 en métropole et dans les DOM-COM"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7yv(Variable):
-    cerfa_field = u"7YV"
+    cerfa_field = "7YV"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2010 ou réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2015 en métropole et dans les DOM-COM"
+    label = "Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2010 ou réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2015 en métropole et dans les DOM-COM"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7yp(Variable):
-    cerfa_field = u"7YP"
+    cerfa_field = "7YP"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2009 ou réalisés en 2010 avec promesse d'achat en 2010 et achevés en 2014 en métropole et dans les DOM-COM"
+    label = "Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2009 ou réalisés en 2010 avec promesse d'achat en 2010 et achevés en 2014 en métropole et dans les DOM-COM"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7yw(Variable):
-    cerfa_field = u"7YW"
+    cerfa_field = "7YW"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2009 ou réalisés en 2010 avec promesse d'achat en 2010 et achevés en 2015 en métropole et dans les DOM-COM"
+    label = "Scellier: report de 1/9 de la réduction d'impôt des investissements réalisés en 2009 ou réalisés en 2010 avec promesse d'achat en 2010 et achevés en 2015 en métropole et dans les DOM-COM"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7yq(Variable):
-    cerfa_field = u"7YQ"
+    cerfa_field = "7YQ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2012 ou réalisés du 1.1.2013 au 31.3.2013 avec promesse d'achat en 2012 et achevés en 2014 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
+    label = "Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2012 ou réalisés du 1.1.2013 au 31.3.2013 avec promesse d'achat en 2012 et achevés en 2014 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7yx(Variable):
-    cerfa_field = u"7YX"
+    cerfa_field = "7YX"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2012 ou réalisés du 1.1.2013 au 31.3.2013 avec promesse d'achat en 2012 et achevés en 2015 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
+    label = "Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2012 ou réalisés du 1.1.2013 au 31.3.2013 avec promesse d'achat en 2012 et achevés en 2015 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7yr(Variable):
-    cerfa_field = u"7YR"
+    cerfa_field = "7YR"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2014 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
+    label = "Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2014 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7yy(Variable):
-    cerfa_field = u"7YY"
+    cerfa_field = "7YY"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2015 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
+    label = "Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2015 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7ys(Variable):
-    cerfa_field = u"7YS"
+    cerfa_field = "7YS"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2014 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
+    label = "Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2014 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7yz(Variable):
-    cerfa_field = u"7YZ"
+    cerfa_field = "7YZ"
     value_type = int
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2015 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
+    label = "Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés en 2011 avec promesse d'achat en 2010 et achevés en 2015 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
@@ -7118,552 +7118,552 @@ class f7yz(Variable):
 
 
 class f7ij(Variable):
-    cerfa_field = u"7IJ"
+    cerfa_field = "7IJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissement destinés à la location meublée non professionnelle: Investissements réalisés en 2011 et achevés en 2012, engagement de réalisation de l'investissement en 2011"
+    label = "Investissement destinés à la location meublée non professionnelle: Investissements réalisés en 2011 et achevés en 2012, engagement de réalisation de l'investissement en 2011"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class f7il(Variable):
-    cerfa_field = u"7IL"
+    cerfa_field = "7IL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissement destinés à la location meublée non professionnelle: Investissements réalisés en 2011 avec promesse d'achat en 2010"
+    label = "Investissement destinés à la location meublée non professionnelle: Investissements réalisés en 2011 avec promesse d'achat en 2010"
     # start_date = date(2010, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7im(Variable):
-    cerfa_field = u"7IM"
+    cerfa_field = "7IM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissement destinés à la location meublée non professionnelle: Investissements réalisés en 2010 avec promesse d'achat en 2010"
+    label = "Investissement destinés à la location meublée non professionnelle: Investissements réalisés en 2010 avec promesse d'achat en 2010"
     # start_date = date(2010, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7ik(Variable):
-    cerfa_field = u"7IK"
+    cerfa_field = "7IK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Reports de 1/9 de l'investissement réalisé et achevé en 2009"
+    label = "Investissements destinés à la location meublée non professionnelle : Reports de 1/9 de l'investissement réalisé et achevé en 2009"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7in(Variable):
-    cerfa_field = u"7IN"
+    cerfa_field = "7IN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, investissement réalisé du 1.1.2011 au 31.3.2011"
+    label = "Investissements destinés à la location meublée non professionnelle : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, investissement réalisé du 1.1.2011 au 31.3.2011"
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7iv(Variable):
-    cerfa_field = u"7IV"
+    cerfa_field = "7IV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, investissement réalisé du 1.4.2011 au 31.12.2011"
+    label = "Investissements destinés à la location meublée non professionnelle : Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2010, investissement réalisé du 1.4.2011 au 31.12.2011"
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7iw(Variable):
-    cerfa_field = u"7IW"
+    cerfa_field = "7IW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2010 avec promesse d'achat en 2009"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2010 avec promesse d'achat en 2009"
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7io(Variable):
-    cerfa_field = u"7IO"
+    cerfa_field = "7IO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : "
+    label = "Investissements destinés à la location meublée non professionnelle : "
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7ip(Variable):
-    cerfa_field = u"7IP"
+    cerfa_field = "7IP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : "
+    label = "Investissements destinés à la location meublée non professionnelle : "
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7ir(Variable):
-    cerfa_field = u"7IR"
+    cerfa_field = "7IR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : "
+    label = "Investissements destinés à la location meublée non professionnelle : "
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7iq(Variable):
-    cerfa_field = u"7IQ"
+    cerfa_field = "7IQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : "
+    label = "Investissements destinés à la location meublée non professionnelle : "
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f7iu(Variable):
-    cerfa_field = u"7IU"
+    cerfa_field = "7IU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non encore imputé"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non encore imputé"
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7it(Variable):
-    cerfa_field = u"7IT"
+    cerfa_field = "7IT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non encore imputé"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non encore imputé"
     # start_date = date(2011, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7is(Variable):
-    cerfa_field = u"7IS"
+    cerfa_field = "7IS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé: année  n-4"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d'impôt non encore imputé: année  n-4"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7ia(Variable):
-    cerfa_field = u"7IA"
+    cerfa_field = "7IA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ib(Variable):
-    cerfa_field = u"7IB"
+    cerfa_field = "7IB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 avec promesse d'achat en 2010 ou réalisés en 2010"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 avec promesse d'achat en 2010 ou réalisés en 2010"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ic(Variable):
-    cerfa_field = u"7IC"
+    cerfa_field = "7IC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2010 et achevés en 2011 avec promesse d'achat en 2009 ou réalisés en 2009"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2010 et achevés en 2011 avec promesse d'achat en 2009 ou réalisés en 2009"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7id(Variable):
-    cerfa_field = u"7ID"
+    cerfa_field = "7ID"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2012, Engagement de réalisation de l'investissement en 2012"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2012, Engagement de réalisation de l'investissement en 2012"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ie(Variable):
-    cerfa_field = u"7IE"
+    cerfa_field = "7IE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2012 avec promesse d'achat en 2011"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2012 avec promesse d'achat en 2011"
     # start_date = date(2012, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7if(Variable):
-    cerfa_field = u"7IF"
+    cerfa_field = "7IF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2012, Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, investissement réalisé du 1.1.2012 au 31.3.2012"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2012, Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, investissement réalisé du 1.1.2012 au 31.3.2012"
     # start_date = date(2012, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7ig(Variable):
-    cerfa_field = u"7IG"
+    cerfa_field = "7IG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2012, Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, investissement réalisé du 1.4.2012 au 31.12.2012"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2012, Logement acquis en l'état futur d'achèvement avec contrat de réservation enregistré au plus tard le 31.12.2011, investissement réalisé du 1.4.2012 au 31.12.2012"
     # start_date = date(2012, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7ix(Variable):
-    cerfa_field = u"7IX"
+    cerfa_field = "7IX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2009; réalisés en 2009 et achevés en 2010; réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report du solde de réduction d'impôt de l'année 2011"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2009; réalisés en 2009 et achevés en 2010; réalisés et achevés en 2010 avec engagement avant le 1.1.2010, Report du solde de réduction d'impôt de l'année 2011"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7ih(Variable):
-    cerfa_field = u"7IH"
+    cerfa_field = "7IH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report du solde de réduction d'impôt de l'année 2011"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report du solde de réduction d'impôt de l'année 2011"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7iz(Variable):
-    cerfa_field = u"7IZ"
+    cerfa_field = "7IZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 : report du solde de réduction d'impôt de l'année 2011"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 : report du solde de réduction d'impôt de l'année 2011"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7jt(Variable):
-    cerfa_field = u"7JT"
+    cerfa_field = "7JT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2013, Engagement de réalisation de l'investissement en 2013"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2013, Engagement de réalisation de l'investissement en 2013"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7ju(Variable):
-    cerfa_field = u"7JU"
+    cerfa_field = "7JU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2013 avec promesse d'achat en 2012"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2013 avec promesse d'achat en 2012"
     # start_date = date(2013, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7ou(Variable):  # noqa 728
-    cerfa_field = u"7OU"
+    cerfa_field = "7OU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2014"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés en 2014"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7jv(Variable):
-    cerfa_field = u"7JV"
+    cerfa_field = "7JV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2012"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7jw(Variable):
-    cerfa_field = u"7JW"
+    cerfa_field = "7JW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7jx(Variable):
-    cerfa_field = u"7JX"
+    cerfa_field = "7JX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2011 avec promesse d'achat en 2010 ou réalisés en 2010"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2011 avec promesse d'achat en 2010 ou réalisés en 2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7jy(Variable):
-    cerfa_field = u"7JY"
+    cerfa_field = "7JY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2010 avec promesse d'achat en 2009 ou réalisés en 2009"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2012, réalisés en 2010 avec promesse d'achat en 2009 ou réalisés en 2009"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7oa(Variable):  # noqa 728
-    cerfa_field = u"7OA"
+    cerfa_field = "7OA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements réalisés et achevés en 2013"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements réalisés et achevés en 2013"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7ob(Variable):  # noqa 728
-    cerfa_field = u"7OB"
+    cerfa_field = "7OB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2013 et réalisés en 2012 ou réalisés en 2013 avec promesse d'achat en 2012"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2013 et réalisés en 2012 ou réalisés en 2013 avec promesse d'achat en 2012"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7oc(Variable):  # noqa 728
-    cerfa_field = u"7OC"
+    cerfa_field = "7OC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2013 et réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2013 et réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7od(Variable):
-    cerfa_field = u"7OD"
+    cerfa_field = "7OD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2013 et réalisés en 2010 ou réalisés en 2011 avec promesse d'achat en 2010"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2013 et réalisés en 2010 ou réalisés en 2011 avec promesse d'achat en 2010"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7oe(Variable):
-    cerfa_field = u"7OE"
+    cerfa_field = "7OE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2013 et réalisés en 2009 ou réalisés en 2010 avec promesse d'achat en 2009"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2013 et réalisés en 2009 ou réalisés en 2010 avec promesse d'achat en 2009"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7of(Variable):
-    cerfa_field = u"7OF"
+    cerfa_field = "7OF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements réalisés en 2013 ou 2014 et achevés en 2014"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements réalisés en 2013 ou 2014 et achevés en 2014"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7og(Variable):
-    cerfa_field = u"7OG"
+    cerfa_field = "7OG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2014 et réalisés en 2012 ou réalisés en 2013 avec promesse d'achat en 2012"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2014 et réalisés en 2012 ou réalisés en 2013 avec promesse d'achat en 2012"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7oh(Variable):  # noqa 728
-    cerfa_field = u"7OH"
+    cerfa_field = "7OH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2014 et réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2014 et réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7oi(Variable):  # noqa 728
-    cerfa_field = u"7OI"
+    cerfa_field = "7OI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2014 et réalisés en 2010 ou réalisés en 2011 avec promesse d'achat en 2010"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2014 et réalisés en 2010 ou réalisés en 2011 avec promesse d'achat en 2010"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7oj(Variable):  # noqa 728
-    cerfa_field = u"7OJ"
+    cerfa_field = "7OJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2014 et réalisés en 2009 ou réalisés en 2010 avec promesse d'achat en 2009"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2014 et réalisés en 2009 ou réalisés en 2010 avec promesse d'achat en 2009"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7op(Variable):
-    cerfa_field = u"7OP"
+    cerfa_field = "7OP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements réalisés en 2013 ou 2014 et achevés en 2016"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements réalisés en 2013 ou 2014 et achevés en 2016"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7oq(Variable):
-    cerfa_field = u"7OQ"
+    cerfa_field = "7OQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2016 et réalisés en 2012 ou réalisés en 2013 avec promesse d'achat en 2012"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2016 et réalisés en 2012 ou réalisés en 2013 avec promesse d'achat en 2012"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7or(Variable):
-    cerfa_field = u"7OR"
+    cerfa_field = "7OR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2016 et réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2016 et réalisés en 2011 ou réalisés en 2012 avec promesse d'achat en 2011"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7os(Variable):
-    cerfa_field = u"7OS"
+    cerfa_field = "7OS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2016 et réalisés en 2010 ou réalisés en 2011 avec promesse d'achat en 2010"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2016 et réalisés en 2010 ou réalisés en 2011 avec promesse d'achat en 2010"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7ot(Variable):  # noqa 728
-    cerfa_field = u"7OT"
+    cerfa_field = "7OT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2016 et réalisés en 2009 ou réalisés en 2010 avec promesse d'achat en 2009"
+    label = "Investissements destinés à la location meublée non professionnelle : Report de 1/9 de la réduction d'impôt. Investissements achevés en 2016 et réalisés en 2009 ou réalisés en 2010 avec promesse d'achat en 2009"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7jc(Variable):
-    cerfa_field = u"7JC"
+    cerfa_field = "7JC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report du solde de réduction d'impôt de l'année 2012"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2010 ; réalisés en 2010 et achevés en 2011 ; réalisés et achevés en 2011 avec engagement en 2010, Report du solde de réduction d'impôt de l'année 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7ji(Variable):
-    cerfa_field = u"7JI"
+    cerfa_field = "7JI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 ; réalisés en 2011 et achevés en 2011 ou 2012 ; réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2012, Report du solde de réduction d'impôt de l'année 2012"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 ; réalisés en 2011 et achevés en 2011 ou 2012 ; réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2012, Report du solde de réduction d'impôt de l'année 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7js(Variable):
-    cerfa_field = u"7JS"
+    cerfa_field = "7JS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 ; réalisés en 2011 et achevés en 2011 ou 2012 ; réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2012, Report du solde de réduction d’impôt de l’année 2012"
+    label = "Investissements destinés à la location meublée non professionnelle : Investissements réalisés et achevés en 2011 ; réalisés en 2011 et achevés en 2011 ou 2012 ; réalisés en 2012 avec promesse d'achat en 2011 et achevés en 2012, Report du solde de réduction d’impôt de l’année 2012"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7pp(Variable):
-    cerfa_field = u"7PP"
+    cerfa_field = "7PP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non imputé de 2016"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non imputé de 2016"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7pq(Variable):
-    cerfa_field = u"7PQ"
+    cerfa_field = "7PQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non imputé de 2016"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non imputé de 2016"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7pr(Variable):
-    cerfa_field = u"7PR"
+    cerfa_field = "7PR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non imputé de 2016"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non imputé de 2016"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7ps(Variable):
-    cerfa_field = u"7PS"
+    cerfa_field = "7PS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non imputé de 2016"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non imputé de 2016"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7pt(Variable):
-    cerfa_field = u"7PT"
+    cerfa_field = "7PT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non imputé de 2016"
+    label = "Investissements destinés à la location meublée non professionnelle : Report du solde de réduction d’impôt non imputé de 2016"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
@@ -7678,33 +7678,33 @@ class f7pt(Variable):
 
 # vérif <=2012
 class f7gt(Variable):
-    cerfa_field = u"7GT"
+    cerfa_field = "7GT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements achevés en 2012 avec promesse d'achat en 2010"
+    label = "Scellier: report de 1/9 de la réduction d'impôt des investissements achevés en 2012 avec promesse d'achat en 2010"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 # vérif <=2012
 class f7gu(Variable):
-    cerfa_field = u"7GU"
+    cerfa_field = "7GU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/9 de la réduction d'impôt des investissements achevés en 2012 avec promesse d'achat en 2009"
+    label = "Scellier: report de 1/9 de la réduction d'impôt des investissements achevés en 2012 avec promesse d'achat en 2009"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 # vérif <=2012
 class f7gv(Variable):
-    cerfa_field = u"7GV"
+    cerfa_field = "7GV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés et achevés en 2012 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
+    label = "Scellier: report de 1/5 de la réduction d'impôt des investissements réalisés et achevés en 2012 en Polynésie, en Nouvelle Calédonie et à Wallis et Futuna "
     # start_date = date(2013, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
@@ -7712,11 +7712,11 @@ class f7gv(Variable):
 
 # vérif <=2012
 class f7xg(Variable):
-    cerfa_field = u"7XG"
+    cerfa_field = "7XG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissement locatif dans le secteur touristique, travaux réalisés dans un village résidentiel de tourisme"
+    label = "Investissement locatif dans le secteur touristique, travaux réalisés dans un village résidentiel de tourisme"
     end = '2012-12-01'
     definition_period = YEAR
 
@@ -7726,197 +7726,197 @@ class f7xg(Variable):
 
 
 class f7uo(Variable):
-    cerfa_field = u"7UO"
+    cerfa_field = "7UO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Acquisition de biens culturels"
+    label = "Acquisition de biens culturels"
     definition_period = YEAR
 
 
 # Mécénat d'entreprise
 class f7us(Variable):
-    cerfa_field = u"7US"
+    cerfa_field = "7US"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Réduction d'impôt mécénat d'entreprise"
+    label = "Réduction d'impôt mécénat d'entreprise"
     definition_period = YEAR
 
 
 # Crédits d’impôt pour dépenses en faveur de la qualité environnementale
 
 class f7sa(Variable):
-    cerfa_field = u"7SA"
+    cerfa_field = "7SA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location du 1.9 au 31.12.2014 : chaudières à condensation "
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location du 1.9 au 31.12.2014 : chaudières à condensation "
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7sb_2011(Variable):
-    cerfa_field = u"7SB"
+    cerfa_field = "7SB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location: crédit à 25 %"
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location: crédit à 25 %"
     # start_date = date(2009, 1, 1)
     end = '2011-12-31'
     definition_period = YEAR
 
 
 class f7sb(Variable):
-    cerfa_field = u"7SB"
+    cerfa_field = "7SB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location, payées du 1.9 au 31.12.2014 : chaudière à micro-cogénération de gaz "
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location, payées du 1.9 au 31.12.2014 : chaudière à micro-cogénération de gaz "
     # start_date = date(2014, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class f7sc_2009(Variable):
-    cerfa_field = u"7SC"
+    cerfa_field = "7SC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédits d’impôt pour dépenses en faveur de la qualité environnementale"
+    label = "Crédits d’impôt pour dépenses en faveur de la qualité environnementale"
     # start_date = date(2009, 1, 1)
     end = '2009-12-01'
     definition_period = YEAR
 
 
 class f7sc(Variable):
-    cerfa_field = u"7SC"
+    cerfa_field = "7SC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location, payées du 1.9 au 31.12.2014 : appareils de régulation du chauffage, matériaux de calorifugeage"
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location, payées du 1.9 au 31.12.2014 : appareils de régulation du chauffage, matériaux de calorifugeage"
     # start_date = date(2014, 1, 1)
     end = '2016-12-01'
     definition_period = YEAR
 
 
 class f7ta(Variable):
-    cerfa_field = u"7TA"
+    cerfa_field = "7TA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 : chaudières à condensation "
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 : chaudières à condensation "
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7tb(Variable):
-    cerfa_field = u"7TB"
+    cerfa_field = "7TB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 : chaudières à micro-génération gaz"
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 : chaudières à micro-génération gaz"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7tc(Variable):
-    cerfa_field = u"7TC"
+    cerfa_field = "7TC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 : appareils de régulation de chauffage"
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 : appareils de régulation de chauffage"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7cb(Variable):
-    cerfa_field = u"7CB"
+    cerfa_field = "7CB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location : chaudières à haute performance energétique "
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location : chaudières à haute performance energétique "
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7aa_2016(Variable):
-    cerfa_field = u"7AA"
+    cerfa_field = "7AA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 (hors bouquet sur 2 ans) : chaudières à condensation "
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 (hors bouquet sur 2 ans) : chaudières à condensation "
     # start_date = date(2015, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f7aa(Variable):
-    cerfa_field = u"7AA"
+    cerfa_field = "7AA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location : Chaudières à haute performance énergétique utilisant le fioul : dépenses payées en 2018 avec acceptation d’un devis et versement d’un acompte au plus tard le 31.12.2017 "
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location : Chaudières à haute performance énergétique utilisant le fioul : dépenses payées en 2018 avec acceptation d’un devis et versement d’un acompte au plus tard le 31.12.2017 "
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 
 class f7ad(Variable):
-    cerfa_field = u"7AD"
+    cerfa_field = "7AD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 (hors bouquet sur 2 ans) : chaudières à micro-génération gaz"
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 (hors bouquet sur 2 ans) : chaudières à micro-génération gaz"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7af(Variable):
-    cerfa_field = u"7AF"
+    cerfa_field = "7AF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 (hors bouquet sur 2 ans) : appareils de régulation de chauffage"
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location en 2015 (hors bouquet sur 2 ans) : appareils de régulation de chauffage"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7ao(Variable):
-    cerfa_field = u"7AO"
+    cerfa_field = "7AO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location : Chaudières à très haute performance énergétique utilisant le fioul : dépenses payées du 1.1.2018 au 30.6.2018 et dépenses payées du 1.7.2018 au 31.12.2018 avec acceptation d’un devis et versement d’un acompte au plus tard le 30.6.2018."
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location : Chaudières à très haute performance énergétique utilisant le fioul : dépenses payées du 1.1.2018 au 30.6.2018 et dépenses payées du 1.7.2018 au 31.12.2018 avec acceptation d’un devis et versement d’un acompte au plus tard le 30.6.2018."
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 
 class f7ap(Variable):
-    cerfa_field = u"7AP"
+    cerfa_field = "7AP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location : Matériaux d’isolation thermique des parois vitrées (fenêtres, portes-fenêtres…) venant en remplacement de simples vitrages."
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location : Matériaux d’isolation thermique des parois vitrées (fenêtres, portes-fenêtres…) venant en remplacement de simples vitrages."
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 
 class f7as(Variable):
-    cerfa_field = u"7AS"
+    cerfa_field = "7AS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location : Pompes à chaleur (autres que air/air) dédiées à la production d’eau chaude sanitaire (chauffe-eaux thermodynamiques); dépenses payées en 2018 avec acceptation d’un devis et versement d’un acompte au plus tard le 31.12.2017"
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location : Pompes à chaleur (autres que air/air) dédiées à la production d’eau chaude sanitaire (chauffe-eaux thermodynamiques); dépenses payées en 2018 avec acceptation d’un devis et versement d’un acompte au plus tard le 31.12.2017"
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 
 class f7bm(Variable):
-    cerfa_field = u"7BM"
+    cerfa_field = "7BM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale des logements donnés en location : Audit énergétique"
+    label = "Dépenses en faveur de la qualité environnementale des logements donnés en location : Audit énergétique"
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
@@ -7926,31 +7926,31 @@ class f7bm(Variable):
 
 
 class f7sd(Variable):
-    cerfa_field = u"7SD"
+    cerfa_field = "7SD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale, économie d'énergie: chaudières à condensation"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale, économie d'énergie: chaudières à condensation"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class f7se(Variable):
-    cerfa_field = u"7SE"
+    cerfa_field = "7SE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale, économie d'énergie: chaudières à micro-cogénération gaz"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale, économie d'énergie: chaudières à micro-cogénération gaz"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class f7sh(Variable):
-    cerfa_field = u"7SH"
+    cerfa_field = "7SH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses en faveur de la qualité environnementale de l'habitation principale, isolation thermique: matériaux d'isolation des toitures (acquisition et pose)"
+    label = "Dépenses en faveur de la qualité environnementale de l'habitation principale, isolation thermique: matériaux d'isolation des toitures (acquisition et pose)"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
@@ -7960,68 +7960,68 @@ class f7sh(Variable):
 # Crédit d'impôt pour dépense d'acquisition ou de transformation d'un véhicule GPL ou mixte en 2007 et investissements forestiers aprés ???
 
 class f7up(Variable):
-    cerfa_field = u"7UP"
+    cerfa_field = "7UP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt pour investissements forestiers: travaux"
+    label = "Crédit d'impôt pour investissements forestiers: travaux"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class f7uq(Variable):
-    cerfa_field = u"7UQ"
+    cerfa_field = "7UQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt pour investissements forestiers: contrat de gestion"
+    label = "Crédit d'impôt pour investissements forestiers: contrat de gestion"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 # Déclaration de déménagement correspondant à un crédit d'impôt aide à la mobilité
 class f1ar(Variable):
-    cerfa_field = u"1AR"
+    cerfa_field = "1AR"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Crédit d'impôt aide à la mobilité : le déclarant déménage à plus de 200 km pour son emploi"
+    label = "Crédit d'impôt aide à la mobilité : le déclarant déménage à plus de 200 km pour son emploi"
     end = '2008-12-31'
     definition_period = YEAR
 
 
 # TODO: QUIFOY
 class f1br(Variable):
-    cerfa_field = u"1BR"
+    cerfa_field = "1BR"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Crédit d'impôt aide à la mobilité : le conjoint déménage à plus de 200 km pour son emploi"
+    label = "Crédit d'impôt aide à la mobilité : le conjoint déménage à plus de 200 km pour son emploi"
     end = '2008-12-31'
     definition_period = YEAR
 
 
 class f1cr(Variable):
-    cerfa_field = u"1CR"
+    cerfa_field = "1CR"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Crédit d'impôt aide à la mobilité : la 1ère personne à charge déménage à plus de 200 km pour son emploi"
+    label = "Crédit d'impôt aide à la mobilité : la 1ère personne à charge déménage à plus de 200 km pour son emploi"
     end = '2008-12-31'
     definition_period = YEAR
 
 
 class f1dr(Variable):
-    cerfa_field = u"1DR"
+    cerfa_field = "1DR"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Crédit d'impôt aide à la mobilité : la 2è personne à charge déménage à plus de 200 km pour son emploi"
+    label = "Crédit d'impôt aide à la mobilité : la 2è personne à charge déménage à plus de 200 km pour son emploi"
     end = '2008-12-31'
     definition_period = YEAR
 
 
 class f1er(Variable):
-    cerfa_field = u"1ER"
+    cerfa_field = "1ER"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Crédit d'impôt aide à la mobilité : la 3è personne à charge déménage à plus de 200 km pour son emploi"
+    label = "Crédit d'impôt aide à la mobilité : la 3è personne à charge déménage à plus de 200 km pour son emploi"
     end = '2006-12-31'
     definition_period = YEAR
 
@@ -8032,11 +8032,11 @@ class f1er(Variable):
 # pour lesquels la cessation ou l'interruption de la location est intervenue en 2013 et qui ont été
 # soumis à la taxe additionnelle au droit de bail
 class f4tq(Variable):
-    cerfa_field = u"4TQ"
+    cerfa_field = "4TQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d’impôt représentatif de la taxe additionnelle au droit de bail"
+    label = "Crédit d’impôt représentatif de la taxe additionnelle au droit de bail"
     definition_period = YEAR
 
 
@@ -8044,127 +8044,127 @@ class f4tq(Variable):
 
 
 class f7sf(Variable):
-    cerfa_field = u"7SF"
+    cerfa_field = "7SF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit de travaux en faveur d'aides aux personnes pour des logements en location (avant 2012 ) / Appareils de régulation du chauffage, matériaux de calorifugeage (après 2011)"
+    label = "Crédit de travaux en faveur d'aides aux personnes pour des logements en location (avant 2012 ) / Appareils de régulation du chauffage, matériaux de calorifugeage (après 2011)"
     definition_period = YEAR
 
 
 class f7si(Variable):
-    cerfa_field = u"7SI"
+    cerfa_field = "7SI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Matériaux d’isolation des planchers bas sur sous-sol, sur vide sanitaire ou sur passage couvert (acquisition et pose)"
+    label = "Matériaux d’isolation des planchers bas sur sous-sol, sur vide sanitaire ou sur passage couvert (acquisition et pose)"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f7vi(Variable):
-    cerfa_field = u"7VI"
+    cerfa_field = "7VI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Matériaux d’isolation des planchers bas sur sous-sol, sur vide sanitaire ou sur passage couvert (acquisition et pose) en 2015"
+    label = "Matériaux d’isolation des planchers bas sur sous-sol, sur vide sanitaire ou sur passage couvert (acquisition et pose) en 2015"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7te(Variable):
-    cerfa_field = u"7TE"
+    cerfa_field = "7TE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses d'investissement forestier"
+    label = "Dépenses d'investissement forestier"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f7tu(Variable):
-    cerfa_field = u"7TU"
+    cerfa_field = "7TU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de travaux dans l'habitation principale"
+    label = "Dépenses de travaux dans l'habitation principale"
     # start_date = date(2012, 1, 1)
 #   end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7tt(Variable):
-    cerfa_field = u"7TT"
+    cerfa_field = "7TT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de travaux dans l'habitation principale"
+    label = "Dépenses de travaux dans l'habitation principale"
     # start_date = date(2012, 1, 1)
 #    end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7tv(Variable):
-    cerfa_field = u"7TV"
+    cerfa_field = "7TV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de travaux dans l'habitation principale"
+    label = "Dépenses de travaux dans l'habitation principale"
     # start_date = date(2012, 1, 1)
 #    end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7tx_2012(Variable):
-    cerfa_field = u"7TX"
+    cerfa_field = "7TX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de travaux dans l'habitation principale ouvrant droit au crédit d'impôt de 26%"
+    label = "Dépenses de travaux dans l'habitation principale ouvrant droit au crédit d'impôt de 26%"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7ty_2012(Variable):
-    cerfa_field = u"7TY"
+    cerfa_field = "7TY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de travaux dans l'habitation principale ouvrant droit au crédit d'impôt de 32%"
+    label = "Dépenses de travaux dans l'habitation principale ouvrant droit au crédit d'impôt de 32%"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f7tx_2015(Variable):
-    cerfa_field = u"7TX"
+    cerfa_field = "7TX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de travaux dans l'habitation principale : dépenses de diagnostic de performance énergétique effectuées en 2015"
+    label = "Dépenses de travaux dans l'habitation principale : dépenses de diagnostic de performance énergétique effectuées en 2015"
     # start_date = date(2015, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class f7ty_2015(Variable):
-    cerfa_field = u"7TY"
+    cerfa_field = "7TY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de travaux dans l'habitation principale : dépenses d'équipements de raccordement à un réseau de chaleur effectuées en 2015"
+    label = "Dépenses de travaux dans l'habitation principale : dépenses d'équipements de raccordement à un réseau de chaleur effectuées en 2015"
     # start_date = date(2015, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class f7tw(Variable):
-    cerfa_field = u"7TW"
+    cerfa_field = "7TW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Dépenses de travaux dans l'habitation principale"
+    label = "Dépenses de travaux dans l'habitation principale"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
@@ -8173,81 +8173,81 @@ class f7tw(Variable):
 # Réduction d'impôts sur les investissements locatifs intermédiaires (loi Duflot)
 
 class f7gh(Variable):
-    cerfa_field = u"7GH"
+    cerfa_field = "7GH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermédiaires en métropole"
+    label = "Investissements locatifs intermédiaires en métropole"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7gi(Variable):
-    cerfa_field = u"7GI"
+    cerfa_field = "7GI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermédiaires outre-mer"
+    label = "Investissements locatifs intermédiaires outre-mer"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f7ek(Variable):
-    cerfa_field = u"7EK"
+    cerfa_field = "7EK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermÃ©diaires du 1.1 au 31.8.2014 en mÃ©tropole"
+    label = "Investissements locatifs intermÃ©diaires du 1.1 au 31.8.2014 en mÃ©tropole"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7el(Variable):
-    cerfa_field = u"7EL"
+    cerfa_field = "7EL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermÃ©diaires du 1.1 au 31.8.2014 en outre-mer"
+    label = "Investissements locatifs intermÃ©diaires du 1.1 au 31.8.2014 en outre-mer"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7fi(Variable):
-    cerfa_field = u"7FI"
+    cerfa_field = "7FI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements rÃ©alisÃ©s et achevÃ©s en 2013 en mÃ©tropole et outre-mer"
+    label = "Report concernant les investissements rÃ©alisÃ©s et achevÃ©s en 2013 en mÃ©tropole et outre-mer"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7fk(Variable):
-    cerfa_field = u"7FK"
+    cerfa_field = "7FK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements rÃ©alisÃ©s et achevÃ©s en 2014 en mÃ©tropole et outre-mer"
+    label = "Report concernant les investissements rÃ©alisÃ©s et achevÃ©s en 2014 en mÃ©tropole et outre-mer"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7fr(Variable):
-    cerfa_field = u"7FR"
+    cerfa_field = "7FR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements rÃ©alisÃ©s et achevÃ©s en 2015 en mÃ©tropole et outre-mer"
+    label = "Report concernant les investissements rÃ©alisÃ©s et achevÃ©s en 2015 en mÃ©tropole et outre-mer"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7fv(Variable):
-    cerfa_field = u"7FV"
+    cerfa_field = "7FV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements réalisés et achevés en 2016 en métropole et outre-mer"
+    label = "Report concernant les investissements réalisés et achevés en 2016 en métropole et outre-mer"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
@@ -8255,251 +8255,251 @@ class f7fv(Variable):
 
 
 class f7qa(Variable):
-    cerfa_field = u"7QA"
+    cerfa_field = "7QA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermédiaires en métropole réalisés du 1.9.2014 au 31.12.2014 avec engagement de location 6 ans"
+    label = "Investissements locatifs intermédiaires en métropole réalisés du 1.9.2014 au 31.12.2014 avec engagement de location 6 ans"
     # start_date = date(2014, 1, 1)
     definition_period = YEAR
 
 
 class f7ai(Variable):
-    cerfa_field = u"7AI"
+    cerfa_field = "7AI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en métropole 2014 avec engagement de location 6 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en métropole 2014 avec engagement de location 6 ans"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7bi(Variable):
-    cerfa_field = u"7BI"
+    cerfa_field = "7BI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en métropole réalisés 2014 avec engagement de location 9 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en métropole réalisés 2014 avec engagement de location 9 ans"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7ci(Variable):
-    cerfa_field = u"7CI"
+    cerfa_field = "7CI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en outre-mer 2014 avec engagement de location 6 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en outre-mer 2014 avec engagement de location 6 ans"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7di(Variable):
-    cerfa_field = u"7DI"
+    cerfa_field = "7DI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en outre-mer 2014 avec engagement de location 9 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en outre-mer 2014 avec engagement de location 9 ans"
     # start_date = date(2015, 1, 1)
     definition_period = YEAR
 
 
 class f7bz(Variable):
-    cerfa_field = u"7BZ"
+    cerfa_field = "7BZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en métropole 2015 avec engagement de location 6 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en métropole 2015 avec engagement de location 6 ans"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7cz(Variable):
-    cerfa_field = u"7CZ"
+    cerfa_field = "7CZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en métropole réalisés 2015 avec engagement de location 9 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en métropole réalisés 2015 avec engagement de location 9 ans"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7dz(Variable):
-    cerfa_field = u"7DZ"
+    cerfa_field = "7DZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en outre-mer 2015 avec engagement de location 6 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en outre-mer 2015 avec engagement de location 6 ans"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7ez(Variable):
-    cerfa_field = u"7EZ"
+    cerfa_field = "7EZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en outre-mer 2015 avec engagement de location 9 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en outre-mer 2015 avec engagement de location 9 ans"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f7qm(Variable):
-    cerfa_field = u"7QM"
+    cerfa_field = "7QM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermédiaires en métropole réalisés en 2017 avec engagement de location 6 ans"
+    label = "Investissements locatifs intermédiaires en métropole réalisés en 2017 avec engagement de location 6 ans"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7qn(Variable):
-    cerfa_field = u"7QN"
+    cerfa_field = "7QN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermédiaires en métropole réalisés en 2017 avec engagement de location 9 ans"
+    label = "Investissements locatifs intermédiaires en métropole réalisés en 2017 avec engagement de location 9 ans"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7qo(Variable):
-    cerfa_field = u"7QO"
+    cerfa_field = "7QO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermédiaires en outre-mer réalisés en 2017 avec engagement de location 6 ans"
+    label = "Investissements locatifs intermédiaires en outre-mer réalisés en 2017 avec engagement de location 6 ans"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7qp(Variable):
-    cerfa_field = u"7QP"
+    cerfa_field = "7QP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermédiaires en outre-mer réalisés en 2017 avec engagement de location 9 ans"
+    label = "Investissements locatifs intermédiaires en outre-mer réalisés en 2017 avec engagement de location 9 ans"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7qr(Variable):
-    cerfa_field = u"7QR"
+    cerfa_field = "7QR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermédiaires en métropole réalisés en 2018 avec engagement de location 6 ans"
+    label = "Investissements locatifs intermédiaires en métropole réalisés en 2018 avec engagement de location 6 ans"
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 
 class f7qs(Variable):
-    cerfa_field = u"7QS"
+    cerfa_field = "7QS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermédiaires en métropole réalisés en 2018 avec engagement de location 9 ans"
+    label = "Investissements locatifs intermédiaires en métropole réalisés en 2018 avec engagement de location 9 ans"
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 
 class f7qt(Variable):
-    cerfa_field = u"7QT"
+    cerfa_field = "7QT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermédiaires en outre-mer réalisés en 2018 avec engagement de location 6 ans"
+    label = "Investissements locatifs intermédiaires en outre-mer réalisés en 2018 avec engagement de location 6 ans"
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 
 class f7qu(Variable):
-    cerfa_field = u"7QU"
+    cerfa_field = "7QU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Investissements locatifs intermédiaires en outre-mer réalisés en 2018 avec engagement de location 9 ans"
+    label = "Investissements locatifs intermédiaires en outre-mer réalisés en 2018 avec engagement de location 9 ans"
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 
 class f7qz(Variable):
-    cerfa_field = u"7QZ"
+    cerfa_field = "7QZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en métropole en 2016 avec engagement de location 6 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en métropole en 2016 avec engagement de location 6 ans"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7rz(Variable):
-    cerfa_field = u"7RZ"
+    cerfa_field = "7RZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en métropole en 2016 avec engagement de location 9 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en métropole en 2016 avec engagement de location 9 ans"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7sz(Variable):
-    cerfa_field = u"7SZ"
+    cerfa_field = "7SZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en outre-mer en 2016 avec engagement de location 6 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en outre-mer en 2016 avec engagement de location 6 ans"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7tz(Variable):
-    cerfa_field = u"7TZ"
+    cerfa_field = "7TZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en outre-mer en 2016 avec engagement de location 9 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en outre-mer en 2016 avec engagement de location 9 ans"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f7ra(Variable):
-    cerfa_field = u"7RA"
+    cerfa_field = "7RA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en métropole en 2017 avec engagement de location 6 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en métropole en 2017 avec engagement de location 6 ans"
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 
 class f7rb(Variable):
-    cerfa_field = u"7RB"
+    cerfa_field = "7RB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en métropole en 2017 avec engagement de location 9 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en métropole en 2017 avec engagement de location 9 ans"
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 
 class f7rc(Variable):
-    cerfa_field = u"7RC"
+    cerfa_field = "7RC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en outre-mer en 2017 avec engagement de location 6 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en outre-mer en 2017 avec engagement de location 6 ans"
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
 
 class f7rd(Variable):
-    cerfa_field = u"7RD"
+    cerfa_field = "7RD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Report concernant les investissements locatifs intermédiaires en outre-mer en 2017 avec engagement de location 9 ans"
+    label = "Report concernant les investissements locatifs intermédiaires en outre-mer en 2017 avec engagement de location 9 ans"
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
@@ -8507,223 +8507,223 @@ class f7rd(Variable):
 
 
 class f8tc(Variable):
-    cerfa_field = u"8TC"
+    cerfa_field = "8TC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt autres entreprises (recherche non encore remboursé (années antérieures))"
+    label = "Crédit d'impôt autres entreprises (recherche non encore remboursé (années antérieures))"
     end = '2008-12-31'
     definition_period = YEAR
 
 
 class f8tb(Variable):
-    cerfa_field = u"8TB"
+    cerfa_field = "8TB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt recherche (entreprises bénéficiant de la restitution immédiate)"
+    label = "Crédit d'impôt recherche (entreprises bénéficiant de la restitution immédiate)"
     definition_period = YEAR
 
 
 class f8te(Variable):
-    cerfa_field = u"8TE"
+    cerfa_field = "8TE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: adhésion à un groupement de prévention agréé"
+    label = "Crédit d'impôt en faveur des entreprises: adhésion à un groupement de prévention agréé"
     definition_period = YEAR
 
 
 class f8tf(Variable):
-    cerfa_field = u"8TF"
+    cerfa_field = "8TF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Reprises de réductions ou de crédits d'impôt"
+    label = "Reprises de réductions ou de crédits d'impôt"
     definition_period = YEAR
 
 
 class f8tg(Variable):
-    cerfa_field = u"8TG"
+    cerfa_field = "8TG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédits d'impôt en faveur des entreprises: Investissement en Corse"
+    label = "Crédits d'impôt en faveur des entreprises: Investissement en Corse"
     definition_period = YEAR
 
 
 class f8tl(Variable):
-    cerfa_field = u"8TL"
+    cerfa_field = "8TL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt compétitivité emploi (CICE), entreprises bénéficiant de la restitution immédiate"
+    label = "Crédit d'impôt compétitivité emploi (CICE), entreprises bénéficiant de la restitution immédiate"
     definition_period = YEAR
 
 
 class f8to(Variable):
-    cerfa_field = u"8TO"
+    cerfa_field = "8TO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: investissement en Corse, report non imputé les années antérieures"
+    label = "Crédit d'impôt en faveur des entreprises: investissement en Corse, report non imputé les années antérieures"
     definition_period = YEAR
 
 
 class f8tp(Variable):
-    cerfa_field = u"8TP"
+    cerfa_field = "8TP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: investissement en Corse, reprise de crédit d'impôt"
+    label = "Crédit d'impôt en faveur des entreprises: investissement en Corse, reprise de crédit d'impôt"
     definition_period = YEAR
 
 
 class f8ts(Variable):
-    cerfa_field = u"8TS"
+    cerfa_field = "8TS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: investissement en Corse, crédit d'impôt"
+    label = "Crédit d'impôt en faveur des entreprises: investissement en Corse, crédit d'impôt"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f8uz(Variable):
-    cerfa_field = u"8UZ"
+    cerfa_field = "8UZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Famille"
+    label = "Crédit d'impôt en faveur des entreprises: Famille"
     definition_period = YEAR
 
 
 class f8uw(Variable):
-    cerfa_field = u"8UW"
+    cerfa_field = "8UW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt compétitivité emploi (CICE), autres entreprises"
+    label = "Crédit d'impôt compétitivité emploi (CICE), autres entreprises"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f8tz(Variable):
-    cerfa_field = u"8TZ"
+    cerfa_field = "8TZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Apprentissage"
+    label = "Crédit d'impôt en faveur des entreprises: Apprentissage"
     definition_period = YEAR
 
 
 class f8wa(Variable):
-    cerfa_field = u"8WA"
+    cerfa_field = "8WA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Agriculture biologique"
+    label = "Crédit d'impôt en faveur des entreprises: Agriculture biologique"
     definition_period = YEAR
 
 
 class f8wb(Variable):
-    cerfa_field = u"8WB"
+    cerfa_field = "8WB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Prospection commerciale"
+    label = "Crédit d'impôt en faveur des entreprises: Prospection commerciale"
     definition_period = YEAR
 
 
 class f8wc__2008(Variable):
-    cerfa_field = u"8WC"
+    cerfa_field = "8WC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Nouvelles technologies"
+    label = "Crédit d'impôt en faveur des entreprises: Nouvelles technologies"
     end = '2008-12-31'
     definition_period = YEAR
 
 
 class f8wc(Variable):
-    cerfa_field = u"8WC"
+    cerfa_field = "8WC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Prêts sans intérêt"
+    label = "Crédit d'impôt en faveur des entreprises: Prêts sans intérêt"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f8wd(Variable):
-    cerfa_field = u"8WD"
+    cerfa_field = "8WD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Formation des chefs d'entreprise"
+    label = "Crédit d'impôt en faveur des entreprises: Formation des chefs d'entreprise"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 class f8we(Variable):
-    cerfa_field = u"8WE"
+    cerfa_field = "8WE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Intéressement"
+    label = "Crédit d'impôt en faveur des entreprises: Intéressement"
     # start_date = date(2008, 1, 1)
     definition_period = YEAR
 
 
 class f8wr(Variable):
-    cerfa_field = u"8WR"
+    cerfa_field = "8WR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Métiers d'art"
+    label = "Crédit d'impôt en faveur des entreprises: Métiers d'art"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 # verif<=2012
 class f8ws(Variable):
-    cerfa_field = u"8WS"
+    cerfa_field = "8WS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Emploi de salariés réservistes"
+    label = "Crédit d'impôt en faveur des entreprises: Emploi de salariés réservistes"
     # start_date = date(2006, 1, 1)
     end = '2009-12-31'
     definition_period = YEAR
 
 
 class f8wt(Variable):
-    cerfa_field = u"8WT"
+    cerfa_field = "8WT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Remplacement pour congé des agriculteurs"
+    label = "Crédit d'impôt en faveur des entreprises: Remplacement pour congé des agriculteurs"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 class f8wu(Variable):
-    cerfa_field = u"8WU"
+    cerfa_field = "8WU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Maître restaurateur"
+    label = "Crédit d'impôt en faveur des entreprises: Maître restaurateur"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 # verif<=2012
 class f8wv(Variable):
-    cerfa_field = u"8WV"
+    cerfa_field = "8WV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Débitants de tabac"
+    label = "Crédit d'impôt en faveur des entreprises: Débitants de tabac"
     # start_date = date(2007, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
@@ -8731,11 +8731,11 @@ class f8wv(Variable):
 
 # verif<=2012
 class f8wx(Variable):
-    cerfa_field = u"8WX"
+    cerfa_field = "8WX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt en faveur des entreprises: Formation des salariés à l'économie d'entreprise"
+    label = "Crédit d'impôt en faveur des entreprises: Formation des salariés à l'économie d'entreprise"
     # start_date = date(2007, 1, 1)
     end = '2009-12-31'
     definition_period = YEAR
@@ -8746,7 +8746,7 @@ class elig_creimp_exc_2008(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Éligibilité au crédit d'impôt exceptionnel sur les revenus 2008"
+    label = "Éligibilité au crédit d'impôt exceptionnel sur les revenus 2008"
     # start_date = date(2008, 1, 1)
     end = '2008-12-31'
     definition_period = YEAR
@@ -8756,7 +8756,7 @@ class elig_creimp_exc_2008(Variable):
 class elig_creimp_jeunes(Variable):
     value_type = bool
     entity = Individu
-    label = u"Éligible au crédit d'impôt jeunes"
+    label = "Éligible au crédit d'impôt jeunes"
     # start_date = date(2005, 1, 1)
     end = '2008-01-01'
     definition_period = YEAR

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -11,7 +11,7 @@ class b1ab(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Valeur de la résidence principale avant abattement"
+    label = "Valeur de la résidence principale avant abattement"
     definition_period = YEAR
 
 
@@ -19,7 +19,7 @@ class b1ac(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Valeur des autres immeubles avant abattement"
+    label = "Valeur des autres immeubles avant abattement"
     definition_period = YEAR
 
 
@@ -28,7 +28,7 @@ class b1bc(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Immeubles non bâtis : bois, fôrets et parts de groupements forestiers"
+    label = "Immeubles non bâtis : bois, fôrets et parts de groupements forestiers"
     definition_period = YEAR
 
 
@@ -36,7 +36,7 @@ class b1be(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Immeubles non bâtis : biens ruraux loués à long termes"
+    label = "Immeubles non bâtis : biens ruraux loués à long termes"
     definition_period = YEAR
 
 
@@ -44,7 +44,7 @@ class b1bh(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Immeubles non bâtis : parts de groupements fonciers agricoles et de groupements agricoles fonciers"
+    label = "Immeubles non bâtis : parts de groupements fonciers agricoles et de groupements agricoles fonciers"
     definition_period = YEAR
 
 
@@ -52,7 +52,7 @@ class b1bk(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Immeubles non bâtis : autres biens"
+    label = "Immeubles non bâtis : autres biens"
     definition_period = YEAR
 
 
@@ -61,7 +61,7 @@ class b1cl(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Parts et actions détenues par les salariés et mandataires sociaux"
+    label = "Parts et actions détenues par les salariés et mandataires sociaux"
     definition_period = YEAR
 
 
@@ -69,7 +69,7 @@ class b1cb(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Parts et actions de sociétés avec engagement de conservation de 6 ans minimum"
+    label = "Parts et actions de sociétés avec engagement de conservation de 6 ans minimum"
     definition_period = YEAR
 
 
@@ -77,7 +77,7 @@ class b1cd(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Droits sociaux de sociétés dans lesquelles vous exercez une fonction ou une activité"
+    label = "Droits sociaux de sociétés dans lesquelles vous exercez une fonction ou une activité"
     definition_period = YEAR
 
 
@@ -85,7 +85,7 @@ class b1ce(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Autres valeurs mobilières"
+    label = "Autres valeurs mobilières"
     definition_period = YEAR
 
 
@@ -93,7 +93,7 @@ class b1cf(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Liquidités"
+    label = "Liquidités"
     definition_period = YEAR
 
 
@@ -101,7 +101,7 @@ class b1cg(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Autres biens meubles"
+    label = "Autres biens meubles"
     definition_period = YEAR
 
 
@@ -109,7 +109,7 @@ class b1co(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Autres biens meubles : contrats d'assurance-vie"
+    label = "Autres biens meubles : contrats d'assurance-vie"
     definition_period = YEAR
 
 
@@ -124,7 +124,7 @@ class b2gh(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Total du passif et autres déductions"
+    label = "Total du passif et autres déductions"
     definition_period = YEAR
 
 
@@ -133,7 +133,7 @@ class b2mt(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Réductions pour investissements directs dans une société"
+    label = "Réductions pour investissements directs dans une société"
     definition_period = YEAR
 
 
@@ -141,7 +141,7 @@ class b2ne(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Réductions pour investissements directs dans une société"
+    label = "Réductions pour investissements directs dans une société"
     definition_period = YEAR
 
 
@@ -149,7 +149,7 @@ class b2mv(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Réductions pour investissements par sociétés interposées, holdings"
+    label = "Réductions pour investissements par sociétés interposées, holdings"
     definition_period = YEAR
 
 
@@ -157,7 +157,7 @@ class b2nf(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Réductions pour investissements par sociétés interposées, holdings"
+    label = "Réductions pour investissements par sociétés interposées, holdings"
     definition_period = YEAR
 
 
@@ -165,7 +165,7 @@ class b2mx(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Réductions pour investissements par le biais de FIP"
+    label = "Réductions pour investissements par le biais de FIP"
     definition_period = YEAR
 
 
@@ -173,7 +173,7 @@ class b2na(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Réductions pour investissements par le biais de FCPI ou FCPR"
+    label = "Réductions pour investissements par le biais de FCPI ou FCPR"
     definition_period = YEAR
 
 
@@ -181,7 +181,7 @@ class b2nc(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Réductions pour dons à certains organismes d'intérêt général"
+    label = "Réductions pour dons à certains organismes d'intérêt général"
     definition_period = YEAR
 
 
@@ -190,7 +190,7 @@ class b4rs(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Montant de l'impôt acquitté hors de France"
+    label = "Montant de l'impôt acquitté hors de France"
     definition_period = YEAR
 
 
@@ -214,7 +214,7 @@ class tax_fonc(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Taxe foncière"
+    label = "Taxe foncière"
     definition_period = YEAR
 
 
@@ -239,7 +239,7 @@ class etr(Variable):
 class isf_ifi_imm_bati(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Base de l'ISF-IFI sur l'immobilier bâti"
+    label = "Base de l'ISF-IFI sur l'immobilier bâti"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -253,7 +253,7 @@ class isf_ifi_imm_bati(Variable):
 class isf_ifi_imm_non_bati(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Base de l'ISF-IFI sur l'immobilier non-bâti"
+    label = "Base de l'ISF-IFI sur l'immobilier non-bâti"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -280,7 +280,7 @@ class isf_ifi_imm_non_bati(Variable):
 class isf_actions_sal(Variable):  # # non présent en 2005##
     value_type = float
     entity = FoyerFiscal
-    label = u"isf_actions_sal"
+    label = "isf_actions_sal"
     definition_period = YEAR
     end = '2017-12-31'
 
@@ -297,7 +297,7 @@ class isf_actions_sal(Variable):  # # non présent en 2005##
 class isf_droits_sociaux(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"isf_droits_sociaux"
+    label = "isf_droits_sociaux"
     definition_period = YEAR
     end = '2017-12-31'
 
@@ -317,7 +317,7 @@ class isf_droits_sociaux(Variable):
 class assiette_isf_ifi(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Assiette de l'ISF-IFI"
+    label = "Assiette de l'ISF-IFI"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -341,7 +341,7 @@ class assiette_isf_ifi(Variable):
 class isf_ifi_iai(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"ISF-IFI avant décote, réductions et plafonnement"
+    label = "ISF-IFI avant décote, réductions et plafonnement"
     definition_period = YEAR
 
     def formula_2002_01_01(foyer_fiscal, period, parameters):
@@ -360,7 +360,7 @@ class isf_ifi_iai(Variable):
 class isf_ifi_avant_reduction(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"ISF-IFI avant réductions et plafonnement"
+    label = "ISF-IFI avant réductions et plafonnement"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -373,7 +373,7 @@ class isf_ifi_avant_reduction(Variable):
 class isf_reduc_pac(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"isf_reduc_pac"
+    label = "isf_reduc_pac"
     end = '2012-12-31'
     definition_period = YEAR
 
@@ -391,7 +391,7 @@ class isf_reduc_pac(Variable):
 class isf_inv_pme(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"isf_inv_pme"
+    label = "isf_inv_pme"
     definition_period = YEAR
 
     def formula_2008(foyer_fiscal, period, parameters):
@@ -418,7 +418,7 @@ class isf_inv_pme(Variable):
 class isf_org_int_gen(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"isf_org_int_gen"
+    label = "isf_org_int_gen"
     definition_period = YEAR
 
     def formula_2008(foyer_fiscal, period, parameters):
@@ -431,7 +431,7 @@ class isf_org_int_gen(Variable):
 class isf_ifi_avant_plaf(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"ISF-IFI avant plafonnement"
+    label = "ISF-IFI avant plafonnement"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -462,7 +462,7 @@ class isf_ifi_avant_plaf(Variable):
 class total_impots_plafonnement_isf_ifi(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Total des impôts dus au titre des revenus et produits (irpp, cehr, prélèvements forfaitaires, prélèvements sociaux) + ISF et IFI. Utilisé pour calculer le montant du plafonnement de l'ISF et de l'IFI."
+    label = "Total des impôts dus au titre des revenus et produits (irpp, cehr, prélèvements forfaitaires, prélèvements sociaux) + ISF et IFI. Utilisé pour calculer le montant du plafonnement de l'ISF et de l'IFI."
     definition_period = YEAR
 
     def formula(foyer_fiscal, period):
@@ -497,7 +497,7 @@ class total_impots_plafonnement_isf_ifi(Variable):
 class revenus_et_produits_plafonnement_isf_ifi(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenus et produits perçus, utilisés pour calculer le montant du plafonnement de l'ISF"
+    label = "Revenus et produits perçus, utilisés pour calculer le montant du plafonnement de l'ISF"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -558,7 +558,7 @@ class revenus_et_produits_plafonnement_isf_ifi(Variable):
 class decote_isf_ifi(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Décote de l'ISF-IFI"
+    label = "Décote de l'ISF-IFI"
     definition_period = YEAR
 
     def formula_2013(foyer_fiscal, period, parameters):
@@ -573,7 +573,7 @@ class decote_isf_ifi(Variable):
 class isf_ifi_apres_plaf(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"ISF-IFI après plafonnement"
+    label = "ISF-IFI après plafonnement"
     definition_period = YEAR
 
     def formula_2002_01_01(foyer_fiscal, period, parameters):
@@ -614,7 +614,7 @@ class isf_ifi_apres_plaf(Variable):
 class isf_ifi(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Montant d'ISF-IFI"
+    label = "Montant d'ISF-IFI"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period):
@@ -632,7 +632,7 @@ class isf_ifi(Variable):
 class rvcm_plus_abat(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"rvcm_plus_abat"
+    label = "rvcm_plus_abat"
     definition_period = YEAR
     end = '2010-12-31'
 
@@ -649,7 +649,7 @@ class rvcm_plus_abat(Variable):
 class maj_cga(Variable):
     value_type = float
     entity = Individu
-    label = u"Majoration pour non adhésion à un centre de gestion agréé (pour chaque individu du foyer)"
+    label = "Majoration pour non adhésion à un centre de gestion agréé (pour chaque individu du foyer)"
     definition_period = YEAR
 
     # TODO: à reintégrer dans irpp (et vérifier au passage que frag_impo est dans la majo_cga
@@ -686,7 +686,7 @@ class maj_cga(Variable):
 class bouclier_rev(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"bouclier_rev"
+    label = "bouclier_rev"
     end = '2010-12-31'
     definition_period = YEAR
 
@@ -747,7 +747,7 @@ class bouclier_rev(Variable):
 class bouclier_imp_gen(Variable):  # # ajouter CSG- CRDS
     value_type = float
     entity = FoyerFiscal
-    label = u"bouclier_imp_gen"
+    label = "bouclier_imp_gen"
     end = '2010-12-31'
     definition_period = YEAR
 
@@ -793,7 +793,7 @@ class bouclier_imp_gen(Variable):  # # ajouter CSG- CRDS
 class restitutions(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"restitutions"
+    label = "restitutions"
     end = '2010-12-31'
     definition_period = YEAR
 
@@ -810,7 +810,7 @@ class restitutions(Variable):
 class bouclier_sumimp(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"bouclier_sumimp"
+    label = "bouclier_sumimp"
     end = '2010-12-31'
     definition_period = YEAR
 
@@ -827,7 +827,7 @@ class bouclier_sumimp(Variable):
 class bouclier_fiscal(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"bouclier_fiscal"
+    label = "bouclier_fiscal"
     end = '2010-12-31'
     reference = "http://fr.wikipedia.org/wiki/Bouclier_fiscal"
     definition_period = YEAR

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 class assiette_csg_abattue(Variable):
     value_type = float
-    label = u"Assiette CSG - CRDS"
+    label = "Assiette CSG - CRDS"
     entity = Individu
     definition_period = MONTH
 
@@ -48,7 +48,7 @@ class assiette_csg_abattue(Variable):
 
 class assiette_csg_non_abattue(Variable):
     value_type = float
-    label = u"Assiette CSG - CRDS"
+    label = "Assiette CSG - CRDS"
     entity = Individu
     definition_period = MONTH
 
@@ -68,7 +68,7 @@ class assiette_csg_non_abattue(Variable):
 class csg_deductible_salaire(Variable):
     calculate_output = calculate_output_add
     value_type = float
-    label = u"CSG déductible sur les salaires"
+    label = "CSG déductible sur les salaires"
     entity = Individu
     definition_period = MONTH
 
@@ -90,7 +90,7 @@ class csg_deductible_salaire(Variable):
 class csg_imposable_salaire(Variable):
     calculate_output = calculate_output_add
     value_type = float
-    label = u"CSG imposables sur les salaires"
+    label = "CSG imposables sur les salaires"
     entity = Individu
     definition_period = MONTH
 
@@ -113,7 +113,7 @@ class csg_imposable_salaire(Variable):
 class crds_salaire(Variable):
     calculate_output = calculate_output_add
     value_type = float
-    label = u"CRDS sur les salaires"
+    label = "CRDS sur les salaires"
     entity = Individu
     definition_period = MONTH
 
@@ -137,7 +137,7 @@ class crds_salaire(Variable):
 class forfait_social(Variable):
     value_type = float
     entity = Individu
-    label = u"Forfait social"
+    label = "Forfait social"
     definition_period = MONTH
     calculate_output = calculate_output_add
 
@@ -182,14 +182,14 @@ class salaire_imposable(Variable):
     value_type = float
     unit = 'currency'
     cerfa_field = {  # (f1aj, f1bj, f1cj, f1dj, f1ej)
-        0: u"1AJ",
-        1: u"1BJ",
-        2: u"1CJ",
-        3: u"1DJ",
-        4: u"1EJ",
+        0: "1AJ",
+        1: "1BJ",
+        2: "1CJ",
+        3: "1DJ",
+        4: "1EJ",
         }
     entity = Individu
-    label = u"Salaires imposables"
+    label = "Salaires imposables"
     set_input = set_input_divide_by_period
     definition_period = MONTH
 
@@ -229,7 +229,7 @@ class salaire_imposable(Variable):
 class salaire_net(Variable):
     value_type = float
     entity = Individu
-    label = u"Salaires nets d'après définition INSEE"
+    label = "Salaires nets d'après définition INSEE"
     set_input = set_input_divide_by_period
     definition_period = MONTH
 
@@ -248,8 +248,8 @@ class salaire_net(Variable):
 class tehr(Variable):
     value_type = float
     entity = Individu
-    label = u"Taxe exceptionnelle de solidarité sur les hautes rémunérations versées par les entreprises"
-    reference = u"art. 15 de la loi 2013-1278 (https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=1AACF2E1F7F065EF9C92B6B91E024EBE.tpdjo02v_1?idArticle=LEGIARTI000028402680&cidTexte=LEGITEXT000028402464&dateTexte=20140113)"
+    label = "Taxe exceptionnelle de solidarité sur les hautes rémunérations versées par les entreprises"
+    reference = "art. 15 de la loi 2013-1278 (https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=1AACF2E1F7F065EF9C92B6B91E024EBE.tpdjo02v_1?idArticle=LEGIARTI000028402680&cidTexte=LEGITEXT000028402464&dateTexte=20140113)"
     calculate_output = calculate_output_divide
     definition_period = YEAR
     end = '2015-01-01'
@@ -266,8 +266,8 @@ class rev_microsocial(Variable):
     """Revenu net des cotisations sociales sous régime microsocial (auto-entrepreneur)"""
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenu net des cotisations sociales pour le régime microsocial"
-    reference = u"http://www.apce.com/pid6137/regime-micro-social.html"
+    label = "Revenu net des cotisations sociales pour le régime microsocial"
+    reference = "http://www.apce.com/pid6137/regime-micro-social.html"
     definition_period = YEAR
 
     def formula_2009_01_01(foyer_fiscal, period, parameters):
@@ -286,7 +286,7 @@ class assiette_csg_crds_non_salarie(Variable):
     """Assiette CSG des personnes non salariées"""
     value_type = float
     entity = Individu
-    label = u"Assiette CSG des personnes non salariées"
+    label = "Assiette CSG des personnes non salariées"
     definition_period = YEAR
 
     def formula(individu, period):
@@ -325,7 +325,7 @@ class assiette_csg_crds_non_salarie(Variable):
 class csg_non_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Assiette CSG des personnes non salariées"
+    label = "Assiette CSG des personnes non salariées"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -338,7 +338,7 @@ class csg_non_salarie(Variable):
 class crds_non_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Assiette CSG des personnes non salariées"
+    label = "Assiette CSG des personnes non salariées"
     definition_period = YEAR
 
     def formula(individu, period, parameters):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -23,7 +23,7 @@ class interets_plan_epargne_logement_moins_de_12_ans_ouvert_avant_2018(Variable)
     """
     value_type = float
     entity = Individu
-    label = u"Intérêts des plans épargne logement (PEL) de moins de 12 ans ouverts avant le 1er janvier 2018"
+    label = "Intérêts des plans épargne logement (PEL) de moins de 12 ans ouverts avant le 1er janvier 2018"
     definition_period = YEAR
 
 
@@ -35,7 +35,7 @@ class interets_plan_epargne_logement_moins_de_12_ans_ouvert_a_partir_de_2018(Var
     """
     value_type = float
     entity = Individu
-    label = u"Intérêts des plans épargne logement (PEL) de moins de 12 ans ouverts à partir du 1er janvier 2018"
+    label = "Intérêts des plans épargne logement (PEL) de moins de 12 ans ouverts à partir du 1er janvier 2018"
     definition_period = YEAR
 
 
@@ -43,7 +43,7 @@ class interets_compte_epargne_logement_ouvert_avant_2018(Variable):
     """ NB : Cette variable est définie indépendemment de epargne_revenus_non_imposables """
     value_type = float
     entity = Individu
-    label = u"Intérêts des comptes épargne logement (CEL) ouverts avant le 1er janvier 2018"
+    label = "Intérêts des comptes épargne logement (CEL) ouverts avant le 1er janvier 2018"
     definition_period = YEAR
 
 
@@ -51,7 +51,7 @@ class interets_compte_epargne_logement_ouvert_a_partir_de_2018(Variable):
     """ NB : Cette variable est définie indépendemment de epargne_revenus_non_imposables """
     value_type = float
     entity = Individu
-    label = u"Intérêts des comptes épargne logement (CEL) ouverts à partir du 1er janvier 2018"
+    label = "Intérêts des comptes épargne logement (CEL) ouverts à partir du 1er janvier 2018"
     definition_period = YEAR
 
 
@@ -59,7 +59,7 @@ class interets_pel_moins_12_ans_cel(Variable):
     """ NB : Cette variable est définie indépendemment de epargne_revenus_non_imposables """
     value_type = float
     entity = Individu
-    label = u"Intérêts des plans épargne logement (PEL) de moins de 12 ans et des comptes épargne logement (CEL)"
+    label = "Intérêts des plans épargne logement (PEL) de moins de 12 ans et des comptes épargne logement (CEL)"
     definition_period = YEAR
 
     def formula(individu, period):
@@ -90,7 +90,7 @@ class interets_pel_moins_12_ans_cel(Variable):
 class assurance_vie_ps_exoneree_irpp_pl(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits d'assurance-vie exonérés d'impôt sur le revenu et de prélèvement libératoire mais soumis aux prélèvements sociaux"
+    label = "Produits d'assurance-vie exonérés d'impôt sur le revenu et de prélèvement libératoire mais soumis aux prélèvements sociaux"
     definition_period = YEAR
 
 
@@ -99,7 +99,7 @@ class assurance_vie_ps_exoneree_irpp_pl(Variable):
 class assiette_csg_plus_values(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Assiette des plus-values soumis à la CSG"
+    label = "Assiette des plus-values soumis à la CSG"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period):
@@ -204,7 +204,7 @@ class assiette_csg_plus_values(Variable):
 class assiette_csg_revenus_capital(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Assiette des revenus du capital soumis à la CSG"
+    label = "Assiette des revenus du capital soumis à la CSG"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -267,7 +267,7 @@ class assiette_csg_revenus_capital(Variable):
 class csg_revenus_capital(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"CSG sur les revenus du capital"
+    label = "CSG sur les revenus du capital"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -285,7 +285,7 @@ class csg_revenus_capital(Variable):
 class crds_revenus_capital(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"CRDS sur les revenus du capital"
+    label = "CRDS sur les revenus du capital"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -301,8 +301,8 @@ class crds_revenus_capital(Variable):
 class prelevements_sociaux_revenus_capital_hors_csg_crds(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Prélèvements sociaux (hors CSG et CRDS) sur les revenus du capital"
-    reference = u"https://www.service-public.fr/particuliers/vosdroits/F2329"
+    label = "Prélèvements sociaux (hors CSG et CRDS) sur les revenus du capital"
+    reference = "https://www.service-public.fr/particuliers/vosdroits/F2329"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -355,8 +355,8 @@ class prelevements_sociaux_revenus_capital_hors_csg_crds(Variable):
 class prelevements_sociaux_revenus_capital(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Prélèvements sociaux sur les revenus du capital"
-    reference = u"https://www.service-public.fr/particuliers/vosdroits/F2329"
+    label = "Prélèvements sociaux sur les revenus du capital"
+    reference = "https://www.service-public.fr/particuliers/vosdroits/F2329"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 class csg(Variable):
     value_type = float
     entity = Individu
-    label = u"Contribution sociale généralisée"
+    label = "Contribution sociale généralisée"
     definition_period = YEAR
 
     def formula(individu, period):
@@ -39,7 +39,7 @@ class csg(Variable):
 class crds(Variable):
     value_type = float
     entity = Individu
-    label = u"Contributions au remboursement de la dette sociale"
+    label = "Contributions au remboursement de la dette sociale"
     definition_period = YEAR
 
     def formula(individu, period):
@@ -64,7 +64,7 @@ class crds(Variable):
 class crds_hors_prestations(Variable):
     value_type = float
     entity = Individu
-    label = u"Contributions au remboursement de la dette sociale (hors celles portant sur les prestations sociales)"
+    label = "Contributions au remboursement de la dette sociale (hors celles portant sur les prestations sociales)"
     definition_period = YEAR
 
     def formula(individu, period):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
@@ -11,10 +11,10 @@ log = logging.getLogger(__name__)
 
 class TypesTauxCSGRemplacement(Enum):
     __order__ = 'non_renseigne exonere taux_reduit taux_plein'  # Needed to preserve the enum order in Python 2
-    non_renseigne = u"Non renseigné/non pertinent"
-    exonere = u"Exonéré"
-    taux_reduit = u"Taux réduit"
-    taux_plein = u"Taux plein"
+    non_renseigne = "Non renseigné/non pertinent"
+    exonere = "Exonéré"
+    taux_reduit = "Taux réduit"
+    taux_plein = "Taux plein"
 
 
 class taux_csg_remplacement(Variable):
@@ -22,7 +22,7 @@ class taux_csg_remplacement(Variable):
     value_type = Enum
     possible_values = TypesTauxCSGRemplacement
     entity = Individu
-    label = u"Taux retenu sur la CSG des revenus de remplacment"
+    label = "Taux retenu sur la CSG des revenus de remplacment"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -50,8 +50,8 @@ class csg_deductible_chomage(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Individu
-    label = u"CSG déductible sur les allocations chômage"
-    reference = u"http://vosdroits.service-public.fr/particuliers/F2329.xhtml"
+    label = "CSG déductible sur les allocations chômage"
+    reference = "http://vosdroits.service-public.fr/particuliers/F2329.xhtml"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -91,8 +91,8 @@ class csg_imposable_chomage(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Individu
-    label = u"CSG imposable sur les allocations chômage"
-    reference = u"http://vosdroits.service-public.fr/particuliers/F2329.xhtml"
+    label = "CSG imposable sur les allocations chômage"
+    reference = "http://vosdroits.service-public.fr/particuliers/F2329.xhtml"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -118,8 +118,8 @@ class crds_chomage(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Individu
-    label = u"CRDS sur les allocations chômage"
-    reference = u"http://www.insee.fr/fr/methodes/default.asp?page=definitions/contrib-remb-dette-sociale.htm"
+    label = "CRDS sur les allocations chômage"
+    reference = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/contrib-remb-dette-sociale.htm"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -155,16 +155,16 @@ class chomage_imposable(Variable):
     value_type = float
     unit = 'currency'
     cerfa_field = {
-        0: u"1AP",
-        1: u"1BP",
-        2: u"1CP",
-        3: u"1DP",
-        4: u"1EP",
+        0: "1AP",
+        1: "1BP",
+        2: "1CP",
+        3: "1DP",
+        4: "1EP",
         }
     entity = Individu
-    label = u"Allocations chômage imposables"
+    label = "Allocations chômage imposables"
     set_input = set_input_divide_by_period
-    reference = u"http://www.insee.fr/fr/methodes/default.asp?page=definitions/chomage.htm"
+    reference = "http://www.insee.fr/fr/methodes/default.asp?page=definitions/chomage.htm"
     definition_period = MONTH
 
     def formula(individu, period):
@@ -177,9 +177,9 @@ class chomage_imposable(Variable):
 class chomage_net(Variable):
     value_type = float
     entity = Individu
-    label = u"Allocations chômage nettes"
+    label = "Allocations chômage nettes"
     set_input = set_input_divide_by_period
-    reference = u"http://vosdroits.service-public.fr/particuliers/N549.xhtml"
+    reference = "http://vosdroits.service-public.fr/particuliers/N549.xhtml"
     definition_period = MONTH
 
     def formula(individu, period):
@@ -196,8 +196,8 @@ class csg_deductible_retraite(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Individu
-    label = u"CSG déductible sur les pensions de retraite"
-    reference = u"https://www.lassuranceretraite.fr/cs/Satellite/PUBPrincipale/Retraites/Paiement-Votre-Retraite/Prelevements-Sociaux?packedargs=null"
+    label = "CSG déductible sur les pensions de retraite"
+    reference = "https://www.lassuranceretraite.fr/cs/Satellite/PUBPrincipale/Retraites/Paiement-Votre-Retraite/Prelevements-Sociaux?packedargs=null"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -219,8 +219,8 @@ class csg_imposable_retraite(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Individu
-    label = u"CSG imposable sur les pensions de retraite"
-    reference = u"https://www.lassuranceretraite.fr/cs/Satellite/PUBPrincipale/Retraites/Paiement-Votre-Retraite/Prelevements-Sociaux?packedargs=null"
+    label = "CSG imposable sur les pensions de retraite"
+    reference = "https://www.lassuranceretraite.fr/cs/Satellite/PUBPrincipale/Retraites/Paiement-Votre-Retraite/Prelevements-Sociaux?packedargs=null"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -239,8 +239,8 @@ class crds_retraite(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Individu
-    label = u"CRDS sur les pensions de retraite"
-    reference = u"http://www.pensions.bercy.gouv.fr/vous-%C3%AAtes-retrait%C3%A9-ou-pensionn%C3%A9/le-calcul-de-ma-pension/les-pr%C3%A9l%C3%A8vements-effectu%C3%A9s-sur-ma-pension"
+    label = "CRDS sur les pensions de retraite"
+    reference = "http://www.pensions.bercy.gouv.fr/vous-%C3%AAtes-retrait%C3%A9-ou-pensionn%C3%A9/le-calcul-de-ma-pension/les-pr%C3%A9l%C3%A8vements-effectu%C3%A9s-sur-ma-pension"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -259,8 +259,8 @@ class crds_retraite(Variable):
 class casa(Variable):
     value_type = float
     entity = Individu
-    label = u"Contribution additionnelle de solidarité et d'autonomie"
-    reference = u"http://www.service-public.fr/actualites/002691.html"
+    label = "Contribution additionnelle de solidarité et d'autonomie"
+    reference = "http://www.service-public.fr/actualites/002691.html"
     definition_period = MONTH
 
     def formula_2013_04_01(individu, period, parameters):
@@ -278,16 +278,16 @@ class retraite_imposable(Variable):
     unit = 'currency'
     value_type = float
     cerfa_field = {
-        0: u"1AS",
-        1: u"1BS",
-        2: u"1CS",
-        3: u"1DS",
-        4: u"1ES",
+        0: "1AS",
+        1: "1BS",
+        2: "1CS",
+        3: "1DS",
+        4: "1ES",
         }
     entity = Individu
-    label = u"Retraites au sens strict imposables (rentes à titre onéreux exclues)"
+    label = "Retraites au sens strict imposables (rentes à titre onéreux exclues)"
     set_input = set_input_divide_by_period
-    reference = u"http://vosdroits.service-public.fr/particuliers/F415.xhtml"
+    reference = "http://vosdroits.service-public.fr/particuliers/F415.xhtml"
     definition_period = MONTH
 
     def formula(individu, period):
@@ -300,9 +300,9 @@ class retraite_imposable(Variable):
 class retraite_nette(Variable):
     value_type = float
     entity = Individu
-    label = u"Pensions de retraite nettes"
+    label = "Pensions de retraite nettes"
     set_input = set_input_divide_by_period
-    reference = u"http://vosdroits.service-public.fr/particuliers/N20166.xhtml"
+    reference = "http://vosdroits.service-public.fr/particuliers/N20166.xhtml"
     definition_period = MONTH
 
     def formula(individu, period):
@@ -317,7 +317,7 @@ class retraite_nette(Variable):
 class crds_pfam(Variable):
     value_type = float
     entity = Famille
-    label = u"CRDS sur les prestations familiales)"
+    label = "CRDS sur les prestations familiales)"
     reference = "http://www.cleiss.fr/docs/regimes/regime_francea1.html"
     definition_period = YEAR
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py
@@ -12,7 +12,7 @@ from openfisca_france.france_taxbenefitsystem import COUNTRY_DIR
 class taux_versement_transport(Variable):
     value_type = float
     entity = Individu
-    label = u""
+    label = ""
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -47,7 +47,7 @@ class taux_versement_transport(Variable):
 class versement_transport(Variable):
     value_type = float
     entity = Individu
-    label = u"Versement transport"
+    label = "Versement transport"
     definition_period = MONTH
 
     def formula(individu, period, parameters):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 class assiette_allegement(Variable):
     value_type = float
     entity = Individu
-    label = u"Assiette des allègements de cotisations sociales employeur"
+    label = "Assiette des allègements de cotisations sociales employeur"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -27,7 +27,7 @@ class assiette_allegement(Variable):
 class coefficient_proratisation(Variable):
     value_type = float
     entity = Individu
-    label = u"Coefficient de proratisation du salaire notamment pour le calcul du SMIC"
+    label = "Coefficient de proratisation du salaire notamment pour le calcul du SMIC"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -119,7 +119,7 @@ class coefficient_proratisation(Variable):
 class credit_impot_competitivite_emploi(Variable):
     value_type = float
     entity = Individu
-    label = u"Crédit d'impôt pour la compétitivité et l'emploi"
+    label = "Crédit d'impôt pour la compétitivité et l'emploi"
     definition_period = MONTH
     calculate_output = calculate_output_add
 
@@ -140,7 +140,7 @@ class credit_impot_competitivite_emploi(Variable):
 class aide_premier_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Aide à l'embauche d'un premier salarié"
+    label = "Aide à l'embauche d'un premier salarié"
     definition_period = MONTH
     calculate_output = calculate_output_add
 
@@ -203,8 +203,8 @@ class aide_premier_salarie(Variable):
 class aide_embauche_pme(Variable):
     value_type = float
     entity = Individu
-    label = u"Aide à l'embauche d'un salarié pour les PME"
-    reference = u"http://travail-emploi.gouv.fr/grands-dossiers/embauchepme"
+    label = "Aide à l'embauche d'un salarié pour les PME"
+    reference = "http://travail-emploi.gouv.fr/grands-dossiers/embauchepme"
     definition_period = MONTH
     calculate_output = calculate_output_add
 
@@ -284,7 +284,7 @@ class aide_embauche_pme(Variable):
 class smic_proratise(Variable):
     value_type = float
     entity = Individu
-    label = u"SMIC proratisé (mensuel)"
+    label = "SMIC proratisé (mensuel)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -298,8 +298,8 @@ class smic_proratise(Variable):
 class allegement_fillon(Variable):
     value_type = float
     entity = Individu
-    label = u"Allègement de charges employeur sur les bas et moyens salaires (dit allègement Fillon)"
-    reference = u"https://www.service-public.fr/professionnels-entreprises/vosdroits/F24542"
+    label = "Allègement de charges employeur sur les bas et moyens salaires (dit allègement Fillon)"
+    reference = "https://www.service-public.fr/professionnels-entreprises/vosdroits/F24542"
     definition_period = MONTH
     calculate_output = calculate_output_add
 
@@ -382,9 +382,9 @@ def compute_allegement_fillon(individu, period, parameters):
 
 class allegement_cotisation_allocations_familiales(Variable):
     value_type = float
-    label = u"Allègement de la cotisation d'allocations familiales sur les bas et moyens salaires"
+    label = "Allègement de la cotisation d'allocations familiales sur les bas et moyens salaires"
     entity = Individu
-    reference = u"https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-dallocations-famil/la-reduction-du-taux-de-la-cotis.html"
+    reference = "https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-dallocations-famil/la-reduction-du-taux-de-la-cotis.html"
     definition_period = MONTH
 
     def formula_2015_01_01(individu, period, parameters):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/apprentissage.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/apprentissage.py
@@ -9,7 +9,7 @@ from openfisca_france.model.base import *
 class apprenti(Variable):
     value_type = bool
     entity = Individu
-    label = u"L'individu est apprenti"
+    label = "L'individu est apprenti"
     reference = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
     definition_period = MONTH
 
@@ -28,7 +28,7 @@ class apprenti(Variable):
 class remuneration_apprenti(Variable):
     value_type = float
     entity = Individu
-    label = u"Rémunération de l'apprenti"
+    label = "Rémunération de l'apprenti"
     reference = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
     definition_period = MONTH
 
@@ -91,7 +91,7 @@ class remuneration_apprenti(Variable):
 class exoneration_cotisations_employeur_apprenti(Variable):
     value_type = float
     entity = Individu
-    label = u"Exonération de cotisations employeur pour l'emploi d'un apprenti"
+    label = "Exonération de cotisations employeur pour l'emploi d'un apprenti"
     reference = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
     definition_period = MONTH
     # Artisans et employeurs de moins de 11 salariés
@@ -145,7 +145,7 @@ class exoneration_cotisations_employeur_apprenti(Variable):
 class exoneration_cotisations_salariales_apprenti(Variable):
     value_type = float
     entity = Individu
-    label = u"Exonération de cotisations salariales pour l'emploi d'un apprenti"
+    label = "Exonération de cotisations salariales pour l'emploi d'un apprenti"
     reference = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
     definition_period = MONTH
 
@@ -160,7 +160,7 @@ class exoneration_cotisations_salariales_apprenti(Variable):
 class prime_apprentissage(Variable):
     value_type = float
     entity = Individu
-    label = u"Prime d'apprentissage pour les entreprise employant un apprenti"
+    label = "Prime d'apprentissage pour les entreprise employant un apprenti"
     reference = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
     definition_period = YEAR
     # L'employeur peut également recevoir de la région dans laquelle est situé l'établissement du lieu de travail,
@@ -187,7 +187,7 @@ class prime_apprentissage(Variable):
 # # class credit_impot_emploi_apprenti(Variable):
 #     value_type = float
 #     entity = Individu
-#     label = u" Crédit d'impôt pour l'emploi d'apprentis"
+#     label = " Crédit d'impôt pour l'emploi d'apprentis"
 #     reference = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
 #
 #     def formula(individu, period, parameters):
@@ -211,7 +211,7 @@ class prime_apprentissage(Variable):
 # # class credit_impot_emploi_apprenti(Variable):
 #     value_type = float
 #     entity = Individu
-#     label = u"Déduction de la créance "bonus alternant"
+#     label = "Déduction de la créance "bonus alternant"
 # Les entreprises de plus de 250 salariés, tous établissements confondus, redevables de la taxe d'apprentissage,
 # qui emploient plus de 4 % de jeunes en apprentissage (5 % pour la taxe payable en 2016 au titre de 2015), dans la
 # limite de 6 % d'alternants, peuvent bénéficier d'une créance à déduire du hors quota de la taxe d'apprentissage (TA).

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/contrat_professionnalisation.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/contrat_professionnalisation.py
@@ -6,7 +6,7 @@ from openfisca_france.model.base import *
 class professionnalisation(Variable):
     value_type = bool
     entity = Individu
-    label = u"L'individu est en contrat de professionnalisation"
+    label = "L'individu est en contrat de professionnalisation"
     reference = "http://www.apce.com/pid879/contrat-de-professionnalisation.html?espace=1&tp=1"
     definition_period = MONTH
 
@@ -27,7 +27,7 @@ class professionnalisation(Variable):
 class remuneration_professionnalisation(Variable):
     value_type = float
     entity = Individu
-    label = u"Rémunération de l'apprenti"
+    label = "Rémunération de l'apprenti"
     reference = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
     definition_period = MONTH
 
@@ -92,7 +92,7 @@ class remuneration_professionnalisation(Variable):
 class exoneration_cotisations_employeur_professionnalisation(Variable):
     value_type = float
     entity = Individu
-    label = u"Exonération de cotisations patronales pour l'emploi d'un apprenti"
+    label = "Exonération de cotisations patronales pour l'emploi d'un apprenti"
     reference = "http://www.apce.com/pid927/contrat-d-apprentissage.html?espace=1&tp=1&pagination=2"
     definition_period = MONTH
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -10,14 +10,14 @@ class jei_date_demande(Variable):
     value_type = date
     default_value = date(2099, 12, 31)
     entity = Individu
-    label = u"Date de demande (et d'octroi) du statut de jeune entreprise innovante (JEI)"
+    label = "Date de demande (et d'octroi) du statut de jeune entreprise innovante (JEI)"
     definition_period = MONTH
 
 
 class exoneration_cotisations_employeur_geographiques(Variable):
     value_type = float
     entity = Individu
-    label = u"Exonérations de cotisations employeur dépendant d'une zone géographique"
+    label = "Exonérations de cotisations employeur dépendant d'une zone géographique"
     reference = "https://www.apce.com/pid815/aides-au-recrutement.html?espace=1&tp=1"
     definition_period = MONTH
 
@@ -38,7 +38,7 @@ class exoneration_cotisations_employeur_geographiques(Variable):
 class exoneration_cotisations_employeur_jei(Variable):
     value_type = float
     entity = Individu
-    label = u"Exonrérations de cotisations employeur pour une jeune entreprise innovante"
+    label = "Exonrérations de cotisations employeur pour une jeune entreprise innovante"
     reference = "http://www.apce.com/pid1653/jeune-entreprise-innovante.html?pid=1653&pagination=2"
     definition_period = MONTH
 
@@ -86,7 +86,7 @@ class exoneration_cotisations_employeur_jei(Variable):
 class exoneration_cotisations_employeur_zfu(Variable):
     value_type = float
     entity = Individu
-    label = u"Exonrérations de cotisations employeur pour l'embauche en zone franche urbaine (ZFU)"
+    label = "Exonrérations de cotisations employeur pour l'embauche en zone franche urbaine (ZFU)"
     reference = "http://www.apce.com/pid553/exoneration-dans-les-zfu.html?espace=1&tp=1&pagination=2"
     definition_period = MONTH
 
@@ -252,7 +252,7 @@ class exoneration_cotisations_employeur_zfu(Variable):
 class exoneration_cotisations_employeur_zrd(Variable):
     value_type = float
     entity = Individu
-    label = u"Exonrérations de cotisations employeur pour l'embauche en zone de restructuration de la Défense (ZRD)"
+    label = "Exonrérations de cotisations employeur pour l'embauche en zone de restructuration de la Défense (ZRD)"
     reference = "http://www.apce.com/pid11668/exoneration-dans-les-zrd.html?espace=1&tp=1"
     definition_period = MONTH
 
@@ -290,7 +290,7 @@ class exoneration_cotisations_employeur_zrd(Variable):
 class exoneration_cotisations_employeur_zrr(Variable):
     value_type = float
     entity = Individu
-    label = u"Exonrérations de cotisations employeur pour l'embauche en zone de revitalisation rurale (ZRR)"
+    label = "Exonrérations de cotisations employeur pour l'embauche en zone de revitalisation rurale (ZRR)"
     reference = "http://www.apce.com/pid538/embauches-en-zru-et-zrr.html?espace=1&tp=1"
     definition_period = MONTH
 
@@ -348,7 +348,7 @@ class exoneration_cotisations_employeur_zrr(Variable):
 class exoneration_is_creation_zrr(Variable):
     value_type = float
     entity = Individu
-    label = u"Exonrérations fiscales pour création d'une entreprise en zone de revitalisation rurale (ZRR)"
+    label = "Exonrérations fiscales pour création d'une entreprise en zone de revitalisation rurale (ZRR)"
     reference = 'http://www.apce.com/pid11690/exonerations-d-impots-zrr.html?espace=1&tp=1'
     definition_period = YEAR
     calculate_output = calculate_output_divide
@@ -402,7 +402,7 @@ class exoneration_is_creation_zrr(Variable):
 # # class bassin_emploi_redynamiser(Variable):
 #     value_type = bool
 #     entity = Individu
-#     label = u"L'entreprise est située danns un bassin d'emploi à redynamiser(BER)"
+#     label = "L'entreprise est située danns un bassin d'emploi à redynamiser(BER)"
 #     # La liste des bassins d'emploi à redynamiser a été fixée par le décret n°2007-228 du 20 février 2007.
 #     # Actuellement, deux régions sont concernées : Champagne-Ardenne (zone d'emploi de la Vallée de la Meuse)
 #     # et Midi-Pyrénées (zone d'emploi de Lavelanet).
@@ -414,7 +414,7 @@ class exoneration_is_creation_zrr(Variable):
 class jeune_entreprise_innovante(Variable):
     value_type = bool
     entity = Individu
-    label = u"L'entreprise est une jeune entreprise innovante"
+    label = "L'entreprise est une jeune entreprise innovante"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -475,7 +475,7 @@ class jeune_entreprise_innovante(Variable):
 class bassin_emploi_redynamiser(Variable):
     value_type = bool
     entity = Individu
-    label = u"L'entreprise est située danns un bassin d'emploi à redynamiser (BER)"
+    label = "L'entreprise est située danns un bassin d'emploi à redynamiser (BER)"
     # La liste des bassins d'emploi à redynamiser a été fixée par le décret n°2007-228 du 20 février 2007.
     # Actuellement, deux régions sont concernées : Champagne-Ardenne (zone d'emploi de la Vallée de la Meuse)
     # et Midi-Pyrénées (zone d'emploi de Lavelanet).
@@ -490,7 +490,7 @@ class bassin_emploi_redynamiser(Variable):
 class zone_restructuration_defense(Variable):
     value_type = bool
     entity = Individu
-    label = u"L'entreprise est située dans une zone de restructuration de la Défense (ZRD)"
+    label = "L'entreprise est située dans une zone de restructuration de la Défense (ZRD)"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -502,7 +502,7 @@ class zone_restructuration_defense(Variable):
 class zone_franche_urbaine(Variable):
     value_type = bool
     entity = Individu
-    label = u"L'entreprise est située danns une zone franche urbaine (ZFU)"
+    label = "L'entreprise est située danns une zone franche urbaine (ZFU)"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -514,7 +514,7 @@ class zone_franche_urbaine(Variable):
 class zone_revitalisation_rurale(Variable):
     value_type = bool
     entity = Individu
-    label = u"L'entreprise est située dans une zone de revitalisation rurale (ZRR)"
+    label = "L'entreprise est située dans une zone de revitalisation rurale (ZRR)"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/stage.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/stage.py
@@ -7,21 +7,21 @@ from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotis
 class stage_duree_heures(Variable):
     value_type = int
     entity = Individu
-    label = u"Nombre d'heures effectuées en stage"
+    label = "Nombre d'heures effectuées en stage"
     definition_period = MONTH
 
 
 class stage_gratification_taux(Variable):
     value_type = float
     entity = Individu
-    label = u"Taux de gratification (en plafond de la Sécurité sociale)"
+    label = "Taux de gratification (en plafond de la Sécurité sociale)"
     definition_period = MONTH
 
 
 class stage_gratification(Variable):
     value_type = float
     entity = Individu
-    label = u"Gratification de stage"
+    label = "Gratification de stage"
     definition_period = MONTH
 
     def formula_2014_11(individu, period, parameters):
@@ -37,7 +37,7 @@ class stage_gratification(Variable):
 class stage_gratification_reintegration(Variable):
     value_type = float
     entity = Individu
-    label = u"Part de la gratification de stage réintégrée à l'assiette des cotisations et contributions sociales"
+    label = "Part de la gratification de stage réintégrée à l'assiette des cotisations et contributions sociales"
     definition_period = MONTH
 
     def formula_2014_11(individu, period, parameters):
@@ -52,7 +52,7 @@ class stage_gratification_reintegration(Variable):
 class stagiaire(Variable):
     value_type = bool
     entity = Individu
-    label = u"L'individu est stagiaire"
+    label = "L'individu est stagiaire"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -63,7 +63,7 @@ class stagiaire(Variable):
 class exoneration_cotisations_employeur_stagiaire(Variable):
     value_type = float
     entity = Individu
-    label = u"Exonrérations de cotisations employeur pour un stagaire"
+    label = "Exonrérations de cotisations employeur pour un stagaire"
     reference = "http://www.apce.com/pid2798/stages.html?espace=3"
     definition_period = MONTH
 
@@ -95,7 +95,7 @@ class exoneration_cotisations_employeur_stagiaire(Variable):
 class exoneration_cotisations_salarie_stagiaire(Variable):
     value_type = float
     entity = Individu
-    label = u"Exonrérations de cotisations salarié pour un stagiaire"
+    label = "Exonrérations de cotisations salarié pour un stagiaire"
     reference = "http://www.apce.com/pid2798/stages.html?espace=3"
     definition_period = MONTH
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
@@ -9,7 +9,7 @@ from openfisca_france.model.prelevements_obligatoires.prelevements_sociaux.cotis
 class allocations_temporaires_invalidite(Variable):
     value_type = float
     entity = Individu
-    label = u"Allocations temporaires d'invalidité (ATI, fonction publique et collectivités locales)"
+    label = "Allocations temporaires d'invalidité (ATI, fonction publique et collectivités locales)"
     definition_period = MONTH
     # patronale, non-contributive
 
@@ -40,7 +40,7 @@ class allocations_temporaires_invalidite(Variable):
 class assiette_cotisations_sociales_public(Variable):
     value_type = float
     entity = Individu
-    label = u"Assiette des cotisations sociales des agents titulaires de la fonction publique"
+    label = "Assiette des cotisations sociales des agents titulaires de la fonction publique"
     definition_period = MONTH
     # TODO: gestion des heures supplémentaires
 
@@ -71,7 +71,7 @@ class assiette_cotisations_sociales_public(Variable):
 class contribution_exceptionnelle_solidarite(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation exceptionnelle au fonds de solidarité (salarié)"
+    label = "Cotisation exceptionnelle au fonds de solidarité (salarié)"
     definition_period = MONTH
     end = '2017-12-31'
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006072050&idArticle=LEGIARTI000006903878&dateTexte=&categorieLien=cid"
@@ -133,7 +133,7 @@ class contribution_exceptionnelle_solidarite(Variable):
 class fonds_emploi_hospitalier(Variable):
     value_type = float
     entity = Individu
-    label = u"Fonds pour l'emploi hospitalier (employeur)"
+    label = "Fonds pour l'emploi hospitalier (employeur)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -154,7 +154,7 @@ class fonds_emploi_hospitalier(Variable):
 class ircantec_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Ircantec salarié"
+    label = "Ircantec salarié"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -176,7 +176,7 @@ class ircantec_salarie(Variable):
 class ircantec_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Ircantec employeur"
+    label = "Ircantec employeur"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -198,7 +198,7 @@ class ircantec_employeur(Variable):
 class pension_civile_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Pension civile salarié"
+    label = "Pension civile salarié"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -222,8 +222,8 @@ class pension_civile_salarie(Variable):
 class pension_civile_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation patronale pension civile"
-    reference = u"http://www.ac-besancon.fr/spip.php?article2662"
+    label = "Cotisation patronale pension civile"
+    reference = "http://www.ac-besancon.fr/spip.php?article2662"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -252,7 +252,7 @@ class pension_civile_employeur(Variable):
 class rafp_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Part salariale de la retraite additionelle de la fonction publique"
+    label = "Part salariale de la retraite additionelle de la fonction publique"
     definition_period = MONTH
     # Part salariale de la retraite additionelle de la fonction publique
     # TODO: ajouter la gipa qui n'est pas affectée par le plafond d'assiette
@@ -282,7 +282,7 @@ class rafp_salarie(Variable):
 class rafp_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Part patronale de la retraite additionnelle de la fonction publique"
+    label = "Part patronale de la retraite additionnelle de la fonction publique"
     definition_period = MONTH
 
     # TODO: ajouter la gipa qui n'est pas affectée par le plafond d'assiette

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
@@ -22,14 +22,14 @@ class categorie_non_salarie(Variable):
     possible_values = TypesCategorieNonSalarie
     default_value = TypesCategorieNonSalarie.non_pertinent
     entity = Individu
-    label = u"Type du travailleur salarié (artisant, commercant, profession libérale, etc)"
+    label = "Type du travailleur salarié (artisant, commercant, profession libérale, etc)"
     definition_period = YEAR
 
 
 class cotisations_non_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisations sociales des travailleurs non salaries"
+    label = "Cotisations sociales des travailleurs non salaries"
     definition_period = YEAR
     calculate_output = calculate_output_add
 
@@ -73,7 +73,7 @@ class cotisations_non_salarie(Variable):
 class deces_artisan_commercant(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation décès des artisans et des commercants"
+    label = "Cotisation décès des artisans et des commercants"
     definition_period = YEAR
     calculate_output = calculate_output_add
 
@@ -96,7 +96,7 @@ class deces_artisan_commercant(Variable):
 class formation_artisan_commercant(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation formation des artisans et des commercants"
+    label = "Cotisation formation des artisans et des commercants"
     definition_period = YEAR
     calculate_output = calculate_output_add
 
@@ -123,7 +123,7 @@ class formation_artisan_commercant(Variable):
 class maladie_maternite_artisan_commercant(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation maladie et maternité des artisans et des commercants"
+    label = "Cotisation maladie et maternité des artisans et des commercants"
     definition_period = YEAR
     calculate_output = calculate_output_add
 
@@ -174,7 +174,7 @@ class maladie_maternite_artisan_commercant(Variable):
 class retraite_complementaire_artisan_commercant(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation de la retraite complémentaire des artisans et des commercants"
+    label = "Cotisation de la retraite complémentaire des artisans et des commercants"
     definition_period = YEAR
     calculate_output = calculate_output_add
 
@@ -197,7 +197,7 @@ class retraite_complementaire_artisan_commercant(Variable):
 class vieillesse_artisan_commercant(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation vieillesse (plafonnée et déplafonnée) des artisans et des commercants"
+    label = "Cotisation vieillesse (plafonnée et déplafonnée) des artisans et des commercants"
     definition_period = YEAR
     calculate_output = calculate_output_add
 
@@ -219,7 +219,7 @@ class vieillesse_artisan_commercant(Variable):
 class famille_independant(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation famille des indépendants"
+    label = "Cotisation famille des indépendants"
     definition_period = YEAR
     calculate_output = calculate_output_add
 
@@ -254,7 +254,7 @@ class famille_independant(Variable):
 class formation_profession_liberale(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation formation professionelle des professions libérales"
+    label = "Cotisation formation professionelle des professions libérales"
     definition_period = YEAR
     calculate_output = calculate_output_add
 
@@ -275,7 +275,7 @@ class formation_profession_liberale(Variable):
 class maladie_maternite_profession_liberale(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation maladie maternité des professions libérales"
+    label = "Cotisation maladie maternité des professions libérales"
     definition_period = YEAR
     calculate_output = calculate_output_add
 
@@ -309,7 +309,7 @@ class maladie_maternite_profession_liberale(Variable):
 class retraite_complementaire_profession_liberale(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation de retraite complémentarie des professions libérales"
+    label = "Cotisation de retraite complémentarie des professions libérales"
     definition_period = YEAR
     calculate_output = calculate_output_add
 
@@ -329,7 +329,7 @@ class retraite_complementaire_profession_liberale(Variable):
 class vieillesse_profession_liberale(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation retraite des professions libérales"
+    label = "Cotisation retraite des professions libérales"
     definition_period = YEAR
     calculate_output = calculate_output_add
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 class assiette_cotisations_sociales(Variable):
     value_type = float
     entity = Individu
-    label = u"Assiette des cotisations sociales des salaries"
+    label = "Assiette des cotisations sociales des salaries"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -37,7 +37,7 @@ class assiette_cotisations_sociales(Variable):
 class assiette_cotisations_sociales_prive(Variable):
     value_type = float
     entity = Individu
-    label = u"Assiette des cotisations sociales des salaries du prive"
+    label = "Assiette des cotisations sociales des salaries du prive"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -74,8 +74,8 @@ class assiette_cotisations_sociales_prive(Variable):
 class indemnite_fin_contrat(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnité de fin de contrat"
-    reference = u"https://www.service-public.fr/particuliers/vosdroits/F40"
+    label = "Indemnité de fin de contrat"
+    reference = "https://www.service-public.fr/particuliers/vosdroits/F40"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -113,7 +113,7 @@ class indemnite_fin_contrat(Variable):
 class reintegration_titre_restaurant_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Prise en charge de l'employeur des dépenses de cantine et des titres restaurants non exonérés de charges sociales"
+    label = "Prise en charge de l'employeur des dépenses de cantine et des titres restaurants non exonérés de charges sociales"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -148,7 +148,7 @@ class reintegration_titre_restaurant_employeur(Variable):
 class penibilite(Variable):
     value_type = float
     entity = Individu
-    label = u"Les dépenses liées à l'utilisation du compte pénibilité par le salarié sont prises en charge par un fonds financé par l'employeur"
+    label = "Les dépenses liées à l'utilisation du compte pénibilité par le salarié sont prises en charge par un fonds financé par l'employeur"
     definition_period = MONTH
 
     def formula_2015_01_01(individu, period, parameters):
@@ -191,7 +191,7 @@ class penibilite(Variable):
 class accident_du_travail(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisations employeur accident du travail et maladie professionelle"
+    label = "Cotisations employeur accident du travail et maladie professionelle"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -210,7 +210,7 @@ class accident_du_travail(Variable):
 class agff_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation retraite AGFF tranche A (salarié)"
+    label = "Cotisation retraite AGFF tranche A (salarié)"
     definition_period = MONTH
     # AGFF: Association pour la gestion du fonds de financement (sous-entendu des départs entre 60 et 65 ans)
 
@@ -229,7 +229,7 @@ class agff_salarie(Variable):
 class agff_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation retraite AGFF tranche A (employeur)"
+    label = "Cotisation retraite AGFF tranche A (employeur)"
     definition_period = MONTH
     # TODO: améliorer pour gérer mensuel/annuel
 
@@ -262,7 +262,7 @@ class agff_employeur(Variable):
 class quotite_de_travail(Variable):
     value_type = float
     entity = Individu
-    label = u"Quotité de travail"
+    label = "Quotité de travail"
     definition_period = MONTH
     # TODO: gestion annuel/mensuel
 
@@ -286,7 +286,7 @@ class quotite_de_travail(Variable):
 class agirc_gmp_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation AGIRC pour la garantie minimale de points (GMP,  salarié)"
+    label = "Cotisation AGIRC pour la garantie minimale de points (GMP,  salarié)"
     definition_period = MONTH
     # TODO: gestion annuel/mensuel
 
@@ -316,7 +316,7 @@ class agirc_gmp_salarie(Variable):
 class agirc_gmp_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation AGIRC pour la garantie minimale de points (GMP, employeur)"
+    label = "Cotisation AGIRC pour la garantie minimale de points (GMP, employeur)"
     definition_period = MONTH
     # TODO: gestion annuel/mensuel
 
@@ -346,7 +346,7 @@ class agirc_gmp_employeur(Variable):
 class agirc_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation AGIRC tranche B (salarié)"
+    label = "Cotisation AGIRC tranche B (salarié)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -365,7 +365,7 @@ class agirc_salarie(Variable):
 class agirc_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation AGIRC tranche B (employeur)"
+    label = "Cotisation AGIRC tranche B (employeur)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -384,7 +384,7 @@ class agirc_employeur(Variable):
 class ags(Variable):
     value_type = float
     entity = Individu
-    label = u"Contribution à l'association pour la gestion du régime de garantie des créances des salariés (AGS, employeur)"
+    label = "Contribution à l'association pour la gestion du régime de garantie des créances des salariés (AGS, employeur)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -402,7 +402,7 @@ class ags(Variable):
 class apec_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisations agence pour l'emploi des cadres (APEC,  salarié)"
+    label = "Cotisations agence pour l'emploi des cadres (APEC,  salarié)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -421,7 +421,7 @@ class apec_salarie(Variable):
 class apec_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisations Agenece pour l'emploi des cadres (APEC, employeur)"
+    label = "Cotisations Agenece pour l'emploi des cadres (APEC, employeur)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -439,7 +439,7 @@ class apec_employeur(Variable):
 class arrco_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation ARRCO tranche 1 (salarié)"
+    label = "Cotisation ARRCO tranche 1 (salarié)"
     definition_period = MONTH
     # TODO: check gestion mensuel/annuel
 
@@ -478,7 +478,7 @@ class arrco_salarie(Variable):
 class arrco_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation ARRCO tranche 1 (employeur)"
+    label = "Cotisation ARRCO tranche 1 (employeur)"
     definition_period = MONTH
     # TODO: check gestion mensuel/annuel
 
@@ -514,7 +514,7 @@ class arrco_employeur(Variable):
 class chomage_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation chômage tranche A (salarié)"
+    label = "Cotisation chômage tranche A (salarié)"
     definition_period = MONTH
     end = '2018-09-30'
 
@@ -533,7 +533,7 @@ class chomage_salarie(Variable):
 class chomage_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation chômage tranche A (employeur)"
+    label = "Cotisation chômage tranche A (employeur)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -551,7 +551,7 @@ class chomage_employeur(Variable):
 class contribution_solidarite_autonomie(Variable):
     value_type = float
     entity = Individu
-    label = u"Contribution solidarité autonomie (employeur)"
+    label = "Contribution solidarité autonomie (employeur)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -569,7 +569,7 @@ class contribution_solidarite_autonomie(Variable):
 class cotisation_exceptionnelle_temporaire_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation_exceptionnelle_temporaire (salarie)"
+    label = "Cotisation_exceptionnelle_temporaire (salarie)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -587,7 +587,7 @@ class cotisation_exceptionnelle_temporaire_salarie(Variable):
 class cotisation_exceptionnelle_temporaire_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation exceptionnelle temporaire (employeur)"
+    label = "Cotisation exceptionnelle temporaire (employeur)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -605,7 +605,7 @@ class cotisation_exceptionnelle_temporaire_employeur(Variable):
 class famille(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation famille (employeur)"
+    label = "Cotisation famille (employeur)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -623,7 +623,7 @@ class famille(Variable):
 class mmid_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation maladie (salarié)"
+    label = "Cotisation maladie (salarié)"
     definition_period = MONTH
 
     def formula_2018(individu, period, parameters):
@@ -673,8 +673,8 @@ class mmid_salarie(Variable):
 class mmid_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation maladie (employeur)"
-    reference = u"https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-maladie---maternit.html"
+    label = "Cotisation maladie (employeur)"
+    reference = "https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-maladie---maternit.html"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -692,7 +692,7 @@ class mmid_employeur(Variable):
 class mmida_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation maladie (employeur)"
+    label = "Cotisation maladie (employeur)"
     definition_period = MONTH
     # Note: this formula is used only to check fiche_de_paie from memento
 
@@ -713,7 +713,7 @@ class mhsup(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Individu
-    label = u"Heures supplémentaires comptées négativement"
+    label = "Heures supplémentaires comptées négativement"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -723,7 +723,7 @@ class mhsup(Variable):
 class plafond_securite_sociale(Variable):
     value_type = float
     entity = Individu
-    label = u"Plafond de la securite sociale"
+    label = "Plafond de la securite sociale"
     definition_period = MONTH
     # TODO gérer les plafonds mensuel, trimestriel, annuel
 
@@ -748,7 +748,7 @@ class plafond_securite_sociale(Variable):
 class prevoyance_obligatoire_cadre(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation de prévoyance pour les cadres et assimilés"
+    label = "Cotisation de prévoyance pour les cadres et assimilés"
     definition_period = MONTH
     # TODO: gérer le mode de recouvrement et l'aspect mensuel/annuel
 
@@ -770,7 +770,7 @@ class prevoyance_obligatoire_cadre(Variable):
 class complementaire_sante_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Couverture complémentaire santé collective d'entreprise - part employeur"
+    label = "Couverture complémentaire santé collective d'entreprise - part employeur"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -785,7 +785,7 @@ class complementaire_sante_employeur(Variable):
 class complementaire_sante_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Couverture complémentaire santé collective d'entreprise - part salarié"
+    label = "Couverture complémentaire santé collective d'entreprise - part salarié"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -799,11 +799,11 @@ class complementaire_sante_salarie(Variable):
 
 class TypesTailleEntreprise(Enum):
     __order__ = 'non_pertinent moins_de_10 de_10_a_19 de_20_a_249 plus_de_250'  # Needed to preserve the enum order in Python 2
-    non_pertinent = u"Non pertinent"
-    moins_de_10 = u"Moins de 10 salariés"
-    de_10_a_19 = u"De 10 à 19 salariés"
-    de_20_a_249 = u"De 20 à 249 salariés"
-    plus_de_250 = u"Plus de 250 salariés"
+    non_pertinent = "Non pertinent"
+    moins_de_10 = "Moins de 10 salariés"
+    de_10_a_19 = "De 10 à 19 salariés"
+    de_20_a_249 = "De 20 à 249 salariés"
+    plus_de_250 = "Plus de 250 salariés"
 
 
 class taille_entreprise(Variable):
@@ -811,8 +811,8 @@ class taille_entreprise(Variable):
     possible_values = TypesTailleEntreprise
     default_value = TypesTailleEntreprise.non_pertinent
     entity = Individu
-    label = u"Catégorie de taille d'entreprise"
-    reference = u"http://www.insee.fr/fr/themes/document.asp?ref_id=ip1321"
+    label = "Catégorie de taille d'entreprise"
+    reference = "http://www.insee.fr/fr/themes/document.asp?ref_id=ip1321"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -840,7 +840,7 @@ class taille_entreprise(Variable):
 class taux_accident_travail(Variable):
     value_type = float
     entity = Individu
-    label = u"Approximation du taux accident à partir de l'exposition au risque donnée"
+    label = "Approximation du taux accident à partir de l'exposition au risque donnée"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -856,7 +856,7 @@ class taux_accident_travail(Variable):
 class vieillesse_deplafonnee_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation vieillesse déplafonnée (salarié)"
+    label = "Cotisation vieillesse déplafonnée (salarié)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -874,7 +874,7 @@ class vieillesse_deplafonnee_salarie(Variable):
 class vieillesse_plafonnee_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation vieillesse plafonnée (salarié)"
+    label = "Cotisation vieillesse plafonnée (salarié)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -892,7 +892,7 @@ class vieillesse_plafonnee_salarie(Variable):
 class vieillesse_deplafonnee_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation vieillesse déplafonnée"
+    label = "Cotisation vieillesse déplafonnée"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -910,7 +910,7 @@ class vieillesse_deplafonnee_employeur(Variable):
 class vieillesse_plafonnee_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation vieillesse plafonnée (employeur)"
+    label = "Cotisation vieillesse plafonnée (employeur)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_totaux.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_totaux.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 class cotisations_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisations sociales employeur"
+    label = "Cotisations sociales employeur"
     set_input = set_input_divide_by_period
     definition_period = MONTH
     calculate_output = calculate_output_add
@@ -33,7 +33,7 @@ class cotisations_employeur(Variable):
 class cotisations_employeur_contributives(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisations sociales employeur contributives"
+    label = "Cotisations sociales employeur contributives"
     set_input = set_input_divide_by_period
     definition_period = MONTH
 
@@ -79,7 +79,7 @@ class cotisations_employeur_contributives(Variable):
 class cotisations_employeur_non_contributives(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisations sociales employeur non-contributives"
+    label = "Cotisations sociales employeur non-contributives"
     set_input = set_input_divide_by_period
     definition_period = MONTH
 
@@ -110,7 +110,7 @@ class cotisations_employeur_non_contributives(Variable):
 class cotisations_salariales_contributives(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisations sociales salariales contributives"
+    label = "Cotisations sociales salariales contributives"
     set_input = set_input_divide_by_period
     definition_period = MONTH
 
@@ -151,7 +151,7 @@ class cotisations_salariales_contributives(Variable):
 class cotisations_salariales_non_contributives(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisations sociales salariales non-contributives"
+    label = "Cotisations sociales salariales non-contributives"
     set_input = set_input_divide_by_period
     definition_period = MONTH
 
@@ -172,7 +172,7 @@ class cotisations_salariales_non_contributives(Variable):
 class cotisations_salariales(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisations sociales salariales"
+    label = "Cotisations sociales salariales"
     set_input = set_input_divide_by_period
     definition_period = MONTH
     calculate_output = calculate_output_add

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/taxes_salaires_main_oeuvre.py
@@ -25,7 +25,7 @@ taux_smt_by_depcom = None
 class conge_individuel_formation_cdd(Variable):
     value_type = float
     entity = Individu
-    label = u"Contribution au financement des congé individuel de formation (CIF) des salariées en CDD"
+    label = "Contribution au financement des congé individuel de formation (CIF) des salariées en CDD"
     definition_period = MONTH
 
     # TODO: date de début
@@ -42,7 +42,7 @@ class conge_individuel_formation_cdd(Variable):
 class redevable_taxe_apprentissage(Variable):
     value_type = bool
     entity = Individu
-    label = u"Entreprise redevable de la taxe d'apprentissage"
+    label = "Entreprise redevable de la taxe d'apprentissage"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -56,7 +56,7 @@ class redevable_taxe_apprentissage(Variable):
 class contribution_developpement_apprentissage(Variable):
     value_type = float
     entity = Individu
-    label = u"Contribution additionnelle au développement de l'apprentissage"
+    label = "Contribution additionnelle au développement de l'apprentissage"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -76,8 +76,8 @@ class contribution_developpement_apprentissage(Variable):
 class contribution_supplementaire_apprentissage(Variable):
     value_type = float
     entity = Individu
-    label = u"Contribution supplémentaire à l'apprentissage"
-    reference = u"https://www.service-public.fr/professionnels-entreprises/vosdroits/F22574"
+    label = "Contribution supplémentaire à l'apprentissage"
+    reference = "https://www.service-public.fr/professionnels-entreprises/vosdroits/F22574"
     definition_period = MONTH
 
     def formula_2010_01_01(individu, period, parameters):
@@ -114,7 +114,7 @@ class contribution_supplementaire_apprentissage(Variable):
 class cotisations_employeur_main_d_oeuvre(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation sociales employeur main d'oeuvre"
+    label = "Cotisation sociales employeur main d'oeuvre"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -153,7 +153,7 @@ class cotisations_employeur_main_d_oeuvre(Variable):
 class fnal(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation fonds national action logement (FNAL)"
+    label = "Cotisation fonds national action logement (FNAL)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -165,7 +165,7 @@ class fnal(Variable):
 class fnal_tranche_a(Variable):
     value_type = float
     entity = Individu
-    label = u"Cotisation fonds national action logement (FNAL tout employeur)"
+    label = "Cotisation fonds national action logement (FNAL tout employeur)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -191,7 +191,7 @@ class fnal_tranche_a(Variable):
 class fnal_tranche_a_plus_20(Variable):
     value_type = float
     entity = Individu
-    label = u"Fonds national action logement (FNAL, employeur avec plus de 20 salariés)"
+    label = "Fonds national action logement (FNAL, employeur avec plus de 20 salariés)"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -216,7 +216,7 @@ class fnal_tranche_a_plus_20(Variable):
 class financement_organisations_syndicales(Variable):
     value_type = float
     entity = Individu
-    label = u"Contribution patronale au financement des organisations syndicales"
+    label = "Contribution patronale au financement des organisations syndicales"
     definition_period = MONTH
 
     def formula_2015_01_01(individu, period, parameters):
@@ -241,8 +241,8 @@ class financement_organisations_syndicales(Variable):
 class formation_professionnelle(Variable):
     value_type = float
     entity = Individu
-    label = u"Formation professionnelle"
-    reference = u"https://www.service-public.fr/professionnels-entreprises/vosdroits/F22570"
+    label = "Formation professionnelle"
+    reference = "https://www.service-public.fr/professionnels-entreprises/vosdroits/F22570"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -285,7 +285,7 @@ class formation_professionnelle(Variable):
 class participation_effort_construction(Variable):
     value_type = float
     entity = Individu
-    label = u"Participation à l'effort de construction"
+    label = "Participation à l'effort de construction"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -309,8 +309,8 @@ class participation_effort_construction(Variable):
 class taxe_apprentissage(Variable):
     value_type = float
     entity = Individu
-    label = u"Taxe d'apprentissage (employeur, entreprise redevable de la taxe d'apprentissage uniquement)"
-    reference = u"https://www.service-public.fr/professionnels-entreprises/vosdroits/F22574"
+    label = "Taxe d'apprentissage (employeur, entreprise redevable de la taxe d'apprentissage uniquement)"
+    reference = "https://www.service-public.fr/professionnels-entreprises/vosdroits/F22574"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -347,7 +347,7 @@ class taxe_apprentissage(Variable):
 class taxe_salaires(Variable):
     value_type = float
     entity = Individu
-    label = u"Taxe sur les salaires"
+    label = "Taxe sur les salaires"
     definition_period = MONTH
 # Voir
 # http://www.impots.gouv.fr/portal/deploiement/p1/fichedescriptiveformulaire_8920/fichedescriptiveformulaire_8920.pdf

--- a/openfisca_france/model/prelevements_obligatoires/taxe_habitation/taxe_habitation.py
+++ b/openfisca_france/model/prelevements_obligatoires/taxe_habitation/taxe_habitation.py
@@ -9,7 +9,7 @@ from openfisca_france.model.base import *
 class valeur_locative_cadastrale_brute(Variable):
     value_type = float
     entity = Menage
-    label = u"Valeur locative cadastrale utilisée pour les impôts locaux, avant abattements"
+    label = "Valeur locative cadastrale utilisée pour les impôts locaux, avant abattements"
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000034111395&cidTexte=LEGITEXT000006069577&dateTexte=20170302"
     definition_period = YEAR
 
@@ -18,7 +18,7 @@ class condition_rfr_exoneration_th(Variable):
     value_type = bool
     default_value = False
     entity = FoyerFiscal
-    label = u"Condition de revenu fiscal de référence pour l'éxonération à l'échelle du foyer fiscal"
+    label = "Condition de revenu fiscal de référence pour l'éxonération à l'échelle du foyer fiscal"
     reference = "http://bofip.impots.gouv.fr/bofip/5934-PGP.html"
     definition_period = YEAR
 
@@ -39,7 +39,7 @@ class exonere_taxe_habitation(Variable):
     value_type = bool
     default_value = False
     entity = Menage
-    label = u"Exonération de la taxe d'habitation"
+    label = "Exonération de la taxe d'habitation"
     reference = "http://vosdroits.service-public.fr/particuliers/F42.xhtml"
     definition_period = YEAR
 
@@ -80,7 +80,7 @@ class exonere_taxe_habitation(Variable):
 class abattement_charge_famille_th_commune(Variable):
     value_type = float
     entity = Menage
-    label = u"Abattement obligatoire pour charges de famille - TH de la commune"
+    label = "Abattement obligatoire pour charges de famille - TH de la commune"
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000033220348&dateTexte=&categorieLien=id"
     definition_period = YEAR
 
@@ -105,7 +105,7 @@ class abattement_charge_famille_th_commune(Variable):
 class abattement_charge_famille_th_epci(Variable):
     value_type = float
     entity = Menage
-    label = u"Abattement obligatoire pour charges de famille - TH de l'EPCI"
+    label = "Abattement obligatoire pour charges de famille - TH de l'EPCI"
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000033220348&dateTexte=&categorieLien=id"
     definition_period = YEAR
 
@@ -130,7 +130,7 @@ class abattement_charge_famille_th_epci(Variable):
 class abattement_personnes_condition_modeste_th_commune(Variable):
     value_type = float
     entity = Menage
-    label = u"Abattement pour personnes de condition modeste - TH de la commune"
+    label = "Abattement pour personnes de condition modeste - TH de la commune"
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000033220348&dateTexte=&categorieLien=id"
     definition_period = YEAR
 
@@ -159,7 +159,7 @@ class abattement_personnes_condition_modeste_th_commune(Variable):
 class abattement_personnes_condition_modeste_th_epci(Variable):
     value_type = float
     entity = Menage
-    label = u"Abattement pour personnes de condition modeste - TH de l'EPCI"
+    label = "Abattement pour personnes de condition modeste - TH de l'EPCI"
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000033220348&dateTexte=&categorieLien=id"
     definition_period = YEAR
 
@@ -188,7 +188,7 @@ class abattement_personnes_condition_modeste_th_epci(Variable):
 class base_nette_th_commune(Variable):
     value_type = float
     entity = Menage
-    label = u"Base nette - TH de la commune"
+    label = "Base nette - TH de la commune"
     definition_period = YEAR
 
     def formula_2017_01_01(menage, period, parameters):
@@ -214,7 +214,7 @@ class base_nette_th_commune(Variable):
 class base_nette_th_epci(Variable):
     value_type = float
     entity = Menage
-    label = u"Base nette - TH de l'EPCI"
+    label = "Base nette - TH de l'EPCI"
     definition_period = YEAR
 
     def formula_2017_01_01(menage, period, parameters):
@@ -240,7 +240,7 @@ class base_nette_th_epci(Variable):
 class taxe_habitation_commune_epci_avant_degrevement(Variable):
     value_type = float
     entity = Menage
-    label = u"Taxe d'habitation de la commune et de l'EPCI avant dégrèvement (frais de gestion inclus)"
+    label = "Taxe d'habitation de la commune et de l'EPCI avant dégrèvement (frais de gestion inclus)"
     definition_period = YEAR
 
     def formula_2017_01_01(menage, period, parameters):
@@ -260,7 +260,7 @@ class taxe_habitation_commune_epci_avant_degrevement(Variable):
 class plafond_taxe_habitation_eligibilite(Variable):
     value_type = bool
     entity = Menage
-    label = u"Eligibilité au plafond de la taxe d'habitation en fonction du revenu fiscal de référence"
+    label = "Eligibilité au plafond de la taxe d'habitation en fonction du revenu fiscal de référence"
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000006312070&dateTexte=&categorieLien=cid"
     definition_period = YEAR
 
@@ -279,7 +279,7 @@ class plafond_taxe_habitation_eligibilite(Variable):
 class plafond_taxe_habitation(Variable):
     value_type = float
     entity = Menage
-    label = u"Plafond de la taxe d'habitation en fonction du revenu fiscal de référence"
+    label = "Plafond de la taxe d'habitation en fonction du revenu fiscal de référence"
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000006312070&dateTexte=&categorieLien=cid"
     definition_period = YEAR
 
@@ -297,7 +297,7 @@ class plafond_taxe_habitation(Variable):
 class degrevement_plafonnement_taxe_habitation(Variable):
     value_type = float
     entity = Menage
-    label = u"Dégrèvement de la taxe d'habitation au titre du plafonnement"
+    label = "Dégrèvement de la taxe d'habitation au titre du plafonnement"
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000006312070&dateTexte=&categorieLien=cid"
     definition_period = YEAR
 
@@ -344,7 +344,7 @@ class degrevement_plafonnement_taxe_habitation(Variable):
 class taxe_habitation_commune_epci_apres_degrevement_plafonnement(Variable):
     value_type = float
     entity = Menage
-    label = u"Taxe d'habitation de la commune et de l'EPCI après dégrèvement pour plafonnement"
+    label = "Taxe d'habitation de la commune et de l'EPCI après dégrèvement pour plafonnement"
     definition_period = YEAR
 
     def formula_2017_01_01(menage, period, parameters):
@@ -356,7 +356,7 @@ class taxe_habitation_commune_epci_apres_degrevement_plafonnement(Variable):
 class degrevement_office_taxe_habitation(Variable):
     value_type = float
     entity = Menage
-    label = u"Dégrèvement d'office de la taxe d'habitation"
+    label = "Dégrèvement d'office de la taxe d'habitation"
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=268AD735F5C69F94FB6756E3125BF0A0.tplgfr43s_1?idArticle=LEGIARTI000036441815&cidTexte=LEGITEXT000006069577&dateTexte=20190513&categorieLien=id&oldAction=&nbResultRech="
     definition_period = YEAR
 
@@ -397,7 +397,7 @@ class degrevement_office_taxe_habitation(Variable):
 class taxe_habitation(Variable):
     value_type = float
     entity = Menage
-    label = u"Taxe d'habitation de la commune et de l'EPCI (Établissement Public de Coopération Intercommunale), frais de gestion inclus"
+    label = "Taxe d'habitation de la commune et de l'EPCI (Établissement Public de Coopération Intercommunale), frais de gestion inclus"
     reference = "https://www.service-public.fr/particuliers/vosdroits/F42"
     definition_period = YEAR
 

--- a/openfisca_france/model/prelevements_obligatoires/taxe_habitation/taxe_habitation_import_baremes_locaux.py
+++ b/openfisca_france/model/prelevements_obligatoires/taxe_habitation/taxe_habitation_import_baremes_locaux.py
@@ -33,7 +33,7 @@ class code_INSEE_commune(Variable):
     default_value = "01001"
     max_length = 5
     entity = Menage
-    label = u"Code INSEE de la commune de résidence du ménage"
+    label = "Code INSEE de la commune de résidence du ménage"
     definition_period = YEAR
 
 
@@ -41,7 +41,7 @@ class taux_th_commune(Variable):
     value_type = float
     default_value = 0
     entity = Menage
-    label = u"Taux de taxe d'habitation de la commune"
+    label = "Taux de taxe d'habitation de la commune"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -66,7 +66,7 @@ class taux_th_epci(Variable):
     value_type = float
     default_value = 0
     entity = Menage
-    label = u"Taux de taxe d'habitation de l'EPCI (Établissement Public de Coopération Intercommunale)"
+    label = "Taux de taxe d'habitation de l'EPCI (Établissement Public de Coopération Intercommunale)"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -91,7 +91,7 @@ class valeur_locative_moyenne_th_commune(Variable):
     value_type = float
     default_value = 0
     entity = Menage
-    label = u"Valeur locative moyenne utilisée pour le calcul des abattements de la taxe d'habitation de la commune"
+    label = "Valeur locative moyenne utilisée pour le calcul des abattements de la taxe d'habitation de la commune"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -116,7 +116,7 @@ class valeur_locative_moyenne_th_epci(Variable):
     value_type = float
     default_value = 0
     entity = Menage
-    label = u"Valeur locative moyenne utilisée pour le calcul des abattements de la taxe d'habitation de l'EPCI (Établissement Public de Coopération Intercommunale)"
+    label = "Valeur locative moyenne utilisée pour le calcul des abattements de la taxe d'habitation de l'EPCI (Établissement Public de Coopération Intercommunale)"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -141,7 +141,7 @@ class abt_general_base_th_commune(Variable):
     value_type = float
     default_value = 0
     entity = Menage
-    label = u"Quotité (ajustée) de l'abattement général à la base - taxe d'habitation de la commune"
+    label = "Quotité (ajustée) de l'abattement général à la base - taxe d'habitation de la commune"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -166,7 +166,7 @@ class abt_general_base_th_epci(Variable):
     value_type = float
     default_value = 0
     entity = Menage
-    label = u"Quotité (ajustée) de l'abattement général à la base - taxe d'habitation de l'EPCI (Établissement Public de Coopération Intercommunale)"
+    label = "Quotité (ajustée) de l'abattement général à la base - taxe d'habitation de l'EPCI (Établissement Public de Coopération Intercommunale)"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -191,7 +191,7 @@ class abt_pac_1_2_th_commune(Variable):
     value_type = float
     default_value = 0
     entity = Menage
-    label = u"Quotité (ajustée) de l'abattement obligatoire pour charges de famille, pour les deux premières personnes à charge - taxe d'habitation de la commune"
+    label = "Quotité (ajustée) de l'abattement obligatoire pour charges de famille, pour les deux premières personnes à charge - taxe d'habitation de la commune"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -216,7 +216,7 @@ class abt_pac_1_2_th_epci(Variable):
     value_type = float
     default_value = 0
     entity = Menage
-    label = u"Quotité (ajustée) de l'abattement obligatoire pour charges de famille, pour les deux premières personnes à charge - taxe d'habitation de l'EPCI (Établissement Public de Coopération Intercommunale)"
+    label = "Quotité (ajustée) de l'abattement obligatoire pour charges de famille, pour les deux premières personnes à charge - taxe d'habitation de l'EPCI (Établissement Public de Coopération Intercommunale)"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -241,7 +241,7 @@ class abt_pac_3pl_th_commune(Variable):
     value_type = float
     default_value = 0
     entity = Menage
-    label = u"Quotité (ajustée) de l'abattement obligatoire pour charges de famille, pour les personnes à charge à partir de la troisième - taxe d'habitation de la commune"
+    label = "Quotité (ajustée) de l'abattement obligatoire pour charges de famille, pour les personnes à charge à partir de la troisième - taxe d'habitation de la commune"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -266,7 +266,7 @@ class abt_pac_3pl_th_epci(Variable):
     value_type = float
     default_value = 0
     entity = Menage
-    label = u"Quotité (ajustée) de l'abattement obligatoire pour charges de famille, pour les personnes à charge à partir de la troisième - taxe d'habitation de l'EPCI (Établissement Public de Coopération Intercommunale)"
+    label = "Quotité (ajustée) de l'abattement obligatoire pour charges de famille, pour les personnes à charge à partir de la troisième - taxe d'habitation de l'EPCI (Établissement Public de Coopération Intercommunale)"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -291,7 +291,7 @@ class abt_condition_modeste_th_commune(Variable):
     value_type = float
     default_value = 0
     entity = Menage
-    label = u"Quotité (ajustée) de l'abattement pour personnes de condition modeste - taxe d'habitation de la commune"
+    label = "Quotité (ajustée) de l'abattement pour personnes de condition modeste - taxe d'habitation de la commune"
     definition_period = YEAR
 
     def formula(menage, period):
@@ -316,7 +316,7 @@ class abt_condition_modeste_th_epci(Variable):
     value_type = float
     default_value = 0
     entity = Menage
-    label = u"Quotité (ajustée) de l'abattement pour personnes de condition modeste - taxe d'habitation de l'EPCI (Établissement Public de Coopération Intercommunale)"
+    label = "Quotité (ajustée) de l'abattement pour personnes de condition modeste - taxe d'habitation de l'EPCI (Établissement Public de Coopération Intercommunale)"
     definition_period = YEAR
 
     def formula(menage, period):

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 class aide_logement(Variable):
     value_type = float
     entity = Famille
-    label = u"Aide au logement (tout type)"
+    label = "Aide au logement (tout type)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -39,8 +39,8 @@ class apl(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"Aide personnalisée au logement"
-    reference = u"http://vosdroits.service-public.fr/particuliers/F12006.xhtml",
+    label = "Aide personnalisée au logement"
+    reference = "http://vosdroits.service-public.fr/particuliers/F12006.xhtml",
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -55,8 +55,8 @@ class als(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"Allocation logement sociale"
-    reference = u"http://vosdroits.service-public.fr/particuliers/F1280.xhtml"
+    label = "Allocation logement sociale"
+    reference = "http://vosdroits.service-public.fr/particuliers/F1280.xhtml"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -73,8 +73,8 @@ class alf(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"Allocation logement familiale"
-    reference = u"http://vosdroits.service-public.fr/particuliers/F13132.xhtml"
+    label = "Allocation logement familiale"
+    reference = "http://vosdroits.service-public.fr/particuliers/F13132.xhtml"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -90,7 +90,7 @@ class alf(Variable):
 class aide_logement_montant(Variable):
     value_type = float
     entity = Famille
-    label = u"Montant des aides au logement net de CRDS"
+    label = "Montant des aides au logement net de CRDS"
     definition_period = MONTH
 
     def formula(famille, period):
@@ -104,8 +104,8 @@ class aide_logement_montant(Variable):
 class aide_logement_montant_brut_crds(Variable):
     value_type = float
     entity = Famille
-    label = u"Montant des aides au logement brut de CRDS"
-    reference = u"https://www.legifrance.gouv.fr/eli/decret/2018/2/27/2018-136/jo/article_1"
+    label = "Montant des aides au logement brut de CRDS"
+    reference = "https://www.legifrance.gouv.fr/eli/decret/2018/2/27/2018-136/jo/article_1"
     definition_period = MONTH
 
     def formula_2018(famille, period, parameters):
@@ -125,8 +125,8 @@ class aide_logement_montant_brut_crds(Variable):
 class aide_logement_montant_brut(Variable):
     value_type = float
     entity = Famille
-    label = u"Montant des aides au logement après degressivité et abattement forfaitaire, avant CRDS"
-    reference = u"https://www.legifrance.gouv.fr/eli/decret/2017/9/28/TERL1721632D/jo/texte"
+    label = "Montant des aides au logement après degressivité et abattement forfaitaire, avant CRDS"
+    reference = "https://www.legifrance.gouv.fr/eli/decret/2017/9/28/TERL1721632D/jo/texte"
     definition_period = MONTH
 
     def formula_2016_07_01(famille, period, parameters):
@@ -165,8 +165,8 @@ class aide_logement_montant_brut(Variable):
 
 class aide_logement_montant_brut_avant_degressivite(Variable):
     value_type = float
-    label = u"Montant des aides aux logements en secteur locatif avant degressivité et brut de CRDS"
-    reference = u"https://www.legifrance.gouv.fr/eli/arrete/2018/2/27/TERL1801552A/jo/article_1"
+    label = "Montant des aides aux logements en secteur locatif avant degressivité et brut de CRDS"
+    reference = "https://www.legifrance.gouv.fr/eli/arrete/2018/2/27/TERL1801552A/jo/article_1"
     entity = Famille
     definition_period = MONTH
 
@@ -200,9 +200,9 @@ class aide_logement_montant_brut_avant_degressivite(Variable):
 
 
 class TypeEtatLogementFoyer(Enum):
-    non_renseigne = u"Non renseigne"
-    logement_rehabilite = u"Logement rehabilité"
-    logement_non_rehabilite = u"Logement non rehabilité"
+    non_renseigne = "Non renseigne"
+    logement_rehabilite = "Logement rehabilité"
+    logement_non_rehabilite = "Logement non rehabilité"
 
 
 class etat_logement_foyer(Variable):
@@ -210,7 +210,7 @@ class etat_logement_foyer(Variable):
     possible_values = TypeEtatLogementFoyer
     entity = Menage
     default_value = TypeEtatLogementFoyer.non_renseigne
-    label = u"Etat du logement crous"
+    label = "Etat du logement crous"
     set_input = set_input_dispatch_by_period
     definition_period = MONTH
 
@@ -218,20 +218,20 @@ class etat_logement_foyer(Variable):
 class logement_conventionne(Variable):
     value_type = bool
     entity = Menage
-    label = u"Logement conventionné"
+    label = "Logement conventionné"
     definition_period = MONTH
 
 
 class TypeEtatLogement(Enum):
     order__ = ' non_renseigne construction_acquisition_logement_neuf travaux_amelioration_residence_principale agrandissement_amenagement acquisition_amelioration acquisition_sans_amelioration_logement_existant amelioration'  # Needed to preserve the enum order in Python 2
-    non_renseigne = u"Non renseigné"
+    non_renseigne = "Non renseigné"
     # Logement neuf
-    construction_acquisition_logement_neuf = u"Construction Acquisition d'un logement NEUF"
+    construction_acquisition_logement_neuf = "Construction Acquisition d'un logement NEUF"
     # Logement ancien
-    acquisition_amelioration = u"Acquisition Amélioration"
-    acquisition_sans_amelioration_logement_existant = u"Acquisition sans amélioration d'un logement existant"
-    amelioration = u"Amélioration"
-    agrandissement_amenagement = u"Agrandissement Aménagement"
+    acquisition_amelioration = "Acquisition Amélioration"
+    acquisition_sans_amelioration_logement_existant = "Acquisition sans amélioration d'un logement existant"
+    amelioration = "Amélioration"
+    agrandissement_amenagement = "Agrandissement Aménagement"
 
 
 class etat_logement(Variable):
@@ -239,8 +239,8 @@ class etat_logement(Variable):
     possible_values = TypeEtatLogement  # defined in model/base.py
     entity = Menage
     default_value = TypeEtatLogement.non_renseigne
-    label = u"Etat du logement"
-    reference = u"http://www.msa.fr/lfy/documents/11566/48471/Certificat+de+pret+pour+APL.pdf"
+    label = "Etat du logement"
+    reference = "http://www.msa.fr/lfy/documents/11566/48471/Certificat+de+pret+pour+APL.pdf"
     set_input = set_input_dispatch_by_period
     definition_period = MONTH
 
@@ -249,7 +249,7 @@ class aide_logement_date_pret_conventionne(Variable):
     value_type = date
     default_value = date.max
     entity = Menage
-    label = u"Date de contraction du prêt conventionné "
+    label = "Date de contraction du prêt conventionné "
     definition_period = ETERNITY
 
 
@@ -257,7 +257,7 @@ class date_debut_chomage(Variable):
     value_type = date
     default_value = date.max
     entity = Individu
-    label = u"Date de début de chômage"
+    label = "Date de début de chômage"
     definition_period = ETERNITY
 
 
@@ -265,7 +265,7 @@ class aides_logement_primo_accedant_eligibilite(Variable):
     value_type = bool
     default_value = False
     entity = Menage
-    reference = u"https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1723900L/jo/article_126"
+    reference = "https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1723900L/jo/article_126"
     definition_period = MONTH
 
     def formula(menage, period):
@@ -327,7 +327,7 @@ class aides_logement_foyer_personne_agee_eligibilite(Variable):
 class al_nb_personnes_a_charge(Variable):
     value_type = int
     entity = Famille
-    label = u"Nombre de personne à charge au sens des allocations logement"
+    label = "Nombre de personne à charge au sens des allocations logement"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -389,9 +389,9 @@ class al_nb_personnes_a_charge(Variable):
 
 class aide_logement_base_ressources_patrimoine(Variable):
     value_type = float
-    label = u"Base de ressources des revenus du patrimoine des aides au logement"
+    label = "Base de ressources des revenus du patrimoine des aides au logement"
     entity = Famille
-    reference = u"https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000033243725&categorieLien=id"
+    reference = "https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000033243725&categorieLien=id"
     definition_period = MONTH
 
     def formula_2016_10_01(famille, period, parameters):
@@ -448,7 +448,7 @@ class aide_logement_base_ressources_patrimoine(Variable):
 class al_couple(Variable):
     value_type = bool
     entity = Famille
-    label = u'Situation de couple pour le calcul des AL'
+    label = 'Situation de couple pour le calcul des AL'
     definition_period = MONTH
 
     def formula(famille, period):
@@ -462,7 +462,7 @@ class al_couple(Variable):
 class aide_logement_base_ressources_eval_forfaitaire(Variable):
     value_type = float
     entity = Famille
-    label = u"Base ressources en évaluation forfaitaire des aides au logement (R351-7 du CCH)"
+    label = "Base ressources en évaluation forfaitaire des aides au logement (R351-7 du CCH)"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -495,7 +495,7 @@ class aide_logement_base_ressources_eval_forfaitaire(Variable):
 class aide_logement_assiette_abattement_chomage(Variable):
     value_type = float
     entity = Individu
-    label = u"Assiette sur lequel un abattement chômage peut être appliqués pour les AL. Ce sont les revenus d'activité professionnelle, moins les abbattements pour frais professionnels."
+    label = "Assiette sur lequel un abattement chômage peut être appliqués pour les AL. Ce sont les revenus d'activité professionnelle, moins les abbattements pour frais professionnels."
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -519,10 +519,10 @@ class aide_logement_assiette_abattement_chomage(Variable):
 class aide_logement_abattement_chomage_indemnise(Variable):
     value_type = float
     entity = Individu
-    label = u"Montant de l'abattement pour personnes au chômage indemnisé (R351-13 du CCH)"
+    label = "Montant de l'abattement pour personnes au chômage indemnisé (R351-13 du CCH)"
     definition_period = MONTH
     # Article R532-7 du Code de la sécurité sociale
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694522&cidTexte=LEGITEXT000006073189"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694522&cidTexte=LEGITEXT000006073189"
 
     def formula(individu, period, parameters):
         activite = individu('activite', period)
@@ -538,10 +538,10 @@ class aide_logement_abattement_chomage_indemnise(Variable):
 class aide_logement_abattement_depart_retraite(Variable):
     value_type = float
     entity = Individu
-    label = u"Montant de l'abattement sur les salaires en cas de départ en retraite"
+    label = "Montant de l'abattement sur les salaires en cas de départ en retraite"
     definition_period = MONTH
     # Article R532-5 du Code de la sécurité sociale
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006750910&cidTexte=LEGITEXT000006073189&dateTexte=20151231"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006750910&cidTexte=LEGITEXT000006073189&dateTexte=20151231"
 
     def formula(individu, period, parameters):
         retraite_n_2 = individu('retraite_imposable', period.n_2, options = [ADD])
@@ -558,13 +558,13 @@ class aide_logement_abattement_depart_retraite(Variable):
 class aide_logement_neutralisation_rsa(Variable):
     value_type = float
     entity = Famille
-    label = u"Abattement sur les revenus n-2 pour les bénéficiaires du RSA"
+    label = "Abattement sur les revenus n-2 pour les bénéficiaires du RSA"
     definition_period = MONTH
     reference = [
         # Article R532-7 du Code de la sécurité sociale
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694522&cidTexte=LEGITEXT000006073189",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694522&cidTexte=LEGITEXT000006073189",
         # Article R351-14-1 du Code de la construction et de l'habitation
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006074096&idArticle=LEGIARTI000006897410"
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006074096&idArticle=LEGIARTI000006897410"
         ]
 
     def formula(famille, period, parameters):
@@ -581,7 +581,7 @@ class aide_logement_neutralisation_rsa(Variable):
 class aide_logement_base_ressources_defaut(Variable):
     value_type = float
     entity = Famille
-    label = u"Base ressource par défaut des allocations logement"
+    label = "Base ressource par défaut des allocations logement"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -628,14 +628,14 @@ class aide_logement_base_ressources_defaut(Variable):
 class aide_logement_base_revenus_fiscaux(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenus fiscaux perçus par le foyer fiscal à prendre en compte dans la base ressource des aides au logement"
+    label = "Revenus fiscaux perçus par le foyer fiscal à prendre en compte dans la base ressource des aides au logement"
     reference = [
-        u"Code de la construction et de l'habitation - Article R351-5",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=F039735F667F9271DFB284F78105BDC0.tplgfr31s_3?idArticle=LEGIARTI000021632267&cidTexte=LEGITEXT000006074096&dateTexte=20171123",
-        u"Code de la sécurité sociale - Article R831-6",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=9A3FFF4142B563EB5510DDE9F2870BF4.tplgfr41s_2?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000020080073&dateTexte=20171222&categorieLien=cid#LEGIARTI000020080073",
-        u"Code de la sécurité sociale - Article D542-10",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=F1CF3B807CE064C9F518B442EF8C856F.tpdila22v_1?idArticle=LEGIARTI000020986758&cidTexte=LEGITEXT000006073189&dateTexte=20170803&categorieLien=id&oldAction=&nbResultRech="
+        "Code de la construction et de l'habitation - Article R351-5",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=F039735F667F9271DFB284F78105BDC0.tplgfr31s_3?idArticle=LEGIARTI000021632267&cidTexte=LEGITEXT000006074096&dateTexte=20171123",
+        "Code de la sécurité sociale - Article R831-6",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=9A3FFF4142B563EB5510DDE9F2870BF4.tplgfr41s_2?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000020080073&dateTexte=20171222&categorieLien=cid#LEGIARTI000020080073",
+        "Code de la sécurité sociale - Article D542-10",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=F1CF3B807CE064C9F518B442EF8C856F.tpdila22v_1?idArticle=LEGIARTI000020986758&cidTexte=LEGITEXT000006073189&dateTexte=20170803&categorieLien=id&oldAction=&nbResultRech="
         ]
     definition_period = YEAR
 
@@ -685,7 +685,7 @@ class aide_logement_base_revenus_fiscaux(Variable):
 class aide_logement_base_ressources(Variable):
     value_type = float
     entity = Famille
-    label = u"Base ressources des allocations logement"
+    label = "Base ressources des allocations logement"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -748,8 +748,8 @@ class aide_logement_base_ressources(Variable):
 class aides_logement_primo_accedant_ressources(Variable):
     value_type = float
     entity = Menage
-    label = u"Allocation logement pour les primo-accédants, plancher de ressources"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=0E9C46E37CA82EB75BD1482030D54BB5.tpdila18v_2?idArticle=LEGIARTI000021632291&cidTexte=LEGITEXT000006074096&dateTexte=20170623&categorieLien=id&oldAction="
+    label = "Allocation logement pour les primo-accédants, plancher de ressources"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=0E9C46E37CA82EB75BD1482030D54BB5.tpdila18v_2?idArticle=LEGIARTI000021632291&cidTexte=LEGITEXT000006074096&dateTexte=20170623&categorieLien=id&oldAction="
     definition_period = MONTH
 
     def formula(menage, period, parameters):
@@ -761,7 +761,7 @@ class aides_logement_primo_accedant_ressources(Variable):
 class aide_logement_loyer_plafond(Variable):
     value_type = float
     entity = Famille
-    label = u"Loyer plafond dans le calcul des aides au logement (L2)"
+    label = "Loyer plafond dans le calcul des aides au logement (L2)"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -793,8 +793,8 @@ class aide_logement_loyer_plafond(Variable):
 class aide_logement_loyer_reel(Variable):
     value_type = float
     entity = Famille
-    label = u"Loyer réel dans le calcul des aides au logement"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=F2CE61DFFD9BD9F08700031784123828.tplgfr28s_2?idArticle=LEGIARTI000006737243&cidTexte=LEGITEXT000006073189&categorieLien=id&dateTexte="
+    label = "Loyer réel dans le calcul des aides au logement"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=F2CE61DFFD9BD9F08700031784123828.tplgfr28s_2?idArticle=LEGIARTI000006737243&cidTexte=LEGITEXT000006073189&categorieLien=id&dateTexte="
     definition_period = MONTH
 
     def formula(famille, period):
@@ -814,7 +814,7 @@ class aide_logement_loyer_reel(Variable):
 class aide_logement_loyer_retenu(Variable):
     value_type = float
     entity = Famille
-    label = u"Loyer retenu (hors charge) dans le calcul des aides au logement"
+    label = "Loyer retenu (hors charge) dans le calcul des aides au logement"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -828,7 +828,7 @@ class aide_logement_loyer_retenu(Variable):
 class aide_logement_charges(Variable):
     value_type = float
     entity = Famille
-    label = u"Charges retenues dans le calcul des aides au logement"
+    label = "Charges retenues dans le calcul des aides au logement"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -845,7 +845,7 @@ class aide_logement_charges(Variable):
 class aide_logement_R0(Variable):
     value_type = float
     entity = Famille
-    label = u"Revenu de référence, basé sur la situation familiale, pris en compte dans le calcul des AL."
+    label = "Revenu de référence, basé sur la situation familiale, pris en compte dans le calcul des AL."
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -904,7 +904,7 @@ class aide_logement_R0(Variable):
 class aide_logement_taux_famille(Variable):
     value_type = float
     entity = Famille
-    label = u"Taux représentant la situation familiale, décroissant avec le nombre de personnes à charge"
+    label = "Taux représentant la situation familiale, décroissant avec le nombre de personnes à charge"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -940,7 +940,7 @@ class aide_logement_taux_famille(Variable):
 class aide_logement_taux_loyer(Variable):
     value_type = float
     entity = Famille
-    label = u"Taux obscur basé sur une comparaison du loyer retenu à un loyer de référence."
+    label = "Taux obscur basé sur une comparaison du loyer retenu à un loyer de référence."
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -972,7 +972,7 @@ class aide_logement_taux_loyer(Variable):
 class aide_logement_participation_personnelle(Variable):
     value_type = float
     entity = Famille
-    label = u"Participation personelle de la famille au loyer"
+    label = "Participation personelle de la famille au loyer"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -996,8 +996,8 @@ class aide_logement_participation_personnelle(Variable):
 
 class TypesAideLogementNonCalculable(Enum):
     __order__ = 'calculable locataire_foyer'  # Needed to preserve the enum order in Python 2
-    calculable = u"Calculable"
-    locataire_foyer = u"Non calculable (Locataire foyer)"
+    calculable = "Calculable"
+    locataire_foyer = "Non calculable (Locataire foyer)"
 
 
 class aide_logement_non_calculable(Variable):
@@ -1005,7 +1005,7 @@ class aide_logement_non_calculable(Variable):
     possible_values = TypesAideLogementNonCalculable
     default_value = TypesAideLogementNonCalculable.calculable
     entity = Famille
-    label = u"Aide au logement non calculable"
+    label = "Aide au logement non calculable"
     definition_period = MONTH
 
     def formula(famille, period):
@@ -1022,8 +1022,8 @@ class crds_logement(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"CRDS des allocations logement"
-    reference = u"http://vosdroits.service-public.fr/particuliers/F17585.xhtml"
+    label = "CRDS des allocations logement"
+    reference = "http://vosdroits.service-public.fr/particuliers/F17585.xhtml"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -1034,10 +1034,10 @@ class crds_logement(Variable):
 
 class TypesZoneApl(Enum):
     __order__ = 'non_renseigne zone_1 zone_2 zone_3'  # Needed to preserve the enum order in Python 2
-    non_renseigne = u"Non renseigné"
-    zone_1 = u"Zone 1"
-    zone_2 = u"Zone 2"
-    zone_3 = u"Zone 3"
+    non_renseigne = "Non renseigné"
+    zone_1 = "Zone 1"
+    zone_2 = "Zone 2"
+    zone_3 = "Zone 3"
 
 
 zone_apl_by_depcom = None
@@ -1075,7 +1075,7 @@ class zone_apl(Variable):
     possible_values = TypesZoneApl
     default_value = TypesZoneApl.zone_2
     entity = Menage
-    label = u"Zone APL"
+    label = "Zone APL"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -1105,10 +1105,10 @@ class zone_apl(Variable):
 class aides_logement_accedant_et_foyer(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation logement pour les primo-accédants"
+    label = "Allocation logement pour les primo-accédants"
     reference = [u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid",
-                 u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000035671385&dateTexte=&categorieLien=id",
-                 u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=8A5E748B84270643BC39A1D691F4FC5C.tplgfr27s_2?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006739837&dateTexte=20181031&categorieLien=cid#LEGIARTI000006739837"
+                 "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000035671385&dateTexte=&categorieLien=id",
+                 "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=8A5E748B84270643BC39A1D691F4FC5C.tplgfr27s_2?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006739837&dateTexte=20181031&categorieLien=cid#LEGIARTI000006739837"
                  ]
     definition_period = MONTH
 
@@ -1132,9 +1132,9 @@ class aides_logement_accedant_et_foyer(Variable):
 class aides_logement_k(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation logement pour les logements foyers loyer minimal"
+    label = "Allocation logement pour les logements foyers loyer minimal"
     reference = [u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006074096&idArticle=LEGIARTI000006898932&dateTexte=&categorieLien=cid",
-                 u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid"]
+                 "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid"]
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -1149,8 +1149,8 @@ class aides_logement_k(Variable):
 class aides_logement_primo_accedant_k(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation logement pour les primo-accédants K"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid"
+    label = "Allocation logement pour les primo-accédants K"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -1168,9 +1168,9 @@ class aides_logement_primo_accedant_k(Variable):
 class aides_logement_foyer_k_al(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation logement pour les logements foyers loyer minimal"
+    label = "Allocation logement pour les logements foyers loyer minimal"
     reference = [u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006074096&idArticle=LEGIARTI000006898932&dateTexte=&categorieLien=cid",
-                 u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid"]
+                 "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid"]
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -1189,9 +1189,9 @@ class aides_logement_foyer_k_al(Variable):
 class aides_logement_foyer_k_apl(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation logement pour les logements foyers loyer minimal"
+    label = "Allocation logement pour les logements foyers loyer minimal"
     reference = [u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006074096&idArticle=LEGIARTI000006898932&dateTexte=&categorieLien=cid",
-                 u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid"]
+                 "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid"]
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -1222,8 +1222,8 @@ class aides_logement_categorie(Variable):
 class aides_logement_nb_part(Variable):
     value_type = float
     entity = Famille
-    label = u"Nombre de parts (paramètre N) pour l'aide au logement"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid"
+    label = "Nombre de parts (paramètre N) pour l'aide au logement"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -1247,8 +1247,8 @@ class aides_logement_nb_part(Variable):
 class aides_logement_loyer_minimal(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation logement pour les logements foyers loyer minimal"
-    reference = u"https://www.legifrance.gouv.fr/eli/arrete/2007/11/8/MLVU0759263A/jo/article_2"
+    label = "Allocation logement pour les logements foyers loyer minimal"
+    reference = "https://www.legifrance.gouv.fr/eli/arrete/2007/11/8/MLVU0759263A/jo/article_2"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -1261,8 +1261,8 @@ class aides_logement_loyer_minimal(Variable):
 class aides_logement_loyer_minimal_al(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation logement loyer minimal"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid"
+    label = "Allocation logement loyer minimal"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -1280,8 +1280,8 @@ class aides_logement_loyer_minimal_al(Variable):
 class aides_logement_loyer_minimal_apl(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation logement pour les logements foyers loyer minimal"
-    reference = u"https://www.legifrance.gouv.fr/eli/arrete/2007/11/8/MLVU0759263A/jo/article_2"
+    label = "Allocation logement pour les logements foyers loyer minimal"
+    reference = "https://www.legifrance.gouv.fr/eli/arrete/2007/11/8/MLVU0759263A/jo/article_2"
     definition_period = MONTH
 
     # Temporairement limitée à après 2007-11 pour pallier des carences de valeurs de paramètres
@@ -1300,7 +1300,7 @@ class aides_logement_loyer_minimal_apl(Variable):
 class aides_logement_plafond_mensualite(Variable):
     value_type = float
     entity = Famille
-    label = u"Plafond de mensualités (formule commune)"
+    label = "Plafond de mensualités (formule commune)"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -1317,8 +1317,8 @@ class aides_logement_plafond_mensualite(Variable):
 class aides_logement_primo_accedant_plafond_mensualite(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation logement pour les primo-accédants plafond mensualité"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006737237&cidTexte=LEGITEXT000006073189&dateTexte=20170811"
+    label = "Allocation logement pour les primo-accédants plafond mensualité"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006737237&cidTexte=LEGITEXT000006073189&dateTexte=20170811"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -1344,8 +1344,8 @@ class aides_logement_foyer_conventionne_plafond(Variable):
 
     value_type = float
     entity = Famille
-    label = u"Allocation logement pour les logements foyers plafond"
-    reference = u"https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11"
+    label = "Allocation logement pour les logements foyers plafond"
+    reference = "https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -1370,9 +1370,9 @@ class aides_logement_foyer_plafond_mensualite(Variable):
 
     value_type = float
     entity = Famille
-    label = u"Allocation logement pour les logements foyers plafond mensualité"
+    label = "Allocation logement pour les logements foyers plafond mensualité"
     reference = [u"https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000035665875&dateTexte=&categorieLien=id",
-                 u"https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11"]
+                 "https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11"]
     definition_period = MONTH
 
     # Temporairement limitée à après 2017 pour pallier des carences de valeurs de paramètres

--- a/openfisca_france/model/prestations/anah/eligibilite_anah.py
+++ b/openfisca_france/model/prestations/anah/eligibilite_anah.py
@@ -7,9 +7,9 @@ from openfisca_france.model.base import *
 class TypesEligibiliteANAH(Enum):
     # Needed to preserve the enum order in Python 2
     __order__ = 'a_verifier modestes tres_modeste'
-    a_verifier = u"A vérifier"
-    modestes = u"Modestes"
-    tres_modeste = u"Très modestes"
+    a_verifier = "A vérifier"
+    modestes = "Modestes"
+    tres_modeste = "Très modestes"
 
 
 class eligibilite_anah(Variable):
@@ -17,7 +17,7 @@ class eligibilite_anah(Variable):
     possible_values = TypesEligibiliteANAH
     default_value = TypesEligibiliteANAH.a_verifier
     entity = Menage
-    label = u"Barème d'éligibilité aux aides ANAH"
+    label = "Barème d'éligibilité aux aides ANAH"
     definition_period = YEAR
 
     def formula(menage, period):

--- a/openfisca_france/model/prestations/autonomie.py
+++ b/openfisca_france/model/prestations/autonomie.py
@@ -5,7 +5,7 @@ from openfisca_france.model.base import *
 
 class base_ressources_apa(Variable):
     value_type = float
-    label = u"Ressources considérées dans le calcul de l'APA"
+    label = "Ressources considérées dans le calcul de l'APA"
     entity = Individu
     definition_period = MONTH
 
@@ -23,7 +23,7 @@ class base_ressources_apa(Variable):
 
 class apa_domicile_participation(Variable):
     value_type = float
-    label = u"Participation du bénéficiaire de l'APA à domicile en euros"
+    label = "Participation du bénéficiaire de l'APA à domicile en euros"
     entity = Individu
     definition_period = MONTH
 
@@ -129,7 +129,7 @@ class apa_domicile_participation(Variable):
 class apa_eligibilite(Variable):
     value_type = bool
     entity = Individu
-    label = u"Allocation personalisée d'autonomie - Éligibilité"
+    label = "Allocation personalisée d'autonomie - Éligibilité"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -151,7 +151,7 @@ class apa_eligibilite(Variable):
 
 class apa_domicile_taux_participation(Variable):
     value_type = float
-    label = u"Taux de participation du bénéficiaire à l'APA à domicile"
+    label = "Taux de participation du bénéficiaire à l'APA à domicile"
     entity = Individu
     definition_period = MONTH
 
@@ -165,7 +165,7 @@ class apa_domicile_taux_participation(Variable):
 
 class apa_domicile(Variable):
     value_type = float
-    label = u"Allocation personalisée d'autonomie"
+    label = "Allocation personalisée d'autonomie"
     entity = Individu
     definition_period = MONTH
 
@@ -184,7 +184,7 @@ class apa_domicile(Variable):
 
 class apa_etablissement(Variable):
     value_type = float
-    label = u"Allocation personalisée d'autonomie en institution"
+    label = "Allocation personalisée d'autonomie en institution"
     entity = Individu
     definition_period = MONTH
 
@@ -250,13 +250,13 @@ class apa_etablissement(Variable):
 
 class TypesGir(Enum):
     __order__ = 'non_defini gir_1 gir_2 gir_3 gir_4 gir_5 gir_6'  # Needed to preserve the enum order in Python 2
-    non_defini = u"Non défini"
-    gir_1 = u"Gir 1"
-    gir_2 = u"Gir 2"
-    gir_3 = u"Gir 3"
-    gir_4 = u"Gir 4"
-    gir_5 = u"Gir 5"
-    gir_6 = u"Gir 6"
+    non_defini = "Non défini"
+    gir_1 = "Gir 1"
+    gir_2 = "Gir 2"
+    gir_3 = "Gir 3"
+    gir_4 = "Gir 4"
+    gir_5 = "Gir 5"
+    gir_6 = "Gir 6"
 
 
 class gir(Variable):
@@ -264,34 +264,34 @@ class gir(Variable):
     possible_values = TypesGir
     default_value = TypesGir.non_defini
     entity = Individu
-    label = u"Groupe iso-ressources de l'individu"
+    label = "Groupe iso-ressources de l'individu"
     definition_period = MONTH
 
 
 class dependance_plan_aide_domicile(Variable):
     value_type = float
     entity = Individu
-    label = u"Coût du plan d'aide à domicile pour une personne dépendante"
+    label = "Coût du plan d'aide à domicile pour une personne dépendante"
     definition_period = MONTH
 
 
 class dependance_tarif_etablissement_gir_5_6(Variable):
     value_type = float
     entity = Individu
-    label = u"Tarif dépendance de l'établissement pour les GIR 5 et 6"
+    label = "Tarif dépendance de l'établissement pour les GIR 5 et 6"
     definition_period = MONTH
 
 
 class dependance_tarif_etablissement_gir_dependant(Variable):
     value_type = float
     entity = Individu
-    label = u"Tarif dépendance de l'établissement pour le GIR de la personne dépendante"
+    label = "Tarif dépendance de l'établissement pour le GIR de la personne dépendante"
     definition_period = MONTH
 
 
 class apa_urgence_domicile(Variable):
     value_type = float
-    label = u"Allocation personalisée d'autonomie d'urgence à domicile"
+    label = "Allocation personalisée d'autonomie d'urgence à domicile"
     entity = Individu
     definition_period = MONTH
 
@@ -306,7 +306,7 @@ class apa_urgence_domicile(Variable):
 
 class apa_urgence_institution(Variable):
     value_type = float
-    label = u"Allocation personalisée d'autonomie en institution"
+    label = "Allocation personalisée d'autonomie en institution"
     entity = Individu
     definition_period = MONTH
 
@@ -320,7 +320,7 @@ class apa_urgence_institution(Variable):
 
 class dependance_plan_aide_domicile_accepte(Variable):
     value_type = float
-    label = u"Coût du plan d'aide plafonné pris en compte pour la détermination de l'APA"
+    label = "Coût du plan d'aide plafonné pris en compte pour la détermination de l'APA"
     entity = Individu
     definition_period = MONTH
     reference = [

--- a/openfisca_france/model/prestations/bourses_superieur.py
+++ b/openfisca_france/model/prestations/bourses_superieur.py
@@ -6,12 +6,12 @@ from openfisca_france.model.base import *
 class echelon_bourse(Variable):
     entity = Individu
     value_type = int
-    label = u"Echelon de la bourse perçue (de 0 à 7)"
+    label = "Echelon de la bourse perçue (de 0 à 7)"
     definition_period = MONTH
 
 
 class boursier(Variable):
     value_type = bool
     entity = Individu
-    label = u"Élève ou étudiant boursier"
+    label = "Élève ou étudiant boursier"
     definition_period = MONTH

--- a/openfisca_france/model/prestations/cheque_energie.py
+++ b/openfisca_france/model/prestations/cheque_energie.py
@@ -7,7 +7,7 @@ class cheque_energie_unites_consommation(Variable):
     entity = Menage
     value_type = float
     reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=1EA40CA7787AF90A95D1E1B3155D9028.tplgfr29s_1?idArticle=LEGIARTI000032497834&cidTexte=LEGITEXT000023983208&dateTexte=20160511"
-    label = u"Unités de consommation du ménage pour le calcul du chèque Énergie"
+    label = "Unités de consommation du ménage pour le calcul du chèque Énergie"
     definition_period = YEAR
 
     def formula_2017(menage, period, parameters):
@@ -27,12 +27,12 @@ class cheque_energie_eligibilite_logement(Variable):
     entity = Menage
     value_type = bool
     reference = [
-        u"Article L124-1 du Code de l'énergie",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=5AB50D02153C9CB753729850314A2E17.tplgfr29s_1?idArticle=LEGIARTI000031057544&cidTexte=LEGITEXT000023983208&dateTexte=20180314",
-        u"Article LO6314-3 du Code général des collectivités territoriales",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=6A3717E70623B148432581CC8F585C5F.tplgfr31s_1?idArticle=LEGIARTI000006394061&cidTexte=LEGITEXT000006070633&dateTexte=20180316",
+        "Article L124-1 du Code de l'énergie",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=5AB50D02153C9CB753729850314A2E17.tplgfr29s_1?idArticle=LEGIARTI000031057544&cidTexte=LEGITEXT000023983208&dateTexte=20180314",
+        "Article LO6314-3 du Code général des collectivités territoriales",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=6A3717E70623B148432581CC8F585C5F.tplgfr31s_1?idArticle=LEGIARTI000006394061&cidTexte=LEGITEXT000006070633&dateTexte=20180316",
         ]
-    label = u"Éligibilité du logement occupé au chèque énergie"
+    label = "Éligibilité du logement occupé au chèque énergie"
     definition_period = MONTH
 
     def formula_2017(menage, period, parameters):
@@ -54,10 +54,10 @@ class cheque_energie_montant(Variable):
     entity = Menage
     value_type = float
     reference = [
-        u"https://www.legifrance.gouv.fr/eli/decret/2016/5/6/DEVR1604032D/jo/article_1",
-        u"https://www.legifrance.gouv.fr/eli/arrete/2018/12/26/TRER1832961A/jo/texte",
+        "https://www.legifrance.gouv.fr/eli/decret/2016/5/6/DEVR1604032D/jo/article_1",
+        "https://www.legifrance.gouv.fr/eli/arrete/2018/12/26/TRER1832961A/jo/texte",
         ]
-    label = u"Montant du chèque énergie"
+    label = "Montant du chèque énergie"
     definition_period = YEAR
 
     def formula_2017(menage, period, parameters):
@@ -79,7 +79,7 @@ class cheque_energie(Variable):
     entity = Menage
     value_type = float
     reference = "https://chequeenergie.gouv.fr"
-    label = u"Montant auquel le ménage peut prétendre au titre du chèque energie"
+    label = "Montant auquel le ménage peut prétendre au titre du chèque energie"
     definition_period = MONTH
 
     def formula_2017(menage, period, parameters):

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -5,7 +5,7 @@ from openfisca_france.model.base import *
 
 class bourse_college_echelon(Variable):
     value_type = int
-    label = u"Échelon de la bourse de collège attribuée"
+    label = "Échelon de la bourse de collège attribuée"
     entity = Famille
     definition_period = MONTH
 
@@ -81,7 +81,7 @@ class bourse_college_echelon(Variable):
 
 class bourse_college(Variable):
     value_type = float
-    label = u"Montant annuel de la bourse de collège"
+    label = "Montant annuel de la bourse de collège"
     entity = Famille
     definition_period = MONTH
     set_input = set_input_divide_by_period
@@ -115,7 +115,7 @@ class bourse_college(Variable):
 
 class bourse_lycee_points_de_charge(Variable):
     value_type = float
-    label = u"Nombre de points de charge pour la bourse de lycée"
+    label = "Nombre de points de charge pour la bourse de lycée"
     entity = Famille
     definition_period = MONTH
     end = '2016-07-01'
@@ -138,7 +138,7 @@ class bourse_lycee_points_de_charge(Variable):
 
 class bourse_lycee_nombre_parts(Variable):
     value_type = float
-    label = u"Nombre de parts pour le calcul du montant de la bourse de lycée"
+    label = "Nombre de parts pour le calcul du montant de la bourse de lycée"
     entity = Famille
     definition_period = MONTH
     end = '2016-07-01'
@@ -167,7 +167,7 @@ class bourse_lycee_nombre_parts(Variable):
 
 class bourse_lycee_echelon(Variable):
     value_type = int
-    label = u"Échelon de la bourse de collège attribuée"
+    label = "Échelon de la bourse de collège attribuée"
     entity = Famille
     definition_period = MONTH
 
@@ -247,7 +247,7 @@ class bourse_lycee_echelon(Variable):
 
 class bourse_lycee(Variable):
     value_type = float
-    label = u"Montant annuel de la bourse de lycée"
+    label = "Montant annuel de la bourse de lycée"
     entity = Famille
     definition_period = MONTH
     set_input = set_input_divide_by_period
@@ -292,9 +292,9 @@ class bourse_lycee(Variable):
 
 class TypesScolarite(Enum):
     __order__ = 'inconnue college lycee'  # Needed to preserve the enum order in Python 2
-    inconnue = u"Inconnue"
-    college = u"Collège"
-    lycee = u"Lycée"
+    inconnue = "Inconnue"
+    college = "Collège"
+    lycee = "Lycée"
 
 
 class scolarite(Variable):
@@ -302,5 +302,5 @@ class scolarite(Variable):
     possible_values = TypesScolarite
     default_value = TypesScolarite.inconnue
     entity = Individu
-    label = u"Scolarité de l'enfant : collège, lycée..."
+    label = "Scolarité de l'enfant : collège, lycée..."
     definition_period = MONTH

--- a/openfisca_france/model/prestations/garantie_jeunes.py
+++ b/openfisca_france/model/prestations/garantie_jeunes.py
@@ -7,7 +7,7 @@ class garantie_jeunes_neet(Variable):
     value_type = bool
     entity = Individu
     definition_period = MONTH
-    label = u"Variable NEET - Ni étudiant, ni employé, ni stagiaire"
+    label = "Variable NEET - Ni étudiant, ni employé, ni stagiaire"
     reference = ['https://fr.wikipedia.org/wiki/NEET']
 
     def formula(individu, period):
@@ -28,7 +28,7 @@ class garantie_jeunes_max(Variable):
     value_type = float
     entity = Individu
     definition_period = MONTH
-    label = u"Montant maximal de l'allocation Garantie Jeune"
+    label = "Montant maximal de l'allocation Garantie Jeune"
     reference = [
         'Article D5131-20 du code du travail',
         'https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=DED54A598193DDE1DF59E0AE16BDE87D.tplgfr21s_3?idArticle=LEGIARTI000033709227&cidTexte=LEGITEXT000006072050'
@@ -46,7 +46,7 @@ class garantie_jeunes_eligibilite_age(Variable):
     value_type = bool
     entity = Individu
     definition_period = MONTH
-    label = u"Éligibilité en fonction de l'âge à la Garantie Jeune"
+    label = "Éligibilité en fonction de l'âge à la Garantie Jeune"
 
     def formula(individu, period, parameters):
         params_age = parameters(period).prestations.garantie_jeunes.critere_age.age
@@ -59,7 +59,7 @@ class garantie_jeunes(Variable):
     value_type = float
     entity = Individu
     definition_period = MONTH
-    label = u"Montant de la Garantie Jeune"
+    label = "Montant de la Garantie Jeune"
 
     def formula(individu, period, parameters):
         montant = individu('garantie_jeunes_max', period)

--- a/openfisca_france/model/prestations/logement_social.py
+++ b/openfisca_france/model/prestations/logement_social.py
@@ -49,9 +49,9 @@ departements_idf = [
 
 class ZoneLogementSocial(Enum):
     __order__ = 'paris_communes_limitrophes ile_de_france autres_regions'
-    paris_communes_limitrophes = u"Paris et communes limitrophes"
-    ile_de_france = u"Île-de-France hors Paris et communes limitrophes"
-    autres_regions = u"Autres régions"
+    paris_communes_limitrophes = "Paris et communes limitrophes"
+    ile_de_france = "Île-de-France hors Paris et communes limitrophes"
+    autres_regions = "Autres régions"
 
 
 class zone_logement_social(Variable):
@@ -60,7 +60,7 @@ class zone_logement_social(Variable):
     default_value = ZoneLogementSocial.autres_regions
     entity = Menage
     definition_period = MONTH
-    label = u"Zone logement social"
+    label = "Zone logement social"
 
     def formula(menage, period):
         depcom = menage('depcom', period)
@@ -83,12 +83,12 @@ class zone_logement_social(Variable):
 
 class CategorieMenageLogementSocial(Enum):
     __order__ = 'categorie_1 categorie_2 categorie_3 categorie_4 categorie_5 categorie_6'
-    categorie_1 = u"Une personne seule"
-    categorie_2 = u"Deux personnes ne comportant aucune pers. à charge à l'exclusion des jeunes ménages"
-    categorie_3 = u"Trois personnes ou une pers. seule avec une pers. à charge ou jeune ménage sans personne à charge"
-    categorie_4 = u"Quatre personnes ou une pers. seule avec deux pers. à charge"
-    categorie_5 = u"Cinq personnes ou une pers. seule avec trois pers. à charge"
-    categorie_6 = u"Six personnes ou une pers. seule avec quatre pers. à charge"
+    categorie_1 = "Une personne seule"
+    categorie_2 = "Deux personnes ne comportant aucune pers. à charge à l'exclusion des jeunes ménages"
+    categorie_3 = "Trois personnes ou une pers. seule avec une pers. à charge ou jeune ménage sans personne à charge"
+    categorie_4 = "Quatre personnes ou une pers. seule avec deux pers. à charge"
+    categorie_5 = "Cinq personnes ou une pers. seule avec trois pers. à charge"
+    categorie_6 = "Six personnes ou une pers. seule avec quatre pers. à charge"
 
 
 class logement_social_categorie_menage(Variable):
@@ -97,10 +97,10 @@ class logement_social_categorie_menage(Variable):
     possible_values = CategorieMenageLogementSocial
     default_value = CategorieMenageLogementSocial.categorie_1
     definition_period = MONTH
-    label = u"Catégorie de ménage pour déterminer le plafond de ressources"
+    label = "Catégorie de ménage pour déterminer le plafond de ressources"
     reference = [
-        u"Arrêté du 29 juillet 1987 relatif aux plafonds de ressources des bénéficiaires de la législation sur les habitations à loyer modéré et des nouvelles aides de l'Etat en secteur locatif",
-        u"https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000294318"
+        "Arrêté du 29 juillet 1987 relatif aux plafonds de ressources des bénéficiaires de la législation sur les habitations à loyer modéré et des nouvelles aides de l'Etat en secteur locatif",
+        "https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000294318"
         ]
 
     def formula(famille, period, parameters):
@@ -142,10 +142,10 @@ class logement_social_plafond_ressources(Variable):
     entity = Famille
     value_type = float
     definition_period = MONTH
-    label = u"Plafonds de ressources des bénéficiaires de la législation sur les habitations à loyer modéré et des nouvelles aides de l'Etat en secteur locatif"
+    label = "Plafonds de ressources des bénéficiaires de la législation sur les habitations à loyer modéré et des nouvelles aides de l'Etat en secteur locatif"
     reference = [
-        u"Arrêté du 22 décembre 2016 modifiant l'arrêté du 29 juillet 1987 relatif aux plafonds de ressources des bénéficiaires de la législation sur les habitations à loyer modéré et des nouvelles aides de l'Etat en secteur locatif ",
-        u"https://www.legifrance.gouv.fr/eli/arrete/2016/12/22/LHAL1629455A/jo/texte",
+        "Arrêté du 22 décembre 2016 modifiant l'arrêté du 29 juillet 1987 relatif aux plafonds de ressources des bénéficiaires de la législation sur les habitations à loyer modéré et des nouvelles aides de l'Etat en secteur locatif ",
+        "https://www.legifrance.gouv.fr/eli/arrete/2016/12/22/LHAL1629455A/jo/texte",
         ]
 
     def formula(famille, period, parameters):
@@ -168,7 +168,7 @@ class logement_social_eligible(Variable):
     entity = Famille
     value_type = bool
     definition_period = MONTH
-    label = u"Logement social - Éligibilité"
+    label = "Logement social - Éligibilité"
 
     def formula_2017(famille, period, parameters):
 

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -19,7 +19,7 @@ from numpy import datetime64
 class aah_date_debut_incarceration(Variable):
     value_type = date
     default_value = date.max
-    label = u"La date de début d'incarcération"
+    label = "La date de début d'incarcération"
     entity = Individu
     definition_period = MONTH
 
@@ -27,14 +27,14 @@ class aah_date_debut_incarceration(Variable):
 class aah_date_debut_hospitalisation(Variable):
     value_type = date
     default_value = date.max
-    label = u"La date de début d'hospitalisation"
+    label = "La date de début d'hospitalisation"
     entity = Individu
     definition_period = MONTH
 
 
 class aah_base_ressources(Variable):
     value_type = float
-    label = u"Base ressources de l'allocation adulte handicapé"
+    label = "Base ressources de l'allocation adulte handicapé"
     entity = Famille
     definition_period = MONTH
 
@@ -76,7 +76,7 @@ class aah_base_ressources(Variable):
 
 class aah_base_ressources_activite_eval_trimestrielle(Variable):
     value_type = float
-    label = u"Base de ressources des revenus d'activité de l'AAH pour un individu, évaluation trimestrielle"
+    label = "Base de ressources des revenus d'activité de l'AAH pour un individu, évaluation trimestrielle"
     entity = Individu
     definition_period = MONTH
 
@@ -127,14 +127,14 @@ class aah_base_ressources_activite_eval_trimestrielle(Variable):
 
 class aah_base_ressources_activite_milieu_protege(Variable):
     value_type = float
-    label = u"Base de ressources de l'AAH des revenus d'activité en milieu protégé pour un individu"
+    label = "Base de ressources de l'AAH des revenus d'activité en milieu protégé pour un individu"
     entity = Individu
     definition_period = MONTH
 
 
 class aah_base_ressources_hors_activite_eval_trimestrielle(Variable):
     value_type = float
-    label = u"Base de ressources hors revenus d'activité de l'AAH pour un individu, évaluation trimestrielle"
+    label = "Base de ressources hors revenus d'activité de l'AAH pour un individu, évaluation trimestrielle"
     entity = Individu
     definition_period = MONTH
 
@@ -178,7 +178,7 @@ class aah_base_ressources_hors_activite_eval_trimestrielle(Variable):
 
 class aah_base_ressources_eval_annuelle(Variable):
     value_type = float
-    label = u"Base de ressources de l'AAH pour un individu, évaluation annuelle"
+    label = "Base de ressources de l'AAH pour un individu, évaluation annuelle"
     entity = Individu
     definition_period = MONTH
 
@@ -194,17 +194,17 @@ class aah_restriction_substantielle_durable_acces_emploi(Variable):
     value_type = bool
     default_value = True
     entity = Individu
-    label = u"Restriction substantielle et durable pour l'accès à l'emploi reconnue par la commission des droits et de l'autonomie des personnes handicapées"
+    label = "Restriction substantielle et durable pour l'accès à l'emploi reconnue par la commission des droits et de l'autonomie des personnes handicapées"
     reference = [
-        u"Article L821-2 du Code de la sécurité sociale",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=17BE3036A19374AA1C8C7A4169702CD7.tplgfr24s_2?idArticle=LEGIARTI000020039305&cidTexte=LEGITEXT000006073189&dateTexte=20180731"
+        "Article L821-2 du Code de la sécurité sociale",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=17BE3036A19374AA1C8C7A4169702CD7.tplgfr24s_2?idArticle=LEGIARTI000020039305&cidTexte=LEGITEXT000006073189&dateTexte=20180731"
         ]
     definition_period = MONTH
 
 
 class aah_eligible(Variable):
     value_type = bool
-    label = u"Eligibilité à l'Allocation adulte handicapé"
+    label = "Eligibilité à l'Allocation adulte handicapé"
     entity = Individu
     definition_period = MONTH
 
@@ -257,7 +257,7 @@ class aah_eligible(Variable):
 
 class aah_base_non_cumulable(Variable):
     value_type = float
-    label = u"Montant de l'Allocation adulte handicapé (hors complément) pour un individu, mensualisée"
+    label = "Montant de l'Allocation adulte handicapé (hors complément) pour un individu, mensualisée"
     entity = Individu
     definition_period = MONTH
 
@@ -267,11 +267,11 @@ class aah_base_non_cumulable(Variable):
 
 class aah_plafond_ressources(Variable):
     value_type = float
-    label = u"Montant plafond des ressources pour bénéficier de l'Allocation adulte handicapé (hors complément)"
+    label = "Montant plafond des ressources pour bénéficier de l'Allocation adulte handicapé (hors complément)"
     entity = Individu
     reference = [
-        u"Article D821-2 du Code de la sécurité sociale",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=4B54EC7065520E4812F84677B918A48E.tplgfr28s_2?idArticle=LEGIARTI000019077584&cidTexte=LEGITEXT000006073189&dateTexte=20081218"
+        "Article D821-2 du Code de la sécurité sociale",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=4B54EC7065520E4812F84677B918A48E.tplgfr28s_2?idArticle=LEGIARTI000019077584&cidTexte=LEGITEXT000006073189&dateTexte=20081218"
         ]
     definition_period = MONTH
 
@@ -293,11 +293,11 @@ class aah_plafond_ressources(Variable):
 class aah_base(Variable):
     calculate_output = calculate_output_add
     value_type = float
-    label = u"Montant de l'Allocation adulte handicapé (hors complément) pour un individu, mensualisée"
+    label = "Montant de l'Allocation adulte handicapé (hors complément) pour un individu, mensualisée"
     entity = Individu
     reference = [
-        u"Article L821-1 du Code de la sécurité sociale",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=53AFF5AA4010B01F0539052A33180B39.tplgfr35s_1?idArticle=LEGIARTI000033813790&cidTexte=LEGITEXT000006073189&dateTexte=20180412"
+        "Article L821-1 du Code de la sécurité sociale",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=53AFF5AA4010B01F0539052A33180B39.tplgfr35s_1?idArticle=LEGIARTI000033813790&cidTexte=LEGITEXT000006073189&dateTexte=20180412"
         ]
     definition_period = MONTH
 
@@ -319,8 +319,8 @@ class aah_base(Variable):
 class aah(Variable):
     calculate_output = calculate_output_add
     value_type = float
-    label = u"Allocation adulte handicapé mensualisée"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006754198"
+    label = "Allocation adulte handicapé mensualisée"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006754198"
     entity = Individu
     definition_period = MONTH
     set_input = set_input_divide_by_period
@@ -340,7 +340,7 @@ class aah(Variable):
 class eligibilite_caah(Variable):
     entity = Individu
     value_type = float
-    label = u"Eligibilité aux compléments à l'aah"
+    label = "Eligibilité aux compléments à l'aah"
     definition_period = MONTH
 
     def formula_2015_07_01(individu, period, parameters):
@@ -367,7 +367,7 @@ class eligibilite_caah(Variable):
 class caah(Variable):
     calculate_output = calculate_output_add
     value_type = float
-    label = u"Complément d'allocation adulte handicapé (mensualisé)"
+    label = "Complément d'allocation adulte handicapé (mensualisé)"
     entity = Individu
     set_input = set_input_divide_by_period
     definition_period = MONTH
@@ -433,8 +433,8 @@ class caah(Variable):
 class complement_ressources_aah(Variable):
     entity = Individu
     value_type = float
-    label = u"Le complément de ressources"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006745305&dateTexte=&categorieLien=cid"
+    label = "Le complément de ressources"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006745305&dateTexte=&categorieLien=cid"
     definition_period = MONTH
 
     def formula_2015_07_01(individu, period, parameters):
@@ -450,8 +450,8 @@ class complement_ressources_aah(Variable):
 class mva(Variable):
     entity = Individu
     value_type = float
-    label = u"Majoration pour la vie autonome"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=6E5B97C7E6C7E06666BCFFA11871E70B.tplgfr43s_2?idArticle=LEGIARTI000006745350&cidTexte=LEGITEXT000006073189&dateTexte=20190124"
+    label = "Majoration pour la vie autonome"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=6E5B97C7E6C7E06666BCFFA11871E70B.tplgfr43s_2?idArticle=LEGIARTI000006745350&cidTexte=LEGITEXT000006073189&dateTexte=20190124"
     definition_period = MONTH
 
     def formula_2015_07_01(individu, period, parameters):
@@ -465,5 +465,5 @@ class mva(Variable):
 class pch(Variable):
     entity = Individu
     value_type = float
-    label = u"Prestation de compensation du handicap"
+    label = "Prestation de compensation du handicap"
     definition_period = MONTH

--- a/openfisca_france/model/prestations/minima_sociaux/ada.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ada.py
@@ -6,7 +6,7 @@ from openfisca_france.model.base import *
 class ada(Variable):
     value_type = float
     entity = Famille
-    label = u"Montant mensuel  de l'aide pour demandeur d'asile"
+    label = "Montant mensuel  de l'aide pour demandeur d'asile"
     definition_period = MONTH
 
     def formula_2015_11(famille, period, parameters):
@@ -31,7 +31,7 @@ class ada(Variable):
 class asile_demandeur(Variable):
     value_type = bool
     entity = Famille
-    label = u"Famille demandant l'asile"
+    label = "Famille demandant l'asile"
     definition_period = MONTH
 
 
@@ -39,5 +39,5 @@ class place_hebergement(Variable):
     value_type = bool
     default_value = True
     entity = Famille
-    label = u"Bénéficie d'une place dans un centre d'hébergement"
+    label = "Bénéficie d'une place dans un centre d'hébergement"
     definition_period = MONTH

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -22,8 +22,8 @@ class aefa(Variable):
     '''
     value_type = float
     entity = Famille
-    label = u"Aide exceptionelle de fin d'année (prime de Noël)"
-    reference = u"https://www.service-public.fr/particuliers/vosdroits/F1325"
+    label = "Aide exceptionelle de fin d'année (prime de Noël)"
+    reference = "https://www.service-public.fr/particuliers/vosdroits/F1325"
     definition_period = YEAR
 
     def formula_2002_01_01(famille, period, parameters):

--- a/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
+++ b/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
@@ -9,8 +9,8 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 class api(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation de parent isolé"
-    reference = u"http://fr.wikipedia.org/wiki/Allocation_de_parent_isol%C3%A9",
+    label = "Allocation de parent isolé"
+    reference = "http://fr.wikipedia.org/wiki/Allocation_de_parent_isol%C3%A9",
     end = '2009-05-31'
     definition_period = MONTH
     calculate_output = calculate_output_add
@@ -96,9 +96,9 @@ class api(Variable):
 class psa(Variable):
     value_type = float
     entity = Famille
-    label = u"Prime de solidarité active"
+    label = "Prime de solidarité active"
     end = '2009-04-30'
-    reference = u"http://www.service-public.fr/actualites/001077.html"
+    reference = "http://www.service-public.fr/actualites/001077.html"
     definition_period = MONTH
     calculate_output = calculate_output_add
 
@@ -132,7 +132,7 @@ class psa(Variable):
 class rmi(Variable):
     value_type = float
     entity = Famille
-    label = u"Revenu Minimum d'Insertion"
+    label = "Revenu Minimum d'Insertion"
     end = '2009-05-31'
     definition_period = MONTH
 
@@ -156,7 +156,7 @@ class rmi(Variable):
 class rsa_activite(Variable):
     value_type = float
     entity = Famille
-    label = u"Revenu de solidarité active - activité"
+    label = "Revenu de solidarité active - activité"
     end = '2015-12-31'
     definition_period = MONTH
 
@@ -172,7 +172,7 @@ class rsa_activite(Variable):
 class rsa_activite_individu(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenu de solidarité active - activité au niveau de l'individu"
+    label = "Revenu de solidarité active - activité au niveau de l'individu"
     end = '2015-12-31'
     definition_period = YEAR
 

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -8,13 +8,13 @@ from openfisca_france.model.base import *
 class inapte_travail(Variable):
     value_type = bool
     entity = Individu
-    label = u"Reconnu inapte au travail"
+    label = "Reconnu inapte au travail"
     definition_period = MONTH
 
 
 class asi_aspa_base_ressources_individu(Variable):
     value_type = float
-    label = u"Base ressources individuelle du minimum vieillesse/ASPA"
+    label = "Base ressources individuelle du minimum vieillesse/ASPA"
     entity = Individu
     definition_period = MONTH
 
@@ -104,7 +104,7 @@ class asi_aspa_base_ressources_individu(Variable):
 
 class asi_aspa_base_ressources(Variable):
     value_type = float
-    label = u"Base ressource du minimum vieillesse et assimilés (ASPA)"
+    label = "Base ressource du minimum vieillesse et assimilés (ASPA)"
     entity = Famille
     definition_period = MONTH
 
@@ -116,7 +116,7 @@ class asi_aspa_base_ressources(Variable):
 
 class aspa_eligibilite(Variable):
     value_type = bool
-    label = u"Indicatrice individuelle d'éligibilité à l'allocation de solidarité aux personnes agées"
+    label = "Indicatrice individuelle d'éligibilité à l'allocation de solidarité aux personnes agées"
     entity = Individu
     definition_period = MONTH
 
@@ -136,7 +136,7 @@ class aspa_eligibilite(Variable):
 
 class asi_eligibilite(Variable):
     value_type = bool
-    label = u"Indicatrice individuelle d'éligibilité à l'allocation supplémentaire d'invalidité"
+    label = "Indicatrice individuelle d'éligibilité à l'allocation supplémentaire d'invalidité"
     entity = Individu
     definition_period = MONTH
 
@@ -161,7 +161,7 @@ class asi_eligibilite(Variable):
 class asi_aspa_condition_nationalite(Variable):
     value_type = bool
     default_value = True
-    label = u"Condition de nationnalité et de titre de séjour pour bénéficier de l'ASPA ou l'ASI"
+    label = "Condition de nationnalité et de titre de séjour pour bénéficier de l'ASPA ou l'ASI"
     entity = Individu
     definition_period = MONTH
 
@@ -175,7 +175,7 @@ class asi_aspa_condition_nationalite(Variable):
 
 class asi_aspa_nb_alloc(Variable):
     value_type = int
-    label = u"Nombre d'allocataires ASI/ASPA"
+    label = "Nombre d'allocataires ASI/ASPA"
     entity = Famille
     definition_period = MONTH
 
@@ -192,8 +192,8 @@ class asi_aspa_nb_alloc(Variable):
 class asi(Variable):
     calculate_output = calculate_output_add
     value_type = float
-    label = u"Allocation supplémentaire d'invalidité"
-    reference = u"http://vosdroits.service-public.fr/particuliers/F16940.xhtml"
+    label = "Allocation supplémentaire d'invalidité"
+    reference = "http://vosdroits.service-public.fr/particuliers/F16940.xhtml"
     entity = Individu
     definition_period = MONTH
     set_input = set_input_divide_by_period
@@ -255,7 +255,7 @@ class asi(Variable):
 
 class aspa_couple(Variable):
     value_type = bool
-    label = u"Couple au sens de l'ASPA"
+    label = "Couple au sens de l'ASPA"
     entity = Famille
     definition_period = MONTH
 
@@ -274,7 +274,7 @@ class aspa(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"Allocation de solidarité aux personnes agées"
+    label = "Allocation de solidarité aux personnes agées"
     reference = "http://vosdroits.service-public.fr/particuliers/F16871.xhtml"
     definition_period = MONTH
     set_input = set_input_divide_by_period

--- a/openfisca_france/model/prestations/minima_sociaux/ass.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ass.py
@@ -8,18 +8,18 @@ from openfisca_france.model.base import *
 class ass_precondition_remplie(Variable):
     value_type = bool
     entity = Individu
-    label = u"Éligible à l'ASS"
+    label = "Éligible à l'ASS"
     definition_period = MONTH
     reference = [
-        u"Article R5423-1 du Code du travail",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006072050&idArticle=LEGIARTI000018525084&dateTexte=20190618&categorieLien=cid#LEGIARTI000018525084"
+        "Article R5423-1 du Code du travail",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006072050&idArticle=LEGIARTI000018525084&dateTexte=20190618&categorieLien=cid#LEGIARTI000018525084"
         ]
     set_input = set_input_dispatch_by_period
 
 
 class ass(Variable):
     value_type = float
-    label = u"Montant de l'ASS pour un individu"
+    label = "Montant de l'ASS pour un individu"
     entity = Individu
     definition_period = MONTH
     set_input = set_input_divide_by_period
@@ -51,7 +51,7 @@ class ass(Variable):
 
 class ass_base_ressources(Variable):
     value_type = float
-    label = u"Base de ressources de l'ASS"
+    label = "Base de ressources de l'ASS"
     entity = Famille
     definition_period = MONTH
 
@@ -65,12 +65,12 @@ class ass_base_ressources(Variable):
 
 class ass_base_ressources_individu(Variable):
     value_type = float
-    label = u"Base de ressources individuelle de l'ASS"
+    label = "Base de ressources individuelle de l'ASS"
     entity = Individu
     definition_period = MONTH
     reference = [
         # Articles R5423-1 à 6 du code du travail
-        u'https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000018525086&cidTexte=LEGITEXT000006072050&dateTexte=20181227'
+        'https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000018525086&cidTexte=LEGITEXT000006072050&dateTexte=20181227'
         ]
 
     def formula(individu, period, parameters):
@@ -119,7 +119,7 @@ class ass_base_ressources_individu(Variable):
 
 class ass_base_ressources_conjoint(Variable):
     value_type = float
-    label = u"Base de ressources individuelle pour le conjoint du demandeur de l'ASS"
+    label = "Base de ressources individuelle pour le conjoint du demandeur de l'ASS"
     entity = Individu
     definition_period = MONTH
 
@@ -169,13 +169,13 @@ def calculateWithAbatement(individu, parameters, period, ressourceName):
 
 class ass_eligibilite_cumul_individu(Variable):
     value_type = bool
-    label = u"Eligibilité au cumul de l'ASS avec un revenu d'activité"
+    label = "Eligibilité au cumul de l'ASS avec un revenu d'activité"
     entity = Individu
     definition_period = MONTH
     reference = [
-        u"Article R5425-2 du code du travail",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006072050&idArticle=LEGIARTI000018496568&dateTexte=",
-        u"https://www.legifrance.gouv.fr/eli/decret/2017/5/5/ETSD1708117D/jo/article_2"
+        "Article R5425-2 du code du travail",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006072050&idArticle=LEGIARTI000018496568&dateTexte=",
+        "https://www.legifrance.gouv.fr/eli/decret/2017/5/5/ETSD1708117D/jo/article_2"
         ]
 
     def formula_2017_09_01(individu, period):
@@ -209,12 +209,12 @@ class ass_eligibilite_cumul_individu(Variable):
 
 class ass_eligibilite_individu(Variable):
     value_type = bool
-    label = u"Éligibilité individuelle à l'ASS"
+    label = "Éligibilité individuelle à l'ASS"
     entity = Individu
     definition_period = MONTH
     reference = [
-        u"Article L5423-1 du code du travail",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006072050&idArticle=LEGIARTI000006903847&dateTexte=&categorieLien=cid",
+        "Article L5423-1 du code du travail",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006072050&idArticle=LEGIARTI000006903847&dateTexte=&categorieLien=cid",
         ]
 
     def formula(individu, period, parameters):

--- a/openfisca_france/model/prestations/minima_sociaux/cmu.py
+++ b/openfisca_france/model/prestations/minima_sociaux/cmu.py
@@ -8,7 +8,7 @@ from openfisca_france.model.base import *
 class cmu_acs_eligibilite(Variable):
     value_type = bool
     entity = Famille
-    label = u"Pré-éligibilité à la CMU, avant prise en compte des ressources"
+    label = "Pré-éligibilité à la CMU, avant prise en compte des ressources"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -38,7 +38,7 @@ class cmu_acs_eligibilite(Variable):
 class acs_montant_i(Variable):
     value_type = float
     entity = Individu
-    label = u"Montant de l'ACS attribué pour une personne en cas d'éligibilité de la famille"
+    label = "Montant de l'ACS attribué pour une personne en cas d'éligibilité de la famille"
     definition_period = MONTH
 
     def formula_2009_08_01(individu, period, parameters):
@@ -62,7 +62,7 @@ class acs_montant_i(Variable):
 class acs_montant(Variable):
     value_type = float
     entity = Famille
-    label = u"Montant de l'ACS en cas d'éligibilité"
+    label = "Montant de l'ACS en cas d'éligibilité"
     definition_period = MONTH
 
     def formula_2009_08_01(famille, period, parameters):
@@ -73,7 +73,7 @@ class acs_montant(Variable):
 class cmu_forfait_logement_base(Variable):
     value_type = float
     entity = Famille
-    label = u"Forfait logement applicable en cas de propriété ou d'occupation à titre gratuit"
+    label = "Forfait logement applicable en cas de propriété ou d'occupation à titre gratuit"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -87,7 +87,7 @@ class cmu_forfait_logement_base(Variable):
 class cmu_forfait_logement_al(Variable):
     value_type = float
     entity = Famille
-    label = u"Forfait logement applicable en cas d'aide au logement"
+    label = "Forfait logement applicable en cas d'aide au logement"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -103,7 +103,7 @@ class cmu_nbp_foyer(Variable):
     value_type = int
     is_period_size_independent = True
     entity = Famille
-    label = u"Nombre de personnes dans le foyer CMU"
+    label = "Nombre de personnes dans le foyer CMU"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -131,9 +131,9 @@ class cmu_eligible_majoration_dom(Variable):
 class cmu_c_plafond(Variable):
     value_type = float
     entity = Famille
-    label = u"Plafond annuel de ressources pour l'éligibilité à la CMU-C"
+    label = "Plafond annuel de ressources pour l'éligibilité à la CMU-C"
     definition_period = MONTH
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006753234"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006753234"
 
     def formula(famille, period, parameters):
         """
@@ -189,7 +189,7 @@ class cmu_c_plafond(Variable):
 class acs_plafond(Variable):
     value_type = float
     entity = Famille
-    label = u"Plafond annuel de ressources pour l'éligibilité à l'ACS"
+    label = "Plafond annuel de ressources pour l'éligibilité à l'ACS"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -201,14 +201,14 @@ class acs_plafond(Variable):
 
 class cmu_base_ressources_individu(Variable):
     value_type = float
-    label = u"Base de ressources de l'individu prise en compte pour l'éligibilité à la CMU-C / ACS"
+    label = "Base de ressources de l'individu prise en compte pour l'éligibilité à la CMU-C / ACS"
     reference = [
-        u"Article R861-8 du code de la Sécurité Sociale",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=DEA53FDC793298CE041862E42D999E84.tplgfr43s_1?idArticle=LEGIARTI000034424885&cidTexte=LEGITEXT000006073189&dateTexte=20180829&categorieLien=id&oldAction=",
-        u"Article R861-10 du code de la Sécurité Sociale pour les ressources exclues",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=DEA53FDC793298CE041862E42D999E84.tplgfr43s_1?idArticle=LEGIARTI000030055485&cidTexte=LEGITEXT000006073189&dateTexte=20180829&categorieLien=id&oldAction=&nbResultRech=",
-        u"Circulaire N°DSS/2A/2002/110 du 22 février 2002 relative à la notion de ressources à prendre en compte pour l'appréciation du droit à la protection complémentaire en matière de santé",
-        u"http://circulaire.legifrance.gouv.fr/pdf/2009/04/cir_6430.pdf"
+        "Article R861-8 du code de la Sécurité Sociale",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=DEA53FDC793298CE041862E42D999E84.tplgfr43s_1?idArticle=LEGIARTI000034424885&cidTexte=LEGITEXT000006073189&dateTexte=20180829&categorieLien=id&oldAction=",
+        "Article R861-10 du code de la Sécurité Sociale pour les ressources exclues",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=DEA53FDC793298CE041862E42D999E84.tplgfr43s_1?idArticle=LEGIARTI000030055485&cidTexte=LEGITEXT000006073189&dateTexte=20180829&categorieLien=id&oldAction=&nbResultRech=",
+        "Circulaire N°DSS/2A/2002/110 du 22 février 2002 relative à la notion de ressources à prendre en compte pour l'appréciation du droit à la protection complémentaire en matière de santé",
+        "http://circulaire.legifrance.gouv.fr/pdf/2009/04/cir_6430.pdf"
         ]
     entity = Individu
     definition_period = MONTH
@@ -315,7 +315,7 @@ class cmu_base_ressources_individu(Variable):
 
 class cmu_base_ressources(Variable):
     value_type = float
-    label = u"Base de ressources prise en compte pour l'éligibilité à la CMU-C / ACS"
+    label = "Base de ressources prise en compte pour l'éligibilité à la CMU-C / ACS"
     entity = Famille
     definition_period = MONTH
 
@@ -365,7 +365,7 @@ class cmu_nb_pac(Variable):
     value_type = int
     is_period_size_independent = True
     entity = Famille
-    label = u"Nombre de personnes à charge au titre de la CMU"
+    label = "Nombre de personnes à charge au titre de la CMU"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -376,7 +376,7 @@ class cmu_nb_pac(Variable):
 
 class cmu_c(Variable):
     value_type = bool
-    label = u"Éligibilité à la CMU-C"
+    label = "Éligibilité à la CMU-C"
     entity = Famille
     definition_period = MONTH
 
@@ -409,7 +409,7 @@ class cmu_c(Variable):
 
 class acs(Variable):
     value_type = float
-    label = u"Montant (annuel) de l'ACS"
+    label = "Montant (annuel) de l'ACS"
     entity = Famille
     definition_period = MONTH
     set_input = set_input_divide_by_period

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -8,7 +8,7 @@ from numpy import round as round_, logical_or as or_, remainder as remainder_, d
 class ppa_eligibilite(Variable):
     value_type = bool
     entity = Famille
-    label = u"Eligibilité à la PPA pour un mois"
+    label = "Eligibilité à la PPA pour un mois"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -23,10 +23,10 @@ class ppa_eligibilite(Variable):
 class ppa_eligibilite_etudiants(Variable):
     value_type = bool
     entity = Famille
-    label = u"Eligibilité à la PPA (condition sur tout le trimestre)"
+    label = "Eligibilité à la PPA (condition sur tout le trimestre)"
     reference = [
         # Article L842-2 du Code de la Sécurité Sociale
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=F2B88CEFCB83FCAFA4AA31671DAC89DD.tplgfr26s_3?idArticle=LEGIARTI000031087615&cidTexte=LEGITEXT000006073189&dateTexte=20181226"
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=F2B88CEFCB83FCAFA4AA31671DAC89DD.tplgfr26s_3?idArticle=LEGIARTI000031087615&cidTexte=LEGITEXT000006073189&dateTexte=20181226"
         ]
     definition_period = MONTH
 
@@ -66,7 +66,7 @@ class ppa_eligibilite_etudiants(Variable):
 class ppa_montant_forfaitaire_familial_non_majore(Variable):
     value_type = float
     entity = Famille
-    label = u"Montant forfaitaire familial (sans majoration)"
+    label = "Montant forfaitaire familial (sans majoration)"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -93,7 +93,7 @@ class ppa_montant_forfaitaire_familial_non_majore(Variable):
 class ppa_montant_forfaitaire_familial_majore(Variable):
     value_type = float
     entity = Famille
-    label = u"Montant forfaitaire familial (avec majoration)"
+    label = "Montant forfaitaire familial (avec majoration)"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -112,7 +112,7 @@ class ppa_montant_forfaitaire_familial_majore(Variable):
 class ppa_revenu_activite(Variable):
     value_type = float
     entity = Famille
-    label = u"Revenu d'activité pris en compte pour la PPA"
+    label = "Revenu d'activité pris en compte pour la PPA"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -126,7 +126,7 @@ class ppa_revenu_activite(Variable):
 class ppa_revenu_activite_individu(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenu d'activité pris en compte pour la PPA (Individu) pour un mois"
+    label = "Revenu d'activité pris en compte pour la PPA (Individu) pour un mois"
     definition_period = MONTH
     reference = [
         'Article L842-4 du code de la sécurité sociale',
@@ -164,7 +164,7 @@ class ppa_revenu_activite_individu(Variable):
 class ppa_rsa_derniers_revenus_tns_annuels_connus(Variable):
     value_type = float
     entity = Individu
-    label = u"Derniers revenus non salariés annualisés connus"
+    label = "Derniers revenus non salariés annualisés connus"
     definition_period = YEAR
 
     def formula(individu, period):
@@ -188,7 +188,7 @@ class ppa_rsa_derniers_revenus_tns_annuels_connus(Variable):
 class ppa_ressources_hors_activite(Variable):
     value_type = float
     entity = Famille
-    label = u"Revenu hors activité pris en compte pour la PPA"
+    label = "Revenu hors activité pris en compte pour la PPA"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -204,13 +204,13 @@ class ppa_ressources_hors_activite(Variable):
 class ppa_ressources_hors_activite_individu(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenu hors activité pris en compte pour la PPA (Individu) pour un mois"
+    label = "Revenu hors activité pris en compte pour la PPA (Individu) pour un mois"
     definition_period = MONTH
     reference = [
         # Article L842-4 du code de la sécurité sociale
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=B1D8827D50F7B3CC603BB7D398E71AA8.tplgfr28s_3?idArticle=LEGIARTI000033813782&cidTexte=LEGITEXT000006073189&dateTexte=20181226",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=B1D8827D50F7B3CC603BB7D398E71AA8.tplgfr28s_3?idArticle=LEGIARTI000033813782&cidTexte=LEGITEXT000006073189&dateTexte=20181226",
         # Article R843-1 du code de la sécurité sociale
-        u"https://www.legifrance.gouv.fr/affichCode.do;jsessionid=3D8AB2FEC931285820291B1F952160BA.tpdila22v_2?idSectionTA=LEGISCTA000031694323&cidTexte=LEGITEXT000006073189&dateTexte=20160215"
+        "https://www.legifrance.gouv.fr/affichCode.do;jsessionid=3D8AB2FEC931285820291B1F952160BA.tpdila22v_2?idSectionTA=LEGISCTA000031694323&cidTexte=LEGITEXT000006073189&dateTexte=20160215"
         ]
 
     def formula(individu, period, parameters):
@@ -263,7 +263,7 @@ class ppa_ressources_hors_activite_individu(Variable):
 class ppa_base_ressources_prestations_familiales(Variable):
     value_type = float
     entity = Famille
-    label = u"Prestations familiales prises en compte dans le calcul de la PPA"
+    label = "Prestations familiales prises en compte dans le calcul de la PPA"
     definition_period = MONTH
     reference = [
         "Pour la prise en compte du complément familial, II. de l'article R844-4 du code de la sécurité sociale",
@@ -299,7 +299,7 @@ class ppa_base_ressources_prestations_familiales(Variable):
 class ppa_base_ressources(Variable):
     value_type = float
     entity = Famille
-    label = u"Bases ressource prise en compte pour la PPA"
+    label = "Bases ressource prise en compte pour la PPA"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -311,7 +311,7 @@ class ppa_base_ressources(Variable):
 class ppa_bonification(Variable):
     value_type = float
     entity = Individu
-    label = u"Bonification de la PPA pour un individu"
+    label = "Bonification de la PPA pour un individu"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -332,8 +332,8 @@ class ppa_bonification(Variable):
 class ppa_forfait_logement(Variable):
     value_type = float
     entity = Famille
-    label = u"Forfait logement intervenant dans le calcul de la prime d'activité"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=9A3FFF4142B563EB5510DDE9F2870BF4.tplgfr41s_2?idArticle=LEGIARTI000031675988&cidTexte=LEGITEXT000006073189"
+    label = "Forfait logement intervenant dans le calcul de la prime d'activité"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=9A3FFF4142B563EB5510DDE9F2870BF4.tplgfr41s_2?idArticle=LEGIARTI000031675988&cidTexte=LEGITEXT000006073189"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -378,7 +378,7 @@ class ppa_forfait_logement(Variable):
 class ppa_fictive_ressource_activite(Variable):
     value_type = float
     entity = Famille
-    label = u"Proportion de ressources provenant de l'activité prise en compte pour la primie d'activité fictive"
+    label = "Proportion de ressources provenant de l'activité prise en compte pour la primie d'activité fictive"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -391,7 +391,7 @@ class ppa_fictive_ressource_activite(Variable):
 class ppa_fictive_montant_forfaitaire(Variable):
     value_type = float
     entity = Famille
-    label = u"Montant forfaitaire de la prime d'activité fictive"
+    label = "Montant forfaitaire de la prime d'activité fictive"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -405,7 +405,7 @@ class ppa_fictive_montant_forfaitaire(Variable):
 class ppa_fictive(Variable):
     value_type = float
     entity = Famille
-    label = u"Prime pour l'activité fictive pour un mois"
+    label = "Prime pour l'activité fictive pour un mois"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -439,11 +439,11 @@ class ppa_fictive(Variable):
 class ppa(Variable):
     value_type = float
     entity = Famille
-    label = u"Prime Pour l'Activité"
+    label = "Prime Pour l'Activité"
     definition_period = MONTH
     calculate_output = calculate_output_add
     # Prime d'activité sur service-public.fr
-    reference = u"https://www.service-public.fr/particuliers/vosdroits/F2882"
+    reference = "https://www.service-public.fr/particuliers/vosdroits/F2882"
 
     def formula_2016_01_01(famille, period, parameters):
         seuil_non_versement = parameters(period).prestations.minima_sociaux.ppa.seuil_non_versement
@@ -460,13 +460,13 @@ class ppa_mois_demande(Variable):
     value_type = date
     entity = Famille
     definition_period = ETERNITY
-    label = u"Date de la demande de la prime pour l'activité"
+    label = "Date de la demande de la prime pour l'activité"
 
 
 class ppa_indice_du_mois_trimestre_reference(Variable):
     value_type = int
     entity = Famille
-    label = u"Nombre de mois par rapport au mois de du précédent recalcul de la prime d'activité"
+    label = "Nombre de mois par rapport au mois de du précédent recalcul de la prime d'activité"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -478,7 +478,7 @@ class ppa_indice_du_mois_trimestre_reference(Variable):
 class ppa_versee(Variable):
     value_type = float
     entity = Famille
-    label = u"Prime pour l'activité versée en prenant en compte la date de la demande"
+    label = "Prime pour l'activité versée en prenant en compte la date de la demande"
     definition_period = MONTH
 
     def formula(famille, period, parameters):

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -10,14 +10,14 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 class rsa_jeune_condition_heures_travail_remplie(Variable):
     value_type = bool
     entity = Individu
-    label = u"Éligible au RSA si la personne a moins de vingt-cinq ans et a travaillé deux ans sur les trois dernières années"
-    reference = u"https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000022743616&cidTexte=LEGITEXT000006074069"
+    label = "Éligible au RSA si la personne a moins de vingt-cinq ans et a travaillé deux ans sur les trois dernières années"
+    reference = "https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000022743616&cidTexte=LEGITEXT000006074069"
     definition_period = MONTH
 
 
 class rsa_base_ressources(Variable):
     value_type = float
-    label = u"Base ressources du Rmi ou du Rsa"
+    label = "Base ressources du Rmi ou du Rsa"
     entity = Famille
     definition_period = MONTH
 
@@ -57,7 +57,7 @@ class rsa_base_ressources(Variable):
 
 class rsa_has_ressources_substitution(Variable):
     value_type = bool
-    label = u"Présence de ressources de substitution au mois M, qui désactivent la neutralisation des revenus professionnels interrompus au moins M."
+    label = "Présence de ressources de substitution au mois M, qui désactivent la neutralisation des revenus professionnels interrompus au moins M."
     entity = Individu
     definition_period = MONTH
 
@@ -71,10 +71,10 @@ class rsa_has_ressources_substitution(Variable):
 
 class rsa_base_ressources_individu(Variable):
     value_type = float
-    label = u"Base ressource individuelle du RSA/RMI (hors revenus d'actvité)"
+    label = "Base ressource individuelle du RSA/RMI (hors revenus d'actvité)"
     entity = Individu
     definition_period = MONTH
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000036393176&dateTexte=&categorieLien=id"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000036393176&dateTexte=&categorieLien=id"
 
     def formula_2009_06_01(individu, period, parameters):
         # Revenus professionels
@@ -185,7 +185,7 @@ class rsa_base_ressources_individu(Variable):
 
 class rsa_base_ressources_minima_sociaux(Variable):
     value_type = float
-    label = u"Minima sociaux inclus dans la base ressource RSA/RMI"
+    label = "Minima sociaux inclus dans la base ressource RSA/RMI"
     entity = Famille
     definition_period = MONTH
 
@@ -203,8 +203,8 @@ class rsa_base_ressources_minima_sociaux(Variable):
 class rsa_base_ressources_prestations_familiales(Variable):
     value_type = float
     entity = Famille
-    label = u"Prestations familiales inclues dans la base ressource RSA/RMI"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=DA7C73D70BE5D3C7BE36D690E75FDC83.tplgfr38s_3?idArticle=LEGIARTI000020526199&cidTexte=LEGITEXT000006074069&categorieLien=id&dateTexte=20161231"
+    label = "Prestations familiales inclues dans la base ressource RSA/RMI"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=DA7C73D70BE5D3C7BE36D690E75FDC83.tplgfr38s_3?idArticle=LEGIARTI000020526199&cidTexte=LEGITEXT000006074069&categorieLien=id&dateTexte=20161231"
     definition_period = MONTH
 
     def formula_2002_01_01(famille, period):
@@ -294,7 +294,7 @@ class rsa_base_ressources_prestations_familiales(Variable):
 class crds_mini(Variable):
     value_type = float
     entity = Famille
-    label = u"CRDS versée sur les minimas sociaux"
+    label = "CRDS versée sur les minimas sociaux"
     definition_period = MONTH
 
     def formula_2016_01_01(famille, period, parameters):
@@ -329,7 +329,7 @@ class enceinte_fam(Variable):
 class rsa_enfant_a_charge(Variable):
     value_type = bool
     entity = Individu
-    label = u"Enfant pris en compte dans le calcul du RSA"
+    label = "Enfant pris en compte dans le calcul du RSA"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -398,7 +398,7 @@ class rsa_enfant_a_charge(Variable):
 class rsa_nb_enfants(Variable):
     value_type = int
     entity = Famille
-    label = u"Nombre d'enfants pris en compte pour le calcul du RSA"
+    label = "Nombre d'enfants pris en compte pour le calcul du RSA"
     definition_period = MONTH
 
     def formula(famille, period):
@@ -408,13 +408,13 @@ class rsa_nb_enfants(Variable):
 class participation_frais(Variable):
     value_type = bool
     entity = Menage
-    label = u"Partipation aux frais de logement pour un hebergé à titre gratuit"
+    label = "Partipation aux frais de logement pour un hebergé à titre gratuit"
     definition_period = MONTH
 
 
 class rsa_revenu_activite(Variable):
     value_type = float
-    label = u"Revenus d'activité du RSA"
+    label = "Revenus d'activité du RSA"
     entity = Famille
     definition_period = MONTH
 
@@ -428,7 +428,7 @@ class rsa_revenu_activite(Variable):
 
 class rsa_indemnites_journalieres_activite(Variable):
     value_type = float
-    label = u"Indemnités journalières prises en compte comme revenu d'activité"
+    label = "Indemnités journalières prises en compte comme revenu d'activité"
     entity = Individu
     definition_period = MONTH
 
@@ -473,7 +473,7 @@ class rsa_indemnites_journalieres_activite(Variable):
 
 class rsa_indemnites_journalieres_hors_activite(Variable):
     value_type = float
-    label = u"Indemnités journalières prises en compte comme revenu de remplacement"
+    label = "Indemnités journalières prises en compte comme revenu de remplacement"
     entity = Individu
     definition_period = MONTH
 
@@ -486,7 +486,7 @@ class rsa_indemnites_journalieres_hors_activite(Variable):
 
 class rsa_revenu_activite_individu(Variable):
     value_type = float
-    label = u"Revenus d'activité du Rsa - Individuel"
+    label = "Revenus d'activité du Rsa - Individuel"
     entity = Individu
     definition_period = MONTH
 
@@ -530,8 +530,8 @@ class rsa_revenu_activite_individu(Variable):
 
 class rsa_montant(Variable):
     value_type = float
-    label = u"Revenu de solidarité active, avant prise en compte de la non-calculabilité."
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=C0E3FD6701B46D63786815D26ADEAD58.tplgfr35s_2?idArticle=LEGIARTI000033979143&cidTexte=LEGITEXT000006074069&dateTexte=20180830"
+    label = "Revenu de solidarité active, avant prise en compte de la non-calculabilité."
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=C0E3FD6701B46D63786815D26ADEAD58.tplgfr35s_2?idArticle=LEGIARTI000033979143&cidTexte=LEGITEXT000006074069&dateTexte=20180830"
     entity = Famille
     definition_period = MONTH
 
@@ -558,7 +558,7 @@ class rsa_montant(Variable):
 class rsa(Variable):
     calculate_output = calculate_output_add
     value_type = float
-    label = u"Revenu de solidarité active"
+    label = "Revenu de solidarité active"
     entity = Famille
     definition_period = MONTH
     set_input = set_input_divide_by_period
@@ -573,15 +573,15 @@ class rsa(Variable):
 class TypesRSANonCalculable(Enum):
     # Needed to preserve the enum order in Python 2
     __order__ = 'calculable tns conjoint_tns'
-    calculable = u"Calculable"
-    tns = u"tns"
-    conjoint_tns = u"conjoint_tns"
+    calculable = "Calculable"
+    tns = "tns"
+    conjoint_tns = "conjoint_tns"
 
 
 class rsa_base_ressources_patrimoine_individu(Variable):
     value_type = float
-    label = u"Base de ressources des revenus du patrimoine du RSA"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006074069&idArticle=LEGIARTI000006905072&dateTexte=&categorieLien=cid"
+    label = "Base de ressources des revenus du patrimoine du RSA"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006074069&idArticle=LEGIARTI000006905072&dateTexte=&categorieLien=cid"
     entity = Individu
     definition_period = MONTH
 
@@ -611,7 +611,7 @@ class rsa_condition_nationalite(Variable):
     value_type = bool
     default_value = True
     entity = Individu
-    label = u"Conditions de nationnalité et de titre de séjour pour bénéficier du RSA"
+    label = "Conditions de nationnalité et de titre de séjour pour bénéficier du RSA"
     definition_period = MONTH
 
     def formula_2009_06_01(individu, period, parameters):
@@ -631,7 +631,7 @@ class rsa_condition_nationalite(Variable):
 class rsa_eligibilite(Variable):
     value_type = bool
     entity = Famille
-    label = u"Eligibilité au RSA et au RMI"
+    label = "Eligibilité au RSA et au RMI"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -673,7 +673,7 @@ class rsa_eligibilite_tns(Variable):
     value_type = bool
     default_value = True
     entity = Famille
-    label = u"Condition de chiffres d'affaires pour qu'un travailleur non salarié soit éligible au RSA"
+    label = "Condition de chiffres d'affaires pour qu'un travailleur non salarié soit éligible au RSA"
     end = '2016-12-31'
     definition_period = MONTH
 
@@ -756,7 +756,7 @@ class rsa_eligibilite_tns(Variable):
 class rsa_forfait_asf(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation de soutien familial forfaitisée pour le RSA"
+    label = "Allocation de soutien familial forfaitisée pour le RSA"
     definition_period = MONTH
     reference = [
         "Pour le revenu de solidarité active, article R262-10-1 du code de l'action sociale et des familles",
@@ -782,8 +782,8 @@ class rsa_forfait_asf(Variable):
 class rsa_forfait_logement(Variable):
     value_type = float
     entity = Famille
-    label = u"Forfait logement intervenant dans le calcul du Rmi ou du Rsa"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694445&cidTexte=LEGITEXT000006074069&dateTexte=20171222&fastPos=2&fastReqId=1534790830&oldAction=rechCodeArticle"
+    label = "Forfait logement intervenant dans le calcul du Rmi ou du Rsa"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031694445&cidTexte=LEGITEXT000006074069&dateTexte=20171222&fastPos=2&fastReqId=1534790830&oldAction=rechCodeArticle"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -833,7 +833,7 @@ class rsa_forfait_logement(Variable):
 class rsa_isolement_recent(Variable):
     value_type = bool
     entity = Famille
-    label = u"Situation d'isolement depuis moins de 18 mois"
+    label = "Situation d'isolement depuis moins de 18 mois"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -841,7 +841,7 @@ class rsa_isolement_recent(Variable):
 class rsa_majore_eligibilite(Variable):
     value_type = bool
     entity = Famille
-    label = u"Eligibilité au RSA majoré pour parent isolé"
+    label = "Eligibilité au RSA majoré pour parent isolé"
     definition_period = MONTH
 
     def formula(famille, period):
@@ -865,7 +865,7 @@ class rsa_non_calculable(Variable):
     possible_values = TypesRSANonCalculable
     default_value = TypesRSANonCalculable.calculable
     entity = Famille
-    label = u"RSA non calculable"
+    label = "RSA non calculable"
     end = '2016-12-31'
     definition_period = MONTH
 
@@ -896,7 +896,7 @@ class rsa_non_calculable(Variable):
 class rsa_non_calculable_tns_individu(Variable):
     value_type = bool
     entity = Individu
-    label = u"RSA non calculable du fait de la situation de l'individu. Dans le cas des TNS, l'utilisateur est renvoyé vers son PCG"
+    label = "RSA non calculable du fait de la situation de l'individu. Dans le cas des TNS, l'utilisateur est renvoyé vers son PCG"
     definition_period = MONTH
 
     # En fait l'évaluation par le PCD est plutôt l'exception que la règle. En général on retient plutôt le bénéfice déclaré au FISC (après abattement forfaitaire ou réel).
@@ -966,7 +966,7 @@ class rsa_socle(Variable):
 class rsa_socle_majore(Variable):
     value_type = float
     entity = Famille
-    label = u"Montant majoré pour parent isolé du Revenu de solidarité active socle"
+    label = "Montant majoré pour parent isolé du Revenu de solidarité active socle"
     definition_period = MONTH
 
     def formula_2009_06_01(famille, period, parameters):

--- a/openfisca_france/model/prestations/prestations_familiales/aeeh.py
+++ b/openfisca_france/model/prestations/prestations_familiales/aeeh.py
@@ -6,14 +6,14 @@ from openfisca_france.model.base import *
 class aeeh_niveau_handicap(Variable):
     value_type = int
     entity = Individu
-    label = u"Catégorie de handicap prise en compte pour l'AEEH"
+    label = "Catégorie de handicap prise en compte pour l'AEEH"
     definition_period = MONTH
 
 
 class aeeh(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation d'éducation de l'enfant handicapé"
+    label = "Allocation d'éducation de l'enfant handicapé"
     reference = "http://vosdroits.service-public.fr/particuliers/N14808.xhtml"
     definition_period = MONTH
     set_input = set_input_divide_by_period

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -9,7 +9,7 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 class af_nbenf(Variable):
     value_type = int
     entity = Famille
-    label = u"Nombre d'enfants dans la famille au sens des allocations familiales"
+    label = "Nombre d'enfants dans la famille au sens des allocations familiales"
     definition_period = MONTH
 
     def formula(famille, period):
@@ -23,7 +23,7 @@ class af_coeff_garde_alternee(Variable):
     value_type = float
     default_value = 1
     entity = Famille
-    label = u"Coefficient à appliquer aux af pour tenir compte de la garde alternée"
+    label = "Coefficient à appliquer aux af pour tenir compte de la garde alternée"
     definition_period = MONTH
 
     def formula_2007_05_01(famille, period):
@@ -43,7 +43,7 @@ class af_coeff_garde_alternee(Variable):
 class af_allocation_forfaitaire_nb_enfants(Variable):
     value_type = int
     entity = Famille
-    label = u"Nombre d'enfants ouvrant droit à l'allocation forfaitaire des AF"
+    label = "Nombre d'enfants ouvrant droit à l'allocation forfaitaire des AF"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -56,7 +56,7 @@ class af_allocation_forfaitaire_nb_enfants(Variable):
 class af_eligibilite_base(Variable):
     value_type = bool
     entity = Famille
-    label = u"Allocations familiales - Éligibilité pour la France métropolitaine sous condition de ressources"
+    label = "Allocations familiales - Éligibilité pour la France métropolitaine sous condition de ressources"
     definition_period = MONTH
 
     def formula(famille, period):
@@ -69,7 +69,7 @@ class af_eligibilite_base(Variable):
 class af_eligibilite_dom(Variable):
     value_type = bool
     entity = Famille
-    label = u"Allocations familiales - Éligibilité pour les DOM (hors Mayotte) sous condition de ressources"
+    label = "Allocations familiales - Éligibilité pour les DOM (hors Mayotte) sous condition de ressources"
     definition_period = MONTH
 
     def formula(famille, period):
@@ -83,7 +83,7 @@ class af_eligibilite_dom(Variable):
 class af_base(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocations familiales - allocation de base"
+    label = "Allocations familiales - allocation de base"
     definition_period = MONTH
     # prestations familiales (brutes de crds)
 
@@ -119,7 +119,7 @@ class af_taux_modulation(Variable):
     value_type = float
     default_value = 1
     entity = Famille
-    label = u"Taux de modulation à appliquer au montant des AF depuis 2015"
+    label = "Taux de modulation à appliquer au montant des AF depuis 2015"
     definition_period = MONTH
 
     def formula_2015_07_01(famille, period, parameters):
@@ -132,7 +132,7 @@ class af_allocation_forfaitaire_taux_modulation(Variable):
     value_type = float
     default_value = 1
     entity = Famille
-    label = u"Taux de modulation à appliquer à l'allocation forfaitaire des AF depuis 2015"
+    label = "Taux de modulation à appliquer à l'allocation forfaitaire des AF depuis 2015"
     definition_period = MONTH
 
     def formula_2015_07_01(famille, period, parameters):
@@ -147,7 +147,7 @@ class af_age_aine(Variable):
     value_type = int
     default_value = -9999
     entity = Famille
-    label = u"Allocations familiales - Âge de l'aîné des enfants éligibles"
+    label = "Allocations familiales - Âge de l'aîné des enfants éligibles"
     definition_period = MONTH
     is_period_size_independent = True
 
@@ -166,7 +166,7 @@ class af_age_aine(Variable):
 class af_majoration_enfant(Variable):
     value_type = float
     entity = Individu
-    label = u"Allocations familiales - Majoration pour âge applicable à l'enfant"
+    label = "Allocations familiales - Majoration pour âge applicable à l'enfant"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -215,7 +215,7 @@ class af_majoration_enfant(Variable):
 class af_majoration(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocations familiales - majoration pour âge"
+    label = "Allocations familiales - majoration pour âge"
     definition_period = MONTH
 
     def formula(famille, period):
@@ -231,7 +231,7 @@ class af_majoration(Variable):
 class af_complement_degressif(Variable):
     value_type = float
     entity = Famille
-    label = u"AF - Complément dégressif en cas de dépassement du plafond"
+    label = "AF - Complément dégressif en cas de dépassement du plafond"
     definition_period = MONTH
 
     def formula_2015_07_01(famille, period, parameters):
@@ -249,7 +249,7 @@ class af_complement_degressif(Variable):
 class af_allocation_forfaitaire_complement_degressif(Variable):
     value_type = float
     entity = Famille
-    label = u"AF - Complément dégressif pour l'allocation forfaitaire en cas de dépassement du plafond"
+    label = "AF - Complément dégressif pour l'allocation forfaitaire en cas de dépassement du plafond"
     definition_period = MONTH
 
     def formula_2015_07_01(famille, period, parameters):
@@ -266,7 +266,7 @@ class af_allocation_forfaitaire_complement_degressif(Variable):
 class af_allocation_forfaitaire(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocations familiales - forfait"
+    label = "Allocations familiales - forfait"
     definition_period = MONTH
 
     def formula_2003_07_01(famille, period, parameters):
@@ -287,7 +287,7 @@ class af(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"Allocations familiales - total des allocations"
+    label = "Allocations familiales - total des allocations"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -7,7 +7,7 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 class ars(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation de rentrée scolaire"
+    label = "Allocation de rentrée scolaire"
     reference = "http://vosdroits.service-public.fr/particuliers/F1878.xhtml"
     definition_period = YEAR
 

--- a/openfisca_france/model/prestations/prestations_familiales/asf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/asf.py
@@ -6,7 +6,7 @@ from openfisca_france.model.base import *
 class asf_elig_enfant(Variable):
     value_type = bool
     entity = Individu
-    label = u"Enfant pouvant ouvrir droit à l'ASF"
+    label = "Enfant pouvant ouvrir droit à l'ASF"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -28,7 +28,7 @@ class asf_elig_enfant(Variable):
 class asf_elig(Variable):
     value_type = bool
     entity = Famille
-    label = u"Éligibilité à l'ASF"
+    label = "Éligibilité à l'ASF"
     reference = ['https://www.aide-sociale.fr/allocation-soutien-familial/']
     definition_period = MONTH
 
@@ -44,7 +44,7 @@ class asf(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"Allocation de soutien familial (ASF)"
+    label = "Allocation de soutien familial (ASF)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -8,7 +8,7 @@ from openfisca_france.model.base import *
 class autonomie_financiere(Variable):
     value_type = bool
     entity = Individu
-    label = u"Indicatrice d'autonomie financière vis-à-vis des prestations familiales"
+    label = "Indicatrice d'autonomie financière vis-à-vis des prestations familiales"
     definition_period = MONTH
     reference = [
         'https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006750602&cidTexte=LEGITEXT000006073189',
@@ -30,7 +30,7 @@ class autonomie_financiere(Variable):
 class prestations_familiales_enfant_a_charge(Variable):
     value_type = bool
     entity = Individu
-    label = u"Enfant considéré à charge au sens des prestations familiales"
+    label = "Enfant considéré à charge au sens des prestations familiales"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -60,7 +60,7 @@ class prestations_familiales_base_ressources_individu(Variable):
     value_type = float
     is_period_size_independent = True
     entity = Individu
-    label = u"Base ressource individuelle des prestations familiales"
+    label = "Base ressource individuelle des prestations familiales"
     definition_period = MONTH
 
     def formula(individu, period):
@@ -82,7 +82,7 @@ class prestations_familiales_base_ressources_individu(Variable):
 class biactivite(Variable):
     value_type = bool
     entity = Famille
-    label = u"Indicatrice de biactivité"
+    label = "Indicatrice de biactivité"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -118,7 +118,7 @@ class biactivite(Variable):
 class rev_coll(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenus perçus par le foyer fiscal à prendre en compte dans la base ressource des prestations familiales"
+    label = "Revenus perçus par le foyer fiscal à prendre en compte dans la base ressource des prestations familiales"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period):
@@ -157,10 +157,10 @@ class rev_coll(Variable):
 class prestations_familiales_base_ressources_communes(Variable):
     value_type = float
     entity = Famille
-    label = u"Ressources non individualisables prises en compte pour les prestations familiales"
+    label = "Ressources non individualisables prises en compte pour les prestations familiales"
     reference = [
-        u"Article D521-4 du Code de la sécurité sociale",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000030678081&cidTexte=LEGITEXT000006073189&categorieLien=id"
+        "Article D521-4 du Code de la sécurité sociale",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000030678081&cidTexte=LEGITEXT000006073189&categorieLien=id"
         ]
     definition_period = MONTH
 
@@ -183,10 +183,10 @@ class prestations_familiales_base_ressources_communes(Variable):
 class prestations_familiales_base_ressources(Variable):
     value_type = float
     entity = Famille
-    label = u"Base ressource des prestations familiales"
+    label = "Base ressource des prestations familiales"
     reference = [
-        u"Article D521-4 du Code de la sécurité sociale",
-        u"https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000030678081&cidTexte=LEGITEXT000006073189&categorieLien=id"
+        "Article D521-4 du Code de la sécurité sociale",
+        "https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000030678081&cidTexte=LEGITEXT000006073189&categorieLien=id"
         ]
     definition_period = MONTH
 
@@ -212,7 +212,7 @@ def nb_enf(famille, period, age_min, age_max):
     Renvoie le nombre d'enfant au sens des allocations familiales dont l'âge est compris entre ag1 et ag2
     """
 
-    assert period.unit == u'month'
+    assert period.unit == 'month'
     assert period.size == 1
 
     age = famille.members('age', period)

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -8,7 +8,7 @@ from openfisca_france.model.base import *
 class cf_enfant_a_charge(Variable):
     value_type = bool
     entity = Individu
-    label = u"Complément familial - Enfant considéré à charge"
+    label = "Complément familial - Enfant considéré à charge"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -27,7 +27,7 @@ class cf_enfant_a_charge(Variable):
 class cf_enfant_eligible(Variable):
     value_type = bool
     entity = Individu
-    label = u"Complément familial - Enfant pris en compte pour l'éligibilité"
+    label = "Complément familial - Enfant pris en compte pour l'éligibilité"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -51,7 +51,7 @@ class cf_enfant_eligible(Variable):
 class cf_dom_enfant_eligible(Variable):
     value_type = bool
     entity = Individu
-    label = u"Complément familial (DOM) - Enfant pris en compte pour l'éligibilité"
+    label = "Complément familial (DOM) - Enfant pris en compte pour l'éligibilité"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -70,7 +70,7 @@ class cf_dom_enfant_eligible(Variable):
 class cf_dom_enfant_trop_jeune(Variable):
     value_type = bool
     entity = Individu
-    label = u"Complément familial (DOM) - Enfant trop jeune pour ouvrir le droit"
+    label = "Complément familial (DOM) - Enfant trop jeune pour ouvrir le droit"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -87,7 +87,7 @@ class cf_dom_enfant_trop_jeune(Variable):
 class cf_base_ressources_individu(Variable):
     value_type = float
     entity = Individu
-    label = u"Complément familial - Ressources de l'individu prises en compte"
+    label = "Complément familial - Ressources de l'individu prises en compte"
     definition_period = MONTH
 
     def formula(individu, period):
@@ -101,7 +101,7 @@ class cf_base_ressources_individu(Variable):
 class cf_plafond(Variable):
     value_type = float
     entity = Famille
-    label = u"Plafond d'éligibilité au Complément Familial"
+    label = "Plafond d'éligibilité au Complément Familial"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -155,7 +155,7 @@ class cf_plafond(Variable):
 class cf_majore_plafond(Variable):
     value_type = float
     entity = Famille
-    label = u"Plafond d'éligibilité au Complément Familial majoré"
+    label = "Plafond d'éligibilité au Complément Familial majoré"
     definition_period = MONTH
 
     def formula_2014_04_01(famille, period, parameters):
@@ -167,7 +167,7 @@ class cf_majore_plafond(Variable):
 class cf_base_ressources(Variable):
     value_type = float
     entity = Famille
-    label = u"Ressources prises en compte pour l'éligibilité au complément familial"
+    label = "Ressources prises en compte pour l'éligibilité au complément familial"
     definition_period = MONTH
 
     def formula(famille, period):
@@ -180,7 +180,7 @@ class cf_base_ressources(Variable):
 class cf_eligibilite_base(Variable):
     value_type = bool
     entity = Famille
-    label = u"Éligibilité au complément familial sous condition de ressources et avant cumul"
+    label = "Éligibilité au complément familial sous condition de ressources et avant cumul"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -195,7 +195,7 @@ class cf_eligibilite_base(Variable):
 class cf_eligibilite_dom(Variable):
     value_type = bool
     entity = Famille
-    label = u"Éligibilité au complément familial pour les DOM sous condition de ressources et avant cumul"
+    label = "Éligibilité au complément familial pour les DOM sous condition de ressources et avant cumul"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -217,7 +217,7 @@ class cf_eligibilite_dom(Variable):
 class cf_non_majore_avant_cumul(Variable):
     value_type = float
     entity = Famille
-    label = u"Complément familial non majoré avant cumul"
+    label = "Complément familial non majoré avant cumul"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -258,7 +258,7 @@ class cf_non_majore_avant_cumul(Variable):
 class cf_majore_avant_cumul(Variable):
     value_type = float
     entity = Famille
-    label = u"Complément familial majoré avant cumul"
+    label = "Complément familial majoré avant cumul"
     definition_period = MONTH
 
     def formula_2014_04_01(famille, period, parameters):
@@ -287,7 +287,7 @@ class cf_majore_avant_cumul(Variable):
 class cf_montant(Variable):
     value_type = float
     entity = Famille
-    label = u"Montant du complément familial, avant prise en compte d'éventuels cumuls"
+    label = "Montant du complément familial, avant prise en compte d'éventuels cumuls"
     definition_period = MONTH
 
     def formula(famille, period):
@@ -301,7 +301,7 @@ class cf(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"Complément familial"
+    label = "Complément familial"
     reference = "http://vosdroits.service-public.fr/particuliers/F13214.xhtml"
     definition_period = MONTH
     set_input = set_input_divide_by_period

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -11,56 +11,56 @@ from openfisca_core.periods import Instant
 class inactif(Variable):
     value_type = bool
     entity = Famille
-    label = u"Parent inactif (PAJE-CLCA)"
+    label = "Parent inactif (PAJE-CLCA)"
     definition_period = MONTH
 
 
 class partiel1(Variable):
     value_type = bool
     entity = Famille
-    label = u"Parent actif à moins de 50% (PAJE-CLCA)"
+    label = "Parent actif à moins de 50% (PAJE-CLCA)"
     definition_period = MONTH
 
 
 class partiel2(Variable):
     value_type = bool
     entity = Famille
-    label = u"Parent actif entre 50% et 80% (PAJE-CLCA)"
+    label = "Parent actif entre 50% et 80% (PAJE-CLCA)"
     definition_period = MONTH
 
 
 class opt_colca(Variable):
     value_type = bool
     entity = Famille
-    label = u"Opte pour le COLCA"
+    label = "Opte pour le COLCA"
     definition_period = MONTH
 
 
 class empl_dir(Variable):
     value_type = bool
     entity = Famille
-    label = u"Emploi direct (CLCMG)"
+    label = "Emploi direct (CLCMG)"
     definition_period = MONTH
 
 
 class ass_mat(Variable):
     value_type = bool
     entity = Famille
-    label = u"Assistante maternelle (CLCMG)"
+    label = "Assistante maternelle (CLCMG)"
     definition_period = MONTH
 
 
 class gar_dom(Variable):
     value_type = bool
     entity = Famille
-    label = u"Garde à domicile (CLCMG)"
+    label = "Garde à domicile (CLCMG)"
     definition_period = MONTH
 
 
 class paje(Variable):
     value_type = float
     entity = Famille
-    label = u"PAJE - Ensemble des prestations"
+    label = "PAJE - Ensemble des prestations"
     reference = "http://www.caf.fr/aides-et-services/s-informer-sur-les-aides/petite-enfance/la-prestation-d-accueil-du-jeune-enfant-paje"
     definition_period = MONTH
 
@@ -92,7 +92,7 @@ class paje_base(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"Allocation de base de la PAJE"
+    label = "Allocation de base de la PAJE"
     reference = "http://vosdroits.service-public.fr/particuliers/F2552.xhtml"
     definition_period = MONTH
     set_input = set_input_divide_by_period
@@ -177,7 +177,7 @@ class paje_base(Variable):
 class enfant_eligible_paje(Variable):
     value_type = bool
     entity = Individu
-    label = u"Enfant ouvrant droit à la PAJE de base"
+    label = "Enfant ouvrant droit à la PAJE de base"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -194,7 +194,7 @@ class paje_naissance(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"Allocation de naissance de la PAJE"
+    label = "Allocation de naissance de la PAJE"
     reference = "http://vosdroits.service-public.fr/particuliers/F2550.xhtml"
     definition_period = MONTH
 
@@ -335,7 +335,7 @@ class paje_prepare(Variable):
     value_type = float
     entity = Famille
     set_input = set_input_divide_by_period
-    label = u"Prestation Partagée d’éducation de l’Enfant (PreParE)"
+    label = "Prestation Partagée d’éducation de l’Enfant (PreParE)"
     reference = "https://www.service-public.fr/particuliers/vosdroits/F32485"
     definition_period = MONTH
 
@@ -344,7 +344,7 @@ class paje_cmg(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"PAJE - Complément de libre choix du mode de garde"
+    label = "PAJE - Complément de libre choix du mode de garde"
     set_input = set_input_divide_by_period
     reference = [
         "http://www.caf.fr/aides-et-services/s-informer-sur-les-aides/petite-enfance/le-complement-de-libre-choix-du-mode-de-garde",
@@ -588,7 +588,7 @@ class paje_cmg(Variable):
 class ape_avant_cumul(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation parentale d'éducation, avant prise en compte de la non-cumulabilité avec le CF et l'APJE"
+    label = "Allocation parentale d'éducation, avant prise en compte de la non-cumulabilité avec le CF et l'APJE"
     end = '2003-12-31'
     reference = "http://fr.wikipedia.org/wiki/Allocation_parentale_d'%C3%A9ducation_en_France"
     definition_period = MONTH
@@ -649,7 +649,7 @@ class ape_avant_cumul(Variable):
 class apje_avant_cumul(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation pour le jeune enfant, avant prise en compte de la non-cumulabilité avec le CF et l'APE"
+    label = "Allocation pour le jeune enfant, avant prise en compte de la non-cumulabilité avec le CF et l'APE"
     end = '2003-12-31'
     reference = "http://vosdroits.service-public.fr/particuliers/F2552.xhtml"
     definition_period = MONTH
@@ -693,7 +693,7 @@ class apje_avant_cumul(Variable):
 class ape(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation parentale d'éducation"
+    label = "Allocation parentale d'éducation"
     end = '2003-12-31'
     reference = "http://fr.wikipedia.org/wiki/Allocation_parentale_d'%C3%A9ducation_en_France"
     definition_period = MONTH
@@ -713,7 +713,7 @@ class ape(Variable):
 class apje(Variable):
     value_type = float
     entity = Famille
-    label = u"Allocation pour le jeune enfant"
+    label = "Allocation pour le jeune enfant"
     end = '2003-12-31'
     reference = "http://vosdroits.service-public.fr/particuliers/F2552.xhtml"
     definition_period = MONTH
@@ -732,7 +732,7 @@ class paje_clca(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"PAJE - Complément de libre choix d'activité - remplacée par paje_prepare à partir de 04/2017"
+    label = "PAJE - Complément de libre choix d'activité - remplacée par paje_prepare à partir de 04/2017"
     reference = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
     definition_period = MONTH
     set_input = set_input_divide_by_period
@@ -805,7 +805,7 @@ class paje_clca(Variable):
 class paje_clca_taux_plein(Variable):
     value_type = bool
     entity = Famille
-    label = u"Indicatrice Clca taux plein"
+    label = "Indicatrice Clca taux plein"
     reference = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
     definition_period = MONTH
     end = '2017-04-01'
@@ -820,7 +820,7 @@ class paje_clca_taux_plein(Variable):
 class paje_clca_taux_partiel(Variable):
     value_type = bool
     entity = Famille
-    label = u"Indicatrice Clca taux partiel"
+    label = "Indicatrice Clca taux partiel"
     reference = "http://vosdroits.service-public.fr/particuliers/F313.xhtml"
     definition_period = MONTH
     end = '2017-04-01'
@@ -838,7 +838,7 @@ class paje_colca(Variable):
     calculate_output = calculate_output_add
     value_type = float
     entity = Famille
-    label = u"PAJE - Complément optionnel de libre choix d'activité"
+    label = "PAJE - Complément optionnel de libre choix d'activité"
     set_input = set_input_divide_by_period
     reference = "http://vosdroits.service-public.fr/particuliers/F15110.xhtml"
     definition_period = MONTH

--- a/openfisca_france/model/prestations/reduction_loyer_solidarite.py
+++ b/openfisca_france/model/prestations/reduction_loyer_solidarite.py
@@ -6,11 +6,11 @@ from openfisca_france.model.base import *
 class reduction_loyer_solidarite_plafond_ressources(Variable):
     value_type = float
     entity = Famille
-    label = u"Plafond de ressources pour le calcul de la réduction du loyer de solidarité"
+    label = "Plafond de ressources pour le calcul de la réduction du loyer de solidarité"
     reference = [
-        u"https://www.anil.org/aj-reduction-loyer-solidarite-rls-apl/",
-        u"https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036650010&dateTexte=&categorieLien=id",
-        u"https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036650026&dateTexte=&categorieLien=id"
+        "https://www.anil.org/aj-reduction-loyer-solidarite-rls-apl/",
+        "https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036650010&dateTexte=&categorieLien=id",
+        "https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036650026&dateTexte=&categorieLien=id"
         ]
     definition_period = MONTH
 
@@ -60,8 +60,8 @@ class reduction_loyer_solidarite_plafond_ressources(Variable):
 class reduction_loyer_solidarite_montant(Variable):
     value_type = float
     entity = Famille
-    label = u"Montant de la réduction du loyer de solidarité"
-    reference = u"https://www.legifrance.gouv.fr/eli/arrete/2018/2/27/TERL1801551A/jo/article_2"
+    label = "Montant de la réduction du loyer de solidarité"
+    reference = "https://www.legifrance.gouv.fr/eli/arrete/2018/2/27/TERL1801551A/jo/article_2"
     definition_period = MONTH
 
     def formula(famille, period, parameters):
@@ -95,11 +95,11 @@ class reduction_loyer_solidarite_montant(Variable):
 class reduction_loyer_solidarite(Variable):
     value_type = float
     entity = Famille
-    label = u"Réduction du loyer de solidarité effectivement versée"
+    label = "Réduction du loyer de solidarité effectivement versée"
     reference = [
-        u"https://www.anil.org/aj-reduction-loyer-solidarite-rls-apl/",
-        u"https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036650010&dateTexte=&categorieLien=id",
-        u"https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036650026&dateTexte=&categorieLien=id"
+        "https://www.anil.org/aj-reduction-loyer-solidarite-rls-apl/",
+        "https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036650010&dateTexte=&categorieLien=id",
+        "https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036650026&dateTexte=&categorieLien=id"
         ]
     definition_period = MONTH
 

--- a/openfisca_france/model/revenus/activite/non_salarie.py
+++ b/openfisca_france/model/revenus/activite/non_salarie.py
@@ -24,13 +24,13 @@ from openfisca_france.model.base import *
 
 # (f5qm, f5rm )
 class f5qm(Variable):
-    cerfa_field = {0: u"5QM",
-        1: u"5RM",
+    cerfa_field = {0: "5QM",
+        1: "5RM",
                    }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Agents généraux d’assurances: indemnités de cessation d’activité"
+    label = "Agents généraux d’assurances: indemnités de cessation d’activité"
     definition_period = YEAR
 
 
@@ -40,39 +40,39 @@ class f5qm(Variable):
 
 # (f5nv, f5ov, f5pv)
 class ppe_du_ns(Variable):
-    cerfa_field = {0: u"5NV",
-        1: u"5OV",
-        2: u"5PV",
+    cerfa_field = {0: "5NV",
+        1: "5OV",
+        2: "5PV",
                    }
     value_type = int
     entity = Individu
-    label = u"Prime pour l'emploi des non-salariés: nombre de jours travaillés dans l'année"
+    label = "Prime pour l'emploi des non-salariés: nombre de jours travaillés dans l'année"
     end = '2014-12-31'
     definition_period = YEAR
 
 
 # (f5nw, f5ow, f5pw)
 class ppe_tp_ns(Variable):
-    cerfa_field = {0: u"5NW",
-        1: u"5OW",
-        2: u"5PW",
+    cerfa_field = {0: "5NW",
+        1: "5OW",
+        2: "5PW",
                    }
     value_type = bool
     entity = Individu
-    label = u"Prime pour l'emploi des non-salariés: indicateur de travail à temps plein sur l'année entière"
+    label = "Prime pour l'emploi des non-salariés: indicateur de travail à temps plein sur l'année entière"
     end = '2014-12-31'
     definition_period = YEAR
 
 
 # (f5hn, f5in, f5jn))
 class frag_exon(Variable):
-    cerfa_field = {0: u"5HN",
-        1: u"5IN",
-        2: u"5JN", }
+    cerfa_field = {0: "5HN",
+        1: "5IN",
+        2: "5JN", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus agricoles exonérés (régime du forfait)"
+    label = "Revenus agricoles exonérés (régime du forfait)"
     # start_date = date(2007, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
@@ -80,13 +80,13 @@ class frag_exon(Variable):
 
 # (f5ho, f5io, f5jo))
 class frag_impo(Variable):
-    cerfa_field = {0: u"5HO",
-        1: u"5IO",
-        2: u"5JO", }
+    cerfa_field = {0: "5HO",
+        1: "5IO",
+        2: "5JO", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus agricoles imposables (régime du forfait)"
+    label = "Revenus agricoles imposables (régime du forfait)"
     # start_date = date(2007, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
@@ -94,91 +94,91 @@ class frag_impo(Variable):
 
 # (f5hb, f5ib, f5jb))
 class arag_exon(Variable):
-    cerfa_field = {0: u"5HB",
-        1: u"5IB",
-        2: u"5JB", }
+    cerfa_field = {0: "5HB",
+        1: "5IB",
+        2: "5JB", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus agricoles exonérés yc plus-values (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur), activités exercées en Corse"
+    label = "Revenus agricoles exonérés yc plus-values (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur), activités exercées en Corse"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 # (f5hc, f5ic, f5jc))
 class arag_impg(Variable):
-    cerfa_field = {0: u"5HC",
-        1: u"5IC",
-        2: u"5JC", }
+    cerfa_field = {0: "5HC",
+        1: "5IC",
+        2: "5JC", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus agricoles imposables, cas général moyenne triennale (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
+    label = "Revenus agricoles imposables, cas général moyenne triennale (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 # (f5hf, f5if, f5jf))
 class arag_defi(Variable):
-    cerfa_field = {0: u"5HF",
-        1: u"5IF",
-        2: u"5JF", }
+    cerfa_field = {0: "5HF",
+        1: "5IF",
+        2: "5JF", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits agricoles (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
+    label = "Déficits agricoles (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 # (f5hh, f5ih, f5jh))
 class nrag_exon(Variable):
-    cerfa_field = {0: u"5HH",
-        1: u"5IH",
-        2: u"5JH", }
+    cerfa_field = {0: "5HH",
+        1: "5IH",
+        2: "5JH", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus agricoles exonérés yc plus-values (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur), activités exercées en Corse"
+    label = "Revenus agricoles exonérés yc plus-values (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur), activités exercées en Corse"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 # (f5hi, f5ii, f5ji))
 class nrag_impg(Variable):
-    cerfa_field = {0: u"5HI",
-        1: u"5II",
-        2: u"5JI", }
+    cerfa_field = {0: "5HI",
+        1: "5II",
+        2: "5JI", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus agricoles imposables, cas général moyenne triennale (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
+    label = "Revenus agricoles imposables, cas général moyenne triennale (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 # (f5hl, f5il, f5jl))
 class nrag_defi(Variable):
-    cerfa_field = {0: u"5HL",
-        1: u"5IL",
-        2: u"5JL", }
+    cerfa_field = {0: "5HL",
+        1: "5IL",
+        2: "5JL", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits agricoles (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
+    label = "Déficits agricoles (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 # (f5hm, f5im, f5jm))
 class nrag_ajag(Variable):
-    cerfa_field = {0: u"5HM",
-        1: u"5IM",
-        2: u"5JM", }
+    cerfa_field = {0: "5HM",
+        1: "5IM",
+        2: "5JM", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Jeunes agriculteurs, Abattement de 50% ou 100% (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
+    label = "Jeunes agriculteurs, Abattement de 50% ou 100% (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
@@ -190,13 +190,13 @@ class nrag_ajag(Variable):
 
 # (f5ta, f5ua, f5va))
 class ebic_impv(Variable):
-    cerfa_field = {0: u"5TA",
-        1: u"5UA",
-        2: u"5VA", }
+    cerfa_field = {0: "5TA",
+        1: "5UA",
+        2: "5VA", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux professionnels imposables: vente de marchandises et assimilées (régime auto-entrepreneur)"
+    label = "Revenus industriels et commerciaux professionnels imposables: vente de marchandises et assimilées (régime auto-entrepreneur)"
     # start_date = date(2009, 1, 1)
     # end = '2016-12-31'
     definition_period = YEAR
@@ -204,13 +204,13 @@ class ebic_impv(Variable):
 
 # (f5tb, f5ub, f5vb))
 class ebic_imps(Variable):
-    cerfa_field = {0: u"5TB",
-        1: u"5UB",
-        2: u"5VB", }
+    cerfa_field = {0: "5TB",
+        1: "5UB",
+        2: "5VB", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux professionnels imposables: prestations de services et locations meublées (régime auto-entrepreneur)"
+    label = "Revenus industriels et commerciaux professionnels imposables: prestations de services et locations meublées (régime auto-entrepreneur)"
     # start_date = date(2009, 1, 1)
     # end = '2016-12-31'
     definition_period = YEAR
@@ -218,13 +218,13 @@ class ebic_imps(Variable):
 
 # (f5te, f5ue, f5ve))
 class ebnc_impo(Variable):
-    cerfa_field = {0: u"5TE",
-        1: u"5UE",
-        2: u"5VE", }
+    cerfa_field = {0: "5TE",
+        1: "5UE",
+        2: "5VE", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus non commerciaux (régime auto-entrepreneur ayant opté pour le versement libératoire)"
+    label = "Revenus non commerciaux (régime auto-entrepreneur ayant opté pour le versement libératoire)"
     # start_date = date(2009, 1, 1)
     # end = '2016-12-31'
     definition_period = YEAR
@@ -232,99 +232,99 @@ class ebnc_impo(Variable):
 
 # (f5kn, f5ln, f5mn))
 class mbic_exon(Variable):
-    cerfa_field = {0: u"5KN",
-        1: u"5LN",
-        2: u"5MN", }
+    cerfa_field = {0: "5KN",
+        1: "5LN",
+        2: "5MN", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux professionnels nets exonérés (régime micro entreprise)"
+    label = "Revenus industriels et commerciaux professionnels nets exonérés (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5kb, f5lb, f5mb))
 class abic_exon(Variable):
-    cerfa_field = {0: u"5KB",
-        1: u"5LB",
-        2: u"5MB", }
+    cerfa_field = {0: "5KB",
+        1: "5LB",
+        2: "5MB", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux nets exonérés yc plus-values avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Revenus industriels et commerciaux nets exonérés yc plus-values avec CGA ou viseur (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5kh, f5lh, f5mh))
 class nbic_exon(Variable):
-    cerfa_field = {0: u"5KH",
-        1: u"5LH",
-        2: u"5MH", }
+    cerfa_field = {0: "5KH",
+        1: "5LH",
+        2: "5MH", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux nets exonérés yc plus-values sans CGA (régime du bénéfice réel)"
+    label = "Revenus industriels et commerciaux nets exonérés yc plus-values sans CGA (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5ko, f5lo, f5mo))
 class mbic_impv(Variable):
-    cerfa_field = {0: u"5KO",
-        1: u"5LO",
-        2: u"5MO", }
+    cerfa_field = {0: "5KO",
+        1: "5LO",
+        2: "5MO", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux professionnels imposables: vente de marchandises (régime micro entreprise)"
+    label = "Revenus industriels et commerciaux professionnels imposables: vente de marchandises (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5kp, f5lp, f5mp))
 class mbic_imps(Variable):
-    cerfa_field = {0: u"5KP",
-        1: u"5LP",
-        2: u"5MP", }
+    cerfa_field = {0: "5KP",
+        1: "5LP",
+        2: "5MP", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux professionnels imposables: prestations de services et locations meublées (régime micro entreprise)"
+    label = "Revenus industriels et commerciaux professionnels imposables: prestations de services et locations meublées (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5kc, f5lc, f5mc))
 class abic_impn(Variable):
-    cerfa_field = {0: u"5KC",
-        1: u"5LC",
-        2: u"5MC", }
+    cerfa_field = {0: "5KC",
+        1: "5LC",
+        2: "5MC", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux imposables: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Revenus industriels et commerciaux imposables: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5kd, f5ld, f5md))
 class abic_imps(Variable):
-    cerfa_field = {0: u"5KD",
-        1: u"5LD",
-        2: u"5MD", }
+    cerfa_field = {0: "5KD",
+        1: "5LD",
+        2: "5MD", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux imposables: régime simplifié avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Revenus industriels et commerciaux imposables: régime simplifié avec CGA ou viseur (régime du bénéfice réel)"
     end = '2009-12-31'
     definition_period = YEAR
 
 
 # (f5ki, f5li, f5mi))
 class nbic_impn(Variable):
-    cerfa_field = {0: u"5KI",
-        1: u"5LI",
-        2: u"5MI", }
+    cerfa_field = {0: "5KI",
+        1: "5LI",
+        2: "5MI", }
 
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux professionnels imposables: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
+    label = "Revenus industriels et commerciaux professionnels imposables: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
     definition_period = YEAR
 
 
@@ -335,13 +335,13 @@ class nbic_impn(Variable):
 
 # (f5kj, f5lj, f5mj))
 class nbic_imps(Variable):
-    cerfa_field = {0: u"5KJ",
-        1: u"5LJ",
-        2: u"5MJ", }
+    cerfa_field = {0: "5KJ",
+        1: "5LJ",
+        2: "5MJ", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux professionnels imposables: régime simplifié sans CGA (régime du bénéfice réel)"
+    label = "Revenus industriels et commerciaux professionnels imposables: régime simplifié sans CGA (régime du bénéfice réel)"
     end = '2009-12-31'
     definition_period = YEAR
 
@@ -350,274 +350,274 @@ class nbic_imps(Variable):
 # NB cette variable devrait s'appeler 'mbic_mvct' comme c'est une variable de régime micro (mais il
 # existe déjà une variable mbic_mvct avec un autre cerfa_fiel (5HU) corresponsant à avant 2012...)
 class nbic_mvct(Variable):
-    cerfa_field = {0: u"5KJ",
-        1: u"5LJ",
-        2: u"5MJ", }
+    cerfa_field = {0: "5KJ",
+        1: "5LJ",
+        2: "5MJ", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux professionnels moins-values nettes à court terme : régime micro-entreprise"
+    label = "Revenus industriels et commerciaux professionnels moins-values nettes à court terme : régime micro-entreprise"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 # (f5kf, f5lf, f5mf))
 class abic_defn(Variable):
-    cerfa_field = {0: u"5KF",
-        1: u"5LF",
-        2: u"5MF", }
+    cerfa_field = {0: "5KF",
+        1: "5LF",
+        2: "5MF", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits industriels et commerciaux: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Déficits industriels et commerciaux: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5kg, f5lg, f5mg))
 # vérif <=2012
 class abic_defs(Variable):
-    cerfa_field = {0: u"5KG",
-        1: u"5LG",
-        2: u"5MG", }
+    cerfa_field = {0: "5KG",
+        1: "5LG",
+        2: "5MG", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits industriels et commerciaux: simplifié avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Déficits industriels et commerciaux: simplifié avec CGA ou viseur (régime du bénéfice réel)"
     end = '2009-12-01'
     definition_period = YEAR
 
 
 # (f5kl, f5ll, f5ml))
 class nbic_defn(Variable):
-    cerfa_field = {0: u"5KL",
-        1: u"5LL",
-        2: u"5ML", }
+    cerfa_field = {0: "5KL",
+        1: "5LL",
+        2: "5ML", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits industriels et commerciaux: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
+    label = "Déficits industriels et commerciaux: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5km, f5lm, f5mm))
 class nbic_defs(Variable):
-    cerfa_field = {0: u"5KM",
-        1: u"5LM",
-        2: u"5MM", }
+    cerfa_field = {0: "5KM",
+        1: "5LM",
+        2: "5MM", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Locations déjà soumises aux prélèvements sociaux sans CGA (régime du bénéfice réel)"
+    label = "Locations déjà soumises aux prélèvements sociaux sans CGA (régime du bénéfice réel)"
     end = '2009-12-31'
     definition_period = YEAR
 
 
 # (f5ks, f5ls, f5ms))
 class nbic_apch(Variable):
-    cerfa_field = {0: u"5KS",
-        1: u"5LS",
-        2: u"5MS", }
+    cerfa_field = {0: "5KS",
+        1: "5LS",
+        2: "5MS", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Artisans pêcheurs : abattement 50% avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Artisans pêcheurs : abattement 50% avec CGA ou viseur (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5nn, f5on, f5pn))
 class macc_exon(Variable):
-    cerfa_field = {0: u"5NN",
-        1: u"5ON",
-        2: u"5PN", }
+    cerfa_field = {0: "5NN",
+        1: "5ON",
+        2: "5PN", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux non professionnels nets exonérés (régime micro entreprise)"
+    label = "Revenus industriels et commerciaux non professionnels nets exonérés (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5nb, f5ob, f5pb))
 class aacc_exon(Variable):
-    cerfa_field = {0: u"5NB",
-        1: u"5OB",
-        2: u"5PB", }
+    cerfa_field = {0: "5NB",
+        1: "5OB",
+        2: "5PB", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux non professionnels exonérés yc plus-values avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Revenus industriels et commerciaux non professionnels exonérés yc plus-values avec CGA ou viseur (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5nh, f5oh, f5ph))
 class nacc_exon(Variable):
-    cerfa_field = {0: u"5NH",
-        1: u"5OH",
-        2: u"5PH", }
+    cerfa_field = {0: "5NH",
+        1: "5OH",
+        2: "5PH", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux non professionnels exonérés yc plus-values sans CGA (régime du bénéfice réel)"
+    label = "Revenus industriels et commerciaux non professionnels exonérés yc plus-values sans CGA (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5no, f5oo, f5po))
 class macc_impv(Variable):
-    cerfa_field = {0: u"5NO",
-        1: u"5OO",
-        2: u"5PO", }
+    cerfa_field = {0: "5NO",
+        1: "5OO",
+        2: "5PO", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux non professionnels imposables: vente de marchandises et assimilées (régime micro entreprise)"
+    label = "Revenus industriels et commerciaux non professionnels imposables: vente de marchandises et assimilées (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5np, f5op, f5pp))
 class macc_imps(Variable):
-    cerfa_field = {0: u"5NP",
-        1: u"5OP",
-        2: u"5PP", }
+    cerfa_field = {0: "5NP",
+        1: "5OP",
+        2: "5PP", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux non professionnels imposables: prestations de services (régime micro entreprise)"
+    label = "Revenus industriels et commerciaux non professionnels imposables: prestations de services (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5nc, f5oc, f5pc))
 class aacc_impn(Variable):
-    cerfa_field = {0: u"5NC",
-        1: u"5OC",
-        2: u"5PC", }
+    cerfa_field = {0: "5NC",
+        1: "5OC",
+        2: "5PC", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux non professionnels imposables: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Revenus industriels et commerciaux non professionnels imposables: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5nd, f5od, f5pd)) #TODO: avant 2010
 class aacc_imps(Variable):
-    cerfa_field = {0: u"5ND",
-        1: u"5OD",
-        2: u"5PD", }
+    cerfa_field = {0: "5ND",
+        1: "5OD",
+        2: "5PD", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Locations meublées non professionnelles (régime micro entreprise)"
+    label = "Locations meublées non professionnelles (régime micro entreprise)"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 # (f5nf, f5of, f5pf))
 class aacc_defn(Variable):
-    cerfa_field = {0: u"5NF",
-        1: u"5OF",
-        2: u"5PF", }
+    cerfa_field = {0: "5NF",
+        1: "5OF",
+        2: "5PF", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits industriels et commerciaux non professionnels: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Déficits industriels et commerciaux non professionnels: régime normal ou simplifié avec CGA ou viseur (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5ng, f5og, f5pg))
 class aacc_gits(Variable):
-    cerfa_field = {0: u"5NG",
-        1: u"5OG",
-        2: u"5PG", }
+    cerfa_field = {0: "5NG",
+        1: "5OG",
+        2: "5PG", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Location de gîtes ruraux, chambres d'hôtes et meublés de tourisme (régime micro entreprise)"
+    label = "Location de gîtes ruraux, chambres d'hôtes et meublés de tourisme (régime micro entreprise)"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 # (f5ni, f5oi, f5pi))
 class nacc_impn(Variable):
-    cerfa_field = {0: u"5NI",
-        1: u"5OI",
-        2: u"5PI", }
+    cerfa_field = {0: "5NI",
+        1: "5OI",
+        2: "5PI", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus industriels et commerciaux non professionnels imposables: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
+    label = "Revenus industriels et commerciaux non professionnels imposables: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5ng, f5og, f5pg))
 class aacc_defs(Variable):
-    cerfa_field = {0: u"5NG",
-        1: u"5OG",
-        2: u"5PG", }
+    cerfa_field = {0: "5NG",
+        1: "5OG",
+        2: "5PG", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits de revenus industriels et commerciaux non professionnels avec CGA (régime simplifié du bénéfice réel)"
+    label = "Déficits de revenus industriels et commerciaux non professionnels avec CGA (régime simplifié du bénéfice réel)"
     end = '2009-12-31'
     definition_period = YEAR
 
 
 # (f5nj, f5oj, f5pj)) #TODO: dates 5PJ, 5PG, 5PD, 5OM
 class nacc_meup(Variable):
-    cerfa_field = {0: u"5NJ",
-        1: u"5OJ",
-        2: u"5PJ", }
+    cerfa_field = {0: "5NJ",
+        1: "5OJ",
+        2: "5PJ", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Locations meublées non professionnelles: Locations déjà soumises aux prélèvements sociaux (régime micro entreprise)"
+    label = "Locations meublées non professionnelles: Locations déjà soumises aux prélèvements sociaux (régime micro entreprise)"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 # (f5nl, f5ol, f5pl))
 class nacc_defn(Variable):
-    cerfa_field = {0: u"5NL",
-        1: u"5OL",
-        2: u"5PL", }
+    cerfa_field = {0: "5NL",
+        1: "5OL",
+        2: "5PL", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits industriels et commerciaux non professionnels: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
+    label = "Déficits industriels et commerciaux non professionnels: régime normal ou simplifié sans CGA (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5nm, f5om, f5pm)) #TODO autres 5NM
 class nacc_defs(Variable):
-    cerfa_field = {0: u"5NM",
-        1: u"5OM",
-        2: u"5PM", }
+    cerfa_field = {0: "5NM",
+        1: "5OM",
+        2: "5PM", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Locations meublées non professionnelles: Gîtes ruraux et chambres d'hôtes déjà soumis aux prélèvements sociaux avec CGA (régime du bénéfice réel)"
+    label = "Locations meublées non professionnelles: Gîtes ruraux et chambres d'hôtes déjà soumis aux prélèvements sociaux avec CGA (régime du bénéfice réel)"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 # (f5ku, f5lu, f5mu))
 class mncn_impo(Variable):
-    cerfa_field = {0: u"5KU",
-        1: u"5LU",
-        2: u"5MU", }
+    cerfa_field = {0: "5KU",
+        1: "5LU",
+        2: "5MU", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus non commerciaux non professionnels imposables (régime déclaratif spécial ou micro BNC)"
+    label = "Revenus non commerciaux non professionnels imposables (régime déclaratif spécial ou micro BNC)"
     definition_period = YEAR
 
 
 # (f5sn, f5ns, f5os))
 class cncn_bene(Variable):
-    cerfa_field = {0: u"5SN",
-        1: u"5NS",
-        2: u"5OS", }
+    cerfa_field = {0: "5SN",
+        1: "5NS",
+        2: "5OS", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus non commerciaux non professionnels imposables sans AA (régime de la déclaration controlée)"
+    label = "Revenus non commerciaux non professionnels imposables sans AA (régime de la déclaration controlée)"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
@@ -625,963 +625,963 @@ class cncn_bene(Variable):
 # (f5sp, f5nu, f5ou, f5sr))
 # pas de f5sr en 2013
 class cncn_defi(Variable):
-    cerfa_field = {0: u"5SP",
-        1: u"5NU",
-        2: u"5OU", }
+    cerfa_field = {0: "5SP",
+        1: "5NU",
+        2: "5OU", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits non commerciaux non professionnels sans AA (régime de la déclaration controlée)"
+    label = "Déficits non commerciaux non professionnels sans AA (régime de la déclaration controlée)"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 # (f5hp, f5ip, f5jp))
 class mbnc_exon(Variable):
-    cerfa_field = {0: u"5HP",
-        1: u"5IP",
-        2: u"5JP", }
+    cerfa_field = {0: "5HP",
+        1: "5IP",
+        2: "5JP", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus non commerciaux professionnels nets exonérés (régime déclaratif spécial ou micro BNC)"
+    label = "Revenus non commerciaux professionnels nets exonérés (régime déclaratif spécial ou micro BNC)"
     definition_period = YEAR
 
 
 # (f5qb, f5rb, f5sb))
 class abnc_exon(Variable):
-    cerfa_field = {0: u"5QB",
-        1: u"5RB",
-        2: u"5SB", }
+    cerfa_field = {0: "5QB",
+        1: "5RB",
+        2: "5SB", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus non commerciaux professionnels exonérés (yc compris plus-values) (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
+    label = "Revenus non commerciaux professionnels exonérés (yc compris plus-values) (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
     definition_period = YEAR
 
 
 # (f5qh, f5rh, f5sh))
 class nbnc_exon(Variable):
-    cerfa_field = {0: u"5QH",
-        1: u"5RH",
-        2: u"5SH", }
+    cerfa_field = {0: "5QH",
+        1: "5RH",
+        2: "5SH", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus non commerciaux professionnels exonérés (yc compris plus-values) (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
+    label = "Revenus non commerciaux professionnels exonérés (yc compris plus-values) (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
     definition_period = YEAR
 
 
 # (f5hq, f5iq, f5jq))
 class mbnc_impo(Variable):
-    cerfa_field = {0: u"5HQ",
-        1: u"5IQ",
-        2: u"5JQ", }
+    cerfa_field = {0: "5HQ",
+        1: "5IQ",
+        2: "5JQ", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus non commerciaux professionnels imposables (régime déclaratif spécial ou micro BNC)"
+    label = "Revenus non commerciaux professionnels imposables (régime déclaratif spécial ou micro BNC)"
     definition_period = YEAR
 
 
 # (f5qc, f5rc, f5sc))
 class abnc_impo(Variable):
-    cerfa_field = {0: u"5QC",
-        1: u"5RC",
-        2: u"5SC", }
+    cerfa_field = {0: "5QC",
+        1: "5RC",
+        2: "5SC", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus non commerciaux professionnels imposables (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
+    label = "Revenus non commerciaux professionnels imposables (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
     definition_period = YEAR
 
 
 # (f5qe, f5re, f5se))
 class abnc_defi(Variable):
-    cerfa_field = {0: u"5QE",
-        1: u"5RE",
-        2: u"5SE", }
+    cerfa_field = {0: "5QE",
+        1: "5RE",
+        2: "5SE", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits non commerciaux professionnels (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
+    label = "Déficits non commerciaux professionnels (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
     definition_period = YEAR
 
 
 # (f5qi, f5ri, f5si))
 class nbnc_impo(Variable):
-    cerfa_field = {0: u"5QI",
-        1: u"5RI",
-        2: u"5SI", }
+    cerfa_field = {0: "5QI",
+        1: "5RI",
+        2: "5SI", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus non commerciaux professionnels imposables (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
+    label = "Revenus non commerciaux professionnels imposables (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
     definition_period = YEAR
 
 
 # (f5qk, f5rk, f5sk))
 class nbnc_defi(Variable):
-    cerfa_field = {0: u"5QK",
-        1: u"5RK",
-        2: u"5SK", }
+    cerfa_field = {0: "5QK",
+        1: "5RK",
+        2: "5SK", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits non commerciaux professionnels (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
+    label = "Déficits non commerciaux professionnels (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
     definition_period = YEAR
 
 
 # (f5hu))
 # vérif <=2012
 class mbic_mvct(Variable):
-    cerfa_field = u"5HU"
+    cerfa_field = "5HU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Moins-values industrielles et commerciales nettes à court terme du foyer (régime micro entreprise)"
+    label = "Moins-values industrielles et commerciales nettes à court terme du foyer (régime micro entreprise)"
     end = '2011-12-31'
     definition_period = YEAR
 
 
 # (f5iu))
 class macc_mvct(Variable):
-    cerfa_field = u"5IU"
+    cerfa_field = "5IU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Moins-values industrielles et commerciales non professionnelles nettes à court terme du foyer (régime micro entreprise)"
+    label = "Moins-values industrielles et commerciales non professionnelles nettes à court terme du foyer (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5ju))
 class mncn_mvct(Variable):
-    cerfa_field = u"5JU"
+    cerfa_field = "5JU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Moins-values non commerciales non professionnelles nettes à court terme du foyer (régime déclaratif spécial ou micro BNC)"
+    label = "Moins-values non commerciales non professionnelles nettes à court terme du foyer (régime déclaratif spécial ou micro BNC)"
     definition_period = YEAR
 
 
 # (f5kz, f5lz , f5mz), f5lz , f5mz sont présentent en 2013
 class mbnc_mvct(Variable):
-    cerfa_field = {0: u"5KZ",  # TODO: pb cerfa field
-        1: u"5LZ",
-        2: u"5MZ", }
+    cerfa_field = {0: "5KZ",  # TODO: pb cerfa field
+        1: "5LZ",
+        2: "5MZ", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Moins-values non commerciales professionnelles nettes à court terme (régime déclaratif spécial ou micro BNC)"
+    label = "Moins-values non commerciales professionnelles nettes à court terme (régime déclaratif spécial ou micro BNC)"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 # (f5hw, f5iw, f5jw))
 class frag_pvct(Variable):
-    cerfa_field = {0: u"5HW",
-        1: u"5IW",
-        2: u"5JW", }
+    cerfa_field = {0: "5HW",
+        1: "5IW",
+        2: "5JW", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values agricoles  à court terme (régime du forfait)"
+    label = "Plus-values agricoles  à court terme (régime du forfait)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 # (f5kx, f5lx, f5mx))
 class mbic_pvct(Variable):
-    cerfa_field = {0: u"5KX",
-        1: u"5LX",
-        2: u"5MX", }
+    cerfa_field = {0: "5KX",
+        1: "5LX",
+        2: "5MX", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values industrielles et commerciales professionnels imposables: plus-values nettes à court terme (régime micro entreprise)"
+    label = "Plus-values industrielles et commerciales professionnels imposables: plus-values nettes à court terme (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5nx, f5ox, f5px))
 class macc_pvct(Variable):
-    cerfa_field = {0: u"5NX",
-        1: u"5OX",
-        2: u"5PX", }
+    cerfa_field = {0: "5NX",
+        1: "5OX",
+        2: "5PX", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values industrielles et commerciales non professionnelles imposables: plus-values nettes à court terme (régime micro entreprise)"
+    label = "Plus-values industrielles et commerciales non professionnelles imposables: plus-values nettes à court terme (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5hv, f5iv, f5jv))
 class mbnc_pvct(Variable):
-    cerfa_field = {0: u"5HV",
-        1: u"5IV",
-        2: u"5JV", }
+    cerfa_field = {0: "5HV",
+        1: "5IV",
+        2: "5JV", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values non commerciales professionnelles imposables et Plus-values nettes à court terme (régime déclaratif spécial ou micro BNC)"
+    label = "Plus-values non commerciales professionnelles imposables et Plus-values nettes à court terme (régime déclaratif spécial ou micro BNC)"
     definition_period = YEAR
 
 
 # (f5ky, f5ly, f5my))
 class mncn_pvct(Variable):
-    cerfa_field = {0: u"5KY",
-        1: u"5LY",
-        2: u"5MY", }
+    cerfa_field = {0: "5KY",
+        1: "5LY",
+        2: "5MY", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values non commerciales non professionnelles imposables et plus-values nettes à court terme (régime déclaratif spécial ou micro BNC)"
+    label = "Plus-values non commerciales non professionnelles imposables et plus-values nettes à court terme (régime déclaratif spécial ou micro BNC)"
     definition_period = YEAR
 
 
 # (f5kr, f5lr, f5mr))
 class mbic_mvlt(Variable):
-    cerfa_field = {0: u"5KR",
-        1: u"5LR",
-        2: u"5MR", }
+    cerfa_field = {0: "5KR",
+        1: "5LR",
+        2: "5MR", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Moins-values industrielles et commerciales professionnels à long terme (régime micro entreprise)"
+    label = "Moins-values industrielles et commerciales professionnels à long terme (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5nr, f5or, f5pr))
 class macc_mvlt(Variable):
-    cerfa_field = {0: u"5NR",
-        1: u"5OR",
-        2: u"5PR", }
+    cerfa_field = {0: "5NR",
+        1: "5OR",
+        2: "5PR", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Moins-values industrielles et commerciales non professionnelles à long terme (régime micro entreprise)"
+    label = "Moins-values industrielles et commerciales non professionnelles à long terme (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5kw, f5lw, f5mw))
 class mncn_mvlt(Variable):
-    cerfa_field = {0: u"5KW",
-        1: u"5LW",
-        2: u"5MW", }
+    cerfa_field = {0: "5KW",
+        1: "5LW",
+        2: "5MW", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Moins-values non commerciales non professionnelles à long terme (régime déclaratif spécial ou micro BNC)"
+    label = "Moins-values non commerciales non professionnelles à long terme (régime déclaratif spécial ou micro BNC)"
     definition_period = YEAR
 
 
 # (f5hs, f5is, f5js))
 class mbnc_mvlt(Variable):
-    cerfa_field = {0: u"5HS",
-        1: u"5IS",
-        2: u"5JS", }
+    cerfa_field = {0: "5HS",
+        1: "5IS",
+        2: "5JS", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Moins-values non commerciales professionnelles à long terme (régime déclaratif spécial ou micro BNC)"
+    label = "Moins-values non commerciales professionnelles à long terme (régime déclaratif spécial ou micro BNC)"
     definition_period = YEAR
 
 
 # (f5hx, f5ix, f5jx))
 class frag_pvce(Variable):
-    cerfa_field = {0: u"5HX",
-        1: u"5IX",
-        2: u"5JX", }
+    cerfa_field = {0: "5HX",
+        1: "5IX",
+        2: "5JX", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values agricoles de cession (régime du forfait)"
+    label = "Plus-values agricoles de cession (régime du forfait)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 # (f5he, f5ie, f5je))
 class arag_pvce(Variable):
-    cerfa_field = {0: u"5HE",
-        1: u"5IE",
-        2: u"5JE", }
+    cerfa_field = {0: "5HE",
+        1: "5IE",
+        2: "5JE", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values agricoles de cession taxables à 16% (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
+    label = "Plus-values agricoles de cession taxables à 16% (Régime du bénéfice réel, revenus bénéficiant de l'abattement CGA ou viseur)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 # TODO: vérif <=2012))  # (f5hk, f5lk, f5jk) codent autre chose sur d'autres années),
 class nrag_pvce(Variable):
-    cerfa_field = {0: u"5HK",
-        1: u"5LK",
-        2: u"5JK", }
+    cerfa_field = {0: "5HK",
+        1: "5LK",
+        2: "5JK", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values agricoles de cession taxables à 16% (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
+    label = "Plus-values agricoles de cession taxables à 16% (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
     end = '2006-12-31'
     definition_period = YEAR
 
 
 # (f5kq, f5lq, f5mq))
 class mbic_pvce(Variable):
-    cerfa_field = {0: u"5KQ",
-        1: u"5LQ",
-        2: u"5MQ", }
+    cerfa_field = {0: "5KQ",
+        1: "5LQ",
+        2: "5MQ", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values industrielles et commerciales professionnelles imposables: plus-values de cession taxables à 16% (régime micro entreprise)"
+    label = "Plus-values industrielles et commerciales professionnelles imposables: plus-values de cession taxables à 16% (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5ke, f5le, f5me))
 class abic_pvce(Variable):
-    cerfa_field = {0: u"5KE",
-        1: u"5LE",
-        2: u"5ME", }
+    cerfa_field = {0: "5KE",
+        1: "5LE",
+        2: "5ME", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values industrielles et commerciales de cession taxables à 16% avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Plus-values industrielles et commerciales de cession taxables à 16% avec CGA ou viseur (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5kk, f5ik, f5mk)) TODO: autre 5KK 2005/20006
 class nbic_pvce(Variable):
-    cerfa_field = {0: u"5IK",
-        1: u"5KK",
-        2: u"5MK", }
+    cerfa_field = {0: "5IK",
+        1: "5KK",
+        2: "5MK", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus non commerciaux non professionnels exonérés sans AA (régime de la déclaration controlée)"
+    label = "Revenus non commerciaux non professionnels exonérés sans AA (régime de la déclaration controlée)"
     # start_date = date(2008, 1, 1)
     definition_period = YEAR
 
 
 # (f5nq, f5oq, f5pq))
 class macc_pvce(Variable):
-    cerfa_field = {0: u"5NQ",
-        1: u"5OQ",
-        2: u"5PQ", }
+    cerfa_field = {0: "5NQ",
+        1: "5OQ",
+        2: "5PQ", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values industrielles et commerciales non professionnelles imposables: plus-values de cession taxables à 16% (régime micro entreprise)"
+    label = "Plus-values industrielles et commerciales non professionnelles imposables: plus-values de cession taxables à 16% (régime micro entreprise)"
     definition_period = YEAR
 
 
 # (f5ne, f5oe, f5pe))
 class aacc_pvce(Variable):
-    cerfa_field = {0: u"5NE",
-        1: u"5OE",
-        2: u"5PE", }
+    cerfa_field = {0: "5NE",
+        1: "5OE",
+        2: "5PE", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values industrielles et commerciales non professionnelles de cession taxables à 16% avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Plus-values industrielles et commerciales non professionnelles de cession taxables à 16% avec CGA ou viseur (régime du bénéfice réel)"
     definition_period = YEAR
 
 
 # (f5nk, f5ok, f5pk)) TODO: 5NK 2005/2006
 class nacc_pvce(Variable):
-    cerfa_field = {0: u"5NK",
-        1: u"5OK",
-        2: u"5PK", }
+    cerfa_field = {0: "5NK",
+        1: "5OK",
+        2: "5PK", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Locations meublées non professionnelles: Revenus imposables sans CGA (régime du bénéfice réel)"
+    label = "Locations meublées non professionnelles: Revenus imposables sans CGA (régime du bénéfice réel)"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 # (f5kv, f5lv, f5mv))
 class mncn_pvce(Variable):
-    cerfa_field = {0: u"5KV",
-        1: u"5LV",
-        2: u"5MV", }
+    cerfa_field = {0: "5KV",
+        1: "5LV",
+        2: "5MV", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values non commerciales non professionnelles de cession taxables à 16% (régime déclaratif spécial ou micro BNC)"
+    label = "Plus-values non commerciales non professionnelles de cession taxables à 16% (régime déclaratif spécial ou micro BNC)"
     definition_period = YEAR
 
 
 # (f5so, f5nt, f5ot))
 class cncn_pvce(Variable):
-    cerfa_field = {0: u"5SO",
-        1: u"5NT",
-        2: u"5OT", }
+    cerfa_field = {0: "5SO",
+        1: "5NT",
+        2: "5OT", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values non commerciales non professionnelles taxables à 16% avec AA ou viseur (régime de la déclaration controlée)"
+    label = "Plus-values non commerciales non professionnelles taxables à 16% avec AA ou viseur (régime de la déclaration controlée)"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 # (f5hr, f5ir, f5jr))
 class mbnc_pvce(Variable):
-    cerfa_field = {0: u"5HR",
-        1: u"5IR",
-        2: u"5JR", }
+    cerfa_field = {0: "5HR",
+        1: "5IR",
+        2: "5JR", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values non commerciales professionnelles de cession taxables à 16% (régime déclaratif spécial ou micro BNC)"
+    label = "Plus-values non commerciales professionnelles de cession taxables à 16% (régime déclaratif spécial ou micro BNC)"
     definition_period = YEAR
 
 
 # (f5qd, f5rd, f5sd))
 class abnc_pvce(Variable):
-    cerfa_field = {0: u"5QD",
-        1: u"5RD",
-        2: u"5SD", }
+    cerfa_field = {0: "5QD",
+        1: "5RD",
+        2: "5SD", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Plus-values non commerciaux professionnels de cession taxables à 16% (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
+    label = "Plus-values non commerciaux professionnels de cession taxables à 16% (régime de la déclaration controlée, revenus bénéficiant de l'abattement association agrée ou viseur)"
     definition_period = YEAR
 
 
 # (f5qj, f5rj, f5sj)) #TODO 5*J 2005/2006 (qui se transforme en 5*D...)
 class nbnc_pvce(Variable):
-    cerfa_field = {0: u"5QJ",
-        1: u"5RJ",
-        2: u"5SJ", }
+    cerfa_field = {0: "5QJ",
+        1: "5RJ",
+        2: "5SJ", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits industriels et commerciaux: locations meublées sans CGA (régime du bénéfice réel)"
+    label = "Déficits industriels et commerciaux: locations meublées sans CGA (régime du bénéfice réel)"
     # start_date = date(2009, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class frag_fore(Variable):
-    cerfa_field = {0: u"5HD",
-        1: u"5ID",
-        2: u"5JD", }
+    cerfa_field = {0: "5HD",
+        1: "5ID",
+        2: "5JD", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus des exploitants forestiers (régime du forfait)"
+    label = "Revenus des exploitants forestiers (régime du forfait)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class arag_sjag(Variable):
-    cerfa_field = {0: u"5HZ",
-        1: u"5IZ",
-        2: u"5JZ", }
+    cerfa_field = {0: "5HZ",
+        1: "5IZ",
+        2: "5JZ", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Abattement pour les jeunes agriculteurs des revenus agricoles sans CGA (régime du bénéfice réel)"
+    label = "Abattement pour les jeunes agriculteurs des revenus agricoles sans CGA (régime du bénéfice réel)"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class abic_impm(Variable):
-    cerfa_field = {0: u"5HA",
-        1: u"5IA",
-        2: u"5JA", }
+    cerfa_field = {0: "5HA",
+        1: "5IA",
+        2: "5JA", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Locations meublées imposables avec CGA ou viseur (régime du bénéfice réel pour les revenus industriels et commerciaux professionnels)"
+    label = "Locations meublées imposables avec CGA ou viseur (régime du bénéfice réel pour les revenus industriels et commerciaux professionnels)"
     # start_date = date(2009, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class nbic_impm(Variable):
-    cerfa_field = {0: u"5KA",
-        1: u"5LA",
-        2: u"5MA", }
+    cerfa_field = {0: "5KA",
+        1: "5LA",
+        2: "5MA", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Locations meublées imposables sans CGA (régime du bénéfice réel)"
+    label = "Locations meublées imposables sans CGA (régime du bénéfice réel)"
     # start_date = date(2009, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class abic_defm(Variable):
-    cerfa_field = {0: u"5QA",
-        1: u"5RA",
-        2: u"5SA", }
+    cerfa_field = {0: "5QA",
+        1: "5RA",
+        2: "5SA", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits de locations meubléesavec CGA ou viseur (régime du bénéfice réel pour les revenus industriels et commerciaux professionnels)"
+    label = "Déficits de locations meubléesavec CGA ou viseur (régime du bénéfice réel pour les revenus industriels et commerciaux professionnels)"
     # start_date = date(2009, 1, 1)
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class alnp_imps(Variable):
-    cerfa_field = {0: u"5NA",
-        1: u"5OA",
-        2: u"5PA", }
+    cerfa_field = {0: "5NA",
+        1: "5OA",
+        2: "5PA", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Locations meublées non professionnelles imposables avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Locations meublées non professionnelles imposables avec CGA ou viseur (régime du bénéfice réel)"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class alnp_defs(Variable):
-    cerfa_field = {0: u"5NY",
-        1: u"5OY",
-        2: u"5PY", }
+    cerfa_field = {0: "5NY",
+        1: "5OY",
+        2: "5PY", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits de locations meublées non professionnelles avec CGA ou viseur (régime du bénéfice réel)"
+    label = "Déficits de locations meublées non professionnelles avec CGA ou viseur (régime du bénéfice réel)"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class nlnp_defs(Variable):
-    cerfa_field = {0: u"5NZ",
-        1: u"5OZ",
-        2: u"5PZ", }
+    cerfa_field = {0: "5NZ",
+        1: "5OZ",
+        2: "5PZ", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits de locations meublées non professionnelles imposables sans CGA (régime du bénéfice réel)"
+    label = "Déficits de locations meublées non professionnelles imposables sans CGA (régime du bénéfice réel)"
     # start_date = date(2009, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class abnc_proc(Variable):
-    cerfa_field = {0: u"5TF",
-        1: u"5UF",
-        2: u"5VF", }
+    cerfa_field = {0: "5TF",
+        1: "5UF",
+        2: "5VF", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Honoraires de prospection commerciale exonérés avec CGA ou viseur (revenus non commerciaux professionnels, régime de la déclaration contrôlée)"
+    label = "Honoraires de prospection commerciale exonérés avec CGA ou viseur (revenus non commerciaux professionnels, régime de la déclaration contrôlée)"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class nbnc_proc(Variable):
-    cerfa_field = {0: u"5TI",
-        1: u"5UI",
-        2: u"5VI", }
+    cerfa_field = {0: "5TI",
+        1: "5UI",
+        2: "5VI", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Honoraires de prospection commerciale exonérés sans CGA (revenus non commerciaux professionnels, régime de la déclaration contrôlée)"
+    label = "Honoraires de prospection commerciale exonérés sans CGA (revenus non commerciaux professionnels, régime de la déclaration contrôlée)"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class mncn_exon(Variable):
-    cerfa_field = {0: u"5TH",
-        1: u"5UH",
-        2: u"5VH", }
+    cerfa_field = {0: "5TH",
+        1: "5UH",
+        2: "5VH", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus nets exonérés non commerciaux non professionnels (régime déclaratif spécial ou micro BNC)"
+    label = "Revenus nets exonérés non commerciaux non professionnels (régime déclaratif spécial ou micro BNC)"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class cncn_exon(Variable):
-    cerfa_field = {0: u"5HK",
-        1: u"5JK",
-        2: u"5LK", }
+    cerfa_field = {0: "5HK",
+        1: "5JK",
+        2: "5LK", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus nets exonérés non commerciaux non professionnels (régime de la déclaration contrôlée)"
+    label = "Revenus nets exonérés non commerciaux non professionnels (régime de la déclaration contrôlée)"
     # start_date = date(2008, 1, 1)
     definition_period = YEAR
 
 
 class cncn_aimp(Variable):
-    cerfa_field = {0: u"5JG",
-        1: u"5RF",
-        2: u"5SF", }
+    cerfa_field = {0: "5JG",
+        1: "5RF",
+        2: "5SF", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus imposables non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
+    label = "Revenus imposables non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class cncn_adef(Variable):
-    cerfa_field = {0: u"5JJ",
-        1: u"5RG",
-        2: u"5SG", }
+    cerfa_field = {0: "5JJ",
+        1: "5RG",
+        2: "5SG", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Déficits non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
+    label = "Déficits non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class cncn_info(Variable):
-    cerfa_field = {0: u"5TC",
-        1: u"5UC",
-        2: u"5VC", }
+    cerfa_field = {0: "5TC",
+        1: "5UC",
+        2: "5VC", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Inventeurs et auteurs de logiciels : produits taxables à 16%, revenus non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
+    label = "Inventeurs et auteurs de logiciels : produits taxables à 16%, revenus non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class cncn_jcre(Variable):
-    cerfa_field = {0: u"5SV",
-        1: u"5SW",
-        2: u"5SX", }
+    cerfa_field = {0: "5SV",
+        1: "5SW",
+        2: "5SX", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Jeunes créateurs : abattement de 50%, revenus non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
+    label = "Jeunes créateurs : abattement de 50%, revenus non commerciaux non professionnels avec CGA (régime de la déclaration contrôlée)"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 class revimpres(Variable):
-    cerfa_field = {0: u"5HY",
-        1: u"5IY",
-        2: u"5JY", }
+    cerfa_field = {0: "5HY",
+        1: "5IY",
+        2: "5JY", }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Revenus nets à imposer aux prélèvements sociaux"
+    label = "Revenus nets à imposer aux prélèvements sociaux"
     definition_period = YEAR
 
 
 class pveximpres(Variable):
-    cerfa_field = {0: u"5HG",
-        1: u"5IG", }
+    cerfa_field = {0: "5HG",
+        1: "5IG", }
     value_type = int
     entity = Individu
-    label = u"Plus-values à long terme exonérées en cas de départ à la retraite à imposer aux prélèvements sociaux"
+    label = "Plus-values à long terme exonérées en cas de départ à la retraite à imposer aux prélèvements sociaux"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 class pvtaimpres(Variable):
-    cerfa_field = {0: u"5HZ",
-        1: u"5IZ",
-        2: u"5JZ", }
+    cerfa_field = {0: "5HZ",
+        1: "5IZ",
+        2: "5JZ", }
     value_type = int
     entity = Individu
-    label = u"Plus-values à long terme taxables à 16% à la retraite à imposer aux prélèvements sociaux"
+    label = "Plus-values à long terme taxables à 16% à la retraite à imposer aux prélèvements sociaux"
     end = '2009-12-31'
     definition_period = YEAR
 
 
 class f5qf(Variable):
-    cerfa_field = u"5QF"
+    cerfa_field = "5QF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-6)"
+    label = "Déficits des revenus agricoles des années antérieures non encore déduits (n-6)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f5qg(Variable):
-    cerfa_field = u"5QG"
+    cerfa_field = "5QG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-5)"
+    label = "Déficits des revenus agricoles des années antérieures non encore déduits (n-5)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f5qn(Variable):
-    cerfa_field = u"5QN"
+    cerfa_field = "5QN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-4)"
+    label = "Déficits des revenus agricoles des années antérieures non encore déduits (n-4)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f5qo(Variable):
-    cerfa_field = u"5QO"
+    cerfa_field = "5QO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-3)"
+    label = "Déficits des revenus agricoles des années antérieures non encore déduits (n-3)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f5qp(Variable):
-    cerfa_field = u"5QP"
+    cerfa_field = "5QP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-2)"
+    label = "Déficits des revenus agricoles des années antérieures non encore déduits (n-2)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f5qq(Variable):
-    cerfa_field = u"5QQ"
+    cerfa_field = "5QQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus agricoles des années antérieures non encore déduits (n-1)"
+    label = "Déficits des revenus agricoles des années antérieures non encore déduits (n-1)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f5ga(Variable):
-    cerfa_field = u"5GA"
+    cerfa_field = "5GA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-10)"
+    label = "Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-10)"
     # start_date = date(2010, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f5gb(Variable):
-    cerfa_field = u"5GB"
+    cerfa_field = "5GB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-9)"
+    label = "Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-9)"
     # start_date = date(2010, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f5gc(Variable):
-    cerfa_field = u"5GC"
+    cerfa_field = "5GC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-8)"
+    label = "Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-8)"
     # start_date = date(2010, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f5gd(Variable):
-    cerfa_field = u"5GD"
+    cerfa_field = "5GD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-7)"
+    label = "Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-7)"
     # start_date = date(2010, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f5ge(Variable):
-    cerfa_field = u"5GE"
+    cerfa_field = "5GE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-6)"
+    label = "Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-6)"
     # start_date = date(2010, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f5gf(Variable):
-    cerfa_field = u"5GF"
+    cerfa_field = "5GF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-5)"
+    label = "Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-5)"
     # start_date = date(2010, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f5gg(Variable):
-    cerfa_field = u"5GG"
+    cerfa_field = "5GG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-4)"
+    label = "Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-4)"
     # start_date = date(2010, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f5gh(Variable):
-    cerfa_field = u"5GH"
+    cerfa_field = "5GH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-3)"
+    label = "Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-3)"
     # start_date = date(2010, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f5gi(Variable):
-    cerfa_field = u"5GI"
+    cerfa_field = "5GI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-2)"
+    label = "Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-2)"
     # start_date = date(2010, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f5gj(Variable):
-    cerfa_field = u"5GJ"
+    cerfa_field = "5GJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-1)"
+    label = "Déficits des revenus de locations meublées non professionnelles années antérieures non encore déduits (n-1)"
     # start_date = date(2010, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f5rn(Variable):
-    cerfa_field = u"5RN"
+    cerfa_field = "5RN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-6)"
+    label = "Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-6)"
     # start_date = date(2010, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f5ro(Variable):
-    cerfa_field = u"5RO"
+    cerfa_field = "5RO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-5)"
+    label = "Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-5)"
     definition_period = YEAR
 
 
 class f5rp(Variable):
-    cerfa_field = u"5RP"
+    cerfa_field = "5RP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-4)"
+    label = "Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-4)"
     definition_period = YEAR
 
 
 class f5rq(Variable):
-    cerfa_field = u"5RQ"
+    cerfa_field = "5RQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-3)"
+    label = "Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-3)"
     definition_period = YEAR
 
 
 class f5rr(Variable):
-    cerfa_field = u"5RR"
+    cerfa_field = "5RR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-2)"
+    label = "Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-2)"
     definition_period = YEAR
 
 
 class f5rw(Variable):
-    cerfa_field = u"5RW"
+    cerfa_field = "5RW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-1)"
+    label = "Déficits des revenus industriels et commerciaux non professionnelles années antérieures non encore déduits (n-1)"
     definition_period = YEAR
 
 
 class f5ht(Variable):
-    cerfa_field = u"5HT"
+    cerfa_field = "5HT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-6)"
+    label = "Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-6)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f5it(Variable):
-    cerfa_field = u"5IT"
+    cerfa_field = "5IT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-5)"
+    label = "Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-5)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f5jt(Variable):
-    cerfa_field = u"5JT"
+    cerfa_field = "5JT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-4)"
+    label = "Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-4)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f5kt(Variable):
-    cerfa_field = u"5KT"
+    cerfa_field = "5KT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-3)"
+    label = "Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-3)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f5lt(Variable):
-    cerfa_field = u"5LT"
+    cerfa_field = "5LT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-2)"
+    label = "Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-2)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f5mt(Variable):
-    cerfa_field = u"5MT"
+    cerfa_field = "5MT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-1)"
+    label = "Déficits des revenus non commerciaux non professionnelles années antérieures non encore déduits (n-1)"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f5sq(Variable):
-    cerfa_field = u"5SQ"
+    cerfa_field = "5SQ"
     value_type = int
     entity = Individu
     definition_period = YEAR
-    label = u"Déficits des années antérieures non encore déduits"
+    label = "Déficits des années antérieures non encore déduits"
     end = '2006-12-31'
 
 
@@ -1599,7 +1599,7 @@ class tns_auto_entrepreneur_chiffre_affaires(Variable):
     value_type = float
     entity = Individu
     set_input = set_input_divide_by_period
-    label = u"Chiffre d'affaires en tant qu'auto-entrepreneur"
+    label = "Chiffre d'affaires en tant qu'auto-entrepreneur"
     definition_period = MONTH
 
 
@@ -1609,15 +1609,15 @@ class tns_auto_entrepreneur_chiffre_affaires(Variable):
 class tns_micro_entreprise_chiffre_affaires(Variable):
     value_type = float
     entity = Individu
-    label = u"Chiffre d'affaires en de micro-entreprise"
+    label = "Chiffre d'affaires en de micro-entreprise"
     definition_period = YEAR
 
 
 class TypesTnsTypeActivite(Enum):
     __order__ = 'achat_revente bic bnc'  # Needed to preserve the enum order in Python 2
-    achat_revente = u'achat_revente'
-    bic = u'bic'
-    bnc = u'bnc'
+    achat_revente = 'achat_revente'
+    bic = 'bic'
+    bnc = 'bnc'
 
 
 # TODO remove this ugly ETERNITY
@@ -1626,7 +1626,7 @@ class tns_auto_entrepreneur_type_activite(Variable):
     possible_values = TypesTnsTypeActivite
     default_value = TypesTnsTypeActivite.achat_revente
     entity = Individu
-    label = u"Type d'activité de l'auto-entrepreneur"
+    label = "Type d'activité de l'auto-entrepreneur"
     definition_period = ETERNITY
 
 
@@ -1636,7 +1636,7 @@ class tns_micro_entreprise_type_activite(Variable):
     possible_values = TypesTnsTypeActivite
     default_value = TypesTnsTypeActivite.achat_revente
     entity = Individu
-    label = u"Type d'activité de la micro-entreprise"
+    label = "Type d'activité de la micro-entreprise"
     definition_period = ETERNITY
 
 
@@ -1644,7 +1644,7 @@ class tns_micro_entreprise_type_activite(Variable):
 class tns_autres_revenus(Variable):
     value_type = float
     entity = Individu
-    label = u"Autres revenus non salariés"
+    label = "Autres revenus non salariés"
     definition_period = YEAR
 
 
@@ -1652,7 +1652,7 @@ class tns_autres_revenus_chiffre_affaires(Variable):
     value_type = float
     entity = Individu
     set_input = set_input_divide_by_period
-    label = u"Chiffre d'affaire pour les TNS non agricoles autres que les AE et ME"
+    label = "Chiffre d'affaire pour les TNS non agricoles autres que les AE et ME"
     definition_period = MONTH
 
 
@@ -1661,7 +1661,7 @@ class tns_autres_revenus_type_activite(Variable):
     possible_values = TypesTnsTypeActivite
     default_value = TypesTnsTypeActivite.achat_revente
     entity = Individu
-    label = u"Type d'activité de l'entreprise non AE ni ME"
+    label = "Type d'activité de l'entreprise non AE ni ME"
     definition_period = MONTH
 
 
@@ -1669,7 +1669,7 @@ class tns_avec_employe(Variable):
     value_type = bool
     entity = Individu
     set_input = set_input_dispatch_by_period
-    label = u"Le TNS a au moins un employé. Ne s'applique pas pour les agricoles ni auto-entrepreneurs ni micro entreprise"
+    label = "Le TNS a au moins un employé. Ne s'applique pas pour les agricoles ni auto-entrepreneurs ni micro entreprise"
     definition_period = MONTH
 
 
@@ -1679,7 +1679,7 @@ class tns_avec_employe(Variable):
 class tns_benefice_exploitant_agricole(Variable):
     value_type = float
     entity = Individu
-    label = u"Dernier bénéfice agricole"
+    label = "Dernier bénéfice agricole"
     definition_period = YEAR
 
 
@@ -1687,7 +1687,7 @@ class tns_benefice_exploitant_agricole(Variable):
 
 
 class travailleur_non_salarie(Variable):
-    label = u"L'individu a une activité professionnelle non salariée"
+    label = "L'individu a une activité professionnelle non salariée"
     value_type = bool
     entity = Individu
     definition_period = MONTH
@@ -1726,7 +1726,7 @@ def compute_benefice_auto_entrepreneur_micro_entreprise(bareme, type_activite, c
 
 class tns_auto_entrepreneur_benefice(Variable):
     value_type = float
-    label = u"Bénéfice en tant qu'auto-entrepreneur"
+    label = "Bénéfice en tant qu'auto-entrepreneur"
     entity = Individu
     definition_period = MONTH
 
@@ -1742,7 +1742,7 @@ class tns_auto_entrepreneur_benefice(Variable):
 
 class tns_micro_entreprise_benefice(Variable):
     value_type = float
-    label = u"Bénéfice de la micro entreprise"
+    label = "Bénéfice de la micro entreprise"
     entity = Individu
     definition_period = YEAR
 
@@ -1764,7 +1764,7 @@ class tns_micro_entreprise_benefice(Variable):
 
 class tns_auto_entrepreneur_revenus_net(Variable):
     value_type = float
-    label = u"Revenu d'un auto-entrepreneur"
+    label = "Revenu d'un auto-entrepreneur"
     entity = Individu
     definition_period = MONTH
 
@@ -1786,7 +1786,7 @@ class tns_auto_entrepreneur_revenus_net(Variable):
 
 class tns_micro_entreprise_revenus_net(Variable):
     value_type = float
-    label = u"Revenu d'un TNS dans une micro-entreprise"
+    label = "Revenu d'un TNS dans une micro-entreprise"
     entity = Individu
     definition_period = MONTH
 

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -8,7 +8,7 @@ from openfisca_france.model.base import *
 class indemnites_stage(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnités de stage"
+    label = "Indemnités de stage"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -16,7 +16,7 @@ class indemnites_stage(Variable):
 class revenus_stage_formation_pro(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenus de stage de formation professionnelle"
+    label = "Revenus de stage de formation professionnelle"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -24,52 +24,52 @@ class revenus_stage_formation_pro(Variable):
 class bourse_recherche(Variable):
     value_type = float
     entity = Individu
-    label = u"Bourse de recherche"
+    label = "Bourse de recherche"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
 
 class sal_pen_exo_etr(Variable):
     cerfa_field = {
-        0: u"1AC",
-        1: u"1BC",
-        2: u"1CC",
-        3: u"1DC",
+        0: "1AC",
+        1: "1BC",
+        2: "1CC",
+        3: "1DC",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Salaires et pensions exonérés de source étrangère retenus pour le calcul du taux effectif"
+    label = "Salaires et pensions exonérés de source étrangère retenus pour le calcul du taux effectif"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class frais_reels(Variable):
     cerfa_field = {
-        0: u"1AK",
-        1: u"1BK",
-        2: u"1CK",
-        3: u"1DK",
-        4: u"1EK",
+        0: "1AK",
+        1: "1BK",
+        2: "1CK",
+        3: "1DK",
+        4: "1EK",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Frais réels"
+    label = "Frais réels"
     definition_period = YEAR
 
 
 class hsup(Variable):
     cerfa_field = {
-        0: u"1AU",
-        1: u"1BU",
-        2: u"1CU",
-        3: u"1DU",
+        0: "1AU",
+        1: "1BU",
+        2: "1CU",
+        3: "1DU",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Heures supplémentaires : revenus exonérés connus"
+    label = "Heures supplémentaires : revenus exonérés connus"
     # start_date = date(2007, 1, 1)
     end = '2013-12-13'
     definition_period = MONTH
@@ -79,15 +79,15 @@ class hsup(Variable):
 
 class ppe_du_sa(Variable):
     cerfa_field = {
-        0: u"1AV",
-        1: u"1BV",
-        2: u"1CV",
-        3: u"1DV",
-        4: u"1QV",
+        0: "1AV",
+        1: "1BV",
+        2: "1CV",
+        3: "1DV",
+        4: "1QV",
         }
     value_type = int
     entity = Individu
-    label = u"Prime pour l'emploi des salariés: nombre d'heures payées"
+    label = "Prime pour l'emploi des salariés: nombre d'heures payées"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -107,15 +107,15 @@ class ppe_du_sa(Variable):
 
 class ppe_tp_sa(Variable):
     cerfa_field = {
-        0: u"1AX",
-        1: u"1BX",
-        2: u"1CX",
-        3: u"1DX",
-        4: u"1QX",
+        0: "1AX",
+        1: "1BX",
+        2: "1CX",
+        3: "1DX",
+        4: "1QX",
         }
     value_type = bool
     entity = Individu
-    label = u"Prime pour l'emploi des salariés: indicateur de travail à temps plein sur l'année entière"
+    label = "Prime pour l'emploi des salariés: indicateur de travail à temps plein sur l'année entière"
     definition_period = YEAR
 
     def formula(individu, period):
@@ -131,10 +131,10 @@ class ppe_tp_sa(Variable):
 
 class TypesExpositionAccident(Enum):
     __order__ = 'faible moyen eleve tres_eleve'  # Needed to preserve the enum order in Python 2
-    faible = u"Faible"
-    moyen = u"Moyen"
-    eleve = u"Élevé"
-    tres_eleve = u"Très élevé"
+    faible = "Faible"
+    moyen = "Moyen"
+    eleve = "Élevé"
+    tres_eleve = "Très élevé"
 
 
 class exposition_accident(Variable):
@@ -142,16 +142,16 @@ class exposition_accident(Variable):
     possible_values = TypesExpositionAccident
     default_value = TypesExpositionAccident.faible
     entity = Individu
-    label = u"Exposition au risque pour les accidents du travail"
+    label = "Exposition au risque pour les accidents du travail"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
 
 class TypesExpositionPenibilite(Enum):
     __order__ = 'nulle simple multiple'  # Needed to preserve the enum order in Python 2
-    nulle = u"Nulle, pas d'exposition de l'employé à un facteur de pénibilité"
-    simple = u"Simple, exposition à un seul facteur de pénibilité"
-    multiple = u"Multiple, exposition à plusieurs facteurs de pénibilité"
+    nulle = "Nulle, pas d'exposition de l'employé à un facteur de pénibilité"
+    simple = "Simple, exposition à un seul facteur de pénibilité"
+    multiple = "Multiple, exposition à plusieurs facteurs de pénibilité"
 
 
 class exposition_penibilite(Variable):
@@ -159,16 +159,16 @@ class exposition_penibilite(Variable):
     possible_values = TypesExpositionPenibilite
     default_value = TypesExpositionPenibilite.nulle
     entity = Individu
-    label = u"Exposition à un ou plusieurs facteurs de pénibilité"
+    label = "Exposition à un ou plusieurs facteurs de pénibilité"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
 
 class TypesAllegementModeRecouvrement(Enum):
     __order__ = 'fin_d_annee anticipe progressif'  # Needed to preserve the enum order in Python 2
-    fin_d_annee = u"fin_d_annee"
-    anticipe = u"anticipe_regularisation_fin_de_periode"
-    progressif = u"progressif"
+    fin_d_annee = "fin_d_annee"
+    anticipe = "anticipe_regularisation_fin_de_periode"
+    progressif = "progressif"
 
 
 class allegement_fillon_mode_recouvrement(Variable):
@@ -176,7 +176,7 @@ class allegement_fillon_mode_recouvrement(Variable):
     possible_values = TypesAllegementModeRecouvrement
     default_value = TypesAllegementModeRecouvrement.fin_d_annee
     entity = Individu
-    label = u"Mode de recouvrement des allègements Fillon"
+    label = "Mode de recouvrement des allègements Fillon"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -186,7 +186,7 @@ class allegement_cotisation_allocations_familiales_mode_recouvrement(Variable):
     possible_values = TypesAllegementModeRecouvrement
     default_value = TypesAllegementModeRecouvrement.fin_d_annee
     entity = Individu
-    label = u"Mode de recouvrement de l'allègement de la cotisation d'allocations familiales"
+    label = "Mode de recouvrement de l'allègement de la cotisation d'allocations familiales"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -194,7 +194,7 @@ class allegement_cotisation_allocations_familiales_mode_recouvrement(Variable):
 class apprentissage_contrat_debut(Variable):
     value_type = date
     entity = Individu
-    label = u"Date de début du contrat d'apprentissage"
+    label = "Date de début du contrat d'apprentissage"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -202,7 +202,7 @@ class apprentissage_contrat_debut(Variable):
 class arrco_tranche_a_taux_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Taux ARRCO tranche A employeur) propre à l'entreprise"
+    label = "Taux ARRCO tranche A employeur) propre à l'entreprise"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -210,7 +210,7 @@ class arrco_tranche_a_taux_employeur(Variable):
 class arrco_tranche_a_taux_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Taux ARRCO tranche A salarié) propre à l'entreprise"
+    label = "Taux ARRCO tranche A salarié) propre à l'entreprise"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -218,7 +218,7 @@ class arrco_tranche_a_taux_salarie(Variable):
 class assujettie_taxe_salaires(Variable):
     value_type = bool
     entity = Individu
-    label = u"Entreprise assujettie à la taxe sur les salaires"
+    label = "Entreprise assujettie à la taxe sur les salaires"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -226,33 +226,33 @@ class assujettie_taxe_salaires(Variable):
 class avantage_en_nature_valeur_reelle(Variable):
     value_type = float
     entity = Individu
-    label = u"Avantages en nature (Valeur réelle)"
+    label = "Avantages en nature (Valeur réelle)"
     definition_period = MONTH
 
 
 class indemnites_compensatrices_conges_payes(Variable):
     value_type = float
     entity = Individu
-    label = u"indemnites_compensatrices_conges_payes"
+    label = "indemnites_compensatrices_conges_payes"
     definition_period = MONTH
 
 
 class indemnite_fin_contrat_due(Variable):
     value_type = bool
     entity = Individu
-    label = u"indemnite_fin_contrat_due"
+    label = "indemnite_fin_contrat_due"
     definition_period = MONTH
 
 
 class TypesContratDeTravail(Enum):
     __order__ = 'temps_plein temps_partiel forfait_heures_semaines forfait_heures_mois forfait_heures_annee forfait_jours_annee sans_objet'  # Needed to preserve the enum order in Python 2
-    temps_plein = u"temps_plein"
-    temps_partiel = u"temps_partiel"
-    forfait_heures_semaines = u"forfait_heures_semaines"
-    forfait_heures_mois = u"forfait_heures_mois"
-    forfait_heures_annee = u"forfait_heures_annee"
-    forfait_jours_annee = u"forfait_jours_annee"
-    sans_objet = u"sans_objet"
+    temps_plein = "temps_plein"
+    temps_partiel = "temps_partiel"
+    forfait_heures_semaines = "forfait_heures_semaines"
+    forfait_heures_mois = "forfait_heures_mois"
+    forfait_heures_annee = "forfait_heures_annee"
+    forfait_jours_annee = "forfait_jours_annee"
+    sans_objet = "sans_objet"
 
 
 class contrat_de_travail(Variable):
@@ -260,7 +260,7 @@ class contrat_de_travail(Variable):
     possible_values = TypesContratDeTravail
     default_value = TypesContratDeTravail.temps_plein
     entity = Individu
-    label = u"Type contrat de travail"
+    label = "Type contrat de travail"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -269,7 +269,7 @@ class contrat_de_travail_debut(Variable):
     value_type = date
     default_value = date(1870, 1, 1)
     entity = Individu
-    label = u"Date d'arrivée dans l'entreprise"
+    label = "Date d'arrivée dans l'entreprise"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -278,15 +278,15 @@ class contrat_de_travail_fin(Variable):
     value_type = date
     default_value = date(2099, 12, 31)
     entity = Individu
-    label = u"Date de départ de l'entreprise"
+    label = "Date de départ de l'entreprise"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
 
 class TypesContratDeTravailDuree(Enum):
     __order__ = 'cdi cdd'  # Needed to preserve the enum order in Python 2
-    cdi = u"CDI"
-    cdd = u"CDD"
+    cdi = "CDI"
+    cdd = "CDD"
 
 
 class contrat_de_travail_duree(Variable):
@@ -294,16 +294,16 @@ class contrat_de_travail_duree(Variable):
     possible_values = TypesContratDeTravailDuree
     default_value = TypesContratDeTravailDuree.cdi
     entity = Individu
-    label = u"Type (durée determinée ou indéterminée) du contrat de travail"
+    label = "Type (durée determinée ou indéterminée) du contrat de travail"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
 
 class TypesCotisationSocialeModeRecouvrement(Enum):
     __order__ = 'mensuel annuel mensuel_strict'  # Needed to preserve the enum order in Python 2
-    mensuel = u"Mensuel avec régularisation en fin d'année"
-    annuel = u"Annuel"
-    mensuel_strict = u"Mensuel strict"
+    mensuel = "Mensuel avec régularisation en fin d'année"
+    annuel = "Annuel"
+    mensuel_strict = "Mensuel strict"
 
 
 class cotisation_sociale_mode_recouvrement(Variable):
@@ -311,7 +311,7 @@ class cotisation_sociale_mode_recouvrement(Variable):
     possible_values = TypesCotisationSocialeModeRecouvrement
     default_value = TypesCotisationSocialeModeRecouvrement.mensuel_strict
     entity = Individu
-    label = u"Mode de recouvrement des cotisations sociales"
+    label = "Mode de recouvrement des cotisations sociales"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -319,7 +319,7 @@ class cotisation_sociale_mode_recouvrement(Variable):
 class entreprise_est_association_non_lucrative(Variable):
     value_type = bool
     entity = Individu
-    label = u"L'entreprise est une association à but non lucratif, par exemple loi de 1901"
+    label = "L'entreprise est une association à but non lucratif, par exemple loi de 1901"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -328,7 +328,7 @@ class depcom_entreprise(Variable):
     value_type = str
     max_length = 5
     entity = Individu
-    label = u"Localisation entreprise (depcom)"
+    label = "Localisation entreprise (depcom)"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -337,7 +337,7 @@ class code_postal_entreprise(Variable):
     value_type = str
     max_length = 5
     entity = Individu
-    label = u"Localisation entreprise (Code postal)"
+    label = "Localisation entreprise (Code postal)"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -345,7 +345,7 @@ class code_postal_entreprise(Variable):
 class salarie_regime_alsace_moselle(Variable):
     entity = Individu
     value_type = bool
-    label = u"Le salarié cotise au régime de l'Alsace-Moselle"
+    label = "Le salarié cotise au régime de l'Alsace-Moselle"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
     # Attention : ce n'est pas équivalent au fait de travailler en Alsace-Moselle !
@@ -355,7 +355,7 @@ class salarie_regime_alsace_moselle(Variable):
 class effectif_entreprise(Variable):
     entity = Individu
     value_type = int
-    label = u"Effectif de l'entreprise"
+    label = "Effectif de l'entreprise"
     set_input = set_input_dispatch_by_period
     definition_period = MONTH
 
@@ -363,14 +363,14 @@ class effectif_entreprise(Variable):
 class entreprise_assujettie_cet(Variable):
     value_type = bool
     entity = Individu
-    label = u"Entreprise assujettie à la contribution économique territoriale"
+    label = "Entreprise assujettie à la contribution économique territoriale"
     definition_period = MONTH
 
 
 class entreprise_assujettie_is(Variable):
     value_type = bool
     entity = Individu
-    label = u"Entreprise assujettie à l'impôt sur les sociétés (IS)"
+    label = "Entreprise assujettie à l'impôt sur les sociétés (IS)"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -379,7 +379,7 @@ class entreprise_benefice(Variable):
     value_type = float
     entity = Individu
     set_input = set_input_divide_by_period
-    label = u"Bénéfice de l'entreprise"
+    label = "Bénéfice de l'entreprise"
     definition_period = MONTH
     calculate_output = calculate_output_add
 
@@ -387,21 +387,21 @@ class entreprise_benefice(Variable):
 class entreprise_bilan(Variable):
     value_type = float
     entity = Individu
-    label = u"Bilan de l'entreprise"
+    label = "Bilan de l'entreprise"
     definition_period = MONTH
 
 
 class entreprise_chiffre_affaire(Variable):
     value_type = float
     entity = Individu
-    label = u"Chiffre d'affaire de l'entreprise"
+    label = "Chiffre d'affaire de l'entreprise"
     definition_period = MONTH
 
 
 class entreprise_creation(Variable):
     value_type = date
     entity = Individu
-    label = u"Date de création de l'entreprise"
+    label = "Date de création de l'entreprise"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -409,14 +409,14 @@ class entreprise_creation(Variable):
 class nombre_tickets_restaurant(Variable):
     value_type = int
     entity = Individu
-    label = u"Nombre de tickets restaurant"
+    label = "Nombre de tickets restaurant"
     definition_period = MONTH
 
 
 class nouvelle_bonification_indiciaire(Variable):
     value_type = float
     entity = Individu
-    label = u"Nouvelle bonification indicaire"
+    label = "Nouvelle bonification indicaire"
     definition_period = MONTH
 
 
@@ -424,7 +424,7 @@ class prevoyance_obligatoire_cadre_taux_employe(Variable):
     value_type = float
     default_value = 0.015  # 1.5% est le minimum en 2014
     entity = Individu
-    label = u"Taux de cotisation employeur pour la prévoyance obligatoire des cadres"
+    label = "Taux de cotisation employeur pour la prévoyance obligatoire des cadres"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -433,7 +433,7 @@ class prevoyance_obligatoire_cadre_taux_employeur(Variable):
     value_type = float
     default_value = 0.015  # 1.5% est le minimum en 2014
     entity = Individu
-    label = u"Taux de cotisation employeur pour la prévoyance obligatoire des cadres"
+    label = "Taux de cotisation employeur pour la prévoyance obligatoire des cadres"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -441,14 +441,14 @@ class prevoyance_obligatoire_cadre_taux_employeur(Variable):
 class primes_salaires(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnités, primes et avantages en argent (brut)"
+    label = "Indemnités, primes et avantages en argent (brut)"
     definition_period = MONTH
 
 
 class complementaire_sante_montant(Variable):
     value_type = float
     entity = Individu
-    label = u"Montant de la complémentaire santé obligatoire retenue par l'employeur"
+    label = "Montant de la complémentaire santé obligatoire retenue par l'employeur"
     definition_period = MONTH
 
 
@@ -457,58 +457,58 @@ class complementaire_sante_taux_employeur(Variable):
     default_value = 0.5
     # La part minimum légale est de 50 %
     entity = Individu
-    label = u"Part de la complémentaire santé obligatoire payée par l'employeur"
+    label = "Part de la complémentaire santé obligatoire payée par l'employeur"
     definition_period = MONTH
 
 
 class prise_en_charge_employeur_prevoyance_complementaire(Variable):
     value_type = float
     entity = Individu
-    label = u"Part salariale des cotisations de prévoyance complémentaire prise en charge par l'employeur"
+    label = "Part salariale des cotisations de prévoyance complémentaire prise en charge par l'employeur"
     definition_period = MONTH
 
 
 class prise_en_charge_employeur_retraite_complementaire(Variable):
     value_type = float
     entity = Individu
-    label = u"Part salariale des cotisations de retraite complémentaire prise en charge par l'employeur"
+    label = "Part salariale des cotisations de retraite complémentaire prise en charge par l'employeur"
     definition_period = MONTH
 
 
 class prise_en_charge_employeur_retraite_supplementaire(Variable):
     value_type = float
     entity = Individu
-    label = u"Part salariale des cotisations de retraite supplémentaire prise en charge par l'employeur"
+    label = "Part salariale des cotisations de retraite supplémentaire prise en charge par l'employeur"
     definition_period = MONTH
 
 
 class ratio_alternants(Variable):
     value_type = float
     entity = Individu
-    label = u"Ratio d'alternants dans l'effectif moyen"
+    label = "Ratio d'alternants dans l'effectif moyen"
     definition_period = MONTH
 
 
 class remboursement_transport_base(Variable):
     value_type = float
     entity = Individu
-    label = u"Base pour le calcul du remboursement des frais de transport"
+    label = "Base pour le calcul du remboursement des frais de transport"
     definition_period = MONTH
 
 
 class indemnites_forfaitaires(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnités forfaitaires (transport, nourriture)"
+    label = "Indemnités forfaitaires (transport, nourriture)"
     definition_period = MONTH
 
 
 class salaire_de_base(Variable):
     value_type = float
     entity = Individu
-    label = u"Salaire de base, en général appelé salaire brut, la 1ère ligne sur la fiche de paie"
+    label = "Salaire de base, en général appelé salaire brut, la 1ère ligne sur la fiche de paie"
     set_input = set_input_divide_by_period
-    reference = u'http://www.insee.fr/fr/methodes/default.asp?page=definitions/salaire-mensuel-base-smb.htm'
+    reference = 'http://www.insee.fr/fr/methodes/default.asp?page=definitions/salaire-mensuel-base-smb.htm'
     definition_period = MONTH
 
 
@@ -516,28 +516,28 @@ class titre_restaurant_taux_employeur(Variable):
     value_type = float
     default_value = 0.5
     entity = Individu
-    label = u"Taux de participation de l'employeur au titre restaurant"
+    label = "Taux de participation de l'employeur au titre restaurant"
     definition_period = MONTH
 
 
 class titre_restaurant_valeur_unitaire(Variable):
     value_type = float
     entity = Individu
-    label = u"Valeur faciale unitaire du titre restaurant"
+    label = "Valeur faciale unitaire du titre restaurant"
     definition_period = MONTH
 
 
 class titre_restaurant_volume(Variable):
     value_type = int
     entity = Individu
-    label = u"Volume des titres restaurant"
+    label = "Volume des titres restaurant"
     definition_period = MONTH
 
 
 class traitement_indiciaire_brut(Variable):
     value_type = float
     entity = Individu
-    label = u"Traitement indiciaire brut (TIB)"
+    label = "Traitement indiciaire brut (TIB)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -547,7 +547,7 @@ class categorie_salarie(Variable):
     possible_values = TypesCategorieSalarie  # defined in model/base.py
     default_value = TypesCategorieSalarie.prive_non_cadre
     entity = Individu
-    label = u"Catégorie de salarié"
+    label = "Catégorie de salarié"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -555,14 +555,14 @@ class categorie_salarie(Variable):
 class heures_duree_collective_entreprise(Variable):
     value_type = int  # TODO default la valeur de la durée légale ?
     entity = Individu
-    label = u"Durée mensuelle collective dans l'entreprise (heures, temps plein)"
+    label = "Durée mensuelle collective dans l'entreprise (heures, temps plein)"
     definition_period = MONTH
 
 
 class heures_non_remunerees_volume(Variable):
     value_type = float
     entity = Individu
-    label = u"Volume des heures non rémunérées (convenance personnelle hors contrat/forfait)"
+    label = "Volume des heures non rémunérées (convenance personnelle hors contrat/forfait)"
     set_input = set_input_divide_by_period
     definition_period = MONTH
 
@@ -570,7 +570,7 @@ class heures_non_remunerees_volume(Variable):
 class heures_remunerees_volume(Variable):
     value_type = float
     entity = Individu
-    label = u"Volume des heures rémunérées contractuellement (heures/mois, temps partiel)"
+    label = "Volume des heures rémunérées contractuellement (heures/mois, temps partiel)"
     set_input = set_input_divide_by_period
     definition_period = MONTH
 
@@ -578,28 +578,28 @@ class heures_remunerees_volume(Variable):
 class forfait_heures_remunerees_volume(Variable):
     value_type = int
     entity = Individu
-    label = u"Volume des heures rémunérées à un forfait heures"
+    label = "Volume des heures rémunérées à un forfait heures"
     definition_period = MONTH
 
 
 class forfait_jours_remuneres_volume(Variable):
     value_type = int
     entity = Individu
-    label = u"Volume des heures rémunérées à forfait jours"
+    label = "Volume des heures rémunérées à forfait jours"
     definition_period = MONTH
 
 
 class volume_jours_ijss(Variable):
     value_type = int
     entity = Individu
-    label = u"Volume des jours pour lesquels sont versés une idemnité journalière par la sécurité sociale"
+    label = "Volume des jours pour lesquels sont versés une idemnité journalière par la sécurité sociale"
     definition_period = MONTH
 
 
 class avantage_en_nature(Variable):
     value_type = float
     entity = Individu
-    label = u"Avantages en nature"
+    label = "Avantages en nature"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -613,7 +613,7 @@ class avantage_en_nature(Variable):
 class avantage_en_nature_valeur_forfaitaire(Variable):
     value_type = float
     entity = Individu
-    label = u"Evaluation fofaitaire des avantages en nature "
+    label = "Evaluation fofaitaire des avantages en nature "
     definition_period = MONTH
 
     # TODO: coplete this function
@@ -627,7 +627,7 @@ class avantage_en_nature_valeur_forfaitaire(Variable):
 class depense_cantine_titre_restaurant_employe(Variable):
     value_type = float
     entity = Individu
-    label = u"Dépense de cantine et de titre restaurant à charge de l'employe"
+    label = "Dépense de cantine et de titre restaurant à charge de l'employe"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -643,7 +643,7 @@ class depense_cantine_titre_restaurant_employe(Variable):
 class depense_cantine_titre_restaurant_employeur(Variable):
     value_type = float
     entity = Individu
-    label = u"Dépense de cantine et de titre restaurant à charge de l'employeur"
+    label = "Dépense de cantine et de titre restaurant à charge de l'employeur"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -658,7 +658,7 @@ class depense_cantine_titre_restaurant_employeur(Variable):
 class nombre_jours_calendaires(Variable):
     value_type = float
     entity = Individu
-    label = u"Nombre de jours calendaires travaillés"
+    label = "Nombre de jours calendaires travaillés"
     definition_period = MONTH
     default_value = 30
 
@@ -683,7 +683,7 @@ class nombre_jours_calendaires(Variable):
 class remboursement_transport(Variable):
     value_type = float
     entity = Individu
-    label = u"Remboursement partiel des frais de transport par l'employeur"
+    label = "Remboursement partiel des frais de transport par l'employeur"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -698,7 +698,7 @@ class remboursement_transport(Variable):
 class gipa(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnité de garantie individuelle du pouvoir d'achat"
+    label = "Indemnité de garantie individuelle du pouvoir d'achat"
     definition_period = MONTH
     # TODO: à coder
 
@@ -706,7 +706,7 @@ class gipa(Variable):
 class indemnite_residence(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnité de résidence des fonctionnaires"
+    label = "Indemnité de résidence des fonctionnaires"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -738,11 +738,11 @@ class indemnite_residence(Variable):
 class indice_majore(Variable):
     value_type = float
     entity = Individu
-    label = u"Indice majoré"
+    label = "Indice majoré"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
-        period = period.start.period(u'month').offset('first-of')
+        period = period.start.period('month').offset('first-of')
         categorie_salarie = individu('categorie_salarie', period)
         traitement_indiciaire_brut = individu('traitement_indiciaire_brut', period)
         _P = parameters(period)
@@ -761,8 +761,8 @@ class indice_majore(Variable):
 class primes_fonction_publique(Variable):
     value_type = float
     entity = Individu
-    label = u"Calcul des primes pour les fonctionnaries"
-    reference = u"http://vosdroits.service-public.fr/particuliers/F465.xhtml"
+    label = "Calcul des primes pour les fonctionnaries"
+    reference = "http://vosdroits.service-public.fr/particuliers/F465.xhtml"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -783,7 +783,7 @@ class primes_fonction_publique(Variable):
 
 class af_nbenf_fonc(Variable):
     value_type = int
-    label = u"Nombre d'enfants dans la famille au sens des allocations familiales pour les fonctionnaires"
+    label = "Nombre d'enfants dans la famille au sens des allocations familiales pour les fonctionnaires"
     entity = Famille
     definition_period = MONTH
 
@@ -818,7 +818,7 @@ class af_nbenf_fonc(Variable):
 class supplement_familial_traitement(Variable):
     value_type = float
     entity = Individu
-    label = u"Supplément familial de traitement"
+    label = "Supplément familial de traitement"
     definition_period = MONTH
     set_input = set_input_divide_by_period
     # Attention : par hypothèse ne peut êre attribué qu'à la tête du ménage
@@ -907,7 +907,7 @@ def _traitement_brut_mensuel(indice_maj, law):
 class remuneration_principale(Variable):
     value_type = float
     entity = Individu
-    label = u"Rémunération principale des agents titulaires de la fonction publique"
+    label = "Rémunération principale des agents titulaires de la fonction publique"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -932,7 +932,7 @@ class remuneration_principale(Variable):
 class salaire_net_a_payer(Variable):
     value_type = float
     entity = Individu
-    label = u"Salaire net à payer (fiche de paie)"
+    label = "Salaire net à payer (fiche de paie)"
     set_input = set_input_divide_by_period
     definition_period = MONTH
 
@@ -960,7 +960,7 @@ class salaire_net_a_payer(Variable):
 class salaire_super_brut_hors_allegements(Variable):
     value_type = float
     entity = Individu
-    label = u"Salaire super-brut (fiche de paie): rémunération + cotisations sociales employeur"
+    label = "Salaire super-brut (fiche de paie): rémunération + cotisations sociales employeur"
     set_input = set_input_divide_by_period
     definition_period = MONTH
 
@@ -995,7 +995,7 @@ class salaire_super_brut_hors_allegements(Variable):
 class salaire_super_brut(Variable):
     value_type = float
     entity = Individu
-    label = u"Coût du travail à court terme. Inclut les exonérations et allègements de charges"
+    label = "Coût du travail à court terme. Inclut les exonérations et allègements de charges"
     set_input = set_input_divide_by_period
     definition_period = MONTH
 
@@ -1010,7 +1010,7 @@ class salaire_super_brut(Variable):
 class exonerations_et_allegements(Variable):
     value_type = float
     entity = Individu
-    label = u"Charges, aides et crédits différées ou particulières"
+    label = "Charges, aides et crédits différées ou particulières"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -1039,7 +1039,7 @@ class exonerations_et_allegements(Variable):
 class cout_du_travail(Variable):
     value_type = float
     entity = Individu
-    label = u"Coût du travail à long terme. Inclut les charges, aides et crédits différés"
+    label = "Coût du travail à long terme. Inclut les charges, aides et crédits différés"
     set_input = set_input_divide_by_period
     definition_period = MONTH
     calculate_output = calculate_output_add
@@ -1054,7 +1054,7 @@ class cout_du_travail(Variable):
 class cout_differe(Variable):
     value_type = float
     entity = Individu
-    label = u"Charges, aides et crédits différées ou particulières"
+    label = "Charges, aides et crédits différées ou particulières"
     definition_period = MONTH
 
     def formula(individu, period, parameters):

--- a/openfisca_france/model/revenus/autres.py
+++ b/openfisca_france/model/revenus/autres.py
@@ -5,16 +5,16 @@ from openfisca_france.model.base import *
 
 class pensions_alimentaires_percues(Variable):
     cerfa_field = {
-        0: u"1AO",
-        1: u"1BO",
-        2: u"1CO",
-        3: u"1DO",
-        4: u"1EO",
+        0: "1AO",
+        1: "1BO",
+        2: "1CO",
+        3: "1DO",
+        4: "1EO",
         }
     value_type = float
     unit = 'currency'
     entity = Individu
-    label = u"Pensions alimentaires perçues"
+    label = "Pensions alimentaires perçues"
     definition_period = MONTH
     set_input = set_input_divide_by_period
     calculate_output = calculate_output_add
@@ -24,14 +24,14 @@ class pensions_alimentaires_percues_decl(Variable):
     value_type = bool
     default_value = True
     entity = Individu
-    label = u"Pension déclarée"
+    label = "Pension déclarée"
     definition_period = YEAR
 
 
 class pensions_alimentaires_versees_individu(Variable):
     value_type = float
     entity = Individu
-    label = u"Pensions alimentaires versées pour un individu"
+    label = "Pensions alimentaires versées pour un individu"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -39,7 +39,7 @@ class pensions_alimentaires_versees_individu(Variable):
 class gains_exceptionnels(Variable):
     value_type = float
     entity = Individu
-    label = u"Gains exceptionnels"
+    label = "Gains exceptionnels"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -47,7 +47,7 @@ class gains_exceptionnels(Variable):
 class allocation_securisation_professionnelle(Variable):
     value_type = float
     entity = Individu
-    label = u"Allocation de sécurisation professionnelle"
+    label = "Allocation de sécurisation professionnelle"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -55,7 +55,7 @@ class allocation_securisation_professionnelle(Variable):
 class prime_forfaitaire_mensuelle_reprise_activite(Variable):
     value_type = float
     entity = Individu
-    label = u"Prime forfaitaire mensuelle pour la reprise d'activité"
+    label = "Prime forfaitaire mensuelle pour la reprise d'activité"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -63,7 +63,7 @@ class prime_forfaitaire_mensuelle_reprise_activite(Variable):
 class indemnites_volontariat(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnités de volontariat"
+    label = "Indemnités de volontariat"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -71,7 +71,7 @@ class indemnites_volontariat(Variable):
 class dedommagement_victime_amiante(Variable):
     value_type = float
     entity = Individu
-    label = u"Dédommagement versé aux victimes de l'amiante"
+    label = "Dédommagement versé aux victimes de l'amiante"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -79,7 +79,7 @@ class dedommagement_victime_amiante(Variable):
 class prestation_compensatoire(Variable):
     value_type = float
     entity = Individu
-    label = u"Prestation compensatoire"
+    label = "Prestation compensatoire"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -87,14 +87,14 @@ class prestation_compensatoire(Variable):
 class pensions_invalidite(Variable):
     value_type = float
     entity = Individu
-    label = u"Pensions d'invalidité"
+    label = "Pensions d'invalidité"
     # Cette case est apparue dans la déclaration 2014
     # Auparavant, les pensions d'invalidité étaient incluses dans la case 1AS
     cerfa_field = {
-        0: u"1AZ",
-        1: u"1BZ",
-        2: u"1CZ",
-        3: u"1DZ",
+        0: "1AZ",
+        1: "1BZ",
+        2: "1CZ",
+        3: "1DZ",
         }
     # start_date = date(2014, 1, 1)
     definition_period = MONTH
@@ -104,7 +104,7 @@ class pensions_invalidite(Variable):
 class bourse_enseignement_sup(Variable):
     value_type = float
     entity = Individu
-    label = u"Bourse de l'enseignement supérieur"
+    label = "Bourse de l'enseignement supérieur"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -112,91 +112,91 @@ class bourse_enseignement_sup(Variable):
 # Avoir fiscaux et crédits d'impôt
 # f2ab déjà disponible
 class f8ta(Variable):
-    cerfa_field = u"8TA"
+    cerfa_field = "8TA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Retenue à la source en France ou impôt payé à l'étranger"
+    label = "Retenue à la source en France ou impôt payé à l'étranger"
     definition_period = YEAR
 
 
 class f8vl(Variable):
-    cerfa_field = u"8VL"
+    cerfa_field = "8VL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Impôt payé à l'étranger sur revenus de capitaux mobiliers et plus-values ouvrant droit à un crédit d'impôt"
+    label = "Impôt payé à l'étranger sur revenus de capitaux mobiliers et plus-values ouvrant droit à un crédit d'impôt"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f8vm(Variable):
     cerfa_field = {
-        0: u"8VM",
-        1: u"8WM",
-        2: u"8UM",
+        0: "8VM",
+        1: "8WM",
+        2: "8UM",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Impôt payé à l'étranger sur revenus de capitaux mobiliers et plus-values ouvrant droit à un crédit d'impôt"
+    label = "Impôt payé à l'étranger sur revenus de capitaux mobiliers et plus-values ouvrant droit à un crédit d'impôt"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f8th(Variable):
-    cerfa_field = u"8TH"
+    cerfa_field = "8TH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Retenue à la source élus locaux"
+    label = "Retenue à la source élus locaux"
     definition_period = YEAR
 
 
 class f8td_2002_2005(Variable):
-    cerfa_field = u"8TD"
+    cerfa_field = "8TD"
     value_type = int
     entity = FoyerFiscal
-    label = u"Contribution exceptionnelle sur les hauts revenus"
+    label = "Contribution exceptionnelle sur les hauts revenus"
     # start_date = date(2002, 1, 1)
     end = '2005-12-31'
     definition_period = YEAR
 
 
 class f8td(Variable):
-    cerfa_field = u"8TD"
+    cerfa_field = "8TD"
     value_type = bool
     entity = FoyerFiscal
-    label = u"Revenus non imposables dépassent la moitié du RFR"
+    label = "Revenus non imposables dépassent la moitié du RFR"
     # start_date = date(2011, 1, 1)
     end = '2014-12-31'
     definition_period = YEAR
 
 
 class f8ti(Variable):
-    cerfa_field = u"8TK"
+    cerfa_field = "8TK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Revenus de l'étranger exonérés d'impôt"
+    label = "Revenus de l'étranger exonérés d'impôt"
     definition_period = YEAR
 
 
 class f8tk(Variable):
-    cerfa_field = u"8TK"
+    cerfa_field = "8TK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Revenus de l'étranger imposables"
+    label = "Revenus de l'étranger imposables"
     definition_period = YEAR
 
 
 # Auto-entrepreneur : versements libératoires d’impôt sur le revenu
 class f8uy(Variable):
-    cerfa_field = u"8UY"
+    cerfa_field = "8UY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Auto-entrepreneur : versements libératoires d’impôt sur le revenu dont le remboursement est demandé"
+    label = "Auto-entrepreneur : versements libératoires d’impôt sur le revenu dont le remboursement est demandé"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR

--- a/openfisca_france/model/revenus/capital/financier.py
+++ b/openfisca_france/model/revenus/capital/financier.py
@@ -14,22 +14,22 @@ from openfisca_france.model.base import *
 # Revenus des valeurs et capitaux mobiliers taxés au prélèvement libératoire
 
 class f2da(Variable):
-    cerfa_field = u"2DA"
+    cerfa_field = "2DA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Revenus des actions et parts soumis au prélèvement libératoire de 21 %"
+    label = "Revenus des actions et parts soumis au prélèvement libératoire de 21 %"
     # start_date = date(2008, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f2dh(Variable):
-    cerfa_field = u"2DH"
+    cerfa_field = "2DH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Produits d’assurance-vie et de capitalisation soumis au prélèvement libératoire de 7.5 %"
+    label = "Produits d’assurance-vie et de capitalisation soumis au prélèvement libératoire de 7.5 %"
     definition_period = YEAR
 
     def formula_2013_01_01(foyer_fiscal, period):
@@ -51,11 +51,11 @@ class f2dh(Variable):
 
 
 class f2ee(Variable):
-    cerfa_field = u"2EE"
+    cerfa_field = "2EE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Autres produits de placement soumis aux prélèvements libératoires"
+    label = "Autres produits de placement soumis aux prélèvements libératoires"
     definition_period = YEAR
 
     def formula_2013_01_01(foyer_fiscal, period):
@@ -99,11 +99,11 @@ class f2ee(Variable):
 
 
 class f2xx(Variable):
-    cerfa_field = u"2XX"
+    cerfa_field = "2XX"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Produits des bons et contrats de capitalisation et d'assurance-vie de moins de 8 ans; produits des versements effectués avant le 27.9.2017; soumis au prélèvement libératoire"
+    label = "Produits des bons et contrats de capitalisation et d'assurance-vie de moins de 8 ans; produits des versements effectués avant le 27.9.2017; soumis au prélèvement libératoire"
     # start_date = date(2108, 1, 1)
     definition_period = YEAR
 
@@ -111,66 +111,66 @@ class f2xx(Variable):
 # Revenus des valeurs et capitaux mobiliers ouvrant droit à abattement
 
 class f2dc(Variable):
-    cerfa_field = u"2DC"
+    cerfa_field = "2DC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Revenus des actions et parts donnant droit à abattement"
+    label = "Revenus des actions et parts donnant droit à abattement"
     definition_period = YEAR
 
 
 class f2fu(Variable):
-    cerfa_field = u"2FU"
+    cerfa_field = "2FU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Revenus imposables des titres non côtés détenus dans le PEA et distributions perçues via votre entreprise donnant droit à abattement"
+    label = "Revenus imposables des titres non côtés détenus dans le PEA et distributions perçues via votre entreprise donnant droit à abattement"
     definition_period = YEAR
 
 
 class f2ch(Variable):
-    cerfa_field = u"2CH"
+    cerfa_field = "2CH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Produits des contrats d'assurance-vie et de capitalisation d'une durée d'au moins 6 ou 8 ans donnant droit à abattement"
+    label = "Produits des contrats d'assurance-vie et de capitalisation d'une durée d'au moins 6 ou 8 ans donnant droit à abattement"
     definition_period = YEAR
 
 
 # Revenus des valeurs et capitaux mobiliers n'ouvrant pas droit à abattement
 
 class f2ts(Variable):
-    cerfa_field = u"2TS"
+    cerfa_field = "2TS"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Revenus de valeurs mobilières, produits des contrats d'assurance-vie d'une durée inférieure à 8 ans et distributions (n'ouvrant pas droit à abattement)"
+    label = "Revenus de valeurs mobilières, produits des contrats d'assurance-vie d'une durée inférieure à 8 ans et distributions (n'ouvrant pas droit à abattement)"
     definition_period = YEAR
 
 
 class f2go(Variable):
-    cerfa_field = u"2GO"
+    cerfa_field = "2GO"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Autres revenus distribués et revenus des structures soumises hors de France à un régime fiscal privilégié (n'ouvrant pas droit à abattement)"
+    label = "Autres revenus distribués et revenus des structures soumises hors de France à un régime fiscal privilégié (n'ouvrant pas droit à abattement)"
     definition_period = YEAR
 
 
 class f2tr(Variable):
-    cerfa_field = u"2TR"
+    cerfa_field = "2TR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Produits de placements à revenu fixe, intérêts et autres revenus assimilés (n'ouvrant pas droit à abattement)"
+    label = "Produits de placements à revenu fixe, intérêts et autres revenus assimilés (n'ouvrant pas droit à abattement)"
     definition_period = YEAR
 
 
 class f2yy(Variable):
-    cerfa_field = u"2YY"
+    cerfa_field = "2YY"
     value_type = float
     entity = FoyerFiscal
-    label = u"Produits des bons ou contrats de capitalisation et d'assurance vie de moins de 8 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées avant le 27 septembre 2017, et qui n'ont pas été soumis au prélèvement libératoire"
+    label = "Produits des bons ou contrats de capitalisation et d'assurance vie de moins de 8 ans pour les contrats souscrits après le 26 septembre 1997, dont le produits sont associés aux primes versées avant le 27 septembre 2017, et qui n'ont pas été soumis au prélèvement libératoire"
     definition_period = YEAR
     # start_date = date(2018, 1, 1)
 
@@ -178,200 +178,200 @@ class f2yy(Variable):
 # Autres revenus des valeurs et capitaux mobiliers
 
 class f2fa(Variable):
-    cerfa_field = u"2FA"
+    cerfa_field = "2FA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêts et autres produits de placement à revenu fixe n'excédant pas 2000 euros, taxables sur option à 24%"
+    label = "Intérêts et autres produits de placement à revenu fixe n'excédant pas 2000 euros, taxables sur option à 24%"
     # start_date = date(2013, 1, 1)
     end = '2017-12-31'
     definition_period = YEAR
 
 
 class f2tt_2016(Variable):
-    cerfa_field = u"2TT"
+    cerfa_field = "2TT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêts des prêts participatifs"
+    label = "Intérêts des prêts participatifs"
     # start_date = date(2016, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f2tt(Variable):
-    cerfa_field = u"2TT"
+    cerfa_field = "2TT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Intérêts des prêts participatifs nettes des pertes à imputer au titre de l'impôt sur le revenu"
+    label = "Intérêts des prêts participatifs nettes des pertes à imputer au titre de l'impôt sur le revenu"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f2tu_2016(Variable):
-    cerfa_field = u"2TU"
+    cerfa_field = "2TU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Pertes en capital sur prêts participatifs en 2016"
+    label = "Pertes en capital sur prêts participatifs en 2016"
     # start_date = date(2016, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f2tu(Variable):
-    cerfa_field = u"2TU"
+    cerfa_field = "2TU"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Pertes en capital sur prêts participatifs en 2016 à reporter sur l'année 2018"
+    label = "Pertes en capital sur prêts participatifs en 2016 à reporter sur l'année 2018"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f2tv(Variable):
-    cerfa_field = u"2TV"
+    cerfa_field = "2TV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Pertes en capital sur prêts participatifs en 2017 à reporter sur l'année 2018"
+    label = "Pertes en capital sur prêts participatifs en 2017 à reporter sur l'année 2018"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f2cg(Variable):
-    cerfa_field = u"2CG"
+    cerfa_field = "2CG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Revenus des lignes 2DC, 2CH, 2TS, 2TR déjà soumis au prélèvement sociaux sans CSG déductible"
+    label = "Revenus des lignes 2DC, 2CH, 2TS, 2TR déjà soumis au prélèvement sociaux sans CSG déductible"
     definition_period = YEAR
 
 
 class f2bh(Variable):
-    cerfa_field = u"2BH"
+    cerfa_field = "2BH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Revenus des lignes 2DC, 2CH, 2TS, 2TR déjà soumis au prélèvement sociaux avec CSG déductible"
+    label = "Revenus des lignes 2DC, 2CH, 2TS, 2TR déjà soumis au prélèvement sociaux avec CSG déductible"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f2ca(Variable):
-    cerfa_field = u"2CA"
+    cerfa_field = "2CA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Frais et charges déductibles"
+    label = "Frais et charges déductibles"
     definition_period = YEAR
 
 
 class f2ck(Variable):
-    cerfa_field = u"2CK"
+    cerfa_field = "2CK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédit d'impôt égal au prélèvement forfaitaire déjà versé"
+    label = "Crédit d'impôt égal au prélèvement forfaitaire déjà versé"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f2ab(Variable):
-    cerfa_field = u"2AB"
+    cerfa_field = "2AB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédits d'impôt sur valeurs étrangères"
+    label = "Crédits d'impôt sur valeurs étrangères"
     definition_period = YEAR
 
 
 class f2bg(Variable):
-    cerfa_field = u"2BG"
+    cerfa_field = "2BG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Crédits d'impôt 'directive épargne' et autres crédits d'impôt restituables"
+    label = "Crédits d'impôt 'directive épargne' et autres crédits d'impôt restituables"
     definition_period = YEAR
 
 
 class f2aa(Variable):
-    cerfa_field = u"2AA"
+    cerfa_field = "2AA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des années antérieures non encore déduits"
+    label = "Déficits des années antérieures non encore déduits"
     # start_date = date(2007, 1, 1)
     definition_period = YEAR
 
 
 class f2al(Variable):
-    cerfa_field = u"2AL"
+    cerfa_field = "2AL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des années antérieures non encore déduits"
+    label = "Déficits des années antérieures non encore déduits"
     # start_date = date(2008, 1, 1)
     definition_period = YEAR
 
 
 class f2am(Variable):
-    cerfa_field = u"2AM"
+    cerfa_field = "2AM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des années antérieures non encore déduits"
+    label = "Déficits des années antérieures non encore déduits"
     # start_date = date(2009, 1, 1)
     definition_period = YEAR
 
 
 class f2an(Variable):
-    cerfa_field = u"2AN"
+    cerfa_field = "2AN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des années antérieures non encore déduits"
+    label = "Déficits des années antérieures non encore déduits"
     # start_date = date(2010, 1, 1)
     definition_period = YEAR
 
 
 class f2aq(Variable):
-    cerfa_field = u"2AQ"
+    cerfa_field = "2AQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des années antérieures non encore déduits"
+    label = "Déficits des années antérieures non encore déduits"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f2ar(Variable):
-    cerfa_field = u"2AR"
+    cerfa_field = "2AR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits des années antérieures non encore déduits"
+    label = "Déficits des années antérieures non encore déduits"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f2dm(Variable):
-    cerfa_field = u"2DM"
+    cerfa_field = "2DM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Impatriés: revenus de capitaux mobiliers perçus à l'étranger, abattement de 50 %"
+    label = "Impatriés: revenus de capitaux mobiliers perçus à l'étranger, abattement de 50 %"
     # start_date = date(2008, 1, 1)
     definition_period = YEAR
 
 
 class f2gr(Variable):
-    cerfa_field = u"2GR"
+    cerfa_field = "2GR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Revenus distribués dans le PEA (pour le calcul du crédit d'impôt de 50 %)"
+    label = "Revenus distribués dans le PEA (pour le calcul du crédit d'impôt de 50 %)"
     # start_date = date(2005, 1, 1)
     end = '2009-12-31'
     definition_period = YEAR
@@ -382,7 +382,7 @@ class f2gr(Variable):
 class livret_a(Variable):
     value_type = float
     entity = Individu
-    label = u"Épargne sur Livret A"
+    label = "Épargne sur Livret A"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -391,7 +391,7 @@ class epargne_revenus_non_imposables(Variable):
     """ NB : cette variable est définie indépendemment des variables commençant par interets_plan_epargne_logement et interets_compte_epargne_logement """
     value_type = float
     entity = Individu
-    label = u"Épargne générant des revenus non imposables hors Livret A"
+    label = "Épargne générant des revenus non imposables hors Livret A"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -399,7 +399,7 @@ class epargne_revenus_non_imposables(Variable):
 class epargne_revenus_imposables(Variable):
     value_type = float
     entity = Individu
-    label = u"Épargne générant des revenus imposables"
+    label = "Épargne générant des revenus imposables"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -409,7 +409,7 @@ class epargne_revenus_imposables(Variable):
 class revenus_capitaux_prelevement_bareme(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenus du capital imposés au barème (montants bruts)"
+    label = "Revenus du capital imposés au barème (montants bruts)"
     set_input = set_input_divide_by_period
     reference = "http://bofip.impots.gouv.fr/bofip/3775-PGP"
     definition_period = MONTH
@@ -481,7 +481,7 @@ class revenus_capitaux_prelevement_bareme(Variable):
 class revenus_capitaux_prelevement_liberatoire(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Revenu du capital imposé au prélèvement libératoire (montants bruts)"
+    label = "Revenu du capital imposé au prélèvement libératoire (montants bruts)"
     set_input = set_input_divide_by_period
     reference = "http://bofip.impots.gouv.fr/bofip/3817-PGP"
     definition_period = MONTH
@@ -517,7 +517,7 @@ class revenus_capitaux_prelevement_liberatoire(Variable):
 class revenus_capital(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenus du capital"
+    label = "Revenus du capital"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 

--- a/openfisca_france/model/revenus/capital/foncier.py
+++ b/openfisca_france/model/revenus/capital/foncier.py
@@ -5,94 +5,94 @@ from openfisca_france.model.base import *
 
 # Rentes viagères
 class f1aw(Variable):
-    cerfa_field = u"1AW"
+    cerfa_field = "1AW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : Moins de 50 ans"
+    label = "Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : Moins de 50 ans"
     definition_period = YEAR
 
 
 class f1bw(Variable):
-    cerfa_field = u"1BW"
+    cerfa_field = "1BW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : De 50 à 59 ans"
+    label = "Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : De 50 à 59 ans"
     definition_period = YEAR
 
 
 class f1cw(Variable):
-    cerfa_field = u"1CW"
+    cerfa_field = "1CW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : De 60 à 69 ans"
+    label = "Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : De 60 à 69 ans"
     definition_period = YEAR
 
 
 class f1dw(Variable):
-    cerfa_field = u"1DW"
+    cerfa_field = "1DW"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : A partir de 70 ans"
+    label = "Rentes viagères à titre onéreux perçues par le foyer par âge d'entrée en jouissance : A partir de 70 ans"
     definition_period = YEAR
 
 
 # Revenus fonciers
 class f4ba(Variable):
-    cerfa_field = u"4BA"
+    cerfa_field = "4BA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Revenus fonciers imposables"
+    label = "Revenus fonciers imposables"
     definition_period = YEAR
 
 
 class f4bb(Variable):
-    cerfa_field = u"4BB"
+    cerfa_field = "4BB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficit imputable sur les revenus fonciers"
+    label = "Déficit imputable sur les revenus fonciers"
     definition_period = YEAR
 
 
 class f4bc(Variable):
-    cerfa_field = u"4BC"
+    cerfa_field = "4BC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficit imputable sur le revenu global"
+    label = "Déficit imputable sur le revenu global"
     definition_period = YEAR
 
 
 class f4bd(Variable):
-    cerfa_field = u"4BD"
+    cerfa_field = "4BD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Déficits antérieurs non encore imputés"
+    label = "Déficits antérieurs non encore imputés"
     definition_period = YEAR
 
 
 class f4be(Variable):
-    cerfa_field = u"4BE"
+    cerfa_field = "4BE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Micro foncier: recettes brutes sans abattement"
+    label = "Micro foncier: recettes brutes sans abattement"
     definition_period = YEAR
 
 
 # Prime d'assurance loyers impayés
 class f4bf(Variable):
-    cerfa_field = u"4BF"
+    cerfa_field = "4BF"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Primes d'assurance pour loyers impayés des locations conventionnées"
+    label = "Primes d'assurance pour loyers impayés des locations conventionnées"
     end = '2016-12-31'
     definition_period = YEAR
 
@@ -109,7 +109,7 @@ class f4bl(Variable):
 class valeur_patrimoine_loue(Variable):
     value_type = float
     entity = Individu
-    label = u"Valeur des biens immobiliers et des terrains loués"
+    label = "Valeur des biens immobiliers et des terrains loués"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -117,7 +117,7 @@ class valeur_patrimoine_loue(Variable):
 class revenus_locatifs(Variable):
     value_type = float
     entity = Individu
-    label = u"Revenus locatifs"
+    label = "Revenus locatifs"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -136,7 +136,7 @@ class revenus_locatifs(Variable):
 class valeur_immo_non_loue(Variable):
     value_type = float
     entity = Individu
-    label = u"Valeur des biens immobiliers possédés et non loués"
+    label = "Valeur des biens immobiliers possédés et non loués"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -144,7 +144,7 @@ class valeur_immo_non_loue(Variable):
 class valeur_locative_immo_non_loue(Variable):
     value_type = float
     entity = Individu
-    label = u"Valeur locative, à l'année, des biens immobiliers possédés et non loués"
+    label = "Valeur locative, à l'année, des biens immobiliers possédés et non loués"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -152,7 +152,7 @@ class valeur_locative_immo_non_loue(Variable):
 class valeur_terrains_non_loues(Variable):
     value_type = float
     entity = Individu
-    label = u"Valeur des terrains possédés et non loués"
+    label = "Valeur des terrains possédés et non loués"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -160,6 +160,6 @@ class valeur_terrains_non_loues(Variable):
 class valeur_locative_terrains_non_loues(Variable):
     value_type = float
     entity = Individu
-    label = u"Valeur locative, à l'année, des terrains possédés et non loués"
+    label = "Valeur locative, à l'année, des terrains possédés et non loués"
     definition_period = MONTH
     set_input = set_input_dispatch_by_period

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -14,214 +14,214 @@ from openfisca_france.model.base import *
 
 class f1tt(Variable):
     cerfa_field = {
-        0: u"1TT",
-        1: u"1UT",
+        0: "1TT",
+        1: "1UT",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Gains de levée d'options sur titres et gains d'acquisition d'actions gratuites attribuées à compter du 28.9.2012"
+    label = "Gains de levée d'options sur titres et gains d'acquisition d'actions gratuites attribuées à compter du 28.9.2012"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f1tv(Variable):
     cerfa_field = {
-        0: u"1TV",
-        1: u"1UV",
+        0: "1TV",
+        1: "1UV",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Gains de levée d'options sur titres en cas de cession ou de conversion au porteur dans le délai d'indisponibilité: entre 1 et 2 ans"
+    label = "Gains de levée d'options sur titres en cas de cession ou de conversion au porteur dans le délai d'indisponibilité: entre 1 et 2 ans"
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class f1tw(Variable):
     cerfa_field = {
-        0: u"1TW",
-        1: u"1UW",
+        0: "1TW",
+        1: "1UW",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Gains de levée d'options sur titres en cas de cession ou de conversion au porteur dans le délai d'indisponibilité: entre 2 et 3 ans"
+    label = "Gains de levée d'options sur titres en cas de cession ou de conversion au porteur dans le délai d'indisponibilité: entre 2 et 3 ans"
     end = '2015-12-31'
     definition_period = YEAR
 
 
 class f1tx(Variable):
     cerfa_field = {
-        0: u"1TX",
-        1: u"1UX",
+        0: "1TX",
+        1: "1UX",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Gains de levée d'options sur titres en cas de cession ou de conversion au porteur dans le délai d'indisponibilité: entre 3 et 4 ans"
+    label = "Gains de levée d'options sur titres en cas de cession ou de conversion au porteur dans le délai d'indisponibilité: entre 3 et 4 ans"
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f3vj(Variable):
     cerfa_field = {
-        0: u"3VJ",
-        1: u"3VK",
+        0: "3VJ",
+        1: "3VK",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Gains imposables sur option dans la catégorie des salaires"
+    label = "Gains imposables sur option dans la catégorie des salaires"
     definition_period = YEAR
 
 
 # Autres plus-values
 
 class f3vg(Variable):
-    cerfa_field = u"3VG"
+    cerfa_field = "3VG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-value imposable sur gains de cession de valeurs mobilières, de droits sociaux et gains assimilés"
+    label = "Plus-value imposable sur gains de cession de valeurs mobilières, de droits sociaux et gains assimilés"
     definition_period = YEAR
 
 
 class f3vh(Variable):
-    cerfa_field = u"3VH"
+    cerfa_field = "3VH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Moins-value imposable su gains de cession de valeurs mobilières, de droits sociaux et gains assimilés"
+    label = "Moins-value imposable su gains de cession de valeurs mobilières, de droits sociaux et gains assimilés"
     definition_period = YEAR
 
 
 class f3vv(Variable):
-    cerfa_field = u"3VV"
+    cerfa_field = "3VV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values réalisées par les non-résidents: montant du prélèvement de 45 % déjà versé"
+    label = "Plus-values réalisées par les non-résidents: montant du prélèvement de 45 % déjà versé"
     # start_date = date(2013, 1, 1)
     end = '2013-12-31'
     definition_period = YEAR
 
 
 class f3vz(Variable):
-    cerfa_field = u"3VZ"
+    cerfa_field = "3VZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values imposables sur cessions d’immeubles ou de biens meubles"
+    label = "Plus-values imposables sur cessions d’immeubles ou de biens meubles"
     # start_date = date(2011, 1, 1)
     definition_period = YEAR
 
 
 class f3vc(Variable):
-    cerfa_field = u"3VC"
+    cerfa_field = "3VC"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Produits et plus-values exonérés provenant de structure de capital-risque"
+    label = "Produits et plus-values exonérés provenant de structure de capital-risque"
     # start_date = date(2006, 1, 1)
     definition_period = YEAR
 
 
 class f3vp(Variable):
-    cerfa_field = u"3VP"
+    cerfa_field = "3VP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values exonérées de cessions de titres de jeunes entreprises innovantes"
+    label = "Plus-values exonérées de cessions de titres de jeunes entreprises innovantes"
     # start_date = date(2007, 1, 1)
     end = '2013-12-31'
     definition_period = YEAR
 
 
 class f3vq(Variable):
-    cerfa_field = u"3VQ"
+    cerfa_field = "3VQ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Cessions de titres détenus à l'étranger par les impatriés : plus-values exonérées (50%)"
+    label = "Cessions de titres détenus à l'étranger par les impatriés : plus-values exonérées (50%)"
     definition_period = YEAR
 
 
 class f3vr(Variable):
-    cerfa_field = u"3VR"
+    cerfa_field = "3VR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Cessions de titres détenus à l'étranger par les impatriés : moins-values non imputables (50%)"
+    label = "Cessions de titres détenus à l'étranger par les impatriés : moins-values non imputables (50%)"
     definition_period = YEAR
 
 
 class f3vy(Variable):
-    cerfa_field = u"3VY"
+    cerfa_field = "3VY"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values exonérées de cessions de participations supérieures à 25% au sein du groupe familial"
+    label = "Plus-values exonérées de cessions de participations supérieures à 25% au sein du groupe familial"
     # start_date = date(2011, 1, 1)
     end = '2013-12-31'
     definition_period = YEAR
 
 
 class f3ve(Variable):
-    cerfa_field = u"3VE"
+    cerfa_field = "3VE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values réalisées par les non-résidents pour lesquelles vous demandez le remboursement de l'excédent du prélèvement de 45 %"
+    label = "Plus-values réalisées par les non-résidents pour lesquelles vous demandez le remboursement de l'excédent du prélèvement de 45 %"
     definition_period = YEAR
 
 
 class f3tz(Variable):
-    cerfa_field = u"3TZ"
+    cerfa_field = "3TZ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values de cession de titres d'OPC monétaires en report d'imposition, plus-values réalisées du 1.1 au 31.3.2017, plus-values en report d'imposition"
+    label = "Plus-values de cession de titres d'OPC monétaires en report d'imposition, plus-values réalisées du 1.1 au 31.3.2017, plus-values en report d'imposition"
     # start_date = date(2016, 1, 1)
     end = '2017-12-31'
     definition_period = YEAR
 
 
 class f3sa(Variable):
-    cerfa_field = u"3SA"
+    cerfa_field = "3SA"
     value_type = int
     entity = FoyerFiscal
-    label = u"Plus-values en report d'imposition, dont le report a expiré cette année; montant avant abattement"
+    label = "Plus-values en report d'imposition, dont le report a expiré cette année; montant avant abattement"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f3sb(Variable):
-    cerfa_field = u"3SB"
+    cerfa_field = "3SB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values en report d'imposition, dont le report a expiré cette année; montant imposable"
+    label = "Plus-values en report d'imposition, dont le report a expiré cette année; montant imposable"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f3wb(Variable):
-    cerfa_field = u"3WB"
+    cerfa_field = "3WB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values des individus transférant leur domicile fiscal hors de France; plus-values et créances ne bénéficiant pas du sursis de paiement; plus-values nettes imposables au barème"
+    label = "Plus-values des individus transférant leur domicile fiscal hors de France; plus-values et créances ne bénéficiant pas du sursis de paiement; plus-values nettes imposables au barème"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f3wd(Variable):
-    cerfa_field = u"3WD"
+    cerfa_field = "3WD"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values des individus transférant leur domicile fiscal hors de France; plus-values et créances ne bénéficiant pas du sursis de paiement; plus-values de base soumise aux prélèvements sociaux"
+    label = "Plus-values des individus transférant leur domicile fiscal hors de France; plus-values et créances ne bénéficiant pas du sursis de paiement; plus-values de base soumise aux prélèvements sociaux"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
@@ -233,50 +233,50 @@ class f3we(Variable):
     Pour les revenus 2014 : complément net de prix perçu pendant l'année (car fin du dispositif)
     Depuis les revenus 2015 : complément brut de prix perçu pendant l'année (l'abattement n'est plus recensé dans les cases 3SG et 3SL)
     """
-    cerfa_field = u"3WE"
+    cerfa_field = "3WE"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values en report d'imposition au sens de l'art. 150-0 D bis du CGI"
+    label = "Plus-values en report d'imposition au sens de l'art. 150-0 D bis du CGI"
     definition_period = YEAR
 
 
 class f3wn(Variable):
-    cerfa_field = u"3WN"
+    cerfa_field = "3WN"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values en report d'imposition dont le report a expiré cette année, réalisées à compter du 1.1.2013 : plus-values avant abattement"
+    label = "Plus-values en report d'imposition dont le report a expiré cette année, réalisées à compter du 1.1.2013 : plus-values avant abattement"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f3wp(Variable):
-    cerfa_field = u"3WP"
+    cerfa_field = "3WP"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values en report d'imposition dont le report a expiré cette année, réalisées à compter du 1.1.2013 : plus-values après abattement"
+    label = "Plus-values en report d'imposition dont le report a expiré cette année, réalisées à compter du 1.1.2013 : plus-values après abattement"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f3wr(Variable):
-    cerfa_field = u"3WR"
+    cerfa_field = "3WR"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values en report d'imposition dont le report a expiré cette année, réalisées à compter du 1.1.2013 : impôt sur le revenu"
+    label = "Plus-values en report d'imposition dont le report a expiré cette année, réalisées à compter du 1.1.2013 : impôt sur le revenu"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f3wt(Variable):
-    cerfa_field = u"3WT"
+    cerfa_field = "3WT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values en report d'imposition dont le report a expiré cette année, réalisées à compter du 1.1.2013 : contribution exceptionnelle sur les hauts revenus"
+    label = "Plus-values en report d'imposition dont le report a expiré cette année, réalisées à compter du 1.1.2013 : contribution exceptionnelle sur les hauts revenus"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
@@ -284,11 +284,11 @@ class f3wt(Variable):
 # Abattements sur plus-values
 
 class f3va_2014(Variable):
-    cerfa_field = u"3VA"
+    cerfa_field = "3VA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Abattements nets (abattement pour durée de détention renforcé et abattement fixe spécial) appliqués sur des plus-values réalisées par les dirigeants de PME lors de leur départ à la retraite"
+    label = "Abattements nets (abattement pour durée de détention renforcé et abattement fixe spécial) appliqués sur des plus-values réalisées par les dirigeants de PME lors de leur départ à la retraite"
     # start_date = date(2006, 1, 1)
     end = '2014-12-31'
     definition_period = YEAR
@@ -296,78 +296,78 @@ class f3va_2014(Variable):
 
 class f3va_2016(Variable):
     cerfa_field = {
-        0: u"3VA",
-        1: u"3VB",
-        2: u"3VO",
-        3: u"3VP",
+        0: "3VA",
+        1: "3VB",
+        2: "3VO",
+        3: "3VP",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Abattements nets (abattement pour durée de détention renforcé et abattement fixe spécial) appliqués sur des plus-values réalisées par les dirigeants de PME lors de leur départ à la retraite"
+    label = "Abattements nets (abattement pour durée de détention renforcé et abattement fixe spécial) appliqués sur des plus-values réalisées par les dirigeants de PME lors de leur départ à la retraite"
     # start_date = date(2015, 1, 1)
     end = '2016-12-31'
     definition_period = YEAR
 
 
 class f3va(Variable):
-    cerfa_field = u"3VA"
+    cerfa_field = "3VA"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Abattement fixe spécial appliqué sur des plus-values réalisées par les dirigeants de PME lors de leur départ à la retraite"
+    label = "Abattement fixe spécial appliqué sur des plus-values réalisées par les dirigeants de PME lors de leur départ à la retraite"
     # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 
 class f3vb(Variable):
-    cerfa_field = u"3VB"
+    cerfa_field = "3VB"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Abattements nets (abattement pour durée de détention renforcé et abattement fixe spécial) appliqués sur des moins-values réalisées par les dirigeants de PME lors de leur départ à la retraite"
+    label = "Abattements nets (abattement pour durée de détention renforcé et abattement fixe spécial) appliqués sur des moins-values réalisées par les dirigeants de PME lors de leur départ à la retraite"
     # start_date = date(2006, 1, 1)
     end = '2014-12-31'
     definition_period = YEAR
 
 
 class f3sg(Variable):
-    cerfa_field = u"3SG"
+    cerfa_field = "3SG"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Abattement net pour durée de détention (détention de droit commun à partir de 2015) : appliqué sur des plus-values"
+    label = "Abattement net pour durée de détention (détention de droit commun à partir de 2015) : appliqué sur des plus-values"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f3sh(Variable):
-    cerfa_field = u"3SH"
+    cerfa_field = "3SH"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Abattement net pour durée de détention : appliqué sur des moins-values"
+    label = "Abattement net pour durée de détention : appliqué sur des moins-values"
     # start_date = date(2013, 1, 1)
     end = '2014-12-31'
     definition_period = YEAR
 
 
 class f3sl(Variable):
-    cerfa_field = u"3SL"
+    cerfa_field = "3SL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Abattement net pour durée de détention renforcée : appliqué sur des plus-values"
+    label = "Abattement net pour durée de détention renforcée : appliqué sur des plus-values"
     # start_date = date(2013, 1, 1)
     definition_period = YEAR
 
 
 class f3sm(Variable):
-    cerfa_field = u"3SM"
+    cerfa_field = "3SM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Abattement net pour durée de détention renforcée : appliqué sur des moins-values"
+    label = "Abattement net pour durée de détention renforcée : appliqué sur des moins-values"
     # start_date = date(2013, 1, 1)
     end = '2014-12-31'
     definition_period = YEAR
@@ -377,8 +377,8 @@ class abattements_plus_values(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    reference = u"http://bofip.impots.gouv.fr/bofip/9540-PGP"
-    label = u"Abattements sur plus-values notamment pour durée de détention de droit commun, renforcé, et abattement en cas de départ à la retraite d'un dirigeant de PME (abattement fixe et pour durée de détention)"
+    reference = "http://bofip.impots.gouv.fr/bofip/9540-PGP"
+    label = "Abattements sur plus-values notamment pour durée de détention de droit commun, renforcé, et abattement en cas de départ à la retraite d'un dirigeant de PME (abattement fixe et pour durée de détention)"
     definition_period = YEAR
     end = '2017-12-31'
 
@@ -413,13 +413,13 @@ class abattements_plus_values(Variable):
 class f3vd(Variable):
     """ ATTENTION : à partir des revenus 2015, la case 3SD est supprimée : seule la case 3VD reste et recense les montants à l'échelle du foyer fiscal. Avec le code actuel, le seul problème serait si la case 3SD était réutilisée un jour pour autre chose dans le formulaire, ce qui n'est pas le cas aujourd'hui """
     cerfa_field = {
-        0: u"3VD",
-        1: u"3SD",
+        0: "3VD",
+        1: "3SD",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 18 %"
+    label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 18 %"
     # start_date = date(2008, 1, 1)
     definition_period = YEAR
 
@@ -427,103 +427,103 @@ class f3vd(Variable):
 class f3vi(Variable):
     """ ATTENTION : à partir des revenus 2015, la case 3SI est supprimée : seule la case 3VI reste et recense les montants à l'échelle du foyer fiscal. Avec le code actuel, le seul problème serait si la case 3SI était réutilisée un jour pour autre chose dans le formulaire, ce qui n'est pas le cas aujourd'hui """
     cerfa_field = {
-        0: u"3VI",
-        1: u"3SI",
+        0: "3VI",
+        1: "3SI",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 30 %"
+    label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 30 %"
     definition_period = YEAR
 
 
 class f3vf(Variable):
     """ ATTENTION : à partir des revenus 2015, la case 3SF est supprimée : seule la case 3VF reste et recense les montants à l'échelle du foyer fiscal. Avec le code actuel, le seul problème serait si la case 3SF était réutilisée un jour pour autre chose dans le formulaire, ce qui n'est pas le cas aujourd'hui """
     cerfa_field = {
-        0: u"3VF",
-        1: u"3SF",
+        0: "3VF",
+        1: "3SF",
         }
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = u"Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 41 %"
+    label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 41 %"
     definition_period = YEAR
 
 
 class f3vm(Variable):
-    cerfa_field = u"3VM"
+    cerfa_field = "3VM"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Clôture du PEA avant l'expiration de la 2e année: gains taxables à 22.5 %"
+    label = "Clôture du PEA avant l'expiration de la 2e année: gains taxables à 22.5 %"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f3vt(Variable):
-    cerfa_field = u"3VT"
+    cerfa_field = "3VT"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Clôture du PEA  entre la 2e et la 5e année: gains taxables à 19 %"
+    label = "Clôture du PEA  entre la 2e et la 5e année: gains taxables à 19 %"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
 
 class f3vl(Variable):
-    cerfa_field = u"3VL"
+    cerfa_field = "3VL"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Distributions par des sociétés de capital-risque taxables à 19 %"
+    label = "Distributions par des sociétés de capital-risque taxables à 19 %"
     end = '2013-12-31'
     definition_period = YEAR
 
 
 class f3sa_2012(Variable):
-    cerfa_field = u"3SA"
+    cerfa_field = "3SA"
     value_type = int
     entity = FoyerFiscal
-    label = u"Plus-values de cessions de titres réalisées par un entrepreneur, taxables à 19%"
+    label = "Plus-values de cessions de titres réalisées par un entrepreneur, taxables à 19%"
     # start_date = date(2012, 1, 1)
     end = '2012-12-31'
     definition_period = YEAR
 
 
 class f3sj(Variable):
-    cerfa_field = u"3SJ"
+    cerfa_field = "3SJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Gains de cession de bons de souscription de parts de créateur d'entreprise : gains taxables à 19%"
+    label = "Gains de cession de bons de souscription de parts de créateur d'entreprise : gains taxables à 19%"
     definition_period = YEAR
 
 
 class f3sk(Variable):
-    cerfa_field = u"3SK"
+    cerfa_field = "3SK"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Gains de cession de bons de souscription de parts de créateur d'entreprise : gains taxables à 30%"
+    label = "Gains de cession de bons de souscription de parts de créateur d'entreprise : gains taxables à 30%"
     definition_period = YEAR
 
 
 class f3wi(Variable):
-    cerfa_field = u"3WI"
+    cerfa_field = "3WI"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values en report d'imposition dont le report a expiré cette année : réalisées du 14.11.2012 au 31.12.2012 et taxables à 24%"
+    label = "Plus-values en report d'imposition dont le report a expiré cette année : réalisées du 14.11.2012 au 31.12.2012 et taxables à 24%"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
 
 class f3wj(Variable):
-    cerfa_field = u"3WJ"
+    cerfa_field = "3WJ"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Plus-values en report d'imposition dont le report a expiré cette année : réalisées du 14.11.2012 au 31.12.2012 et taxables à 19%"
+    label = "Plus-values en report d'imposition dont le report a expiré cette année : réalisées du 14.11.2012 au 31.12.2012 et taxables à 19%"
     # start_date = date(2016, 1, 1)
     definition_period = YEAR
 
@@ -531,19 +531,19 @@ class f3wj(Variable):
 # Autres variables
 
 class f3vv_end_2010(Variable):
-    cerfa_field = u"3VV"
+    cerfa_field = "3VV"
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = u"Pertes ouvrant droit au crédit d’impôt de 19 % "
+    label = "Pertes ouvrant droit au crédit d’impôt de 19 % "
     # start_date = date(2010, 1, 1)
     end = '2010-12-31'
     definition_period = YEAR
 
 
 class f3ua(Variable):
-    cerfa_field = u"3UA"
-    label = u"Plus-values bénéficiant de l'abattement pour durée de détention renforcé et plus-values réalisées par les dirigeants de PME lors de leur départ à la retraite : plus-values après abattements"
+    cerfa_field = "3UA"
+    label = "Plus-values bénéficiant de l'abattement pour durée de détention renforcé et plus-values réalisées par les dirigeants de PME lors de leur départ à la retraite : plus-values après abattements"
     value_type = float
     entity = FoyerFiscal
     # start_date = date(2017, 1, 1) NB : Cette case existait avant 2017, mais les montants qui y étaient indiqués étaient également indiqués case 3VG

--- a/openfisca_france/model/revenus/remplacement/chomage.py
+++ b/openfisca_france/model/revenus/remplacement/chomage.py
@@ -5,15 +5,15 @@ from openfisca_france.model.base import *
 
 class chomeur_longue_duree(Variable):
     cerfa_field = {
-        0: u"1AI",
-        1: u"1BI",
-        2: u"1CI",
-        3: u"1DI",
-        4: u"1EI",
+        0: "1AI",
+        1: "1BI",
+        2: "1CI",
+        3: "1DI",
+        4: "1EI",
         }
     value_type = bool
     entity = Individu
-    label = u"Demandeur d'emploi inscrit depuis plus d'un an"
+    label = "Demandeur d'emploi inscrit depuis plus d'un an"
     definition_period = YEAR
     # Pour toutes les variables de ce type, les pac3 ne sont plus proposés après 2007
 
@@ -21,7 +21,7 @@ class chomeur_longue_duree(Variable):
 class chomage_brut(Variable):
     value_type = float
     entity = Individu
-    label = u"Chômage brut"
+    label = "Chômage brut"
     definition_period = MONTH
     set_input = set_input_divide_by_period
     calculate_output = calculate_output_add
@@ -30,6 +30,6 @@ class chomage_brut(Variable):
 class indemnites_chomage_partiel(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnités de chômage partiel"
+    label = "Indemnités de chômage partiel"
     definition_period = MONTH
     set_input = set_input_divide_by_period

--- a/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
+++ b/openfisca_france/model/revenus/remplacement/indemnites_journalieres_securite_sociale.py
@@ -6,7 +6,7 @@ from openfisca_france.model.base import *
 class indemnites_journalieres_maternite(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnités journalières de maternité"
+    label = "Indemnités journalières de maternité"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -14,7 +14,7 @@ class indemnites_journalieres_maternite(Variable):
 class indemnites_journalieres_paternite(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnités journalières de paternité"
+    label = "Indemnités journalières de paternité"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -22,7 +22,7 @@ class indemnites_journalieres_paternite(Variable):
 class indemnites_journalieres_adoption(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnités journalières d'adoption"
+    label = "Indemnités journalières d'adoption"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -30,7 +30,7 @@ class indemnites_journalieres_adoption(Variable):
 class indemnites_journalieres_maladie(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnités journalières de maladie"
+    label = "Indemnités journalières de maladie"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -38,7 +38,7 @@ class indemnites_journalieres_maladie(Variable):
 class indemnites_journalieres_accident_travail(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnités journalières d'accident du travail"
+    label = "Indemnités journalières d'accident du travail"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -46,14 +46,14 @@ class indemnites_journalieres_accident_travail(Variable):
 class indemnites_journalieres_maladie_professionnelle(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnités journalières de maladie professionnelle"
+    label = "Indemnités journalières de maladie professionnelle"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
 
 class indemnites_journalieres(Variable):
     value_type = float
-    label = u"Total des indemnités journalières"
+    label = "Total des indemnités journalières"
     entity = Individu
     definition_period = MONTH
 
@@ -73,7 +73,7 @@ class indemnites_journalieres(Variable):
 
 class indemnites_journalieres_imposables(Variable):
     value_type = float
-    label = u"Total des indemnités journalières imposables"
+    label = "Total des indemnités journalières imposables"
     entity = Individu
     reference = "http://vosdroits.service-public.fr/particuliers/F3152.xhtml"
     definition_period = MONTH
@@ -93,5 +93,5 @@ class date_arret_de_travail(Variable):
     value_type = date
     default_value = date.min
     entity = Individu
-    label = u"Date depuis laquelle la personne est en arrêt de travail"
+    label = "Date depuis laquelle la personne est en arrêt de travail"
     definition_period = ETERNITY

--- a/openfisca_france/model/revenus/remplacement/rente_accident_travail.py
+++ b/openfisca_france/model/revenus/remplacement/rente_accident_travail.py
@@ -6,8 +6,8 @@ from openfisca_france.model.base import *
 class rente_accident_travail(Variable):
     value_type = float
     entity = Individu
-    label = u"Montant mensuel de la rente d’accident du travail"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006743072&dateTexte=&categorieLien=cid"
+    label = "Montant mensuel de la rente d’accident du travail"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006743072&dateTexte=&categorieLien=cid"
     definition_period = MONTH
 
     def formula(individu, period):
@@ -22,8 +22,8 @@ class rente_accident_travail(Variable):
 class rente_accident_travail_salarie(Variable):
     value_type = float
     entity = Individu
-    label = u"Montant de la rente d’accident du travail pour les victimes salariées"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006743072&dateTexte=&categorieLien=cid"
+    label = "Montant de la rente d’accident du travail pour les victimes salariées"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006743072&dateTexte=&categorieLien=cid"
     definition_period = MONTH
 
     def formula(individu, period):
@@ -46,8 +46,8 @@ class rente_accident_travail_salarie(Variable):
 class rente_accident_travail_exploitant_agricole(Variable):
     value_type = float
     entity = Individu
-    label = u"Montant de la rente d’accident du travail pour les chefs d'exploitation ou d'entreprise agricole"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006071367&idArticle=LEGIARTI000006598097&dateTexte=&categorieLien=cid"
+    label = "Montant de la rente d’accident du travail pour les chefs d'exploitation ou d'entreprise agricole"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006071367&idArticle=LEGIARTI000006598097&dateTexte=&categorieLien=cid"
     definition_period = MONTH
 
     def formula(individu, period):
@@ -69,8 +69,8 @@ class rente_accident_travail_exploitant_agricole(Variable):
 class indemnite_accident_travail(Variable):
     value_type = float
     entity = Individu
-    label = u"Indemnité selon le taux d'incapacité"
-    reference = u"https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000006172216&cidTexte=LEGITEXT000006073189"
+    label = "Indemnité selon le taux d'incapacité"
+    reference = "https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000006172216&cidTexte=LEGITEXT000006073189"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -83,8 +83,8 @@ class indemnite_accident_travail(Variable):
 class rente_accident_travail_base(Variable):
     value_type = float
     entity = Individu
-    label = u"Montant de base de la rente d’accident du travail"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006743072&dateTexte=&categorieLien=cid"
+    label = "Montant de base de la rente d’accident du travail"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006743072&dateTexte=&categorieLien=cid"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -100,14 +100,14 @@ class rente_accident_travail_base(Variable):
 class demande_rachat(Variable):
     value_type = bool
     entity = Individu
-    label = u"La victime a demandé le rachat partiel de la rente"
+    label = "La victime a demandé le rachat partiel de la rente"
     definition_period = MONTH
 
 
 class rente_accident_travail_apres_rachat(Variable):
     value_type = float
     entity = Individu
-    label = u"Rente d’accident du travail, reliquat suite à conversion en capital"
+    label = "Rente d’accident du travail, reliquat suite à conversion en capital"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -124,8 +124,8 @@ class rente_accident_travail_apres_rachat(Variable):
 class rente_accident_travail_rachat(Variable):
     value_type = float
     entity = Individu
-    label = u"Rachat de la rente d’accident du travail"
-    reference = u"https://www.legifrance.gouv.fr/eli/arrete/2016/12/19/AFSS1637858A/jo/texte"
+    label = "Rachat de la rente d’accident du travail"
+    reference = "https://www.legifrance.gouv.fr/eli/arrete/2016/12/19/AFSS1637858A/jo/texte"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -142,16 +142,16 @@ class rente_accident_travail_rachat(Variable):
 class pcrtp_nombre_actes_assistance(Variable):
     value_type = int
     entity = Individu
-    label = u"Nombre d'actes nécessitant l'assistance d'une tierce personne"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=6D8F7F6917ADFBDEAFE1D8A432F39229.tplgfr23s_2?idArticle=LEGIARTI000027267037&cidTexte=LEGITEXT000006073189&dateTexte=20181218"
+    label = "Nombre d'actes nécessitant l'assistance d'une tierce personne"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=6D8F7F6917ADFBDEAFE1D8A432F39229.tplgfr23s_2?idArticle=LEGIARTI000027267037&cidTexte=LEGITEXT000006073189&dateTexte=20181218"
     definition_period = MONTH
 
 
 class pcrtp(Variable):
     value_type = float
     entity = Individu
-    label = u"Prestation complémentaire pour recours à tierce personne (PCRTP)"
-    reference = u"https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000006172216&cidTexte=LEGITEXT000006073189"
+    label = "Prestation complémentaire pour recours à tierce personne (PCRTP)"
+    reference = "https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000006172216&cidTexte=LEGITEXT000006073189"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -166,8 +166,8 @@ class pcrtp(Variable):
 class rente_accident_travail_salaire_utile(Variable):
     value_type = float
     entity = Individu
-    label = u"Salaire utile pour calculer la rente d’accident du travail"
-    reference = u"https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=7392B9902E4B974EAE8783FAF2D69849.tplgfr30s_1?idArticle=LEGIARTI000006750376&cidTexte=LEGITEXT000006073189&dateTexte=20180823"
+    label = "Salaire utile pour calculer la rente d’accident du travail"
+    reference = "https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=7392B9902E4B974EAE8783FAF2D69849.tplgfr30s_1?idArticle=LEGIARTI000006750376&cidTexte=LEGITEXT000006073189&dateTexte=20180823"
     definition_period = MONTH
 
     def formula(individu, period, parameters):

--- a/openfisca_france/model/revenus/remplacement/retraite.py
+++ b/openfisca_france/model/revenus/remplacement/retraite.py
@@ -6,7 +6,7 @@ from openfisca_france.model.base import *
 class retraite_brute(Variable):
     value_type = float
     entity = Individu
-    label = u"Retraite brute"
+    label = "Retraite brute"
     definition_period = MONTH
     set_input = set_input_divide_by_period
     calculate_output = calculate_output_add
@@ -15,7 +15,7 @@ class retraite_brute(Variable):
 class aer(Variable):
     value_type = int
     entity = Individu
-    label = u"Allocation équivalent retraite (AER)"
+    label = "Allocation équivalent retraite (AER)"
     # L'AER est remplacée depuis le 1er juillet 2011 par l'allocation transitoire de solidarité (ATS).
     definition_period = MONTH
 
@@ -23,6 +23,6 @@ class aer(Variable):
 class retraite_combattant(Variable):
     value_type = float
     entity = Individu
-    label = u"Retraite du combattant"
+    label = "Retraite du combattant"
     definition_period = MONTH
     set_input = set_input_divide_by_period

--- a/openfisca_france/parameters/prestations/minima_sociaux/rsa/rsa_jeune.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/rsa/rsa_jeune.yaml
@@ -1,5 +1,5 @@
 description: La date de début RSA jeune
-reference: u"https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006074069&idArticle=LEGIARTI000021636574&dateTexte=&categorieLien=cid"
+reference: "https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006074069&idArticle=LEGIARTI000021636574&dateTexte=&categorieLien=cid"
 unit: currency
 values:
   2009-06-01:

--- a/openfisca_france/reforms/allocations_familiales_imposables.py
+++ b/openfisca_france/reforms/allocations_familiales_imposables.py
@@ -16,10 +16,10 @@ def modify_parameters(parameters):
 
 
 class allocations_familiales_imposables(Reform):
-    name = u'Allocations familiales imposables'
+    name = 'Allocations familiales imposables'
 
     class rbg(Variable):
-        label = u"Nouveau revenu brut global intégrant les allocations familiales"
+        label = "Nouveau revenu brut global intégrant les allocations familiales"
         definition_period = YEAR
 
         def formula(foyer_fiscal, period, parameters):
@@ -45,7 +45,7 @@ class allocations_familiales_imposables(Reform):
                 )
 
     class rfr(Variable):
-        label = u"Nouveau revenu fiscal de référence intégrant les allocations familiales"
+        label = "Nouveau revenu fiscal de référence intégrant les allocations familiales"
         definition_period = YEAR
 
         def formula(foyer_fiscal, period, parameters):
@@ -82,7 +82,7 @@ class allocations_familiales_imposables(Reform):
     class allocations_familiales_imposables(Variable):
         value_type = float
         entity = FoyerFiscal
-        label = u"Allocations familiales imposables"
+        label = "Allocations familiales imposables"
         definition_period = YEAR
 
         def formula(foyer_fiscal, period, parameters):

--- a/openfisca_france/reforms/cesthra_invalidee.py
+++ b/openfisca_france/reforms/cesthra_invalidee.py
@@ -20,7 +20,7 @@ def modify_parameters(parameters):
 class cesthra(Variable):
     value_type = float
     entity = entities.FoyerFiscal
-    label = u"Contribution exceptionnelle de solidarité sur les très hauts revenus d'activité"
+    label = "Contribution exceptionnelle de solidarité sur les très hauts revenus d'activité"
     definition_period = YEAR
     # PLF 2013 (rejeté) : 'taxe à 75%'
 
@@ -34,7 +34,7 @@ class cesthra(Variable):
 
 
 class irpp(Variable):
-    label = u"Impôt sur le revenu des personnes physiques (réformée pour intégrer la cesthra)"
+    label = "Impôt sur le revenu des personnes physiques (réformée pour intégrer la cesthra)"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -60,7 +60,7 @@ class irpp(Variable):
 
 
 class cesthra_invalidee(Reform):
-    name = u"Contribution execptionnelle sur les très hauts revenus d'activité (invalidée par le CC)"
+    name = "Contribution execptionnelle sur les très hauts revenus d'activité (invalidée par le CC)"
 
     def apply(self):
         self.add_variable(cesthra)

--- a/openfisca_france/reforms/de_net_a_brut.py
+++ b/openfisca_france/reforms/de_net_a_brut.py
@@ -31,7 +31,7 @@ def calculate_net_from(salaire_de_base, individu, period):
 class salaire_de_base(Variable):
     value_type = float
     entity = entities.Individu
-    label = u"Salaire brut"
+    label = "Salaire brut"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
@@ -56,7 +56,7 @@ class salaire_de_base(Variable):
 
 
 class de_net_a_brut(Reform):
-    name = u'Inversion du calcul brut -> net'
+    name = 'Inversion du calcul brut -> net'
 
     def apply(self):
         self.update_variable(salaire_de_base)

--- a/openfisca_france/reforms/inversion_directe_salaires.py
+++ b/openfisca_france/reforms/inversion_directe_salaires.py
@@ -12,7 +12,7 @@ TAUX_DE_PRIME = .10
 class salaire_imposable_pour_inversion(Variable):
     value_type = float
     entity = Individu
-    label = u'Salaire imposable utilisé pour remonter au salaire brut'
+    label = 'Salaire imposable utilisé pour remonter au salaire brut'
     definition_period = MONTH
 
 
@@ -150,7 +150,7 @@ class primes_fonction_publique(Variable):
 
 class inversion_directe_salaires(Reform):
     key = 'inversion_directe_salaires'
-    name = u'Inversion des revenus'
+    name = 'Inversion des revenus'
 
     def apply(self):
         self.add_variable(salaire_imposable_pour_inversion)

--- a/openfisca_france/reforms/inversion_revenus.py
+++ b/openfisca_france/reforms/inversion_revenus.py
@@ -21,33 +21,33 @@ def build_reform(tax_benefit_system):
 
     Reform = reforms.make_reform(
         key = 'inversion_revenus',
-        name = u'Inversion des revenus',
+        name = 'Inversion des revenus',
         reference_tax_benefit_system = tax_benefit_system,
         )
 
     class salaire_imposable_pour_inversion(Reform.Variable):
         value_type = float
         entity = entities.Individu
-        label = u'Salaire imposable utilisé pour remonter au salaire brut'
+        label = 'Salaire imposable utilisé pour remonter au salaire brut'
         definition_period = YEAR
 
     class chomage_imposable_pour_inversion(Reform.Variable):
         value_type = float
         entity = entities.Individu
-        label = u'Autres revenus imposables (chômage, préretraite), utilisé pour l’inversion'
+        label = 'Autres revenus imposables (chômage, préretraite), utilisé pour l’inversion'
         definition_period = YEAR
 
     class retraite_imposable_pour_inversion(Reform.Variable):
         value_type = float
         entity = entities.Individu
-        label = u'Pensions, retraites, rentes connues imposables, utilisé pour l’inversion'
+        label = 'Pensions, retraites, rentes connues imposables, utilisé pour l’inversion'
         definition_period = YEAR
 
     class salaire_de_base(Reform.Variable):
         value_type = float
         entity = entities.Individu
-        label = u"Salaire brut ou traitement indiciaire brut"
-        reference = u"http://www.trader-finance.fr/lexique-finance/definition-lettre-S/Salaire-brut.html"
+        label = "Salaire brut ou traitement indiciaire brut"
+        reference = "http://www.trader-finance.fr/lexique-finance/definition-lettre-S/Salaire-brut.html"
         definition_period = MONTH
 
         def formula(individu, period, parameters):
@@ -173,8 +173,8 @@ def build_reform(tax_benefit_system):
     class chomage_brut(Reform.Variable):
         value_type = float
         entity = entities.Individu
-        label = u"Allocations chômage brutes"
-        reference = u"http://vosdroits.service-public.fr/particuliers/N549.xhtml"
+        label = "Allocations chômage brutes"
+        reference = "http://vosdroits.service-public.fr/particuliers/N549.xhtml"
         definition_period = MONTH
 
         def formula(individu, period, parameters):
@@ -222,8 +222,8 @@ def build_reform(tax_benefit_system):
     class retraite_brute(Reform.Variable):
         value_type = float
         entity = entities.Individu
-        label = u"Pensions de retraite brutes"
-        reference = u"http://vosdroits.service-public.fr/particuliers/N20166.xhtml"
+        label = "Pensions de retraite brutes"
+        reference = "http://vosdroits.service-public.fr/particuliers/N20166.xhtml"
         definition_period = MONTH
 
         def formula(individu, period, parameters):

--- a/openfisca_france/reforms/landais_piketty_saez.py
+++ b/openfisca_france/reforms/landais_piketty_saez.py
@@ -17,7 +17,7 @@ dir_path = os.path.join(os.path.dirname(__file__), 'parameters')
 class assiette_csg(Variable):
     value_type = float
     entity = Individu
-    label = u"Assiette de la CSG"
+    label = "Assiette de la CSG"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -33,7 +33,7 @@ class assiette_csg(Variable):
 class impot_revenu_lps(Variable):
     value_type = float
     entity = Individu
-    label = u"Impôt individuel sur l'ensemble de l'assiette de la csg, comme proposé par Landais, Piketty et Saez"
+    label = "Impôt individuel sur l'ensemble de l'assiette de la csg, comme proposé par Landais, Piketty et Saez"
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -57,8 +57,8 @@ class impot_revenu_lps(Variable):
 class revenu_disponible(Variable):
     value_type = float
     entity = Menage
-    label = u"Revenu disponible du ménage"
-    reference = u"http://fr.wikipedia.org/wiki/Revenu_disponible"
+    label = "Revenu disponible du ménage"
+    reference = "http://fr.wikipedia.org/wiki/Revenu_disponible"
     definition_period = YEAR
 
     def formula(menage, period, parameters):
@@ -84,7 +84,7 @@ def modify_parameters(parameters):
 
 
 class landais_piketty_saez(Reform):
-    name = u'Landais Piketty Saez'
+    name = 'Landais Piketty Saez'
 
     def apply(self):
         for variable in [assiette_csg, impot_revenu_lps, revenu_disponible]:

--- a/openfisca_france/reforms/plf2015.py
+++ b/openfisca_france/reforms/plf2015.py
@@ -23,7 +23,7 @@ def modify_parameters(parameters):
 
 
 class decote(Variable):
-    label = u"Décote IR 2015 appliquée sur IR 2014 (revenus 2013)"
+    label = "Décote IR 2015 appliquée sur IR 2014 (revenus 2013)"
     definition_period = YEAR
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
@@ -37,7 +37,7 @@ class decote(Variable):
 
 
 class plf2015(Reform):
-    name = u"Projet de Loi de Finances 2015 appliquée aux revenus 2013"
+    name = "Projet de Loi de Finances 2015 appliquée aux revenus 2013"
 
     def apply(self):
         self.update_variable(decote)

--- a/openfisca_france/reforms/plf2016.py
+++ b/openfisca_france/reforms/plf2016.py
@@ -19,11 +19,11 @@ def reform_modify_parameters(parameters):
 
 
 class plf2016(Reform):
-    name = u'Projet de Loi de Finances 2016 appliquée aux revenus 2014'
+    name = 'Projet de Loi de Finances 2016 appliquée aux revenus 2014'
     # key = 'plf2016'
 
     class decote(Variable):
-        label = u"Décote IR 2016 appliquée en 2015 sur revenus 2014"
+        label = "Décote IR 2016 appliquée en 2015 sur revenus 2014"
         definition_period = YEAR
 
         # This formula is copy-pasted from the reference decote formula, so that we only change the decote formula for 2014
@@ -84,11 +84,11 @@ def counterfactual_modify_parameters(parameters):
 
 
 class plf2016_counterfactual(Reform):
-    name = u'Contrefactuel du PLF 2016 sur les revenus 2015'
+    name = 'Contrefactuel du PLF 2016 sur les revenus 2015'
     # key = 'plf2016_counterfactual'
 
     class decote(Variable):
-        label = u"Décote IR 2015 appliquée sur revenus 2015 (contrefactuel)"
+        label = "Décote IR 2015 appliquée sur revenus 2015 (contrefactuel)"
         definition_period = YEAR
 
         def formula_2015_01_01(foyer_fiscal, period, parameters):
@@ -115,7 +115,7 @@ class plf2016_counterfactual(Reform):
             return min_(max_(plafond + montant - rfr, 0), montant)
 
     class reductions(Variable):
-        label = u"Somme des réductions d'impôt"
+        label = "Somme des réductions d'impôt"
         definition_period = YEAR
 
         def formula_2013_01_01(foyer_fiscal, period, parameters):
@@ -182,7 +182,7 @@ def counterfactual_2014_modify_parameters(parameters):
 
 
 class plf2016_counterfactual_2014(Reform):
-    name = u'Contrefactuel 2014 du PLF 2016 sur les revenus 2015'
+    name = 'Contrefactuel 2014 du PLF 2016 sur les revenus 2015'
     key = 'plf2016_counterfactual_2014'
 
     class decote(Variable):
@@ -212,7 +212,7 @@ class plf2016_counterfactual_2014(Reform):
             return min_(max_(plafond + montant - rfr, 0), montant)
 
     class reductions(Variable):
-        label = u"Somme des réductions d'impôt"
+        label = "Somme des réductions d'impôt"
         definition_period = YEAR
 
         def formula_2013_01_01(foyer_fiscal, period, parameters):

--- a/openfisca_france/reforms/plf2016_ayrault_muet.py
+++ b/openfisca_france/reforms/plf2016_ayrault_muet.py
@@ -30,14 +30,14 @@ class variator(Variable):
     value_type = float
     default_value = 1
     entity = FoyerFiscal
-    label = u'Multiplicateur du seuil de régularisation'
+    label = 'Multiplicateur du seuil de régularisation'
     definition_period = YEAR
 
 
 class reduction_csg(Variable):
     value_type = float
     entity = Individu
-    label = u"Réduction dégressive de CSG"
+    label = "Réduction dégressive de CSG"
     definition_period = YEAR
 
     def formula_2015_01_01(individu, period, parameters):
@@ -60,7 +60,7 @@ class reduction_csg(Variable):
 
 class reduction_csg_foyer_fiscal(Variable):
     entity = FoyerFiscal
-    label = u"Réduction dégressive de CSG des memebres du foyer fiscal"
+    label = "Réduction dégressive de CSG des memebres du foyer fiscal"
     value_type = float
     definition_period = YEAR
 
@@ -72,7 +72,7 @@ class reduction_csg_foyer_fiscal(Variable):
 class reduction_csg_nette(Variable):
     value_type = float
     entity = Individu
-    label = u"Réduction dégressive de CSG"
+    label = "Réduction dégressive de CSG"
     definition_period = YEAR
 
     def formula_2015_01_01(individu, period):
@@ -84,7 +84,7 @@ class reduction_csg_nette(Variable):
 class ppe_elig_bis(Variable):
     value_type = bool
     entity = FoyerFiscal
-    label = u"ppe_elig_bis"
+    label = "ppe_elig_bis"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -108,7 +108,7 @@ class ppe_elig_bis(Variable):
 class regularisation_reduction_csg(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Régularisation complète réduction dégressive de CSG"
+    label = "Régularisation complète réduction dégressive de CSG"
     definition_period = YEAR
 
     def formula_2015_01_01(foyer_fiscal, period, parameters):
@@ -118,7 +118,7 @@ class regularisation_reduction_csg(Variable):
 
 
 class ayrault_muet(Reform):
-    name = u'Amendement Ayrault-Muet au PLF2016'
+    name = 'Amendement Ayrault-Muet au PLF2016'
     key = 'ayrault_muet'
 
     def apply(self):

--- a/openfisca_france/reforms/plfr2014.py
+++ b/openfisca_france/reforms/plfr2014.py
@@ -12,7 +12,7 @@ dir_path = os.path.join(os.path.dirname(__file__), 'parameters')
 # par le Conseil constitutionnel
 
 class plfr2014(Reform):
-    name = u'Projet de Loi de Finances Rectificative 2014'
+    name = 'Projet de Loi de Finances Rectificative 2014'
 
     class reduction_impot_exceptionnelle(Variable):
         definition_period = YEAR
@@ -29,7 +29,7 @@ class plfr2014(Reform):
             return min_(max_(plafond + montant - rfr, 0), montant)
 
     class reductions(Variable):
-        label = u"Somme des réductions d'impôt à intégrer pour l'année 2013"
+        label = "Somme des réductions d'impôt à intégrer pour l'année 2013"
         definition_period = YEAR
 
         def formula_2013_01_01(foyer_fiscal, period, parameters):

--- a/openfisca_france/reforms/simulation_reform.py
+++ b/openfisca_france/reforms/simulation_reform.py
@@ -7,14 +7,14 @@ from openfisca_core import reforms
 class date_simulation(Variable):
     value_type = date
     entity = Individu
-    label = u"Date de la simulation"
+    label = "Date de la simulation"
     definition_period = MONTH
 
 
 class aah(Variable):
     calculate_output = calculate_output_add
     value_type = float
-    label = u"Allocation adulte handicapé (Individu) mensualisée"
+    label = "Allocation adulte handicapé (Individu) mensualisée"
     entity = Individu
     definition_period = MONTH
     set_input = set_input_divide_by_period

--- a/openfisca_france/reforms/smic_h_b_9_euros.py
+++ b/openfisca_france/reforms/smic_h_b_9_euros.py
@@ -9,7 +9,7 @@ def modify_parameters(parameters):
 
 
 class smic_h_b_9_euros(Reform):
-    name = u"Réforme pour simulation ACOSS SMIC horaire brut fixe à 9 euros"
+    name = "Réforme pour simulation ACOSS SMIC horaire brut fixe à 9 euros"
 
     def apply(self):
         self.modify_parameters(modifier_function = modify_parameters)

--- a/openfisca_france/reforms/trannoy_wasmer.py
+++ b/openfisca_france/reforms/trannoy_wasmer.py
@@ -17,7 +17,7 @@ def modify_parameters(parameters):
 
 
 class charges_deduc(Variable):
-    label = u"Charge déductibles intégrant la charge pour loyer (Trannoy-Wasmer)"
+    label = "Charge déductibles intégrant la charge pour loyer (Trannoy-Wasmer)"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -31,7 +31,7 @@ class charges_deduc(Variable):
 class charge_loyer(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = u"Charge déductible pour paiement d'un loyer"
+    label = "Charge déductible pour paiement d'un loyer"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):
@@ -49,7 +49,7 @@ class charge_loyer(Variable):
 
 
 class trannoy_wasmer(Reform):
-    name = u'Loyer comme charge déductible (Trannoy-Wasmer)'
+    name = 'Loyer comme charge déductible (Trannoy-Wasmer)'
 
     def apply(self):
         self.update_variable(charges_deduc)

--- a/openfisca_france/scripts/download_mes_aides_tests.py
+++ b/openfisca_france/scripts/download_mes_aides_tests.py
@@ -43,20 +43,20 @@ def fetch_json(url):
 
 
 def fetch_situation(api_base_url, situation_id):
-    url = u'{}/api/situations/{}/openfisca-request'.format(api_base_url, situation_id)
-    log.info(u'fetch situation: GET "{}"'.format(url))
+    url = '{}/api/situations/{}/openfisca-request'.format(api_base_url, situation_id)
+    log.info('fetch situation: GET "{}"'.format(url))
     return fetch_json(url)
 
 
 def fetch_tests(api_base_url):
-    url = u'{}/api/public/acceptance-tests'.format(api_base_url)
-    log.info(u'fetch tests: GET "{}"'.format(url))
+    url = '{}/api/public/acceptance-tests'.format(api_base_url)
+    log.info('fetch tests: GET "{}"'.format(url))
     return fetch_json(url)
 
 
 def iter_yaml_items(api_base_url, test):
     test_case = fetch_situation(api_base_url = api_base_url, situation_id = test['scenario']['situationId'])
-    log.info(u'ID: {} [{}] {}'.format(test['_id'], u', '.join(sorted(test['keywords'])), test['name']))
+    log.info('ID: {} [{}] {}'.format(test['_id'], ', '.join(sorted(test['keywords'])), test['name']))
     yield 'name', test['name'], None
     yield 'keywords', sorted(test['keywords']), None
     description = test.get('description', None)
@@ -81,11 +81,11 @@ def iter_yaml_items(api_base_url, test):
 
 def main():
     parser = argparse.ArgumentParser(description = __doc__)
-    parser.add_argument('--api-base-url', default = u'https://mes-aides.gouv.fr', help = u'Ludwig API base URL')
-    parser.add_argument('--output-dir', default = tests_dir_path, help = u'Where to write the tests')
-    parser.add_argument('--tests-json', default = None, help = u'Do not download tests, use given file')
-    parser.add_argument('--test-ids', default = None, help = u'Download only those IDs', nargs = '+')
-    parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = u'Increase output verbosity')
+    parser.add_argument('--api-base-url', default = 'https://mes-aides.gouv.fr', help = 'Ludwig API base URL')
+    parser.add_argument('--output-dir', default = tests_dir_path, help = 'Where to write the tests')
+    parser.add_argument('--tests-json', default = None, help = 'Do not download tests, use given file')
+    parser.add_argument('--test-ids', default = None, help = 'Download only those IDs', nargs = '+')
+    parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = 'Increase output verbosity')
     args = parser.parse_args()
     logging.basicConfig(level = logging.DEBUG if args.verbose else logging.WARNING, stream = sys.stdout)
     logging.getLogger("requests").setLevel(logging.WARNING)
@@ -98,7 +98,7 @@ def main():
     if args.tests_json is None:
         tests_json = fetch_tests(api_base_url = args.api_base_url)
     else:
-        log.info(u'load tests JSON file "{}"'.format(args.tests_json))
+        log.info('load tests JSON file "{}"'.format(args.tests_json))
         with open(args.tests_json) as tests_json_file:
             tests_json_str = tests_json_file.read()
             tests_json = json.loads(tests_json_str)
@@ -113,11 +113,11 @@ def main():
         last_execution = test_json['lastExecution']
         assert test_json['currentStatus'] == last_execution['status']
         if any('expectedValue' in result and 'status' in result and result['status'] not in ('accepted-exact', 'accepted-2pct') for result in last_execution['results']):
-            log.info(u'Test "{}" doesn\'t return the expected value (yet), so skip it.'.format(test_json['_id']))
+            log.info('Test "{}" doesn\'t return the expected value (yet), so skip it.'.format(test_json['_id']))
             continue
 
         # Write test_yaml to output_dir_path
-        yaml_file_name = u'test_mes_aides_{}.yaml'.format(test_json['_id'])
+        yaml_file_name = 'test_mes_aides_{}.yaml'.format(test_json['_id'])
         yaml_file_path = os.path.join(args.output_dir, yaml_file_name)
         with open(yaml_file_path, 'w') as yaml_file:
             for yaml_key, yaml_value, default_style in iter_yaml_items(api_base_url = args.api_base_url,
@@ -135,7 +135,7 @@ def main():
 
     if args.test_ids is None:
         for file_name in sorted(existing_yaml_files_name):
-            log.info(u'Deleting obsolete test: "{}"'.format(file_name))
+            log.info('Deleting obsolete test: "{}"'.format(file_name))
             file_path = os.path.join(args.output_dir, file_name)
             os.remove(file_path)
 

--- a/openfisca_france/scripts/inspect_dgfip_variable.py
+++ b/openfisca_france/scripts/inspect_dgfip_variable.py
@@ -24,21 +24,21 @@ def inspect_dgfip_variable(variable, year, browser_name):
     assert matched is not None, 'Invalid variable: {}'.format(variable)
     section_number = variable[1]
     case = variable[2:4].upper()
-    log.info(u"section %s, case %s", section_number, case)
-    url_base = u"http://www3.impots.gouv.fr/simulateur/calcul_impot/" + str(year + 1) + "/aides/"
+    log.info("section %s, case %s", section_number, case)
+    url_base = "http://www3.impots.gouv.fr/simulateur/calcul_impot/" + str(year + 1) + "/aides/"
     url_section = {
-        '2': u"capitaux_mobiliers.htm",
-        '3': u"gains_c.htm",
-        '4': u"fonciers.htm",
-        # '5': u"charges_s.htm",
-        '6': u"charges.htm",
-        '7': u"reductions.htm",
-        '8': u"autres_imputations.htm",
+        '2': "capitaux_mobiliers.htm",
+        '3': "gains_c.htm",
+        '4': "fonciers.htm",
+        # '5': "charges_s.htm",
+        '6': "charges.htm",
+        '7': "reductions.htm",
+        '8': "autres_imputations.htm",
         }.get(section_number)
     assert url_section is not None, 'Unhandled section number: {}'.format(section_number)
     url = url_base + url_section
     if section_number not in ('3', '4'):
-        url += u'#' + case
+        url += '#' + case
 
     browser = webbrowser.get(browser_name)
     browser.open_new_tab(url)
@@ -46,17 +46,17 @@ def inspect_dgfip_variable(variable, year, browser_name):
 
 def main():
     parser = argparse.ArgumentParser(description = __doc__)
-    parser.add_argument('variable_name', help = u'Name of the variable to inspect. Example: "f7wr"')
-    parser.add_argument('--browser', dest = 'browser_name', default = 'chromium', help = u'Open links in this browser')
-    parser.add_argument('--min-year', default = None, help = u'Year to start from', type = int)
-    parser.add_argument('--max-year', default = None, help = u'Year to stop to', type = int)
+    parser.add_argument('variable_name', help = 'Name of the variable to inspect. Example: "f7wr"')
+    parser.add_argument('--browser', dest = 'browser_name', default = 'chromium', help = 'Open links in this browser')
+    parser.add_argument('--min-year', default = None, help = 'Year to start from', type = int)
+    parser.add_argument('--max-year', default = None, help = 'Year to stop to', type = int)
     parser.add_argument('-v', '--verbose', action = 'store_true', default = False, help = "Increase output verbosity")
-    parser.add_argument('--year', default = None, help = u'Inspect the variable for the given year', type = int)
+    parser.add_argument('--year', default = None, help = 'Inspect the variable for the given year', type = int)
     args = parser.parse_args()
     logging.basicConfig(level = logging.DEBUG if args.verbose else logging.WARNING, stream = sys.stdout)
 
     if args.year and (args.min_year or args.max_year):
-        parser.error(u'year and {min,max}-year arguments cannot be used together')
+        parser.error('year and {min,max}-year arguments cannot be used together')
 
     if args.min_year or args.max_year:
         if args.min_year and args.max_year:
@@ -64,15 +64,15 @@ def main():
                 try:
                     inspect_dgfip_variable(args.variable_name, year, args.browser_name)
                 except ValueError:
-                    log.error(u'Variable "%s" not found', args.variable_name)
+                    log.error('Variable "%s" not found', args.variable_name)
         else:
-            parser.error(u'Please give min and max year')
+            parser.error('Please give min and max year')
     else:
         year = args.year or DEFAULT_YEAR
         try:
             inspect_dgfip_variable(args.variable_name, year, args.browser_name)
         except ValueError:
-            log.error(u'Variable "%s" not found', args.variable_name)
+            log.error('Variable "%s" not found', args.variable_name)
 
 
 if __name__ == '__main__':

--- a/openfisca_france/scripts/parameters/reduce_parameters_paths.py
+++ b/openfisca_france/scripts/parameters/reduce_parameters_paths.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 def clean_from_filename(relative_path):
     last_separator_index = relative_path.rfind(os.path.sep)
     if last_separator_index == -1:
-        raise ValueError(u'Directory expected but none found in: ' + relative_path)
+        raise ValueError('Directory expected but none found in: ' + relative_path)
     return relative_path[:last_separator_index]
 
 
@@ -119,7 +119,7 @@ def parse_and_clean(directory, paths_to_clean):
 
 
 long_parameters_paths = list_long_paths(PARAMETERS_DIRECTORY)
-logger.info(u"{} directories have files with more than {} characters in their paths starting from this directory: {}".format(len(long_parameters_paths), PATH_MAX_LENGTH, PARENT_DIRECTORY).encode('utf-8'))
+logger.info("{} directories have files with more than {} characters in their paths starting from this directory: {}".format(len(long_parameters_paths), PATH_MAX_LENGTH, PARENT_DIRECTORY).encode('utf-8'))
 
 while len(long_parameters_paths) > 0:
     parse_and_clean(PARAMETERS_DIRECTORY, long_parameters_paths)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.3.0",
+    version = "48.3.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/reforms/test_parametric_reform.py
+++ b/tests/reforms/test_parametric_reform.py
@@ -20,7 +20,7 @@ def modify_parameters(parameters):
 
 
 class ir_100_tranche_1(Reform):
-    name = u"Imposition à 100% dès le premier euro et jusqu'à la fin de la 1ère tranche"
+    name = "Imposition à 100% dès le premier euro et jusqu'à la fin de la 1ère tranche"
 
     def apply(self):
         self.modify_parameters(modifier_function = modify_parameters)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -41,7 +41,7 @@ class depcom(Variable):
     value_type = str
     max_length = 5
     entity = Menage
-    label = u"""Code INSEE "depcom" de la commune de résidence de la famille"""
+    label = """Code INSEE "depcom" de la commune de résidence de la famille"""
     definition_period = ETERNITY
 
 # This tests are more about core than france, but we need france entities to run some of them.


### PR DESCRIPTION
* Changement mineur
* Zones impactées : `**/*`.
* Détails :
  - Supprime le keyword unicode `u`, qui n'est plus nécessaire depuis Python 3

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
