### PR TITLE
Ajoute is_period_size_independent = True pour les variable de patrimoine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 50.0.3 [#1475](https://github.com/openfisca/openfisca-france/pull/1475)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `model/revenus/capital/financier.py`.
+* Détails :
+  - Rend les variables de valeur de patrimoine indépendantes de la taille de la période.
+
 ### 50.0.2 [#1474](https://github.com/openfisca/openfisca-france/pull/1474)
 
 * Changement mineur.

--- a/openfisca_france/model/revenus/capital/financier.py
+++ b/openfisca_france/model/revenus/capital/financier.py
@@ -395,6 +395,7 @@ class livret_a(Variable):
     entity = Individu
     label = "Épargne sur Livret A"
     definition_period = MONTH
+    is_period_size_independent = True
     set_input = set_input_dispatch_by_period
 
 
@@ -404,6 +405,7 @@ class epargne_revenus_non_imposables(Variable):
     entity = Individu
     label = "Épargne générant des revenus non imposables hors Livret A"
     definition_period = MONTH
+    is_period_size_independent = True
     set_input = set_input_dispatch_by_period
 
 
@@ -412,6 +414,7 @@ class epargne_revenus_imposables(Variable):
     entity = Individu
     label = "Épargne générant des revenus imposables"
     definition_period = MONTH
+    is_period_size_independent = True
     set_input = set_input_dispatch_by_period
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "50.0.2",
+    version = "50.0.3",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `model/revenus/capital/financier.py`.
* Détails :
  - Rend les variables de valeur de patrimoine indépendantes de la taille de la période.
