### PR TITLE
Revalorisation des paramètres RLS pour janvier et octobre 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 48.15.6 [#1456](https://github.com/openfisca/openfisca-france/pull/1456)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2020.
+* Zones impactées : `openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/`
+* Détails :
+  - Mise à jour des montants de réduction de loyer de solidarité (RLS) pour janvier et octobre 2020.
+
 ### 48.15.5 [#1447](https://github.com/openfisca/openfisca-france/pull/1447)
 
 * Amélioration technique.
@@ -310,9 +318,9 @@
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/06/2009.
 * Zones impactées :
-`openfisca_france/model/prestations/minima_sociaux/rsa.py`
-`openfisca_france/parameters/prestations/minima_sociaux/rsa/duree_min_titre_sejour.yaml`
-`openfisca_france/tests/formulas/rsa/rsa_condition_nationalite.yaml`
+  - `openfisca_france/model/prestations/minima_sociaux/rsa.py`
+  - `openfisca_france/parameters/prestations/minima_sociaux/rsa/duree_min_titre_sejour.yaml`
+  - `openfisca_france/tests/formulas/rsa/rsa_condition_nationalite.yaml`
 * Détails :
   - Avant cette modification, un ressortissant de l'EEE était considéré comme ayant toujours droit au RSA, alors qu'en réalité il doit être en France depuis au moins 3 mois pour y avoir droit.
 

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/couples.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/couples.yaml
@@ -7,3 +7,7 @@ values:
   2019-01-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 38.99
+  2020-01-01:
+    value: 59.70
+  2020-10-01:
+    value: 41.13

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/couples.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/couples.yaml
@@ -8,6 +8,8 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 38.99
   2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/12/31/LOGL1934007A/jo/texte
     value: 59.70
   2020-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2020/9/30/LOGL2020748A/jo/texte
     value: 41.13

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/famille_1pac.yaml
@@ -8,6 +8,8 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 44.06
   2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/12/31/LOGL1934007A/jo/texte
     value: 67.46
   2020-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2020/9/30/LOGL2020748A/jo/texte
     value: 46.47

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/famille_1pac.yaml
@@ -7,3 +7,7 @@ values:
   2019-01-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 44.06
+  2020-01-01:
+    value: 67.46
+  2020-10-01:
+    value: 46.47

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/majoration_par_pac_supp.yaml
@@ -8,6 +8,8 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 6.39
   2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/12/31/LOGL1934007A/jo/texte
     value: 9.78
   2020-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2020/9/30/LOGL2020748A/jo/texte
     value: 6.74

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/majoration_par_pac_supp.yaml
@@ -7,3 +7,7 @@ values:
   2019-01-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 6.39
+  2020-01-01:
+    value: 9.78
+  2020-10-01:
+    value: 6.74

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/personnes_seules.yaml
@@ -7,3 +7,7 @@ values:
   2019-01-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 32.33
+  2020-01-01:
+    value: 49.50
+  2020-10-01:
+    value: 34.10

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_1/personnes_seules.yaml
@@ -8,6 +8,8 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 32.33
   2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/12/31/LOGL1934007A/jo/texte
     value: 49.50
   2020-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2020/9/30/LOGL2020748A/jo/texte
     value: 34.10

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/couples.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/couples.yaml
@@ -8,6 +8,8 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 34.48
   2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/12/31/LOGL1934007A/jo/texte
     value: 52.79
   2020-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2020/9/30/LOGL2020748A/jo/texte
     value: 36.37

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/couples.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/couples.yaml
@@ -7,3 +7,7 @@ values:
   2019-01-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 34.48
+  2020-01-01:
+    value: 52.79
+  2020-10-01:
+    value: 36.37

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/famille_1pac.yaml
@@ -8,6 +8,8 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 38.8
   2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/12/31/LOGL1934007A/jo/texte
     value: 59.40
   2020-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2020/9/30/LOGL2020748A/jo/texte
     value: 40.92

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/famille_1pac.yaml
@@ -7,3 +7,7 @@ values:
   2019-01-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 38.8
+  2020-01-01:
+    value: 59.40
+  2020-10-01:
+    value: 40.92

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/majoration_par_pac_supp.yaml
@@ -7,3 +7,7 @@ values:
   2019-01-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 5.65
+  2020-01-01:
+    value: 8.65
+  2020-10-01:
+    value: 5.96

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/majoration_par_pac_supp.yaml
@@ -8,6 +8,8 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 5.65
   2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/12/31/LOGL1934007A/jo/texte
     value: 8.65
   2020-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2020/9/30/LOGL2020748A/jo/texte
     value: 5.96

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/personnes_seules.yaml
@@ -7,3 +7,7 @@ values:
   2019-01-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 28.18
+  2020-01-01:
+    value: 43.14
+  2020-10-01:
+    value: 29.72

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_2/personnes_seules.yaml
@@ -8,6 +8,8 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 28.18
   2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/12/31/LOGL1934007A/jo/texte
     value: 43.14
   2020-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2020/9/30/LOGL2020748A/jo/texte
     value: 29.72

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/couples.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/couples.yaml
@@ -8,6 +8,8 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 32.01
   2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/12/31/LOGL1934007A/jo/texte
     value: 49.01
   2020-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2020/9/30/LOGL2020748A/jo/texte
     value: 33.76

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/couples.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/couples.yaml
@@ -7,3 +7,7 @@ values:
   2019-01-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 32.01
+  2020-01-01:
+    value: 49.01
+  2020-10-01:
+    value: 33.76

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/famille_1pac.yaml
@@ -8,6 +8,8 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 35.89
   2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/12/31/LOGL1934007A/jo/texte
     value: 54.95
   2020-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2020/9/30/LOGL2020748A/jo/texte
     value: 37.85

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/famille_1pac.yaml
@@ -7,3 +7,7 @@ values:
   2019-01-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 35.89
+  2020-01-01:
+    value: 54.95
+  2020-10-01:
+    value: 37.85

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/majoration_par_pac_supp.yaml
@@ -8,6 +8,8 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 5.14
   2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/12/31/LOGL1934007A/jo/texte
     value: 7.87
   2020-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2020/9/30/LOGL2020748A/jo/texte
     value: 5.42

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/majoration_par_pac_supp.yaml
@@ -7,3 +7,7 @@ values:
   2019-01-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 5.14
+  2020-01-01:
+    value: 7.87
+  2020-10-01:
+    value: 5.42

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/personnes_seules.yaml
@@ -7,3 +7,7 @@ values:
   2019-01-01:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 26.41
+  2020-01-01:
+    value: 40.43
+  2020-10-01:
+    value: 27.85

--- a/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/zone_3/personnes_seules.yaml
@@ -8,6 +8,8 @@ values:
     reference: https://www.legifrance.gouv.fr/eli/arrete/2018/12/27/LOGL1831321A/jo/texte
     value: 26.41
   2020-01-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2019/12/31/LOGL1934007A/jo/texte
     value: 40.43
   2020-10-01:
+    reference: https://www.legifrance.gouv.fr/eli/arrete/2020/9/30/LOGL2020748A/jo/texte
     value: 27.85

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.15.5",
+    version = "48.15.6",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
📍 Cette PR intègre les commits MSA de la branche `msa_fork_al_css_v1_7_1` concernant le dispositif de réduction de loyer de solidarité (RLS). À l'ouverture de cette PR, elle équivaut à l'intégration du commit 1463766e5cce5df0e6c921b5e5b85f9af334af4d  à `master` sans autre altération.
Noter qu'il s'agit aussi à ce jour du dernier commit (le plus récent) de `msa_fork_al_css_v1_7_1`.

---

* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2020.
* Zones impactées : `openfisca_france/parameters/prestations/reduction_loyer_solidarite/montant/par_zone/`.
* Détails :
  - Mise à jour des montants de réduction de loyer de solidarité (RLS) pour janvier et octobre 2020.


- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).