### PR TITLE
Corrige zone_logement_social pour retourner un vecteur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 48.9.5 [#1395](https://github.com/openfisca/openfisca-france/pull/1395)
+
+* Amélioration technique.
+* Périodes concernées : toutes.
+* Zones impactées : `model/prestations/logement_social.py`.
+* Détails :
+  - La formule zone_logement_social retournait un scalar `numpy.ndarray[int]`.
+  - Corrige zone_logement_social pour retourner un vecteur `numpy.ndarray[bool]`.
+  - Note : à partir de Numpy 1.18, l'utilisation de `select` avec une valeur non `bool` est dépréciée.
+
 ### 48.9.4 [#1399](https://github.com/openfisca/openfisca-france/pull/1399)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/logement_social.py
+++ b/openfisca_france/model/prestations/logement_social.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from numpy.core.defchararray import startswith
 from openfisca_france.model.base import *
 

--- a/openfisca_france/model/prestations/logement_social.py
+++ b/openfisca_france/model/prestations/logement_social.py
@@ -1,5 +1,11 @@
+from numpy import logical_not as not_, select
 from numpy.core.defchararray import startswith
-from openfisca_france.model.base import *
+
+from openfisca_core.indexed_enums import Enum
+from openfisca_core.periods import MONTH
+from openfisca_core.variables import Variable
+
+from openfisca_france.entities import Famille, Menage
 
 paris_communes_limitrophes = [
     b'75056',  # Paris

--- a/openfisca_france/model/prestations/logement_social.py
+++ b/openfisca_france/model/prestations/logement_social.py
@@ -1,5 +1,4 @@
-from numpy import isin, logical_not as not_, select
-from numpy.core.defchararray import startswith
+from numpy import char, isin, logical_not as not_, select
 
 from openfisca_core.indexed_enums import Enum
 from openfisca_core.periods import MONTH
@@ -69,7 +68,7 @@ class zone_logement_social(Variable):
     def formula(menage, period):
         depcom = menage('depcom', period)
         in_paris_communes_limitrophes = isin(depcom, paris_communes_limitrophes)
-        in_idf = isin([True], startswith(depcom, departements_idf))
+        in_idf = isin(char.ljust(depcom, 2), departements_idf)
 
         return select(
             [

--- a/openfisca_france/model/prestations/logement_social.py
+++ b/openfisca_france/model/prestations/logement_social.py
@@ -1,4 +1,4 @@
-from numpy import logical_not as not_, select
+from numpy import isin, logical_not as not_, select
 from numpy.core.defchararray import startswith
 
 from openfisca_core.indexed_enums import Enum
@@ -68,9 +68,8 @@ class zone_logement_social(Variable):
 
     def formula(menage, period):
         depcom = menage('depcom', period)
-
-        in_paris_communes_limitrophes = sum([depcom == commune_proche_paris for commune_proche_paris in paris_communes_limitrophes])
-        in_idf = sum([startswith(depcom, departement) for departement in departements_idf])
+        in_paris_communes_limitrophes = isin(depcom, paris_communes_limitrophes)
+        in_idf = isin([True], startswith(depcom, departements_idf))
 
         return select(
             [

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,4 +17,3 @@ in-place     = true
 addopts      = --showlocals --exitfirst --doctest-modules --disable-pytest-warnings
 testpaths    = tests
 python_files = **/*.py
-

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.9.4",
+    version = "48.9.5",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Fixes #1394 

* Amélioration technique.
* Périodes concernées : toutes.
* Zones impactées : `model/prestations/logement_social.py`.
* Détails :
  - La formule zone_logement_social retournait un scalar `numpy.ndarray[int]`.
  - Corrige zone_logement_social pour retourner un vecteur `numpy.ndarray[bool]`.
  - Note : à partir de Numpy 1.18, l'utilisation de `select` avec un valeur non `bool` est dépréciée.

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus