### PR TITLE
Met à jour la dépendance numpy à sa version 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 # 50.0.0 [#1431](https://github.com/openfisca/openfisca-france/pull/1431)
 
-* Amélioration technique.
+* Amélioration technique non rétro-compatible.
 * Périodes concernées : toutes.
 * Détails :
-  - Adapte OpenFisca-France à `Numpy` v1.18 au travers de la mise à jour de Core.
+  - Adapte OpenFisca-France à [numpy v1.18](https://numpy.org/devdocs/release/1.18.0-notes.html#expired-deprecations) au travers de la mise à jour à Core v35.
+  - Impacte les syntaxes des formules de calcul possibles du dépôt et de ses extensions.
 
 ### 49.0.1 [#1466](https://github.com/openfisca/openfisca-france/pull/1466)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 # Changelog
 
+# 50.0.0 [#1431](https://github.com/openfisca/openfisca-france/pull/1431)
+
+* Amélioration technique.
+* Périodes concernées : toutes.
+* Détails :
+  - Adapte OpenFisca-France à `Numpy` v1.18 au travers de la mise à jour de Core.
+
 ### 49.0.1 [#1466](https://github.com/openfisca/openfisca-france/pull/1466)
 
 * Correction d'un crash.
 * Périodes concernées : toutes. 
 * Zones impactées : openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
 * Détails :
-  - Correction dans l'appel de certaines cases de crédits d'impôts qui n'avaient pas été changé après renommage
-  - Suppression de l'appel de la variable f8tk dans les crédits d'impôts car ce n'en ai pas un
+  - Correction dans l'appel de certaines cases de crédits d'impôts qui n'avaient pas été changées après renommage
+  - Suppression de l'appel de la variable `f8tk` dans les crédits d'impôts car ce n'en est pas un
 
 # 49.0.0 [#1462](https://github.com/openfisca/openfisca-france/pull/1462)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "49.0.1",
+    version = "50.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         },
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
-        "OpenFisca-Core >=34.6,<35.0",
+        "OpenFisca-Core >=34.6,<36.0",
         ],
     message_extractors = {"openfisca_france": [
         ("**.py", "python", None),


### PR DESCRIPTION
Connected to openfisca/openfisca-core#924

⚠️  Branche de référence sur CircleCI définie sur les travaux Core de mise à jour de numpy.

Documentation : 
* Changements apportés par [numpy 1.18](https://numpy.org/devdocs/release/1.18.0-notes.html)
* Évolution de [numpy.select()](https://github.com/openfisca/openfisca-core/issues/924#issuecomment-615512006)

---
* Amélioration technique non rétro-compatible.
* Périodes concernées : toutes.
* Détails :
  - Adapte OpenFisca-France à [numpy v1.18](https://numpy.org/devdocs/release/1.18.0-notes.html#expired-deprecations) au travers de la mise à jour à Core v35.
  - Impacte les syntaxes des formules de calcul possibles du dépôt et de ses extensions.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient l'_API publique_ d'OpenFisca France : par exemple renommage ou suppression de fonctions numpy employables dans les formules des variables du modèle et de ses extensions.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

