### PR TITLE
Ajoute la revalorisation RSA d'avril 2020 et fiabilise le cas apprenti

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 48.17.0 [#1453](https://github.com/openfisca/openfisca-france/pull/1453)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir de 06/2009 (base ressources).
+* Zones impactées :
+  - `openfisca_france/model/prestations/minima_sociaux/rsa.py`
+  - `openfisca_france/parameters/prestations/minima_sociaux/rsa/montant_de_base_du_rsa.yaml`
+* Détails : 
+  - Met à jour le montant de base du RSA pour avril 2020.
+  - Ajoute les ressources de l'apprenti à la base de ressources du RSA via `rsa_revenu_activite_individu` et le teste.
+
 ### 48.16.2 [#1428](https://github.com/openfisca/openfisca-france/pull/1428)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -500,6 +500,7 @@ class rsa_revenu_activite_individu(Variable):
         types_revenus_activite = [
             'salaire_net',
             'indemnites_chomage_partiel',
+            'remuneration_apprenti',
             'indemnites_volontariat',
             'revenus_stage_formation_pro',
             'bourse_recherche',

--- a/openfisca_france/parameters/prestations/minima_sociaux/rsa/montant_de_base_du_rsa.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/rsa/montant_de_base_du_rsa.yaml
@@ -38,3 +38,5 @@ values:
   2019-04-01:
     value: 559.74
     reference: https://www.legifrance.gouv.fr/eli/decret/2019/5/2/2019-400/jo/texte
+  2020-04-01:
+    value: 564.78

--- a/openfisca_france/parameters/prestations/minima_sociaux/rsa/montant_de_base_du_rsa.yaml
+++ b/openfisca_france/parameters/prestations/minima_sociaux/rsa/montant_de_base_du_rsa.yaml
@@ -40,3 +40,4 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/decret/2019/5/2/2019-400/jo/texte
   2020-04-01:
     value: 564.78
+    reference: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000041835196

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.16.2",
+    version = "48.17.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/rsa.yaml
+++ b/tests/formulas/rsa.yaml
@@ -638,7 +638,7 @@
     rsa: 0
 
 
-- name: RSA avec revenu d'apprenti - la condition d'accés est remplie sur les 3 ans qui précède la demande soit les 3214 heures d'activité
+- name: RSA avec revenu d'apprenti - la condition d'accès est remplie sur les 3 ans qui précèdent la demande soit les 3214 heures d'activité
   period: 2021-04
   absolute_error_margin: 0.03
   input:

--- a/tests/formulas/rsa.yaml
+++ b/tests/formulas/rsa.yaml
@@ -602,3 +602,73 @@
         age: 35
   output:
     rsa: 826.40 - 200
+
+- name: RSA avec revenu d'apprenti
+  period: 2020-04
+  absolute_error_margin: 0.03
+  input:
+    famille:
+      parents: [personne1]
+      aide_logement:
+        2020-04: 250
+        2020-03: 250
+        2020-02: 250
+        2020-01: 250
+    foyer_fiscal:
+      declarants: [personne1]
+    menage:
+      personne_de_reference: personne1
+      statut_occupation_logement: locataire_vide
+    individus:
+      personne1:
+        date_naissance: 1980-01-01
+        remuneration_apprenti:
+          2020-04: 960
+          2020-03: 960
+          2020-02: 960
+          2020-01: 960
+        salaire_imposable:
+          2020-04: 0
+          2020-03: 0
+          2020-02: 0
+          2020-01: 0
+  output:
+    rsa_forfait_logement: 67.17
+    rsa_base_ressources: 960
+    rsa: 0
+
+
+- name: RSA avec revenu d'apprenti - la condition d'accés est remplie sur les 3 ans qui précède la demande soit les 3214 heures d'activité
+  period: 2020-04
+  absolute_error_margin: 0.03
+  input:
+    famille:
+      parents: [personne1]
+      aide_logement:
+        2020-04: 120
+        2020-03: 120
+        2020-02: 120
+        2020-01: 120
+    foyer_fiscal:
+      declarants: [personne1]
+    menage:
+      personne_de_reference: personne1
+      statut_occupation_logement: locataire_vide
+    individus:
+      personne1:
+        date_naissance: 2000-01-01
+        remuneration_apprenti:
+          2020-04: 943
+          2020-03: 943
+          2020-02: 943
+          2020-01: 943
+        rsa_jeune_condition_heures_travail_remplie: true
+        salaire_imposable:
+          2020-04: 0
+          2020-03: 0
+          2020-02: 0
+          2020-01: 0
+  output:
+    rsa_forfait_logement: 67.17
+    rsa_base_ressources: 943
+    rsa: 0

--- a/tests/formulas/rsa.yaml
+++ b/tests/formulas/rsa.yaml
@@ -604,16 +604,16 @@
     rsa: 826.40 - 200
 
 - name: RSA avec revenu d'apprenti
-  period: 2020-04
+  period: 2021-04
   absolute_error_margin: 0.03
   input:
     famille:
       parents: [personne1]
       aide_logement:
-        2020-04: 250
-        2020-03: 250
-        2020-02: 250
-        2020-01: 250
+        2021-04: 250
+        2021-03: 250
+        2021-02: 250
+        2021-01: 250
     foyer_fiscal:
       declarants: [personne1]
     menage:
@@ -623,32 +623,32 @@
       personne1:
         date_naissance: 1980-01-01
         remuneration_apprenti:
-          2020-04: 960
-          2020-03: 960
-          2020-02: 960
-          2020-01: 960
+          2021-04: 960
+          2021-03: 960
+          2021-02: 960
+          2021-01: 960
         salaire_imposable:
-          2020-04: 0
-          2020-03: 0
-          2020-02: 0
-          2020-01: 0
+          2021-04: 0
+          2021-03: 0
+          2021-02: 0
+          2021-01: 0
   output:
-    rsa_forfait_logement: 67.17
+    rsa_forfait_logement: 67.77
     rsa_base_ressources: 960
     rsa: 0
 
 
 - name: RSA avec revenu d'apprenti - la condition d'accés est remplie sur les 3 ans qui précède la demande soit les 3214 heures d'activité
-  period: 2020-04
+  period: 2021-04
   absolute_error_margin: 0.03
   input:
     famille:
       parents: [personne1]
       aide_logement:
-        2020-04: 120
-        2020-03: 120
-        2020-02: 120
-        2020-01: 120
+        2021-04: 120
+        2021-03: 120
+        2021-02: 120
+        2021-01: 120
     foyer_fiscal:
       declarants: [personne1]
     menage:
@@ -658,17 +658,17 @@
       personne1:
         date_naissance: 2000-01-01
         remuneration_apprenti:
-          2020-04: 943
-          2020-03: 943
-          2020-02: 943
-          2020-01: 943
+          2021-04: 943
+          2021-03: 943
+          2021-02: 943
+          2021-01: 943
         rsa_jeune_condition_heures_travail_remplie: true
         salaire_imposable:
-          2020-04: 0
-          2020-03: 0
-          2020-02: 0
-          2020-01: 0
+          2021-04: 0
+          2021-03: 0
+          2021-02: 0
+          2021-01: 0
   output:
-    rsa_forfait_logement: 67.17
+    rsa_forfait_logement: 67.77
     rsa_base_ressources: 943
     rsa: 0


### PR DESCRIPTION
📍 Cette PR intègre les commits MSA de la branche `msa_fork_al_css_v1_7_1` concernant le RSA.
Elle équivaut à l'intégration des commits suivants à `master` sans autre altération : dfc2d5717c9ea474de8b3b61a36746539b9aacd0, 48051dd312ee4993bfb784987cd286107d2b59d7 et 5423f92ff1938685ee9eabd984510ef5345cf72b.

---

* Évolution du système socio-fiscal.
* Périodes concernées : à partir de 06/2009 (base ressources).
* Zones impactées :
  - `openfisca_france/model/prestations/minima_sociaux/rsa.py`
  - `openfisca_france/parameters/prestations/minima_sociaux/rsa/montant_de_base_du_rsa.yaml`
* Détails : 
  - Met à jour le montant de base du RSA pour avril 2020.
  - Ajoute les ressources de l'apprenti à la base de ressources du RSA via `rsa_revenu_activite_individu` et le teste.

- - - -

Ces changements : 

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
