### PR TITLE
Ignore virtual environment folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Développement sur GitPod
 build
 
+.venv
+
 *~
 .idea*
 .tags*


### PR DESCRIPTION
* Amélioration technique.
* Zones impactées : `.gitignore`.
* Détails :
  - Empêche le versionnement des environnements virtuels.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).