### PR TITLE
Supprime option d'internationalisation du setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 51.7.1 [#1496](https://github.com/openfisca/openfisca-france/pull/1496)
+
+* Changement mineur.
+* Détails :
+  - Supprime option d'internationalisation du `setup.py`
+  - On utilise `python setup.py --version` pour vérifier la version
+    - Le fichier `setup.py` contenait l'option `message_extractors`
+    - Cette option d'internationalisation n'est pas reconnue par `distutils`
+    - Puisqu'aucune internationalisation n'est prévue, il semblerait être une option qui n'est plus valide ni nécessaire
+    - La suppression de l'option `message_extractors` corrige aussi le script de vérification de version
+
 ## 51.7.0 [#1499](https://github.com/openfisca/openfisca-france/pull/1499)
 
 * Évolution du système socio-fiscal.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "51.7.0",
+    version = "51.7.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,6 @@ setup(
     install_requires = [
         "OpenFisca-Core >=35.2.0,<36.0",
         ],
-    message_extractors = {"openfisca_france": [
-        ("**.py", "python", None),
-        ]},
     packages = find_packages(exclude = [
         "openfisca_france.tests*",
         "openfisca_france.assets.taxe_habitation.source*",


### PR DESCRIPTION
Fixes #1458 

* Changement mineur.
* Détails :
  - Supprime option d'internationalisation du `setup.py`
  - On utilise `python setup.py --version` pour vérifier la version
    - Le fichier `setup.py` contenait l'option `message_extractors`
    - Cette option d'internationalisation n'est pas reconnue par `distutils`
    - Puisqu'aucune internationalisation n'est prévue, il semblerait être une option qui n'est plus valide ni nécessaire
    - La suppression de l'option `message_extractors` corrige aussi le script de vérification de version

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

- - - -

##### Avant

<img width="1140" alt="Capture d’écran 2021-03-25 à 21 42 20" src="https://user-images.githubusercontent.com/329236/112540917-09eb2580-8db3-11eb-8f30-38edeedb95cb.png">

##### Après

<img width="1141" alt="Capture d’écran 2021-03-25 à 21 44 35" src="https://user-images.githubusercontent.com/329236/112541147-5898bf80-8db3-11eb-8853-da4be0ee4106.png">
