### PR TITLE
Corrige l'application de l'abattement sur dividendes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 48.10.2 [#1410](https://github.com/openfisca/openfisca-france/pull/1410)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : jusqu'au 01/01/2013.
+* `model/prelevements_obligatoires/impot_revenu/ir.py`.
+* Détails :
+  - Ajoute un test sur les abattements sur dividendes
+  - Simplifie le calcul du revenu catégoriel du capital
+  - Corrige l'application de l'abattement sur dividendes
+
 ### 48.10.1 [#1409](https://github.com/openfisca/openfisca-france/pull/1409)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -709,11 +709,10 @@ class revenu_categoriel_capital(Variable):
         f2tr = foyer_fiscal('f2tr', period)
         P = parameters(period).impot_revenu.rvcm
 
-        den = ((f2dc + f2ts) != 0) * (f2dc + f2ts) + ((f2dc + f2ts) == 0)
-        F1 = f2ca / den * f2dc
-        g12a = -min_(f2dc * (1 - P.taux_abattement_capitaux_mobiliers * (f2da == 0)) - F1, 0)
+        part_frais_imputes_sur_f2dc = f2ca / max_(1, f2dc + f2ts) * f2dc
+        part_frais_restant_a_imputer = -min_(f2dc * (1 - P.taux_abattement_capitaux_mobiliers * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
 
-        dividendes_apres_abattements = max_(f2dc * (1 - P.taux_abattement_capitaux_mobiliers * (f2da == 0)) - F1, 0)
+        dividendes_apres_abattements = max_(f2dc * (1 - P.taux_abattement_capitaux_mobiliers * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
         revenus_assurance_vie_apres_abattements = f2ch - min_(f2ch, P.abat_assvie * (1 + maries_ou_pacses))
         rvcm_apres_abattements_proportionnels = (
             revenus_assurance_vie_apres_abattements
@@ -723,9 +722,9 @@ class revenu_categoriel_capital(Variable):
             )
         rvcm_apres_abattements_proportionnels_et_fixes = max_(0, rvcm_apres_abattements_proportionnels - P.abatmob * (1 + maries_ou_pacses))
         autres_rvcm_sans_abattements = (
-            f2ts - (f2ca - F1)
+            f2ts - (f2ca - part_frais_imputes_sur_f2dc)
             + f2go * P.majoration_revenus_reputes_distribues
-            + f2tr - g12a
+            + f2tr - part_frais_restant_a_imputer
             )
 
         return max_(rvcm_apres_abattements_proportionnels_et_fixes + autres_rvcm_sans_abattements - deficit_rcm, 0)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -708,21 +708,17 @@ class revenu_categoriel_capital(Variable):
         f2tr = foyer_fiscal('f2tr', period)
         rvcm = parameters(period).impot_revenu.rvcm
 
-        # Add f2da to f2dc and f2ee to f2tr when no PFL
-        f2dc_bis = f2dc
-        f2tr_bis = f2tr
-        # # Calcul du revenu catégoriel
         # 1.2 Revenus des valeurs et capitaux mobiliers
         b12 = min_(f2ch, rvcm.abat_assvie * (1 + maries_ou_pacses))
-        TOT1 = f2ch - b12  # c12
+        TOT1 = f2ch - b12
         # Part des frais s'imputant sur les revenus déclarés case DC
-        den = ((f2dc_bis + f2ts) != 0) * (f2dc_bis + f2ts) + ((f2dc_bis + f2ts) == 0)
-        F1 = f2ca / den * f2dc_bis  # f12
+        den = ((f2dc + f2ts) != 0) * (f2dc + f2ts) + ((f2dc + f2ts) == 0)
+        F1 = f2ca / den * f2dc
         # Revenus de capitaux mobiliers nets de frais, ouvrant droit à abattement
         # partie négative (à déduire des autres revenus nets de frais d'abattements
-        g12a = -min_(f2dc_bis * (1 - rvcm.taux_abattement_capitaux_mobiliers) - F1, 0)
+        g12a = -min_(f2dc * (1 - rvcm.taux_abattement_capitaux_mobiliers) - F1, 0)
         # partie positive
-        g12b = max_(f2dc_bis * (1 - rvcm.taux_abattement_capitaux_mobiliers) - F1, 0)
+        g12b = max_(f2dc * (1 - rvcm.taux_abattement_capitaux_mobiliers) - F1, 0)
         rev = g12b + f2gr + f2fu * (1 - rvcm.taux_abattement_capitaux_mobiliers)
 
         # Abattements, limité au revenu
@@ -732,7 +728,7 @@ class revenu_categoriel_capital(Variable):
 
         # Part des frais s'imputant sur les revenus déclarés ligne TS
         F2 = f2ca - F1
-        TOT3 = (f2ts - F2) + f2go * rvcm.majoration_revenus_reputes_distribues + f2tr_bis - g12a
+        TOT3 = (f2ts - F2) + f2go * rvcm.majoration_revenus_reputes_distribues + f2tr - g12a
 
         DEF = deficit_rcm
         return max_(TOT1 + TOT2 + TOT3 - DEF, 0)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -699,6 +699,7 @@ class revenu_categoriel_capital(Variable):
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
         deficit_rcm = foyer_fiscal('deficit_rcm', period)
         f2ch = foyer_fiscal('f2ch', period)
+        f2da = foyer_fiscal('f2da', period)
         f2dc = foyer_fiscal('f2dc', period)
         f2ts = foyer_fiscal('f2ts', period)
         f2ca = foyer_fiscal('f2ca', period)
@@ -710,14 +711,15 @@ class revenu_categoriel_capital(Variable):
 
         den = ((f2dc + f2ts) != 0) * (f2dc + f2ts) + ((f2dc + f2ts) == 0)
         F1 = f2ca / den * f2dc
-        g12a = -min_(f2dc * (1 - P.taux_abattement_capitaux_mobiliers) - F1, 0)
-        dividendes_apres_abattements = max_(f2dc * (1 - P.taux_abattement_capitaux_mobiliers) - F1, 0)
+        g12a = -min_(f2dc * (1 - P.taux_abattement_capitaux_mobiliers * (f2da == 0)) - F1, 0)
+
+        dividendes_apres_abattements = max_(f2dc * (1 - P.taux_abattement_capitaux_mobiliers * (f2da == 0)) - F1, 0)
         revenus_assurance_vie_apres_abattements = f2ch - min_(f2ch, P.abat_assvie * (1 + maries_ou_pacses))
         rvcm_apres_abattements_proportionnels = (
             revenus_assurance_vie_apres_abattements
             + dividendes_apres_abattements
             + f2gr
-            + f2fu * (1 - P.taux_abattement_capitaux_mobiliers)
+            + f2fu * (1 - P.taux_abattement_capitaux_mobiliers * (f2da == 0))
             )
         rvcm_apres_abattements_proportionnels_et_fixes = max_(0, rvcm_apres_abattements_proportionnels - P.abatmob * (1 + maries_ou_pacses))
         autres_rvcm_sans_abattements = (
@@ -847,6 +849,7 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
 
     def formula(foyer_fiscal, period, parameters):
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        f2da = foyer_fiscal('f2da', period)
         f2dc = foyer_fiscal('f2dc', period)
         f2ts = foyer_fiscal('f2ts', period)
         f2ca = foyer_fiscal('f2ca', period)
@@ -861,13 +864,13 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
         F1 = f2ca / den * f2dc  # f12
         # Revenus de capitaux mobiliers nets de frais, ouvrant droit à abattement
         # partie positive
-        g12b = max_(f2dc * (1 - rvcm.taux_abattement_capitaux_mobiliers) - F1, 0)
-        rev = g12b + f2gr + f2fu * (1 - rvcm.taux_abattement_capitaux_mobiliers)
+        g12b = max_(f2dc * (1 - rvcm.taux_abattement_capitaux_mobiliers * (f2da == 0)) - F1, 0)
+        rev = g12b + f2gr + f2fu * (1 - rvcm.taux_abattement_capitaux_mobiliers * (f2da == 0))
 
         # Abattements, limité au revenu
         h12 = rvcm.abatmob * (1 + maries_ou_pacses)
         i121 = - min_(0, rev - h12)
-        return max_((rvcm.taux_abattement_capitaux_mobiliers) * (f2dc + f2fu) - i121, 0)
+        return max_((rvcm.taux_abattement_capitaux_mobiliers) * (f2dc + f2fu) * (f2da == 0) - i121, 0)
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         f2dc = foyer_fiscal('f2dc', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -706,29 +706,29 @@ class revenu_categoriel_capital(Variable):
         f2go = foyer_fiscal('f2go', period)
         f2gr = foyer_fiscal('f2gr', period)
         f2tr = foyer_fiscal('f2tr', period)
-        rvcm = parameters(period).impot_revenu.rvcm
+        P = parameters(period).impot_revenu.rvcm
 
         # 1.2 Revenus des valeurs et capitaux mobiliers
-        b12 = min_(f2ch, rvcm.abat_assvie * (1 + maries_ou_pacses))
+        b12 = min_(f2ch, P.abat_assvie * (1 + maries_ou_pacses))
         TOT1 = f2ch - b12
         # Part des frais s'imputant sur les revenus déclarés case DC
         den = ((f2dc + f2ts) != 0) * (f2dc + f2ts) + ((f2dc + f2ts) == 0)
         F1 = f2ca / den * f2dc
         # Revenus de capitaux mobiliers nets de frais, ouvrant droit à abattement
         # partie négative (à déduire des autres revenus nets de frais d'abattements
-        g12a = -min_(f2dc * (1 - rvcm.taux_abattement_capitaux_mobiliers) - F1, 0)
+        g12a = -min_(f2dc * (1 - P.taux_abattement_capitaux_mobiliers) - F1, 0)
         # partie positive
-        g12b = max_(f2dc * (1 - rvcm.taux_abattement_capitaux_mobiliers) - F1, 0)
-        rev = g12b + f2gr + f2fu * (1 - rvcm.taux_abattement_capitaux_mobiliers)
+        g12b = max_(f2dc * (1 - P.taux_abattement_capitaux_mobiliers) - F1, 0)
+        rev = g12b + f2gr + f2fu * (1 - P.taux_abattement_capitaux_mobiliers)
 
         # Abattements, limité au revenu
-        h12 = rvcm.abatmob * (1 + maries_ou_pacses)
+        h12 = P.abatmob * (1 + maries_ou_pacses)
         TOT2 = max_(0, rev - h12)
         # i121= -min_(0,rev - h12)
 
         # Part des frais s'imputant sur les revenus déclarés ligne TS
         F2 = f2ca - F1
-        TOT3 = (f2ts - F2) + f2go * rvcm.majoration_revenus_reputes_distribues + f2tr - g12a
+        TOT3 = (f2ts - F2) + f2go * P.majoration_revenus_reputes_distribues + f2tr - g12a
 
         DEF = deficit_rcm
         return max_(TOT1 + TOT2 + TOT3 - DEF, 0)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -707,23 +707,23 @@ class revenu_categoriel_capital(Variable):
         f2go = foyer_fiscal('f2go', period)
         f2gr = foyer_fiscal('f2gr', period)
         f2tr = foyer_fiscal('f2tr', period)
-        P = parameters(period).impot_revenu.rvcm
+        parameter_rvcm = parameters(period).impot_revenu.rvcm
 
         part_frais_imputes_sur_f2dc = f2ca / max_(1, f2dc + f2ts) * f2dc
-        part_frais_restant_a_imputer = -min_(f2dc * (1 - P.taux_abattement_capitaux_mobiliers * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
+        part_frais_restant_a_imputer = -min_(f2dc * (1 - parameter_rvcm.taux_abattement_capitaux_mobiliers * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
 
-        dividendes_apres_abattements = max_(f2dc * (1 - P.taux_abattement_capitaux_mobiliers * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
-        revenus_assurance_vie_apres_abattements = f2ch - min_(f2ch, P.abat_assvie * (1 + maries_ou_pacses))
+        dividendes_apres_abattements = max_(f2dc * (1 - parameter_rvcm.taux_abattement_capitaux_mobiliers * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
+        revenus_assurance_vie_apres_abattements = f2ch - min_(f2ch, parameter_rvcm.abat_assvie * (1 + maries_ou_pacses))
         rvcm_apres_abattements_proportionnels = (
             revenus_assurance_vie_apres_abattements
             + dividendes_apres_abattements
             + f2gr
-            + f2fu * (1 - P.taux_abattement_capitaux_mobiliers * (f2da == 0))
+            + f2fu * (1 - parameter_rvcm.taux_abattement_capitaux_mobiliers * (f2da == 0))
             )
-        rvcm_apres_abattements_proportionnels_et_fixes = max_(0, rvcm_apres_abattements_proportionnels - P.abatmob * (1 + maries_ou_pacses))
+        rvcm_apres_abattements_proportionnels_et_fixes = max_(0, rvcm_apres_abattements_proportionnels - parameter_rvcm.abatmob * (1 + maries_ou_pacses))
         autres_rvcm_sans_abattements = (
             f2ts - (f2ca - part_frais_imputes_sur_f2dc)
-            + f2go * P.majoration_revenus_reputes_distribues
+            + f2go * parameter_rvcm.majoration_revenus_reputes_distribues
             + f2tr - part_frais_restant_a_imputer
             )
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.10.1",
+    version = "48.10.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/calculateur_impots/yaml/abat_dividendes.yaml
+++ b/tests/calculateur_impots/yaml/abat_dividendes.yaml
@@ -1,4 +1,4 @@
-- name: abat_dividendes_only_bareme
+- name: Impôt sur le revenu avant 2013 - Déclaration avec option barème progressif uniquement (abattement de 40%)
   period: 2012
   absolute_error_margin: 1
   input:
@@ -37,7 +37,7 @@
     rbg: 194000.0
     rfr: 198000.0
     rni: 194000.0
-- name: abat_dividendes_mixtes
+- name: Impôt sur le revenu avant 2013 - Déclaration avec option barème progressif et PFL (pas d'abattement de 40%)
   period: 2012
   absolute_error_margin: 1
   input:

--- a/tests/calculateur_impots/yaml/abat_dividendes.yaml
+++ b/tests/calculateur_impots/yaml/abat_dividendes.yaml
@@ -1,0 +1,79 @@
+- name: abat_dividendes_only_bareme
+  period: 2012
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      caseF: false
+      caseG: false
+      caseL: false
+      caseP: true
+      caseS: false
+      caseT: false
+      caseW: false
+      f2dc: 10000.0
+      declarants:
+      - ind0
+      nbF: 0.0
+      nbG: 0.0
+      nbH: 0.0
+      nbI: 0.0
+      nbJ: 0
+      nbR: 0
+    individus:
+      ind0:
+        activite: actif
+        date_naissance: '1970-01-01'
+        salaire_imposable: 200000.0
+        statut_marital: celibataire
+    famille:
+      parents:
+      - ind0
+    menage:
+      personne_de_reference: ind0
+  output:
+    irpp: -69742.0
+    nbptr: 1.0
+    ppe: 0.0
+    rbg: 194000.0
+    rfr: 198000.0
+    rni: 194000.0
+- name: abat_dividendes_mixtes
+  period: 2012
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      caseF: false
+      caseG: false
+      caseL: false
+      caseP: true
+      caseS: false
+      caseT: false
+      caseW: false
+      f2da: 50000.0
+      f2dc: 10000.0
+      declarants:
+      - ind0
+      nbF: 0.0
+      nbG: 0.0
+      nbH: 0.0
+      nbI: 0.0
+      nbJ: 0
+      nbR: 0
+    individus:
+      ind0:
+        activite: actif
+        date_naissance: '1970-01-01'
+        salaire_imposable: 200000.0
+        statut_marital: celibataire
+    famille:
+      parents:
+      - ind0
+    menage:
+      personne_de_reference: ind0
+  output:
+    irpp: -69742.0
+    nbptr: 1.0
+    ppe: 0.0
+    rbg: 198000.0
+    rfr: 248000.0
+    rni: 198000.0

--- a/tests/calculateur_impots/yaml/abat_dividendes.yaml
+++ b/tests/calculateur_impots/yaml/abat_dividendes.yaml
@@ -6,7 +6,7 @@
       caseF: false
       caseG: false
       caseL: false
-      caseP: true
+      caseP: false
       caseS: false
       caseT: false
       caseW: false
@@ -31,7 +31,7 @@
     menage:
       personne_de_reference: ind0
   output:
-    irpp: -69742.0
+    irpp: -67942.0
     nbptr: 1.0
     ppe: 0.0
     rbg: 194000.0
@@ -45,7 +45,7 @@
       caseF: false
       caseG: false
       caseL: false
-      caseP: true
+      caseP: false
       caseS: false
       caseT: false
       caseW: false


### PR DESCRIPTION
**Contexte** 

Avant 2013, il existait deux systèmes d'imposition des dividendes à l'impôt sur le revenu : au barème progressif ou au prélèvement forfaitaire libératoire (PFL). Dans la déclaration de revenus, un contribuable doit déclarer ses dividendes en case 2DA si il a opté pour le PFL et en case 2DC si il a opté pour le barème. En pratique, il est possible de choisir une option "mixte", c'est-à-dire d'imposer une partie de ses dividendes à un des régimes d'imposition et une autre partie à l'autre régime. Cependant, si un contribuable opte pour une option "mixte", il perd le bénéfice de l'abattement de 40% applicable aux dividendes imposés au barème.

**Bug constaté**

Dans Openfisca, on simule bien l'abattement de 40% sur les dividendes pour les contribuables au barème mais on fait bénéficier de cet abattement également aux contribuables qui sont au régime "mixte" d'imposition, ce qui est incorrect.

Ce diagnostique est effectué en lançant 2 tests (voir script `tests/calculateur_impots/yaml/abat_dividendes.yaml`). Les résultats attendus sont obtenus à partir du [simulateur en ligne de l'impôt de la DGFiP](https://www3.impots.gouv.fr/simulateur/calcul_impot/2013/index.htm) : 
- Cas option barème : 1AJ = 200 000, 2DC = 10000 
=> RNI = 1AJ (200000) - abat frais pro plafonné (12000) + 2DC (10000) - 40% * 2DC (4000) = 194000; IR = 67942
- Cas option mixtes : 1AJ = 200 000, 2DC = 10000, 2DA = 5000 
=> RNI = 1AJ (200000) - abat frais pro plafonné (12000) + 2DC (10000) = 198000;  IR = 69742

**Solution proposée**

* Évolution/Correction du système socio-fiscal. 
* Périodes concernées : jusqu'au 01/01/2013
* Zones impactées : `model/prelevements_obligatoires/impot_revenu/ir.py`.
* Détails :
  - Ajoute un test sur les abattements sur dividendes
  - Simplifie le calcul du revenu catégoriel du capital
  - Corrige l'application de l'abattement sur dividendes

- - - -

Ces changements  :

- Modifient l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.
- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).
