### PR TITLE
Calcule la tranche et le taux marginal IR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 48.10.0 [#1393](https://github.com/openfisca/openfisca-france/pull/1393)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : `prelevements_obligatoires/impot_revenu/ir`.
+* Détails :
+  - Ajout du calcul du taux marginal et de la tranche applicable pour l'impôt sur le revenu
+
 ### 48.9.9 [#1408](https://github.com/openfisca/openfisca-france/pull/1408)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1119,7 +1119,7 @@ class ir_taux_marginal(Variable):
         taux_effectif = foyer_fiscal('taux_effectif', period)
         rni = foyer_fiscal('rni', period)
         bareme = parameters(period).impot_revenu.bareme
-        return (taux_effectif == 0) * bareme.compute_marginal_rate(rni / nbptr) + taux_effectif
+        return (taux_effectif == 0) * bareme.marginal_rates(rni / nbptr) + taux_effectif
 
 
 class ir_tranche(Variable):
@@ -1132,7 +1132,7 @@ class ir_tranche(Variable):
         nbptr = foyer_fiscal('nbptr', period)
         rni = foyer_fiscal('rni', period)
         bareme = parameters(period).impot_revenu.bareme
-        return bareme.compute_bracket_index(rni / nbptr)
+        return bareme.bracket_indices(rni / nbptr)
 
 
 class ir_ss_qf(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1108,6 +1108,33 @@ class ir_brut(Variable):
         return (taux_effectif == 0) * nbptr * bareme.calc(rni / nbptr) + taux_effectif * rni
 
 
+class ir_taux_marginal(Variable):
+    value_type = float
+    entity = FoyerFiscal
+    label = "Taux marginal de l'impôt sur le revenu"
+    definition_period = YEAR
+
+    def formula(foyer_fiscal, period, parameters):
+        nbptr = foyer_fiscal('nbptr', period)
+        taux_effectif = foyer_fiscal('taux_effectif', period)
+        rni = foyer_fiscal('rni', period)
+        bareme = parameters(period).impot_revenu.bareme
+        return (taux_effectif == 0) * bareme.compute_marginal_rate(rni / nbptr) + taux_effectif
+
+
+class ir_tranche(Variable):
+    value_type = int
+    entity = FoyerFiscal
+    label = "Tranche du barème appliquée"
+    definition_period = YEAR
+
+    def formula(foyer_fiscal, period, parameters):
+        nbptr = foyer_fiscal('nbptr', period)
+        rni = foyer_fiscal('rni', period)
+        bareme = parameters(period).impot_revenu.bareme
+        return bareme.compute_bracket_index(rni / nbptr)
+
+
 class ir_ss_qf(Variable):
     value_type = float
     entity = FoyerFiscal

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1112,6 +1112,7 @@ class ir_taux_marginal(Variable):
     value_type = float
     entity = FoyerFiscal
     label = "Taux marginal d'imposition à l'impôt sur le revenu"
+    reference = "http://impotsurlerevenu.org/fonctionnement-de-l-impot/60-calculer-le-tmi.php"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1127,6 +1127,7 @@ class ir_tranche(Variable):
     value_type = int
     entity = FoyerFiscal
     label = "Tranche du barème appliquée"
+    reference = "https://impots.dispofi.fr/bareme-impot/calcul-impot-par-tranche"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1111,7 +1111,7 @@ class ir_brut(Variable):
 class ir_taux_marginal(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = "Taux marginal de l'impôt sur le revenu"
+    label = "Taux marginal d'imposition à l'impôt sur le revenu"
     definition_period = YEAR
 
     def formula(foyer_fiscal, period, parameters):

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         },
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
-        "OpenFisca-Core >=31.0,<35.0",
+        "OpenFisca-Core >=34.6,<35.0",
         ],
     message_extractors = {"openfisca_france": [
         ("**.py", "python", None),

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.9.9",
+    version = "48.10.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/ir_taux_marginal.yaml
+++ b/tests/formulas/ir_taux_marginal.yaml
@@ -1,0 +1,31 @@
+- name: IRPP - Célibataire ayant des revenus salariaux (1AJ) de 5000 €
+  period: 2018
+  absolute_error_margin: 0.0001
+  input:
+    salaire_imposable: 5000
+  output:
+    ir_tranche: 0
+    ir_taux_marginal: 0
+    irpp: 0
+
+
+- name: IRPP - Célibataire ayant des revenus salariaux (1AJ) de 20 000 €
+  period: 2018
+  absolute_error_margin: 0.0001
+  input:
+    salaire_imposable: 20000
+  output:
+    ir_tranche: 1
+    ir_taux_marginal: .14
+    irpp: -618
+
+
+- name: IRPP - Célibataire ayant des revenus salariaux (1AJ) de 500 000 €
+  period: 2018
+  relative_error_margin: 0.0001
+  input:
+    salaire_imposable: 500000
+  output:
+    ir_tranche: 4
+    ir_taux_marginal: .45
+    irpp: -206430

--- a/tests/formulas/ir_taux_marginal.yaml
+++ b/tests/formulas/ir_taux_marginal.yaml
@@ -1,31 +1,23 @@
-- name: IRPP - Célibataire ayant des revenus salariaux (1AJ) de 5000 €
+- name: Taux marginal d'imposition à l'impôt sur le revenu - Célibataire ayant des revenus salariaux (1AJ) de 5000 €
   period: 2018
   absolute_error_margin: 0.0001
   input:
     salaire_imposable: 5000
   output:
-    ir_tranche: 0
     ir_taux_marginal: 0
-    irpp: 0
 
-
-- name: IRPP - Célibataire ayant des revenus salariaux (1AJ) de 20 000 €
+- name: Taux marginal d'imposition à l'impôt sur le revenu - Célibataire ayant des revenus salariaux (1AJ) de 20 000 €
   period: 2018
   absolute_error_margin: 0.0001
   input:
     salaire_imposable: 20000
   output:
-    ir_tranche: 1
     ir_taux_marginal: .14
-    irpp: -618
 
-
-- name: IRPP - Célibataire ayant des revenus salariaux (1AJ) de 500 000 €
+- name: Taux marginal d'imposition à l'impôt sur le revenu - Célibataire ayant des revenus salariaux (1AJ) de 500 000 €
   period: 2018
   relative_error_margin: 0.0001
   input:
     salaire_imposable: 500000
   output:
-    ir_tranche: 4
     ir_taux_marginal: .45
-    irpp: -206430

--- a/tests/formulas/ir_tranche.yaml
+++ b/tests/formulas/ir_tranche.yaml
@@ -1,0 +1,20 @@
+- name: Tranche du barème appliquée - Célibataire ayant des revenus salariaux (1AJ) de 5000 €
+  period: 2018
+  input:
+    salaire_imposable: 5000
+  output:
+    ir_tranche: 0
+
+- name: Tranche du barème appliquée - Célibataire ayant des revenus salariaux (1AJ) de 20 000 €
+  period: 2018
+  input:
+    salaire_imposable: 20000
+  output:
+    ir_tranche: 1
+
+- name: Tranche du barème appliquée - Célibataire ayant des revenus salariaux (1AJ) de 500 000 €
+  period: 2018
+  input:
+    salaire_imposable: 500000
+  output:
+    ir_tranche: 4


### PR DESCRIPTION
Fixes #1386 
Depends on openfisca/openfisca-core#920

* Évolution du système socio-fiscal.
* Périodes concernées : toutes. 
* Zones impactées : `prelevements_obligatoires/impot_revenu/ir`.
* Détails :
  - Ajout du calcul du taux marginal et de la tranche applicable pour l'impôt sur le revenu

- - - -

Ces changements:

- Ajoutent une fonctionnalité (voir #1386) :
  - ajout de la variable `ir_tranche`.
  - ajout de la variable `ir_taux_marginal`.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
