### PR TITLE
Corrige calcul nombre de parts veuf·ve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 48.17.1 [#1461](https://github.com/openfisca/openfisca-france/pull/1461)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : `prelevements_obligatoires/impot_revenu/ir.py`.
+* Détails :
+  - Corrige le calcul du nombre de parts pour un·e veuf·ve
+  - Dans le cas où un·e veuf·ve aurait au moins un·e enfant à charge en garde alternée
+
 ## 48.17.0 [#1453](https://github.com/openfisca/openfisca-france/pull/1453)
 
 * Évolution du système socio-fiscal.
@@ -7,7 +16,7 @@
 * Zones impactées :
   - `openfisca_france/model/prestations/minima_sociaux/rsa.py`
   - `openfisca_france/parameters/prestations/minima_sociaux/rsa/montant_de_base_du_rsa.yaml`
-* Détails : 
+* Détails :
   - Met à jour le montant de base du RSA pour avril 2020.
   - Ajoute les ressources de l'apprenti à la base de ressources du RSA via `rsa_revenu_activite_individu` et le teste.
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -3249,7 +3249,7 @@ class nbptr(Variable):
         nb_parts_famille = 1 + quotient_familial.conj + enf + n2 + n4
 
         # # veufs  hors jeune_veuf
-        nb_parts_veuf = 1 + quotient_familial.veuf * has_pac + enf + n2 + n3 + n5 + n6
+        nb_parts_veuf = 1 + quotient_familial.veuf * (has_pac | has_alt) + enf + n2 + n3 + n5 + n6
 
         # # celib div
         nb_parts_celib = 1 + enf + n2 + n3 + n6 + n7

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "48.17.0",
+    version = "48.17.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/impot_revenu/nombre_de_parts/celibataire_ou_divorce.yaml
+++ b/tests/impot_revenu/nombre_de_parts/celibataire_ou_divorce.yaml
@@ -1,0 +1,173 @@
+- name: Célibataire ou divorcé·e - Cas général
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      celibataire_ou_divorce: true
+  output:
+    nbptr: 1.0
+
+- name: Veuf·ve·s - Invalidité
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseP: true
+  output:
+    nbptr: 1.5
+
+- name: Célibataire ou divorcé·e - Agé de plus de 75 ans et carte du combattant / pension militaire d'invalidité / de victime de guerre
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseW: true
+  output:
+    nbptr: 1.5
+
+- name: Célibataire ou divorcé·e - Vit seul·e au 1er janvier de l'année d'imposition et a un·e enfant majeur non rattaché et a élevé seul cet enfant pendant au moins 5 années
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseL: true
+  output:
+    nbptr: 1.5
+
+- name: Célibataire ou divorcé·e - 1 x personne à charge
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      celibataire_ou_divorce: true
+      nbF: 1
+  output:
+    nbptr: 1.5
+
+- name: Célibataire ou divorcé·e - 2 x personnes à charge
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      celibataire_ou_divorce: true
+      nbF: 2
+  output:
+    nbptr: 2.0
+
+- name: Célibataire ou divorcé·e - 4 x personnes à charge
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      celibataire_ou_divorce: true
+      nbF: 4
+  output:
+    nbptr: 4.0
+
+- name: Célibataire ou divorcé·e - 4 x personnes à charge dont 2 x invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      celibataire_ou_divorce: true
+      nbF: 4
+      nbG: 2
+  output:
+    nbptr: 5.0
+
+- name: Célibataire ou divorcé·e - 4 x personnes à charge dont 4 x invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      celibataire_ou_divorce: true
+      nbF: 4
+      nbG: 4
+  output:
+    nbptr: 6.0
+
+- name: Célibataire ou divorcé·e - 2 x personnes à charge et 2 x résidence alternée
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      celibataire_ou_divorce: true
+      nbF: 2
+      nbH: 2
+  output:
+    nbptr: 3.0
+
+- name: Célibataire ou divorcé·e - 4 x résidence alternée
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      celibataire_ou_divorce: true
+      nbH: 4
+  output:
+    nbptr: 2.5
+
+- name: Célibataire ou divorcé·e - 2 x personnes à charge et 2 x résidence alternée et invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      celibataire_ou_divorce: true
+      nbF: 2
+      nbH: 2
+      nbI: 2
+  output:
+    nbptr: 3.5
+
+- name: Célibataire ou divorcé·e - 4 x résidence alternée et invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      celibataire_ou_divorce: true
+      nbH: 4
+      nbI: 4
+  output:
+    nbptr: 3.5

--- a/tests/impot_revenu/nombre_de_parts/maries_ou_pacses.yaml
+++ b/tests/impot_revenu/nombre_de_parts/maries_ou_pacses.yaml
@@ -1,0 +1,200 @@
+- name: Marié·e·s ou pacsé·e·s - Cas général
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+  output:
+    nbptr: 2.0
+
+- name: Marié·e·s ou pacsé·e·s - 1 x invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+      caseP: true
+  output:
+    nbptr: 2.5
+
+- name: Marié·e·s ou pacsé·e·s - 2 x invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+      caseP: true
+      caseF: true
+  output:
+    nbptr: 3.0
+
+- name: Marié·e·s ou pacsé·e·s - 1 x agé de plus de 75 ans et carte du combattant / pension militaire d'invalidité / de victime de guerre
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+      caseS: true
+  output:
+    nbptr: 2.5
+
+- name: Marié·e·s ou pacsé·e·s - 1 x personne à charge
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+      nbF: 1
+  output:
+    nbptr: 2.5
+
+- name: Marié·e·s ou pacsé·e·s - 2 x personnes à charge
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+      nbF: 2
+  output:
+    nbptr: 3.0
+
+- name: Marié·e·s ou pacsé·e·s - 4 x personnes à charge
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+      nbF: 4
+  output:
+    nbptr: 5.0
+
+- name: Marié·e·s ou pacsé·e·s - 4 x personnes à charge dont 2 x invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+      nbF: 4
+      nbG: 2
+  output:
+    nbptr: 6.0
+
+- name: Marié·e·s ou pacsé·e·s - 4 x personnes à charge dont 4 x invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+      nbF: 4
+      nbG: 4
+  output:
+    nbptr: 7.0
+
+- name: Marié·e·s ou pacsé·e·s - 2 x personnes à charge et 2 x résidence alternée
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+      nbF: 2
+      nbH: 2
+  output:
+    nbptr: 4.0
+
+- name: Marié·e·s ou pacsé·e·s - 4 x résidence alternée
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+      nbH: 4
+  output:
+    nbptr: 3.5
+
+- name: Marié·e·s ou pacsé·e·s - 2 x personnes à charge et 2 x résidence alternée et invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+      nbF: 2
+      nbH: 2
+      nbI: 2
+  output:
+    nbptr: 4.5
+
+- name: Marié·e·s ou pacsé·e·s - 4 x résidence alternée et invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+      individu2: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+        - individu2
+      maries_ou_pacses: true
+      nbH: 4
+      nbI: 4
+  output:
+    nbptr: 4.5

--- a/tests/impot_revenu/nombre_de_parts/parent_isole.yaml
+++ b/tests/impot_revenu/nombre_de_parts/parent_isole.yaml
@@ -1,0 +1,122 @@
+- name: Parent isolé·e - 1 x personne à charge
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseT: true
+      nbF: 1
+  output:
+    nbptr: 2.0
+
+- name: Parent isolé·e - 2 x personnes à charge
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseT: true
+      nbF: 2
+  output:
+    nbptr: 2.5
+
+- name: Parent isolé·e - 4 x personnes à charge
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseT: true
+      nbF: 4
+  output:
+    nbptr: 4.5
+
+- name: Parent isolé·e - 4 x personnes à charge dont 2 x invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseT: true
+      nbF: 4
+      nbG: 2
+  output:
+    nbptr: 5.5
+
+- name: Parent isolé·e - 4 x personnes à charge dont 4 x invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseT: true
+      nbF: 4
+      nbG: 4
+  output:
+    nbptr: 6.5
+
+- name: Parent isolé·e - 2 x personnes à charge et 2 x résidence alternée
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseT: true
+      nbF: 2
+      nbH: 2
+  output:
+    nbptr: 3.5
+
+- name: Parent isolé·e - 4 x résidence alternée
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseT: true
+      nbH: 4
+  output:
+    nbptr: 3.0
+
+- name: Parent isolé·e - 2 x personnes à charge et 2 x résidence alternée et invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseT: true
+      nbF: 2
+      nbH: 2
+      nbI: 2
+  output:
+    nbptr: 4.0
+
+- name: Parent isolé·e - 4 x résidence alternée et invalidité
+  period: 2019
+  input:
+    individus:
+      individu1: {}
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseT: true
+      nbH: 4
+      nbI: 4
+  output:
+    nbptr: 4.0

--- a/tests/impot_revenu/nombre_de_parts/veufs.yaml
+++ b/tests/impot_revenu/nombre_de_parts/veufs.yaml
@@ -1,0 +1,186 @@
+- name: Veuf·ve·s - Cas général
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+  output:
+    nbptr: 1.0
+
+- name: Veuf·ve·s - Invalidité
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseP: true
+  output:
+    nbptr: 1.5
+
+- name: Veuf·ve·s - Agé de plus de 75 ans et carte du combattant / pension militaire d'invalidité / de victime de guerre
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseW: true
+  output:
+    nbptr: 1.5
+
+- name: Veuf·ve·s - Vit seul·e au 1er janvier de l'année d'imposition et a un·e enfant majeur non rattaché et a élevé seul cet enfant pendant au moins 5 années
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseL: true
+  output:
+    nbptr: 1.5
+
+- name: Veuf·ve·s - Titulaire d'une pension de veuve de guerre
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      caseG: true
+  output:
+    nbptr: 1.5
+
+- name: Veuf·ve·s - 1 x personne à charge
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      nbF: 1
+  output:
+    nbptr: 2.5
+
+- name: Veuf·ve·s - 2 x personnes à charge
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      nbF: 2
+  output:
+    nbptr: 3.0
+
+- name: Veuf·ve·s - 4 x personnes à charge
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      nbF: 4
+  output:
+    nbptr: 5.0
+
+- name: Veuf·ve·s - 4 x personnes à charge dont 2 x invalidité
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      nbF: 4
+      nbG: 2
+  output:
+    nbptr: 6.0
+
+- name: Veuf·ve·s - 4 x personnes à charge dont 4 x invalidité
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      nbF: 4
+      nbG: 4
+  output:
+    nbptr: 7.0
+
+- name: Veuf·ve·s - 2 x personnes à charge et 2 x résidence alternée
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      nbF: 2
+      nbH: 2
+  output:
+    nbptr: 4.0
+
+- name: Veuf·ve·s - 4 x résidence alternée
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      nbH: 4
+  output:
+    nbptr: 3.5
+
+- name: Veuf·ve·s - 2 x personnes à charge et 2 x résidence alternée et invalidité
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      nbF: 2
+      nbH: 2
+      nbI: 2
+  output:
+    nbptr: 4.5
+
+- name: Veuf·ve·s - 4 x résidence alternée et invalidité
+  period: 2019
+  input:
+    individus:
+      individu1:
+        statut_marital: veuf
+    foyer_fiscal:
+      declarants:
+        - individu1
+      nbH: 4
+      nbI: 4
+  output:
+    nbptr: 4.5


### PR DESCRIPTION
Fixes #1418 

* Évolution du système socio-fiscal. 
* Périodes concernées : toutes.
* Zones impactées : `prelevements_obligatoires/impot_revenu/ir.py`.
* Détails :
  - Corrige le calcul du nombre de parts pour un·e veuf·ve
  - Dans le cas où un·e veuf·ve aurait au moins un·e enfant à charge en garde alternée

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus