### PR TITLE
Force la réinstallation du build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 51.3.1 [#1495](https://github.com/openfisca/openfisca-france/pull/1495)
+
+* Correction d'un crash.
+* Détails :
+  - Force la réinstallation d'OpenFisca France lors de la création du fichier de distribution d'OpenFisca France
+  - Erreur constatée lors du lancements des tests sur CircleCI :
+    - CircleCI utilise ce fichier pour faire tourner les tests
+    - Or, si de commits ont déjà été poussés sur un branch, CircleCI ne réinstalle pas OpenFisca France
+    - Ce qui est inattendu puisque si l'on ajoute par exemple un paramètre ou une variable après avoir poussé les changements une première fois, CircleCI va échouer car la version utilisée pour lancer les tests ne contient pas ces derniers changements
+
 ## 51.3.0 [#1486](https://github.com/openfisca/openfisca-france/pull/1486)
 
 * Évolution du système socio-fiscal.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build: clean deps
 	@# `make build` allows us to be be sure tests are run against the packaged version
 	@# of OpenFisca-France, the same we put in the hands of users and reusers.
 	python setup.py bdist_wheel
-	find dist -name "*.whl" -exec pip install --upgrade {}[dev] \;
+	find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
 	pip install openfisca-core[web-api]
 
 check-syntax-errors:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "51.3.0",
+    version = "51.3.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Fixes #1494 

* Correction d'un crash.
* Détails :
  - Force la réinstallation d'OpenFisca France lors de la création du fichier de distribution d'OpenFisca France
  - Erreur constatée lors du lancements des tests sur CircleCI :
    - CircleCI utilise ce fichier pour faire tourner les tests
    - Or, si de commits ont déjà été poussés sur un branch, CircleCI ne réinstalle pas OpenFisca France
    - Ce qui est inattendu puisque si l'on ajoute par exemple un paramètre ou une variable après avoir poussé les changements une première fois, CircleCI va échouer car la version utilisée pour lancer les tests ne contient pas ces derniers changements

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus