### PR TITLE
Ajoute le smic horaire brut 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 48.9.8 [#1406](https://github.com/openfisca/openfisca-france/pull/1406)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2020
+* Zones impactées : `openfisca_france/parameters/cotsoc/gen/smic_h_b.yaml`.
+* Détails :
+  - Mise à jour du smic horaire brut suite au décret n° 2019-1387 du 18 décembre 2019 portant relèvement du salaire minimum de croissance.
+
 ### 48.9.7 [#1402](https://github.com/openfisca/openfisca-france/pull/1402)
 
 * Changement mineur.
@@ -61,7 +69,7 @@
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2018.
-* Zones impactées : `mode/prelevements_obligatoires/impot_revenu`.
+* Zones impactées : `model/prelevements_obligatoires/impot_revenu`.
 * Détails :
    - Ajout de nouvelles variables liées au nouveau formulaire de l'IR (et supprime celles qui disparaissent)
    - Mise à jour de la formule des charges déductibles pour grosse réparation
@@ -75,7 +83,7 @@
 * Périodes concernées : à partir du 01/01/2002.
 * Zones impactées : `model/prestations/autonomie.py`.
 * Détails :
-  - Améliore formule pour déterminer le tarif établissement pour le GIR de la personne dépendante.
+  - Améliore la formule pour déterminer le tarif établissement pour le GIR de la personne dépendante.
 
 ### 48.7.2 [#1374](https://github.com/openfisca/openfisca-france/pull/1374)
 

--- a/openfisca_france/parameters/cotsoc/gen/smic_h_b.yaml
+++ b/openfisca_france/parameters/cotsoc/gen/smic_h_b.yaml
@@ -47,3 +47,6 @@ values:
     value: 9.88
   2019-01-01:
     value: 10.03
+  2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/decret/2019/12/18/MTRX1933646D/jo/texte
+    value: 10.15

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.9.7",
+    version = "48.9.8",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Fixes #1405

* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2020
* Zones impactées : `openfisca_france/parameters/cotsoc/gen/smic_h_b.yaml`.
* Détails :
  - Mise à jour du smic horaire brut suite au décret n° 2019-1387 du 18 décembre 2019 portant relèvement du salaire minimum de croissance 


- - - -

Ces changements :
- Corrigent ou améliorent un calcul déjà existant.

> D'où un `smic_proratise` de `1539.4166 €` cohérent avec les `1 539,42 €` mensuels pour 35h du décret. 

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus