### PR TITLE
Corrige la formule APA urgence (institution)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## 48.7.1 [#1378](https://github.com/openfisca/openfisca-france/pull/1378)
+### 48.7.2 [#1374](https://github.com/openfisca/openfisca-france/pull/1374)
+
+* Correction d'un crash.
+* Périodes concernées : à partir du 01/01/2002.
+* Zones impactées : `prestations/autonomie.py`.
+* Détails :
+  - Corrige `apa_urgence_institution`
+  - Corrige une date manquant dans l'appel de l'arbre de paramètres
+
+### 48.7.1 [#1378](https://github.com/openfisca/openfisca-france/pull/1378)
 
 * Revalorisation périodique.
 * Périodes concernées : à partir du 01/10/2019.

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/remplacement.py
@@ -29,7 +29,7 @@ class taux_csg_remplacement(Variable):
     def formula_2015(individu, period, parameters):
         rfr = individu.foyer_fiscal('rfr', period = period.n_2)
         nbptr = individu.foyer_fiscal('nbptr', period = period.n_2)
-        seuils = parameters(period.start).prelevements_sociaux.contributions.csg.remplacement.pensions_de_retraite_et_d_invalidite
+        seuils = parameters(period).prelevements_sociaux.contributions.csg.remplacement.pensions_de_retraite_et_d_invalidite
         seuil_exoneration = seuils.seuil_de_rfr_1 + (nbptr - 1) * seuils.demi_part_suppl
         seuil_reduction = seuils.seuil_de_rfr_2 + (nbptr - 1) * seuils.demi_part_suppl
         taux_csg_remplacement = where(
@@ -58,7 +58,7 @@ class csg_deductible_chomage(Variable):
         chomage_brut = individu('chomage_brut', period)
         csg_imposable_chomage = individu('csg_imposable_chomage', period)
         taux_csg_remplacement = individu('taux_csg_remplacement', period)
-        parameters = parameters(period.start)
+        parameters = parameters(period)
         montant_csg = montant_csg_crds(
             base_avec_abattement = chomage_brut,
             indicatrice_taux_plein = (taux_csg_remplacement == TypesTauxCSGRemplacement.taux_plein),
@@ -97,7 +97,7 @@ class csg_imposable_chomage(Variable):
 
     def formula(individu, period, parameters):
         chomage_brut = individu('chomage_brut', period)
-        parameters = parameters(period.start)
+        parameters = parameters(period)
 
         montant_csg = montant_csg_crds(
             base_avec_abattement = chomage_brut,
@@ -127,7 +127,7 @@ class crds_chomage(Variable):
         csg_deductible_chomage = individu('csg_deductible_chomage', period)
         csg_imposable_chomage = individu('csg_imposable_chomage', period)
         taux_csg_remplacement = individu('taux_csg_remplacement', period)
-        law = parameters(period.start)
+        law = parameters(period)
         smic_h_b = law.cotsoc.gen.smic_h_b
         # salaire_mensuel_reference = chomage_brut / .7
         # heures_mensuelles = min_(salaire_mensuel_reference / smic_h_b, 35 * 52 / 12)  # TODO: depuis 2001 mais avant ?
@@ -203,7 +203,7 @@ class csg_deductible_retraite(Variable):
     def formula(individu, period, parameters):
         retraite_brute = individu('retraite_brute', period)
         taux_csg_remplacement = individu('taux_csg_remplacement', period)
-        law = parameters(period.start)
+        law = parameters(period)
 
         montant_csg = montant_csg_crds(
             base_sans_abattement = retraite_brute,
@@ -225,7 +225,7 @@ class csg_imposable_retraite(Variable):
 
     def formula(individu, period, parameters):
         retraite_brute = individu('retraite_brute', period)
-        law = parameters(period.start)
+        law = parameters(period)
 
         montant_csg = montant_csg_crds(
             base_sans_abattement = retraite_brute,
@@ -246,7 +246,7 @@ class crds_retraite(Variable):
     def formula(individu, period, parameters):
         retraite_brute = individu('retraite_brute', period)
         taux_csg_remplacement = individu('taux_csg_remplacement', period)
-        law = parameters(period.start)
+        law = parameters(period)
 
         montant_crds = montant_csg_crds(
             base_sans_abattement = retraite_brute,
@@ -266,7 +266,7 @@ class casa(Variable):
     def formula_2013_04_01(individu, period, parameters):
         retraite_brute = individu('retraite_brute', period = period)
         taux_csg_remplacement = individu('taux_csg_remplacement', period)
-        contributions = parameters(period.start).prelevements_sociaux.contributions
+        contributions = parameters(period).prelevements_sociaux.contributions
         casa = (
             (taux_csg_remplacement == TypesTauxCSGRemplacement.taux_plein)
             * contributions.casa.calc(retraite_brute)
@@ -329,6 +329,6 @@ class crds_pfam(Variable):
         paje = famille('paje', period, options = [ADD])
         ape = famille('ape', period, options = [ADD])
         apje = famille('apje', period, options = [ADD])
-        taux_crds = parameters(period.start).prelevements_sociaux.contributions.crds.taux
+        taux_crds = parameters(period).prelevements_sociaux.contributions.crds.taux
 
         return -(af + cf + asf + ars + paje + ape + apje) * taux_crds

--- a/openfisca_france/model/prestations/autonomie.py
+++ b/openfisca_france/model/prestations/autonomie.py
@@ -9,7 +9,7 @@ class base_ressources_apa(Variable):
     entity = Individu
     definition_period = MONTH
 
-    def formula(individu, period):
+    def formula_2002(individu, period):
         period = period.first_month
         revenu_fiscal_de_reference = individu.foyer_fiscal('rfr', period.n_2) / 12
         aide_logement_montant = individu.famille('aide_logement_montant', period)
@@ -32,17 +32,17 @@ class apa_domicile_participation(Variable):
         # entre le 1er mars 2016 et le 28 février 2017
         base_ressources_apa = individu('base_ressources_apa', period)
         en_couple = individu.famille('en_couple', period)
-        parameters = parameters(period.start).autonomie
-        seuil_inf = parameters.apa_domicile.seuil_de_revenu_en_part_du_mtp.seuil_inferieur
-        seuil_sup = parameters.apa_domicile.seuil_de_revenu_en_part_du_mtp.seuil_superieur
-        majoration_tierce_personne = parameters.mtp.mtp
-        taux_min_participation = parameters.apa_domicile.taux_de_participation_minimum
-        taux_max_participation = parameters.apa_domicile.taux_de_participation_maximum
+        autonomie = parameters(period).autonomie
+        seuil_inf = autonomie.apa_domicile.seuil_de_revenu_en_part_du_mtp.seuil_inferieur
+        seuil_sup = autonomie.apa_domicile.seuil_de_revenu_en_part_du_mtp.seuil_superieur
+        majoration_tierce_personne = autonomie.mtp.mtp
+        taux_min_participation = autonomie.apa_domicile.taux_de_participation_minimum
+        taux_max_participation = autonomie.apa_domicile.taux_de_participation_maximum
 
         proratisation_couple = (
             1
             + en_couple
-            * (parameters.apa_domicile.divison_des_ressources_du_menage_pour_les_couples - 1)
+            * (autonomie.apa_domicile.divison_des_ressources_du_menage_pour_les_couples - 1)
             )
 
         dependance_plan_aide_domicile_accepte = individu('dependance_plan_aide_domicile_accepte', period)
@@ -68,7 +68,7 @@ class apa_domicile_participation(Variable):
         base_ressources_apa = individu('base_ressources_apa', period)
         en_couple = individu.famille('en_couple', period)
         dependance_plan_aide_domicile_accepte = individu('dependance_plan_aide_domicile_accepte', period)
-        parameters = parameters(period.start).autonomie
+        parameters = parameters(period).autonomie
         majoration_tierce_personne = parameters.mtp.mtp
 
         proratisation_couple = (
@@ -132,9 +132,9 @@ class apa_eligibilite(Variable):
     label = "Allocation personalisée d'autonomie - Éligibilité"
     definition_period = MONTH
 
-    def formula(individu, period, parameters):
+    def formula_2002(individu, period, parameters):
         period = period.start.offset('first-of', 'month').period('month')
-        parameters = parameters(period.start).autonomie
+        parameters = parameters(period).autonomie
         age = individu('age', period)
         apa_age_min = parameters.age_ouverture_des_droits.age_d_ouverture_des_droits
 
@@ -155,7 +155,7 @@ class apa_domicile_taux_participation(Variable):
     entity = Individu
     definition_period = MONTH
 
-    def formula(individu, period, parameters):
+    def formula_2002(individu, period, parameters):
         apa_domicile = individu('apa_domicile', period)
         dependance_plan_aide_domicile_accepte = individu('dependance_plan_aide_domicile_accepte', period)
         apa_domicile_participation = individu('apa_domicile_participation', period)
@@ -169,9 +169,9 @@ class apa_domicile(Variable):
     entity = Individu
     definition_period = MONTH
 
-    def formula(individu, period, parameters):
+    def formula_2002(individu, period, parameters):
         period = period.start.offset('first-of', 'month').period('month')
-        parameters = parameters(period.start).autonomie
+        parameters = parameters(period).autonomie
         apa_eligibilite = individu('apa_eligibilite', period)
         seuil_non_versement = parameters.seuil_de_versement_de_l_apa.seuil_versement.seuil_de_versement_de_l_apa
         dependance_plan_aide_domicile_accepte = individu('dependance_plan_aide_domicile_accepte', period)
@@ -188,9 +188,9 @@ class apa_etablissement(Variable):
     entity = Individu
     definition_period = MONTH
 
-    def formula(individu, period, parameters):
+    def formula_2002(individu, period, parameters):
         period = period.start.offset('first-of', 'month').period('month')
-        parameters = parameters(period.start).autonomie
+        parameters = parameters(period).autonomie
         seuil_non_versement = parameters.seuil_de_versement_de_l_apa.seuil_versement.seuil_de_versement_de_l_apa
 
         en_couple = individu.famille('en_couple', period)
@@ -275,6 +275,20 @@ class dependance_plan_aide_domicile(Variable):
     definition_period = MONTH
 
 
+class dependance_tarif_etablissement_gir_1_2(Variable):
+    value_type = float
+    entity = Individu
+    label = "Tarif dépendance de l'établissement pour les GIR 1 et 2"
+    definition_period = MONTH
+
+
+class dependance_tarif_etablissement_gir_3_4(Variable):
+    value_type = float
+    entity = Individu
+    label = "Tarif dépendance de l'établissement pour les GIR 3 et 4"
+    definition_period = MONTH
+
+
 class dependance_tarif_etablissement_gir_5_6(Variable):
     value_type = float
     entity = Individu
@@ -295,9 +309,9 @@ class apa_urgence_domicile(Variable):
     entity = Individu
     definition_period = MONTH
 
-    def formula(individu, period, parameters):
+    def formula_2002(individu, period, parameters):
         period = period.first_month
-        autonomie = parameters(period.start).autonomie
+        autonomie = parameters(period).autonomie
         majoration_tierce_personne = autonomie.mtp.mtp
         plafond_gir1 = autonomie.apa_domicile.plafond_de_l_apa_a_domicile_en_part_du_mtp.gir_1
         part_urgence_domicile = autonomie.apa_domicile.apa_d_urgence.part_du_plafond_de_l_apa_a_domicile
@@ -310,10 +324,10 @@ class apa_urgence_institution(Variable):
     entity = Individu
     definition_period = MONTH
 
-    def formula(individu, period, parameters):
+    def formula_2002(individu, period, parameters):
         period = period.start.offset('first-of', 'month').period('month')
-        dependance_tarif_etablissement_gir_1_2 = individu('dependance_tarif_etablissement_gir_5_6', period)
-        part_urgence_institution = parameters.apa_institution.apa_d_urgence.part_du_tarif_dependance_gir_1_2_de_l_etablissement_d_accueil
+        dependance_tarif_etablissement_gir_1_2 = individu('dependance_tarif_etablissement_gir_1_2', period)
+        part_urgence_institution = parameters(period).autonomie.apa_institution.apa_d_urgence.part_du_tarif_dependance_gir_1_2_de_l_etablissement_d_accueil
         apa_urgence_institution = part_urgence_institution * dependance_tarif_etablissement_gir_1_2
         return apa_urgence_institution
 
@@ -328,10 +342,10 @@ class dependance_plan_aide_domicile_accepte(Variable):
         'https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=4D213136F764CDAC77B33F705B4DE178.tplgfr41s_1?idArticle=LEGIARTI000032133764&cidTexte=LEGITEXT000006074069&dateTexte=20170929&categorieLien=id&oldAction=&nbResultRech='
         ]
 
-    def formula(individu, period, parameters):
+    def formula_2002(individu, period, parameters):
         gir = individu('gir', period)
         dependance_plan_aide_domicile = individu('dependance_plan_aide_domicile', period)
-        parameters_autonomie = parameters(period.start).autonomie
+        parameters_autonomie = parameters(period).autonomie
 
         plafond_gir1 = parameters_autonomie.apa_domicile.plafond_de_l_apa_a_domicile_en_part_du_mtp.gir_1
         plafond_gir2 = parameters_autonomie.apa_domicile.plafond_de_l_apa_a_domicile_en_part_du_mtp.gir_2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.7.1",
+    version = "48.7.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/autonomie.yaml
+++ b/tests/formulas/autonomie.yaml
@@ -273,7 +273,6 @@
   output:
     base_ressources_apa: 4000
 
-
 - name: Test plafond taux participation APA domicile
   description: Montant APA
   period: 2017-05
@@ -283,3 +282,17 @@
     base_ressources_apa: 3000
   output:
     apa_domicile_taux_participation: 0.9
+
+- name: APA établissement - test situation d'urgence
+  description: Montant APA forfataire en cas d'urgence
+  input:
+    dependance_tarif_etablissement_gir_1_2:
+      2001-12: 600
+      2002-01: 600
+    dependance_tarif_etablissement_gir_3_4:
+      2001-12: 400
+      2002-01: 400
+  output:
+    apa_urgence_institution:
+      2001-12: 0
+      2002-01: 300 # 600 * 0.5


### PR DESCRIPTION
Fix #1364

* Correction d'un crash.
* Périodes concernées : à partir du 01/01/2002.
* Zones impactées : `prestations/autonomie.py`.
* Détails :
  - Corrige `apa_urgence_institution`
  - Corrige une date manquant dans l'appel de l'arbre de paramètres
  

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
