### PR TITLE
Corrige la nouvelle variable ppa_plancher_revenu_activite_etudiant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-### 48.3.3 [#1361](https://github.com/openfisca/openfisca-france/pull/1361)
+### 48.4.0 [#1368](https://github.com/openfisca/openfisca-france/pull/1368)
+
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées : `prestations/minima_sociaux/ppa`.
+* Détails :
+  - Change l'entité associée à `ppa_plancher_revenu_activite_etudiant`
+
+### ~48.3.3 [#1361](https://github.com/openfisca/openfisca-france/pull/1361)~ Version dé-publiée
+
+> Cette version a été dé-publiée pour éviter un changement majeur pour le correctif apporté par la 48.4.0
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : toutes.

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -22,7 +22,7 @@ class ppa_eligibilite(Variable):
 
 class ppa_plancher_revenu_activite_etudiant(Variable):
     value_type = float
-    entity = Famille
+    entity = Individu
     label = u"Plancher des revenus d'activité pour être éligible à la PPA en tant qu'étudiant"
     definition_period = MONTH
 
@@ -52,7 +52,7 @@ class ppa_eligibilite_etudiants(Variable):
         ppa_majoree_eligibilite = famille('rsa_majore_eligibilite', period)
 
         etudiant_i = famille.members('etudiant', period)
-        plancher_etudiant = famille('ppa_plancher_revenu_activite_etudiant', period)
+        plancher_etudiant = famille.members('ppa_plancher_revenu_activite_etudiant', period)
 
         def condition_ressource(period2, plancher):
             revenu_activite = famille.members('ppa_revenu_activite_individu', period2)

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -70,9 +70,9 @@ class ppa_eligibilite_etudiants(Variable):
 
         condition_non_etudiant_i = (
             not_(etudiant_i) * (
-                condition_ressource(m_1, 1)
-                + condition_ressource(m_2, 2)
-                + condition_ressource(m_3, 3)
+                condition_ressource(m_1, 0)
+                + condition_ressource(m_2, 0)
+                + condition_ressource(m_3, 0)
                 )
             )
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.3.3",
+    version = "48.4.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `prestations/minima_sociaux/ppa`.
* Détails :
  - Change l'entité associée à `ppa_plancher_revenu_activite_etudiant`

- - - -
