### PR TITLE
Ajoute l'éligibilité au repas CROUS à 1€ pour tout étudiant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-##
+## [#1485](https://github.com/openfisca/openfisca-france/pull/1485)
 
 * Évolution du système socio-fiscal.
-* Périodes concernées : À partir de 01/2021.
+* Périodes concernées : à partir de 01/2021.
 * Zones impactées :
   - `prestations/alimentation.py`
 * Détails :
-  - Ajoute l'éligibilité à l'aide repas crous à 1€ pour tout étudiant.
+  - Ajoute l'éligibilité à l'aide repas CROUS à 1€ pour tout étudiant.
 
 ## 51.1.0 [#1445](https://github.com/openfisca/openfisca-france/pull/1445)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+##
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : À partir de 01/2021.
+* Zones impactées :
+  - `prestations/alimentation.py`
+* Détails :
+  - Ajoute l'éligibilité à l'aide repas crous à 1€ pour tout étudiant.
 
 ## 51.1.0 [#1445](https://github.com/openfisca/openfisca-france/pull/1445)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [#1485](https://github.com/openfisca/openfisca-france/pull/1485)
+## 51.2.0 [#1485](https://github.com/openfisca/openfisca-france/pull/1485)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir de 01/2021.
@@ -78,8 +78,8 @@
 * Périodes concernées : toutes.
 * Zones impactées : `parameters/prestations/prestations_familiales/af/modulation/plafond_tranche_1.yaml.`
 `parameters/prestations/prestations_familiales/af/modulation/plafond_tranche_2.yaml.`
-Détails :
-- Corrige un encodage empêchant le bon import des paramètres
+* Détails :
+  - Corrige un encodage empêchant le bon import des paramètres
 
 ### 50.0.1 [#1471](https://github.com/openfisca/openfisca-france/pull/1471)
 
@@ -256,12 +256,12 @@ Détails :
 * Évolution du système socio-fiscal
 * Périodes concernées : à partir du 01/01/2018 jusqu'au 31/12/2019
 * Zones impactées :
-- `openfisca_france/parameters/impot_revenu/plus_values.yaml`.
-- `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`
-- `openfisca_france/model/revenus/capital/plus_value.py`
-`openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py`
-- openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
-- tests/calculateur_impots/yaml/pv_pfu.yaml
+  - `openfisca_france/parameters/impot_revenu/plus_values.yaml`.
+  - `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`
+  - `openfisca_france/model/revenus/capital/plus_value.py`
+  - `openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py`
+  - `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py`
+  - `tests/calculateur_impots/yaml/pv_pfu.yaml`
 
 * Détails :
   - Le modèle de calcul de l'IR est mis à jour avec les cases pour 2019 et 2020 pour l'imposition des plus-values survenues du 01/01/2018 jusqu'au 31/12/2019 et qui sont taxées forfaitairement hors barème.

--- a/openfisca_france/model/prestations/alimentation.py
+++ b/openfisca_france/model/prestations/alimentation.py
@@ -1,7 +1,7 @@
 from openfisca_france.model.base import *
 
 
-class repas_crous_eligibilite(Variable):
+class crous_repas_un_euro_eligibilite(Variable):
     value_type = bool
     label = "Éligibilité au repas Crous à un euro"
     entity = Individu
@@ -17,5 +17,4 @@ class repas_crous_eligibilite(Variable):
     '''
 
     def formula_2021_01(individu, period, parameters):
-        etudiant = individu("etudiant", period)
-        return etudiant
+        return individu("etudiant", period)

--- a/openfisca_france/model/prestations/alimentation.py
+++ b/openfisca_france/model/prestations/alimentation.py
@@ -1,0 +1,21 @@
+from openfisca_france.model.base import *
+
+
+class repas_crous_eligible(Variable):
+    value_type = bool
+    label = "Éligibilité au repas Crous à un euro"
+    entity = Individu
+    definition_period = MONTH
+    reference = "https://www.etudiant.gouv.fr/fr/le-repas-au-crous-passe-1-euro-pour-tous-les-etudiants-2314"
+    documentation = '''
+    Suite à la crise Covid-19, tous les étudiants, boursiers ou non, peuvent bénéficier
+    de deux repas par jour au tarif de 1 euro.
+    Pour en bénéficier, il suffit d’activer son compte Izly.
+    Pour les étudiants déjà titulaires d’un compte Izly,
+    la modification de tarif a été effectuée à partir du vendredi 22 janvier
+    et jusqu’au début de la semaine du 25 janvier.
+    '''
+
+    def formula_2021_01_22(individu, period, parameters):
+        etudiant = individu("etudiant", period)
+        return etudiant

--- a/openfisca_france/model/prestations/alimentation.py
+++ b/openfisca_france/model/prestations/alimentation.py
@@ -1,7 +1,7 @@
 from openfisca_france.model.base import *
 
 
-class repas_crous_eligible(Variable):
+class repas_crous_eligibilite(Variable):
     value_type = bool
     label = "Éligibilité au repas Crous à un euro"
     entity = Individu
@@ -16,6 +16,6 @@ class repas_crous_eligible(Variable):
     et jusqu’au début de la semaine du 25 janvier.
     '''
 
-    def formula_2021_01_22(individu, period, parameters):
+    def formula_2021_01(individu, period, parameters):
         etudiant = individu("etudiant", period)
         return etudiant

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "51.1.0",
+    version = "51.2.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/crous_repas_un_euro.yaml
+++ b/tests/formulas/crous_repas_un_euro.yaml
@@ -1,6 +1,6 @@
 - name: Covid-19 - Deux repas par jour au Crous à 1 € pour tous les étudiants.
   period: 2021-01
   input:
-    etudiant: [True, False]
+    etudiant: [true, false]
   output:
-    crous_repas_un_euro_eligibilite: [True, False]
+    crous_repas_un_euro_eligibilite: [true, false]

--- a/tests/formulas/repas_crous.yaml
+++ b/tests/formulas/repas_crous.yaml
@@ -1,7 +1,6 @@
 - name: Covid-19 - Deux repas par jour au Crous à 1 € pour tous les étudiants.
   period: 2021-01
   input:
-    activite: [etudiant, inactif]
-  output:
     etudiant: [True, False]
-    repas_crous_eligibilite: [True, False]
+  output:
+    crous_repas_un_euro_eligibilite: [True, False]

--- a/tests/formulas/repas_crous.yaml
+++ b/tests/formulas/repas_crous.yaml
@@ -1,0 +1,7 @@
+- name: Covid-19 - Deux repas par jour au Crous à 1 € pour tous les étudiants.
+  period: 2021-01
+  input:
+    activite: [etudiant, inactif]
+  output:
+    etudiant: [True, False]
+    repas_crous_eligibilite: [True, False]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir de 01/2021.
* Zones impactées :
  - `prestations/alimentation.py`
* Détails :
  - Ajoute l'éligibilité à l'aide repas CROUS à 1€ pour tout étudiant.

- - - -

Ces changements :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

---

Informations complémentaires : 
* L'aide _tout étudiant_ est entrée en application entre le 22 et le 25 janvier de cette année.
* Une aide équivalente mais réservée aux _étudiants boursiers_ existait à partir de septembre 2020 d'après [service-public](https://www.service-public.fr/particuliers/actualites/A14614) mais elle n'est pas représentée ici.
* L'aide est conditionnée à la création d'un compte Izly (CROUS). La condition est ignorée ici.
  * La création de [compte Izly](https://www.izly.fr) ne semble pas requérir d'autre condition que d'être étudiant. 
* L'aide donne accès à deux repas à 1€ par jour (le nombre de repas est ignoré ici)