### PR TITLE
Ajoute l'éligibilité au prêt pour la formation au permis de conduire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-##
+## [#1486](https://github.com/openfisca/openfisca-france/pull/1486)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : toutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+##
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `prestations/transport.py`
+* Détails :
+  - Ajoute l'éligibilité au prêt à la formation au permis de conduire à 1€ par jour
+
 ## 51.2.0 [#1485](https://github.com/openfisca/openfisca-france/pull/1485)
 
 * Évolution du système socio-fiscal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [#1486](https://github.com/openfisca/openfisca-france/pull/1486)
+## 51.3.0 [#1486](https://github.com/openfisca/openfisca-france/pull/1486)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : toutes.

--- a/openfisca_france/model/prestations/transport.py
+++ b/openfisca_france/model/prestations/transport.py
@@ -1,0 +1,33 @@
+from openfisca_france.model.base import Variable, Individu, MONTH, not_
+
+class pret_formation_permis(Variable):
+    value_type = bool
+    label = "Bénéficiaire du prêt à la formation au permis de conduire à 1 euro par jour"
+    entity = Individu
+    definition_period = MONTH
+    reference = [
+        "https://www.legifrance.gouv.fr/loda/id/LEGITEXT000006052491/",
+        "https://www.securite-routiere.gouv.fr/passer-son-permis-de-conduire/financement-du-permis-de-conduire/permis-1-eu-par-jour"
+        ]
+    documentation = '''
+    Le prêt « permis à un euro par jour » est exclusivement destiné au financement
+    d’une formation initiale ou, dans le cas d’un échec à l’épreuve pratique 
+    de l’examen du permis de conduire, d’une formation complémentaire. 
+    '''
+
+
+class pret_formation_permis_eligibilite(Variable):
+    value_type = bool
+    label = "Éligibilité au prêt de formation au permis de conduire à 1 euro par jour"
+    entity = Individu
+    definition_period = MONTH
+    reference = [
+        "https://www.legifrance.gouv.fr/loda/id/LEGITEXT000006052491/",
+        "https://www.securite-routiere.gouv.fr/passer-son-permis-de-conduire/financement-du-permis-de-conduire/permis-1-eu-par-jour"
+        ]
+
+    def formula(individu, period):
+        pret_formation_permis = individu('pret_formation_permis', period)
+        age = individu('age', period)
+        condition_age = (15 <= age) * (age <= 25)
+        return not_(pret_formation_permis) * condition_age

--- a/openfisca_france/model/prestations/transport.py
+++ b/openfisca_france/model/prestations/transport.py
@@ -27,7 +27,7 @@ class pret_formation_permis_eligibilite(Variable):
         "https://www.securite-routiere.gouv.fr/passer-son-permis-de-conduire/financement-du-permis-de-conduire/permis-1-eu-par-jour"
         ]
 
-    def formula(individu, period, parameters):
+    def formula_2005_09_30(individu, period, parameters):
         pret_formation_permis = individu('pret_formation_permis', period)
         age = individu('age', period)
         criteres_age = parameters(period).prestations.transport.pret_formation_permis.age

--- a/openfisca_france/model/prestations/transport.py
+++ b/openfisca_france/model/prestations/transport.py
@@ -1,20 +1,4 @@
-from openfisca_france.model.base import Variable, Individu, MONTH, not_
-
-
-class pret_formation_permis(Variable):
-    value_type = bool
-    label = "Bénéficiaire du prêt à la formation au permis de conduire à 1 euro par jour"
-    entity = Individu
-    definition_period = MONTH
-    reference = [
-        "https://www.legifrance.gouv.fr/loda/id/LEGITEXT000006052491/",
-        "https://www.securite-routiere.gouv.fr/passer-son-permis-de-conduire/financement-du-permis-de-conduire/permis-1-eu-par-jour"
-        ]
-    documentation = '''
-    Le prêt « permis à un euro par jour » est exclusivement destiné au financement
-    d’une formation initiale ou, dans le cas d’un échec à l’épreuve pratique
-    de l’examen du permis de conduire, d’une formation complémentaire.
-    '''
+from openfisca_france.model.base import Variable, Individu, MONTH
 
 
 class pret_formation_permis_eligibilite(Variable):
@@ -26,10 +10,17 @@ class pret_formation_permis_eligibilite(Variable):
         "https://www.legifrance.gouv.fr/loda/id/LEGITEXT000006052491/",
         "https://www.securite-routiere.gouv.fr/passer-son-permis-de-conduire/financement-du-permis-de-conduire/permis-1-eu-par-jour"
         ]
+    documentation = '''
+    Le prêt « permis à un euro par jour » est exclusivement destiné au financement
+    d’une formation initiale ou, dans le cas d’un échec à l’épreuve pratique
+    de l’examen du permis de conduire, d’une formation complémentaire.
+    Conditions non modélisées :
+    Il ne peut être attribué qu’une seule fois à un même bénéficiaire et pour une même catégorie de permis.
+    Ces formations doivent viser l’obtention du permis de conduire soit de la catégorie A1,
+    soit de la catégorie A2, soit de la catégorie B.
+    '''
 
     def formula_2005_09_30(individu, period, parameters):
-        pret_formation_permis = individu('pret_formation_permis', period)
         age = individu('age', period)
         criteres_age = parameters(period).prestations.transport.pret_formation_permis.age
-        condition_age = (criteres_age.minimum <= age) * (age <= criteres_age.maximum)
-        return not_(pret_formation_permis) * condition_age
+        return (criteres_age.minimum <= age) * (age <= criteres_age.maximum)

--- a/openfisca_france/model/prestations/transport.py
+++ b/openfisca_france/model/prestations/transport.py
@@ -12,8 +12,8 @@ class pret_formation_permis(Variable):
         ]
     documentation = '''
     Le prêt « permis à un euro par jour » est exclusivement destiné au financement
-    d’une formation initiale ou, dans le cas d’un échec à l’épreuve pratique 
-    de l’examen du permis de conduire, d’une formation complémentaire. 
+    d’une formation initiale ou, dans le cas d’un échec à l’épreuve pratique
+    de l’examen du permis de conduire, d’une formation complémentaire.
     '''
 
 

--- a/openfisca_france/model/prestations/transport.py
+++ b/openfisca_france/model/prestations/transport.py
@@ -1,5 +1,6 @@
 from openfisca_france.model.base import Variable, Individu, MONTH, not_
 
+
 class pret_formation_permis(Variable):
     value_type = bool
     label = "Bénéficiaire du prêt à la formation au permis de conduire à 1 euro par jour"
@@ -26,8 +27,9 @@ class pret_formation_permis_eligibilite(Variable):
         "https://www.securite-routiere.gouv.fr/passer-son-permis-de-conduire/financement-du-permis-de-conduire/permis-1-eu-par-jour"
         ]
 
-    def formula(individu, period):
+    def formula(individu, period, parameters):
         pret_formation_permis = individu('pret_formation_permis', period)
         age = individu('age', period)
-        condition_age = (15 <= age) * (age <= 25)
+        criteres_age = parameters(period).prestations.transport.pret_formation_permis.age
+        condition_age = (criteres_age.minimum <= age) * (age <= criteres_age.maximum)
         return not_(pret_formation_permis) * condition_age

--- a/openfisca_france/parameters/prestations/transport/pret_formation_permis.yaml
+++ b/openfisca_france/parameters/prestations/transport/pret_formation_permis.yaml
@@ -1,0 +1,12 @@
+age:
+  minimum:
+    description: Age minimal d'éligibilité au prêt à la formation au permis de conduire
+    reference: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000030316244/2015-03-06
+    values:
+      2005-09-30: 16
+      2015-03-06: 15
+  maximum:
+    description: Age maximal révolu d'éligibilité au prêt à la formation au permis de conduire
+    reference: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000006245493/2005-09-30
+    values:
+      2005-09-30: 25

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "51.2.0",
+    version = "51.3.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/pret_formation_permis.yaml
+++ b/tests/formulas/pret_formation_permis.yaml
@@ -1,0 +1,8 @@
+- name: Éligibilité au prêt de formation au permis de conduire à 1 euro par jour
+  period: 2021-01
+  relative_error_margin: 0.05
+  input:
+    pret_formation_permis: [True, False, False, False, False]
+    age: [20, 14, 15, 25, 26]
+  output:
+    pret_formation_permis_eligibilite: [False, False, True, True, False]

--- a/tests/formulas/pret_formation_permis.yaml
+++ b/tests/formulas/pret_formation_permis.yaml
@@ -2,7 +2,7 @@
   period: 2021-01
   relative_error_margin: 0.05
   input:
-    pret_formation_permis: [True, False, False, False, False]
+    pret_formation_permis: [true, false, false, false, false]
     age: [20, 14, 15, 25, 26]
   output:
-    pret_formation_permis_eligibilite: [False, False, True, True, False]
+    pret_formation_permis_eligibilite: [false, false, true, true, false]

--- a/tests/formulas/pret_formation_permis.yaml
+++ b/tests/formulas/pret_formation_permis.yaml
@@ -1,8 +1,6 @@
 - name: Éligibilité au prêt de formation au permis de conduire à 1 euro par jour
   period: 2021-01
-  relative_error_margin: 0.05
   input:
-    pret_formation_permis: [true, false, false, false, false]
-    age: [20, 14, 15, 25, 26]
+    age: [14, 15, 25, 26]
   output:
-    pret_formation_permis_eligibilite: [false, false, true, true, false]
+    pret_formation_permis_eligibilite: [false, true, true, false]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées :
  - `prestations/transport.py`
* Détails :
  - Ajoute l'éligibilité au prêt à la formation au permis de conduire à 1€ par jour
  - Le prêt est un prêt à taux zéro dont les intérêts sont pris en charge par l'État

- - - -

Ces changements :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

---

Informations complémentaires : 
* L'existence d'un prêt à la formation au permis de conduire est antérieure à cette année. Mais je n'ai pas retrouvé depuis quand il permettait un permis à 1€ par jour.
* Les conditions d'attribution suivantes n'ont pas été intégrées parce qu'elles ne semblaient pas nécessaire à l'évaluation d'éligibilité en simulateur individuel (mais n'hésitez pas à contre dire cet avis le cas échéant) : 
  * catégorie de permis (A1, A2, B), 
  * non cumul pour la même catégorie de permis, 
  * école de conduite partenaire (disposant du label de l'Etat « qualité des formations au sein des écoles de conduite »),
  * accord d'un organisme financier. 