### PR TITLE
Met à jour la dépendance pytest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 48.15.1 [#1443](https://github.com/openfisca/openfisca-france/pull/1443)
+
+* Correction d'un crash.
+* Détails :
+  - Met à jour la librairie `pytest` employée pour les tests Python et YAML via la commande `openfisca test` héritée d'openfisca-core, pour les cibles d'installation `dev` et `casd-dev`.
+  - Corrige le décalage de version de `pytest` entre `Core` et `France`.
+
 ## 48.15.0 [#1434](https://github.com/openfisca/openfisca-france/pull/1434)
 
 * Évolution du système socio-fiscal.

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
             "autopep8 ==1.5.1",
             "flake8 >=3.7.0,<3.8.0",
             "flake8-print",
-            "pytest <5.0",
+            "pytest >= 5.0.0, < 6.0.0",
             "scipy >= 0.17",  # Only used to test de_net_a_brut reform
             "requests >= 2.8",
             "yamllint >=1.11.1,<1.23"
@@ -52,7 +52,7 @@ setup(
         "casd-dev": [
             # Same as dev with packages not available at CASD removed
             "autopep8 >=1.3.2",
-            "pytest < 5.0",
+            "pytest >= 5.0.0, < 6.0.0",
             "requests >= 2.8",
             "scipy >= 0.17",  # Only used to test de_net_a_brut reform
             ]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.15.0",
+    version = "48.15.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Connected to openfisca/openfisca-core#958

⚠️ Fixation d'un bug spécifique à France suite à la dernière PR Core mergée openfisca/openfisca-core#958.

* Correction d'un crash.
* Détails :
  - Met à jour la librairie `pytest` employée pour les tests Python et YAML via la commande `openfisca test` héritée d'openfisca-core, pour les cibles d'installation `dev` et `casd-dev`.
  - Corrige le décalage de version de `pytest` entre `Core` et `France`.

**Corrige ce bug :** 

Bug dû à la situation particulière de France qui spécifiait un `pytest < 5.0` avec OpenFisca-Core `34.7.5` spécifiant un `pytest >= 5.0` : 

```shell
$ openfisca test --country-package openfisca_france tests

========================================================= test session starts =========================================================
platform darwin -- Python 3.7.7, pytest-4.6.11, py-1.9.0, pluggy-0.13.1
rootdir: /.../openfisca-france, inifile: setup.cfg
collected 0 items / 1 errors                                                                                                          

=============================================================== ERRORS ================================================================
____________________________________________________ ERROR collecting test session ____________________________________________________
../../../.local/share/virtualenvs/fmaster/lib/python3.7/site-packages/pluggy/hooks.py:286: in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
../../../.local/share/virtualenvs/fmaster/lib/python3.7/site-packages/pluggy/manager.py:93: in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
../../../.local/share/virtualenvs/fmaster/lib/python3.7/site-packages/pluggy/manager.py:87: in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
../../../.local/share/virtualenvs/fmaster/lib/python3.7/site-packages/openfisca_core/tools/test_runner.py:256: in pytest_collect_file
    return YamlFile.from_parent(parent, path = path, fspath = path,
E   AttributeError: type object 'YamlFile' has no attribute 'from_parent'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
======================================================= 1 error in 0.34 seconds =======================================================
```

**Information complémentaire :**

En choisissant de maîtriser la version de `pytest` dans OpenFisca-France (nous d'indiquons une version pour cette librairie dans le`setup.py` France), nous avons introduit une incohérence. En effet, si cela permet de maîtriser le moment de mise à jour des syntaxes des tests au format Python, cela crée un décalage pour les tests au format YAML.

En particulier, `pytest` est la librairie sous-jacente à la commande `openfisca test` qu'un usager d'OpenFisca-France va installer au travers de la dépendance `OpenFisca-Core` (via [cette ligne du setup.py Core](https://github.com/openfisca/openfisca-core/blob/ca083858b9f0cfd3fe49fc76b5e6726a300b9d38/setup.py#L62)). Commande qui aura donc été construite pour la version `pytest` de Core. 

Je vous propose finalement de revenir sur cette décision et de ne plus spécifier de version `pytest` pour France. Dans l'immédiat, ceci peut être fait en deux temps : cette PR de mise à jour + une autre PR de suppression après vérification des impacts pour tous (en particulier pour le CASD).

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus