### PR TITLE
Corrige le code relatif à l'abattement fixe sur RVCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 48.6.1 [#1375](https://github.com/openfisca/openfisca-france/pull/1375)
+
+* Changement mineur.
+* Périodes concernées : à partir du 01/01/2012.
+* Zones impactées : `prelevements_obligatoires/impot_revenu/ir.py`.
+* Détails :
+  - Enlève des lignes mettant en dur à zéro à partir de 2012 des termes dépendant de `abatmob`, lui-même à zéro dans les paramètres à partir de cette date. Fait que pas possible de simuler des réformes relatives à cet abattement.
+
 ## 48.6.0 [#1369](https://github.com/openfisca/openfisca-france/pull/1369)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -726,10 +726,7 @@ class revenu_categoriel_capital(Variable):
         rev = g12b + f2gr + f2fu * (1 - rvcm.taux_abattement_capitaux_mobiliers)
 
         # Abattements, limité au revenu
-        if period.start.date >= date(2012, 1, 1):
-            h12 = 0
-        else:
-            h12 = rvcm.abatmob * (1 + maries_ou_pacses)
+        h12 = rvcm.abatmob * (1 + maries_ou_pacses)
         TOT2 = max_(0, rev - h12)
         # i121= -min_(0,rev - h12)
 
@@ -877,10 +874,7 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
         rev = g12b + f2gr + f2fu * (1 - rvcm.taux_abattement_capitaux_mobiliers)
 
         # Abattements, limité au revenu
-        if period.start.date >= date(2012, 1, 1):
-            h12 = 0
-        else:
-            h12 = rvcm.abatmob * (1 + maries_ou_pacses)
+        h12 = rvcm.abatmob * (1 + maries_ou_pacses)
         i121 = - min_(0, rev - h12)
         return max_((rvcm.taux_abattement_capitaux_mobiliers) * (f2dc + f2fu) - i121, 0)
 

--- a/openfisca_france/parameters/impot_revenu/rvcm/abatmob.yaml
+++ b/openfisca_france/parameters/impot_revenu/rvcm/abatmob.yaml
@@ -13,4 +13,4 @@ values:
   2006-01-01:
     value: 1525.0
   2012-01-01:
-    value: null
+    value: 0.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.6.0",
+    version = "48.6.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/2012.
* Zones impactées : `prelevements_obligatoires/impot_revenu/ir.py`.
* Détails :
  - Enlève des lignes mettant en dur à zéro à partir de 2012 des termes dépendant de `abatmob`, lui-même à zéro dans les paramètres à partir de cette date. Fait que pas possible de simuler des réformes relatives à cet abattement.
