### PR TITLE
Corrige la non applicabilité du complément dégressif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
 # Changelog
 
+### 48.16.2 [#1428](https://github.com/openfisca/openfisca-france/pull/1428)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes
+* Zones impactées : `openfisca_france/model/prestations/prestations_familiales/af.py`.
+* Détails :
+  - Revalorisation des AF au 01/01/2020
+  - Ajoute la non applicabilité du complément dégressif des allocations familiales pour une famille ayant un enfant et résidant en DOM hors Mayotte
+  - En effet, le deuxième alinéa de l'article L. 755-12 du code de la sécurité sociale dispose que _toutefois, les quatre derniers alinéas de l’article L. 521-1 ne sont pas applicables lorsque le ménage ou la personne a un seul enfant à charge._
+  - Cet article s'applique dans le cas des allocations familiales dans les DOM hors Mayotte. Or, le dernier alinéa de l'article L. 521-1 correspond au complément dégressif des allocations familiales et de leur majoration. Le complément dégressif ne devrait donc pas s'appliquer dans le cas d'un ménage résidant en DOM hors Mayotte et ayant un enfant à charge.
+
 ### 48.16.1 [#1452](https://github.com/openfisca/openfisca-france/pull/1452)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/04/2020.
-* Zones impactées : 
-  - `openfisca_france/parameters/prestations/prestations_familiales/af/modulation/` (plafonds) 
+* Zones impactées :
+  - `openfisca_france/parameters/prestations/prestations_familiales/af/modulation/` (plafonds)
   - `openfisca_france/parameters/prestations/prestations_familiales/cf/plafond_de_ressources_0_enfant.yaml`
 * Détails :
   - Revalorisation d'avril 2020 des plafonds de modulation des allocations familiales selon ressources
@@ -15,7 +26,7 @@
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : toutes (base ressources) et à partir du 01/04/2020 (montant de base).
-* Zones impactées : 
+* Zones impactées :
   - `openfisca_france/model/prestations/minima_sociaux/ppa.py`
   - `openfisca_france/parameters/prestations/minima_sociaux/ppa/montant_de_base.yaml`
 * Détails :

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -235,19 +235,18 @@ class af_complement_degressif(Variable):
     definition_period = MONTH
 
     def formula_2015_07_01(famille, period, parameters):
-        af_nbenf = famille('af_nbenf', period)
-
-        depassement_mensuel = depassement_helper(famille, period, parameters, af_nbenf)
-
-        residence_dom = famille.demandeur.menage('residence_dom', period)
-        residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
-        non_eligible = residence_dom * not_(residence_mayotte) * (af_nbenf == 1)
-
+        eligibilite_dom = famille('af_eligibilite_dom', period)
         af_base = famille('af_base', period)
         af_majoration = famille('af_majoration', period)
         af = af_base + af_majoration
+        af_nbenf = famille('af_nbenf', period)
+        depassement_mensuel = depassement_helper(famille, period, parameters, af_nbenf)
 
-        return max_(0, af - depassement_mensuel) * (depassement_mensuel > 0) * not_(non_eligible)
+        return (
+            + not_(eligibilite_dom)
+            * (depassement_mensuel > 0)
+            * max_(0, af - depassement_mensuel)
+            )
 
 
 class af_allocation_forfaitaire_complement_degressif(Variable):

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -239,11 +239,15 @@ class af_complement_degressif(Variable):
 
         depassement_mensuel = depassement_helper(famille, period, parameters, af_nbenf)
 
+        residence_dom = famille.demandeur.menage('residence_dom', period)
+        residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
+        non_eligible = residence_dom * not_(residence_mayotte) * (af_nbenf == 1)
+
         af_base = famille('af_base', period)
         af_majoration = famille('af_majoration', period)
         af = af_base + af_majoration
 
-        return max_(0, af - depassement_mensuel) * (depassement_mensuel > 0)
+        return max_(0, af - depassement_mensuel) * (depassement_mensuel > 0) * not_(non_eligible)
 
 
 class af_allocation_forfaitaire_complement_degressif(Variable):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.16.1",
+    version = "48.16.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/af_2019_1_dom_complement.yaml
+++ b/tests/formulas/af_2019_1_dom_complement.yaml
@@ -1,0 +1,54 @@
+- name: Allocations familiales - Cas N°1
+  description: Montant AF
+  period: 2019-01
+  absolute_error_margin: 0.02
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1]
+    foyer_fiscal:
+      declarants: [parent1, parent2]
+      personnes_a_charge: [enfant1]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1]
+      residence_dom: true
+      residence_mayotte: false
+    individus:
+      parent1:
+        age: 38
+        revenu_assimile_salaire:
+          # 62533 est égal au premier plafond de modulation des allocations
+          # familiales dans le cas d'un enfant à charge.
+          # Ici, le revenu est calculé de telle sorte que l'on se place
+          # juste au dessus du plafond en termes de ressources de base
+          # des allocations familiales.
+          2016: 62533 / 0.90 / 2 + 20 / 0.90 / 2
+          2017: 62533 / 0.90 / 2 + 20 / 0.90 / 2
+          2018: 62533 / 0.90 / 2 + 20 / 0.90 / 2
+          2019: 62533 / 0.90 / 2 + 20 / 0.90 / 2
+      parent2:
+        age: 35
+        revenu_assimile_salaire:
+          2016: 62533 / 0.90 / 2 + 20 / 0.90 / 2
+          2017: 62533 / 0.90 / 2 + 20 / 0.90 / 2
+          2018: 62533 / 0.90 / 2 + 20 / 0.90 / 2
+          2019: 62533 / 0.90 / 2 + 20 / 0.90 / 2
+      enfant1:
+        age: 10
+  output:
+    af_taux_modulation: 0.5
+    af_base: 12.11
+    af_majoration: 0
+    # Jusqu'ici, tout va bien. Cependant, nous sommes ici dans le cas d'un ménage
+    # à un enfant en DOM hors Mayotte. Le deuxième alinéa de l'article L. 755-12
+    # du code de la sécurité sociale stipule:
+    # "Toutefois, les quatre derniers alinéas de l’article L. 521-1 ne sont pas applicables lorsque le
+    #  ménage ou la personne a un seul enfant à charge."
+    # Or, le dernier alinéa de l'article L. 521-1 correspond au complément dégressif
+    # des allocations familiales et de leur majoration. Ce complément dégressif
+    # ne devrait pas donc être versé dans cette situation.
+    af_complement_degressif: 0.
+    # Les allocations famililes sont bien la somme de la base et du complément.
+    af: 12.11

--- a/tests/formulas/af_2020_04.yaml
+++ b/tests/formulas/af_2020_04.yaml
@@ -1,7 +1,14 @@
+<<<<<<< HEAD:tests/formulas/af_2019_1_dom_complement.yaml
 - name: Allocations familiales - Cas N°1
   description: Montant AF
   period: 2019-01
   absolute_error_margin: 0.02
+=======
+- name: Allocations familiales - Couple, 1 enfant, résidence DOM hors Mayotte
+  description: Montant AF + majoration + complément dégressif
+  period: 2020-04
+  absolute_error_margin: 0.01
+>>>>>>> ef848d259... Refactoring:tests/formulas/af_2020_04.yaml
   input:
     famille:
       parents: [parent1, parent2]
@@ -19,27 +26,21 @@
       parent1:
         age: 38
         revenu_assimile_salaire:
-          # 62533 est égal au premier plafond de modulation des allocations
+          # 63534 est égal au premier plafond de modulation des allocations
           # familiales dans le cas d'un enfant à charge.
           # Ici, le revenu est calculé de telle sorte que l'on se place
           # juste au dessus du plafond en termes de ressources de base
           # des allocations familiales.
-          2016: 62533 / 0.90 / 2 + 20 / 0.90 / 2
-          2017: 62533 / 0.90 / 2 + 20 / 0.90 / 2
-          2018: 62533 / 0.90 / 2 + 20 / 0.90 / 2
-          2019: 62533 / 0.90 / 2 + 20 / 0.90 / 2
+          2018: 63534 / 0.90 / 2 + 20 / 0.90 / 2
       parent2:
         age: 35
         revenu_assimile_salaire:
-          2016: 62533 / 0.90 / 2 + 20 / 0.90 / 2
-          2017: 62533 / 0.90 / 2 + 20 / 0.90 / 2
-          2018: 62533 / 0.90 / 2 + 20 / 0.90 / 2
-          2019: 62533 / 0.90 / 2 + 20 / 0.90 / 2
+          2018: 63534 / 0.90 / 2 + 20 / 0.90 / 2
       enfant1:
         age: 10
   output:
     af_taux_modulation: 0.5
-    af_base: 12.11
+    af_base: 12.19
     af_majoration: 0
     # Jusqu'ici, tout va bien. Cependant, nous sommes ici dans le cas d'un ménage
     # à un enfant en DOM hors Mayotte. Le deuxième alinéa de l'article L. 755-12
@@ -49,6 +50,6 @@
     # Or, le dernier alinéa de l'article L. 521-1 correspond au complément dégressif
     # des allocations familiales et de leur majoration. Ce complément dégressif
     # ne devrait pas donc être versé dans cette situation.
-    af_complement_degressif: 0.
+    af_complement_degressif: 0
     # Les allocations famililes sont bien la somme de la base et du complément.
-    af: 12.11
+    af: 12.19

--- a/tests/formulas/af_2020_04.yaml
+++ b/tests/formulas/af_2020_04.yaml
@@ -1,14 +1,7 @@
-<<<<<<< HEAD:tests/formulas/af_2019_1_dom_complement.yaml
-- name: Allocations familiales - Cas N°1
-  description: Montant AF
-  period: 2019-01
-  absolute_error_margin: 0.02
-=======
 - name: Allocations familiales - Couple, 1 enfant, résidence DOM hors Mayotte
   description: Montant AF + majoration + complément dégressif
   period: 2020-04
   absolute_error_margin: 0.01
->>>>>>> ef848d259... Refactoring:tests/formulas/af_2020_04.yaml
   input:
     famille:
       parents: [parent1, parent2]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes
* Zones impactées : `openfisca_france/model/prestations/prestations_familiales/af.py`.
* Détails :  Le deuxième alinéa de l'article L. 755-12 du code de la sécurité sociale dispose :
 > "Toutefois, les quatre derniers alinéas de l’article L. 521-1 ne sont pas applicables lorsque le ménage ou la personne a un seul enfant à charge.

Cet article s'applique dans le cas des allocations familiales dans les DOM hors Mayotte. Or, le dernier alinéa de l'article L. 521-1 correspond au complément dégressif des allocations familiales et de leur majoration. Le complément dégressif ne devrait donc pas s'appliquer dans le cas d'un ménage résidant en DOM hors Mayotte et ayant un enfant à charge.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
