### PR TITLE
Revalorisation paramètres aides au logement au 01/10/19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+### 48.6.2 [#1372](https://github.com/openfisca/openfisca-france/pull/1372)
+
+* Revalorisation périodique.
+* Périodes concernées : à partir du 01/10/2019.
+* Zones impactées :
+  - `parameters/prestations/aides_logement/al_charge`.
+  - `parameters/prestations/aides_logement/forfait_charges`.
+  - `parameters/prestations/aides_logement/loyers_plafond`.
+  - `parameters/prestations/al_plafonds_accession`.
+  - `parameters/prestations/al_plafonds_logement_foyer`.
+  - `parameters/prestations/al_plafonds_logement_foyer_crous`.
+
+* Détails :
+  - Revalorisation annuelle des paramètres de calcul de l’APL, de l’ALF et de l’ALS au 1 octobre 2019.
+
 ### 48.6.1 [#1375](https://github.com/openfisca/openfisca-france/pull/1375)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prestations/aides_logement/al_charge/personne_isolee_ou_menage_seul/cas_des_colocataires_ou_des_proprietaires_1.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/al_charge/personne_isolee_ou_menage_seul/cas_des_colocataires_ou_des_proprietaires_1.yaml
@@ -34,3 +34,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_5
     value: 26.83
+  2019-10-01:
+    value: 26.91

--- a/openfisca_france/parameters/prestations/aides_logement/forfait_charges/cas_general.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/forfait_charges/cas_general.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_5
     value: 53.67
+  2019-10-01:
+    value: 53.83

--- a/openfisca_france/parameters/prestations/aides_logement/forfait_charges/majoration_par_enfant.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/forfait_charges/majoration_par_enfant.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_5
     value: 12.16
+  2019-10-01:
+    value: 12.20

--- a/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_1/couples.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_1/couples.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_1
     value: 355.85
+  2019-10-01:
+    value: 356.92

--- a/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_1/majoration_par_enf_supp.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_1/majoration_par_enf_supp.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_1
     value: 58.34
+  2019-10-01:
+    value: 58.52

--- a/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_1/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_1/personnes_seules.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_1
     value: 295.05
+  2019-10-01:
+    value: 295.94

--- a/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_1/un_enfant.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_1/un_enfant.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_1
     value: 402.18
+  2019-10-01:
+    value: 403.39

--- a/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_2/couples.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_2/couples.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_1
     value: 314.74
+  2019-10-01:
+    value: 315.68

--- a/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_2/majoration_par_enf_supp.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_2/majoration_par_enf_supp.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_1
     value: 51.54
+  2019-10-01:
+    value: 51.69

--- a/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_2/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_2/personnes_seules.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_1
     value: 257.14
+  2019-10-01:
+    value: 257.91

--- a/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_2/un_enfant.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_2/un_enfant.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_1
     value: 354.17
+  2019-10-01:
+    value: 355.23

--- a/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_3/couples.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_3/couples.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_1
     value: 292.16
+  2019-10-01:
+    value: 293.04

--- a/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_3/majoration_par_enf_supp.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_3/majoration_par_enf_supp.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_1
     value: 46.95
+  2019-10-01:
+    value: 47.09

--- a/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_3/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_3/personnes_seules.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_1
     value: 241.0
+  2019-10-01:
+    value: 241.72

--- a/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_3/un_enfant.yaml
+++ b/openfisca_france/parameters/prestations/aides_logement/loyers_plafond/par_zone/zone_3/un_enfant.yaml
@@ -35,3 +35,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_1
     value: 327.59
+  2019-10-01:
+    value: 328.57

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_1_enfant.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_1_enfant.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 406.65
+  2019-10-01:
+    value: 407.87

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_2_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_2_enfants.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 418.01
+  2019-10-01:
+    value: 419.26

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_3_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_3_enfants.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 429.77
+  2019-10-01:
+    value: 431.06

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_4_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_4_enfants.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 441.3
+  2019-10-01:
+    value: 442.62

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_5_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_avec_5_enfants.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 450.64
+  2019-10-01:
+    value: 451.99

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_par_enfant_en_plus.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_ou_isole_par_enfant_en_plus.yaml
@@ -45,3 +45,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 39.24
+  2019-10-01:
+    value: 39.36

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_seul.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/menage_seul.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 378.2
+  2019-10-01:
+    value: 379.33

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/personne_isolee_sans_enfant.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_1/personne_isolee_sans_enfant.yaml
@@ -31,3 +31,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 313.82
+  2019-10-01:
+    value: 314.79

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_1_enfant.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_1_enfant.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 365.36
+  2019-10-01:
+    value: 366.46

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_2_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_2_enfants.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 378.01
+  2019-10-01:
+    value: 379.14

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_3_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_3_enfants.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 391.05
+  2019-10-01:
+    value: 392.22

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_4_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_4_enfants.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 403.89
+  2019-10-01:
+    value: 405.10

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_5_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_avec_5_enfants.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 432.48
+  2019-10-01:
+    value: 433.78

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_par_enfant_en_plus.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_ou_isole_par_enfant_en_plus.yaml
@@ -45,3 +45,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 37.6
+  2019-10-01:
+    value: 37.71

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_seul.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/menage_seul.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 337.51
+  2019-10-01:
+    value: 338.52

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/personne_isolee_sans_enfant.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_2/personne_isolee_sans_enfant.yaml
@@ -31,3 +31,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 275.31
+  2019-10-01:
+    value: 276.14

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_1_enfant.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_1_enfant.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 341.52
+  2019-10-01:
+    value: 342.54

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_2_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_2_enfants.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 355.64
+  2019-10-01:
+    value: 356.71

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_3_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_3_enfants.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 369.96
+  2019-10-01:
+    value: 371.07

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_4_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_4_enfants.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 384.06
+  2019-10-01:
+    value: 385.21

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_5_enfants.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_avec_5_enfants.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 412.68
+  2019-10-01:
+    value: 413.92

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_par_enfant_en_plus.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_ou_isole_par_enfant_en_plus.yaml
@@ -45,3 +45,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 35.78
+  2019-10-01:
+    value: 35.89

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_seul.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/menage_seul.yaml
@@ -47,3 +47,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 313.25
+  2019-10-01:
+    value: 314.19

--- a/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/personne_isolee_sans_enfant.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_accession/zone_3/personne_isolee_sans_enfant.yaml
@@ -31,3 +31,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_14
     value: 258.26
+  2019-10-01:
+    value: 259.03

--- a/openfisca_france/parameters/prestations/al_plafonds_logement_foyer/conventionne/zone_1.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_logement_foyer/conventionne/zone_1.yaml
@@ -5,27 +5,41 @@ menage_ou_isole_avec_1_enfant:
   values:
     2017-10-01:
       value: 552.23
+    2019-10-01:
+      value: 553.89
 menage_ou_isole_avec_2_enfants:
  values:
   2017-10-01:
     value: 590.99
+  2019-10-01:
+    value: 592.76
 menage_ou_isole_avec_3_enfants:
   values:
     2017-10-01:
       value: 629.90
+    2019-10-01:
+      value: 631.79
 menage_ou_isole_avec_4_enfants:
   values:
     2017-10-01:
       value: 679.42
+    2019-10-01:
+      value: 681.46
 menage_ou_isole_par_enfant_en_plus:
   values:
     2017-10-01:
       value: 70.46
+    2019-10-01:
+      value: 70.67
 menage_seul:
   values:
     2017-10-01:
       value: 517.91
+    2019-10-01:
+      value: 519.46
 personne_isolee_sans_enfant:
   values:
     2017-10-01:
       value: 441.78
+    2019-10-01:
+      value: 443.11

--- a/openfisca_france/parameters/prestations/al_plafonds_logement_foyer/conventionne/zone_2.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_logement_foyer/conventionne/zone_2.yaml
@@ -5,27 +5,41 @@ menage_ou_isole_avec_1_enfant:
   values:
     2017-10-01:
       value: 502.73
+    2019-10-01:
+      value: 504.24
 menage_ou_isole_avec_2_enfants:
   values:
     2017-10-01:
       value: 538.15
+    2019-10-01:
+      value: 539.76
 menage_ou_isole_avec_3_enfants:
   values:
     2017-10-01:
       value: 573.42
+    2019-10-01:
+      value: 575.14
 menage_ou_isole_avec_4_enfants:
   values:
     2017-10-01:
       value: 611.02
+    2019-10-01:
+      value: 612.85
 menage_ou_isole_par_enfant_en_plus:
   values:
     2017-10-01:
       value: 63.68
+    2019-10-01:
+      value: 63.87
 menage_seul:
   values:
     2017-10-01:
       value: 471.50
+    2019-10-01:
+      value: 472.91
 personne_isolee_sans_enfant:
   values:
     2017-10-01:
       value: 404.00
+    2019-10-01:
+      value: 405.21

--- a/openfisca_france/parameters/prestations/al_plafonds_logement_foyer/conventionne/zone_3.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_logement_foyer/conventionne/zone_3.yaml
@@ -5,27 +5,41 @@ menage_ou_isole_avec_1_enfant:
   values:
     2017-10-01:
       value: 473.18
+    2019-10-01:
+      value: 474.60
 menage_ou_isole_avec_2_enfants:
   values:
     2017-10-01:
       value: 504.40
+    2019-10-01:
+      value: 505.91
 menage_ou_isole_avec_3_enfants:
   values:
     2017-10-01:
       value: 535.63
+    2019-10-01:
+      value: 537.24
 menage_ou_isole_avec_4_enfants:
   values:
     2017-10-01:
       value: 570.73
+    2019-10-01:
+      value: 572.44
 menage_ou_isole_par_enfant_en_plus:
   values:
     2017-10-01:
       value: 59.10
+    2019-10-01:
+      value: 59.28
 menage_seul:
   values:
     2017-10-01:
       value: 446.01
+    2019-10-01:
+      value: 447.35
 personne_isolee_sans_enfant:
   values:
     2017-10-01:
       value: 383.47
+    2019-10-01:
+      value: 384.62

--- a/openfisca_france/parameters/prestations/al_plafonds_logement_foyer/personne_agee/couple.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_logement_foyer/personne_agee/couple.yaml
@@ -4,3 +4,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11
     value: 317.47
+  2019-10-01:
+    value: 318.42

--- a/openfisca_france/parameters/prestations/al_plafonds_logement_foyer/personne_agee/personne_isolee.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_logement_foyer/personne_agee/personne_isolee.yaml
@@ -4,3 +4,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11
     value: 204.32
+  2019-10-01:
+    value: 204.93

--- a/openfisca_france/parameters/prestations/al_plafonds_logement_foyer_crous/non_rehabilitee/couple.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_logement_foyer_crous/non_rehabilitee/couple.yaml
@@ -7,3 +7,5 @@ values:
   2017-10-01:
     reference:  https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11
     value: 129.68
+  2019-10-01:
+    value: 130.07

--- a/openfisca_france/parameters/prestations/al_plafonds_logement_foyer_crous/non_rehabilitee/personne_isolee.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_logement_foyer_crous/non_rehabilitee/personne_isolee.yaml
@@ -7,3 +7,5 @@ values:
   2017-10-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11
     value: 83.29
+  2019-10-01:
+    value: 83.54

--- a/openfisca_france/parameters/prestations/al_plafonds_logement_foyer_crous/rehabilitee/couple.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_logement_foyer_crous/rehabilitee/couple.yaml
@@ -4,3 +4,5 @@ values:
   2017-10-01:
     reference:  https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11
     value: 261.72
+  2019-10-01:
+    value: 262.51

--- a/openfisca_france/parameters/prestations/al_plafonds_logement_foyer_crous/rehabilitee/personne_isolee.yaml
+++ b/openfisca_france/parameters/prestations/al_plafonds_logement_foyer_crous/rehabilitee/personne_isolee.yaml
@@ -4,3 +4,5 @@ values:
   2017-10-01:
     reference:  https://www.legifrance.gouv.fr/eli/arrete/2017/9/28/TERL1725443A/jo/article_11
     value: 168.39
+  2019-10-01:
+    value: 168.90

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.6.1",
+    version = "48.6.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Revalorisation périodique.
* Périodes concernées : à partir du 01/10/2019.
* Zones impactées : 
  - `parameters/prestations/aides_logement/al_charge`.
  - `parameters/prestations/aides_logement/forfait_charges`.
  - `parameters/prestations/aides_logement/loyers_plafond`.
  - `parameters/prestations/al_plafonds_accession`.
  - `parameters/prestations/al_plafonds_logement_foyer`.
  - `parameters/prestations/al_plafonds_logement_foyer_crous`.

* Détails :
  - Revalorisation annuelle des paramètres de calcul de l’APL, de l’ALF et de l’ALS au 1 octobre 2019.
