### PR TITLE
Améliore calcul identifier tarif GIR de personne APA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 48.8.0 [#1380](https://github.com/openfisca/openfisca-france/pull/1380)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2002.
+* Zones impactées : `model/prestations/autonomie.py`.
+* Détails :
+  - Améliore formule pour déterminer le tarif établissement pour le GIR de la personne dépendante.
+
 ### 48.7.2 [#1374](https://github.com/openfisca/openfisca-france/pull/1374)
 
 * Correction d'un crash.

--- a/openfisca_france/model/prestations/autonomie.py
+++ b/openfisca_france/model/prestations/autonomie.py
@@ -299,8 +299,21 @@ class dependance_tarif_etablissement_gir_5_6(Variable):
 class dependance_tarif_etablissement_gir_dependant(Variable):
     value_type = float
     entity = Individu
-    label = "Tarif dépendance de l'établissement pour le GIR de la personne dépendante"
     definition_period = MONTH
+    label = "Tarif dépendance de l'établissement pour le GIR de la personne dépendante"
+    reference = ["https://www.service-public.fr/particuliers/vosdroits/F10009"]
+
+    def formula_2002(individu, period):
+        gir = individu("gir", period)
+        tarif_gir_1_2 = individu("dependance_tarif_etablissement_gir_1_2", period)
+        tarif_gir_3_4 = individu("dependance_tarif_etablissement_gir_3_4", period)
+
+        # Vérifie si l'individu est rattaché à l'un des groupes 1 à 4 de la grille Aggir
+        gir_1_2 = (gir == TypesGir.gir_1) + (gir == TypesGir.gir_2)
+        gir_3_4 = (gir == TypesGir.gir_3) + (gir == TypesGir.gir_4)
+
+        # Sélectionne le tarif correspondant à la grille de la personne
+        return select([gir_1_2, gir_3_4], [tarif_gir_1_2, tarif_gir_3_4])
 
 
 class apa_urgence_domicile(Variable):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.7.2",
+    version = "48.8.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/autonomie.yaml
+++ b/tests/formulas/autonomie.yaml
@@ -283,6 +283,29 @@
   output:
     apa_domicile_taux_participation: 0.9
 
+- name: Test tarif dépendance de l'établissement
+  description: Tarif dépendance de l'établissement pour le GIR de la personne dépendante
+  period: 2002-01
+  input:
+    individus:
+      personne1:
+        gir: gir_1
+        dependance_tarif_etablissement_gir_1_2: 300
+      personne2:
+        gir: gir_3
+        dependance_tarif_etablissement_gir_3_4: 200
+      personne3:
+        gir: gir_5
+        dependance_tarif_etablissement_gir_5_6: 100
+  output:
+    individus:
+      personne1:
+        dependance_tarif_etablissement_gir_dependant: 300
+      personne2:
+        dependance_tarif_etablissement_gir_dependant: 200
+      personne3:
+        dependance_tarif_etablissement_gir_dependant: 0
+
 - name: APA établissement - test situation d'urgence
   description: Montant APA forfataire en cas d'urgence
   input:


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2002.
* Zones impactées : `model/prestations/autonomie.py`.
* Détails :
  - Améliore formule pour déterminer le tarif établissement pour le GIR de la personne dépendante.

- - - -

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
