### PR TITLE
Intègre la condition d'obtention du RSA pour les ressortissants de l'EEE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 48.7.0 [#1371](https://github.com/openfisca/openfisca-france/pull/1371)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/06/2009.
+* Zones impactées :
+`openfisca_france/model/prestations/minima_sociaux/rsa.py`
+`openfisca_france/parameters/prestations/minima_sociaux/rsa/duree_min_titre_sejour.yaml`
+`openfisca_france/tests/formulas/rsa/rsa_condition_nationalite.yaml`
+* Détails :
+  - Avant cette modification, un ressortissant de l'EEE était considéré comme ayant toujours droit au RSA, alors qu'en réalité il doit être en France depuis au moins 3 mois pour y avoir droit.
+  - Ce changement est lié à une évolution de l'interface Mes Aides : on y pose désormais une question sur la durée de résidence en France pour les ressortissants étrangers, et on souhaite se servir de cette donnée pour fiabiliser les résultats.
+
 ### 48.6.2 [#1372](https://github.com/openfisca/openfisca-france/pull/1372)
 
 * Revalorisation périodique.
@@ -33,6 +45,9 @@
 * Détails :
   - Intègre la fusion de l'ACS dans la CMU-C, sous la forme d'une CMU-C étendue appelée Complémentaire Sante Solidaire (CSS)
   - Intègre la cotisation forfataire par individu membre de la famille en fonction de l'âge prévue par la réforme.
+=======
+  - Ce changement est lié à une évolution de l'interface Mes Aides : on y pose désormais une question sur la durée de résidence en France pour les ressortissants étrangers, et on souhaite donc se servir de cette donnée pour fiabiliser les résultats.
+>>>>>>> Corrige les tests sur rsa_condition_nationalite et MAJ le changelog
 
 ### 48.5.2 [#1370](https://github.com/openfisca/openfisca-france/pull/1370)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 `openfisca_france/tests/formulas/rsa/rsa_condition_nationalite.yaml`
 * Détails :
   - Avant cette modification, un ressortissant de l'EEE était considéré comme ayant toujours droit au RSA, alors qu'en réalité il doit être en France depuis au moins 3 mois pour y avoir droit.
-  - Ce changement est lié à une évolution de l'interface Mes Aides : on y pose désormais une question sur la durée de résidence en France pour les ressortissants étrangers, et on souhaite se servir de cette donnée pour fiabiliser les résultats.
 
 ### 48.6.2 [#1372](https://github.com/openfisca/openfisca-france/pull/1372)
 
@@ -45,7 +44,6 @@
 * Détails :
   - Intègre la fusion de l'ACS dans la CMU-C, sous la forme d'une CMU-C étendue appelée Complémentaire Sante Solidaire (CSS)
   - Intègre la cotisation forfataire par individu membre de la famille en fonction de l'âge prévue par la réforme.
-  - Ce changement est lié à une évolution de l'interface Mes Aides : on y pose désormais une question sur la durée de résidence en France pour les ressortissants étrangers, et on souhaite donc se servir de cette donnée pour fiabiliser les résultats.
 
 ### 48.5.2 [#1370](https://github.com/openfisca/openfisca-france/pull/1370)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,7 @@
 * Détails :
   - Intègre la fusion de l'ACS dans la CMU-C, sous la forme d'une CMU-C étendue appelée Complémentaire Sante Solidaire (CSS)
   - Intègre la cotisation forfataire par individu membre de la famille en fonction de l'âge prévue par la réforme.
-=======
   - Ce changement est lié à une évolution de l'interface Mes Aides : on y pose désormais une question sur la durée de résidence en France pour les ressortissants étrangers, et on souhaite donc se servir de cette donnée pour fiabiliser les résultats.
->>>>>>> Corrige les tests sur rsa_condition_nationalite et MAJ le changelog
 
 ### 48.5.2 [#1370](https://github.com/openfisca/openfisca-france/pull/1370)
 

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -323,7 +323,7 @@ class ressortissant_eee(Variable):
 
 
 class duree_possession_titre_sejour(Variable):
-    value_type = int
+    value_type = float
     entity = Individu
     label = "Durée depuis laquelle l'individu possède un titre de séjour (en années)"
     definition_period = MONTH

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -615,10 +615,16 @@ class rsa_condition_nationalite(Variable):
     definition_period = MONTH
 
     def formula_2009_06_01(individu, period, parameters):
+        fr = individu('nationalite', period) == b'FR'
         ressortissant_eee = individu('ressortissant_eee', period)
+
         duree_possession_titre_sejour = individu('duree_possession_titre_sejour', period)
         duree_min_titre_sejour = parameters(period).prestations.minima_sociaux.rsa.duree_min_titre_sejour
-        return or_(ressortissant_eee, duree_possession_titre_sejour >= duree_min_titre_sejour)
+
+        eligibilite_eee = ressortissant_eee * duree_possession_titre_sejour >= duree_min_titre_sejour.eee
+        eligibilite_non_eee = not_(ressortissant_eee) * duree_possession_titre_sejour >= duree_min_titre_sejour.non_eee
+
+        return fr + eligibilite_eee + eligibilite_non_eee
 
     # RMI
     def formula(individu, period, parameters):

--- a/openfisca_france/parameters/prestations/minima_sociaux/rsa/duree_min_titre_sejour.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/rsa/duree_min_titre_sejour.yaml
@@ -1,6 +1,14 @@
-description: Durée minimale de titre du séjour permettant de bénéficier du RSA
-reference: https://www.ipp.eu/outils/baremes-ipp/
-unit: year
-values:
-  2009-06-01:
-    value: 5.0
+non_eee:
+  description: Durée minimale de titre du séjour permettant de bénéficier du RSA
+  reference: https://www.ipp.eu/outils/baremes-ipp/
+  unit: year
+  values:
+    2009-06-01:
+      value: 5.0
+eee:
+  description: Durée minimale de titre du séjour permettant de bénéficier du RSA pour un ressortissant de l'EEE
+  reference: https://www.service-public.fr/particuliers/vosdroits/F19778
+  unit: year
+  values:
+    2009-06-01:
+      value: 0.25 # 3/12 (3 mois)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.6.2",
+    version = "48.7.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/rsa/rsa_condition_nationalite.yaml
+++ b/tests/formulas/rsa/rsa_condition_nationalite.yaml
@@ -1,0 +1,7 @@
+- period: 2018-06
+  input:
+    nationalite: [null, null, null, null, FR]
+    ressortissant_eee: [true, true, false, false, null]
+    duree_possession_titre_sejour: [0.2, 0.25, 4.9, 5, 0]
+  output:
+    rsa_condition_nationalite: [false, true, false, true, true]

--- a/tests/formulas/rsa/rsa_condition_nationalite.yaml
+++ b/tests/formulas/rsa/rsa_condition_nationalite.yaml
@@ -1,7 +1,13 @@
 - period: 2018-06
   input:
-    nationalite: [null, null, null, null, FR]
-    ressortissant_eee: [true, true, false, false, null]
-    duree_possession_titre_sejour: [0.2, 0.25, 4.9, 5, 0]
+    nationalite: FR
   output:
-    rsa_condition_nationalite: [false, true, false, true, true]
+    rsa_condition_nationalite: true
+
+- period: 2018-06
+  input:
+    nationalite: [CH, CH, NZ, NZ]
+    duree_possession_titre_sejour: [0.2, 0.25, 4.9, 5]
+  output:
+    ressortissant_eee: [true, true, false, false]
+    rsa_condition_nationalite: [false, true, false, true]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/06/2009.
* Zones impactées :
`openfisca_france/model/prestations/minima_sociaux/rsa.py`
`openfisca_france/parameters/prestations/minima_sociaux/rsa/duree_min_titre_sejour.yaml`
`openfisca_france/tests/formulas/rsa/rsa_condition_nationalite.yaml`
* Détails :
  - Avant cette modification, un ressortissant de l'EEE était considéré comme ayant toujours droit au RSA, alors qu'en réalité il doit être en France depuis au moins 3 mois pour y avoir droit.
  - Ce changement est lié à une évolution de l'interface Mes Aides : on y pose désormais une question sur la durée de résidence en France pour les ressortissants étrangers, et on souhaite donc se servir de cette donnée pour fiabiliser les résultats.

- - - -

Ces changements :
- Modifient un paramètre : divise `duree_min_titre_sejour` en `duree_min_titre_sejour.eee` et `duree_min_titre_sejour.non_eee`
- Corrigent ou améliorent un calcul déjà existant : `rsa_condition_nationalite`
- Modifient des éléments non fonctionnels de ce dépôt : ajout de 2 tests `rsa_condition_nationalite`