### PR TITLE
Corrige le calcul de la réduction d'impôt sous conditions de ressources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 48.9.4 [#1399](https://github.com/openfisca/openfisca-france/pull/1399)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2016.
+* Zones impactées : `prelevements_obligatoires/impot_revenu/ir.py`.
+* Détails :
+  - Corrige le calcul de la réduction d'impît dans le cas d'un couple au-dessus du premier seuil.
+
 ### 48.9.3 [#1388](https://github.com/openfisca/openfisca-france/pull/1388)
 
 * Changement mineur.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1399,7 +1399,7 @@ class reduction_ss_condition_revenus(Variable):
         plafond1 = P.seuil1 * nb_adult + P.seuil_maj_enf * 2 * (nb_parts - nb_adult)
         plafond2 = P.seuil2 * nb_adult + P.seuil_maj_enf * 2 * (nb_parts - nb_adult)
         reduction1 = P.taux * ir_apres_plaf_qf_et_decote
-        reduction2 = (P.taux * ir_apres_plaf_qf_et_decote * (plafond2 - rfr)) / ((plafond2 - plafond1) * nb_adult)
+        reduction2 = P.taux * ir_apres_plaf_qf_et_decote * (plafond2 - rfr) / (plafond2 - plafond1)
 
         reduction_sous_condition_de_ressources = (
             (rfr < plafond1) * reduction1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.9.3",
+    version = "48.9.4",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/calculateur_impots/yaml/reduc_sous_conditions_ressources.yaml
+++ b/tests/calculateur_impots/yaml/reduc_sous_conditions_ressources.yaml
@@ -1,0 +1,125 @@
+- name: Réduction sous conditions de ressources - cas d'un couple avec enfants dans la zone à 20%
+  period: 2018
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      caseF: false
+      caseG: false
+      caseP: false
+      caseS: false
+      caseW: false
+      declarants:
+      - ind0
+      - ind1
+      nbF: 2.0
+      nbG: 0.0
+      nbH: 0.0
+      nbI: 0.0
+      nbJ: 0
+      nbN: 0
+      nbR: 0
+      personnes_a_charge:
+      - ind2
+      - ind3
+    individus:
+      ind0:
+        activite: actif
+        date_naissance: '1970-01-01'
+        salaire_imposable: 25000.0
+        statut_marital: marie
+      ind1:
+        activite: actif
+        date_naissance: '1970-01-01'
+        salaire_imposable: 20000.0
+        statut_marital: marie
+      ind2:
+        activite: etudiant
+        date_naissance: '2002-01-01'
+      ind3:
+        activite: etudiant
+        date_naissance: '2003-01-01'
+    famille:
+      enfants:
+      - ind2
+      - ind3
+      parents:
+      - ind0
+      - ind1
+    menage:
+      conjoint: ind1
+      enfants:
+      - ind2
+      - ind3
+      personne_de_reference: ind0
+  output:
+    decote_gain_fiscal: 856.0
+    irpp: -503.0
+    nbptr: 3.0
+    ppe: 0.0
+    reduction_ss_condition_revenus: 126.0
+    rbg: 40500.0
+    rfr: 40500.0
+    rni: 40500.0
+
+- name: Réduction sous conditions de ressources - cas d'un couple avec enfants dans la zone dégressive
+  period: 2018
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      caseF: false
+      caseG: false
+      caseP: false
+      caseS: false
+      caseW: false
+      declarants:
+      - ind0
+      - ind1
+      nbF: 2.0
+      nbG: 0.0
+      nbH: 0.0
+      nbI: 0.0
+      nbJ: 0
+      nbN: 0
+      nbR: 0
+      personnes_a_charge:
+      - ind2
+      - ind3
+    individus:
+      ind0:
+        activite: actif
+        date_naissance: '1952-01-01'
+        revenu_assimile_pension: 25000.0
+        statut_marital: marie
+      ind1:
+        activite: actif
+        date_naissance: '1952-01-01'
+        revenu_assimile_pension: 25000.0
+        statut_marital: marie
+      ind2:
+        activite: etudiant
+        date_naissance: '2002-01-01'
+      ind3:
+        activite: etudiant
+        date_naissance: '2003-01-01'
+    famille:
+      enfants:
+      - ind2
+      - ind3
+      parents:
+      - ind0
+      - ind1
+    menage:
+      conjoint: ind1
+      enfants:
+      - ind2
+      - ind3
+      personne_de_reference: ind0
+  output:
+    decote_gain_fiscal: 259.0
+    irpp: -1679.0
+    nbptr: 3.0
+    ppe: 0.0
+    reduction_ss_condition_revenus: 343.0
+    rbg: 46188.0
+    rfr: 46188.0
+    rni: 46188.0


### PR DESCRIPTION

* Évolution / Correction du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2016.
* Zones impactées : `prelevements_obligatoires/impot_revenu/ir.py`.
* Détails :
  - Corrige le calcul de la réduction dans le cas d'un couple au-dessus du premier seuil.

Fix #1390 
