### PR TITLE
Calcule la majorité civile et améliore le calcul de l'éligibilité au prêt étudiant garanti par l'État

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 51.6.0 [#1498](https://github.com/openfisca/openfisca-france/pull/1498)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir de 1579 (XVIᵉ siècle).
+* Zones impactées :
+  - `parameters/demographie/age_majorite.yaml`
+* Détails :
+  - Ajoute la variable `majeur` qui calcule si la personne a atteint la majorité civile par son âge on son émancipation.
+  - Ajoute la variable `mineur_emancipe`.
+  - Ajoute le paramètre `demographie.age_majorite` qui donne l'âge d'obtention de la majorité civile.
+  - Améliore le calcul de `garantie_pret_etudiant` en utilisant une condition de majorite et non d'âge.
+
 ## 51.5.0 [#1489](https://github.com/openfisca/openfisca-france/pull/1489)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -9,6 +9,27 @@ class date_naissance(Variable):
     definition_period = ETERNITY
 
 
+class majeur(Variable):
+    value_type = bool
+    entity = Individu
+    label = "L'individu est considéré comme majeur"
+    definition_period = MONTH
+
+    def formula(individu, period, parameters):
+        majeur = individu('age', period) >= parameters(period).demographie.age_majorite
+        mineur_emancipe = individu('mineur_emancipe', period)
+
+        return majeur + mineur_emancipe
+
+
+class mineur_emancipe(Variable):
+    value_type = bool
+    default_value = False
+    entity = Individu
+    label = "L'individu est émancipé"
+    definition_period = MONTH
+
+
 class adoption(Variable):
     value_type = bool
     entity = Individu

--- a/openfisca_france/model/prestations/garantie_pret_etudiant.py
+++ b/openfisca_france/model/prestations/garantie_pret_etudiant.py
@@ -9,13 +9,15 @@ class garantie_pret_etudiant_eligibilite(Variable):
     reference = "https://www.service-public.fr/particuliers/vosdroits/F986"
 
     def formula_2020_06_08(individu, period, parameters):
+        majeur = individu('majeur', period)
+
         age = individu('age', period)
-        condition_age = (age >= 18) * (age <= parameters(period).prestations.garantie_pret_etudiant.age_max)  # approximation : en cas d'émancipation, un·e mineur·e est éligible
+        condition_age = (age <= parameters(period).prestations.garantie_pret_etudiant.age_max)
 
         etudiant = individu('etudiant', period)
         condition_nationalite = individu('garantie_pret_etudiant_condition_nationalite', period)
 
-        return etudiant * condition_nationalite * condition_age
+        return majeur * etudiant * condition_age * condition_nationalite
 
 
 class garantie_pret_etudiant_condition_nationalite(Variable):

--- a/openfisca_france/parameters/demographie/age_majorite.yaml
+++ b/openfisca_france/parameters/demographie/age_majorite.yaml
@@ -1,0 +1,13 @@
+description: Âge à partir duquel un individu obtient la majorité civile (en années).
+reference: https://fr.wikipedia.org/wiki/Majorité_civile_en_France#Historique
+unit: year
+values:
+  1579-01-01:  # date et mois approximatifs
+    value: 25
+    reference: Ordonnance de Blois
+  1792-09-20:
+    value: 21
+    reference: Décret du 20 septembre 1792 de la première république
+  1974-07-05:
+    value: 18
+    reference: Loi n°74-631

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "51.5.0",
+    version = "51.6.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/demographie/majeur.yaml
+++ b/tests/formulas/demographie/majeur.yaml
@@ -1,0 +1,41 @@
+- name: Cas général de majorité
+  period: 2021-01
+  input:
+    age:
+      - 15
+      - 16
+      - 18
+      - 25
+  output:
+    majeur:
+      - false
+      - false
+      - true
+      - true
+
+- name: Cas des mineurs émancipés
+  period: 2021-01
+  input:
+    age:
+      - 16
+      - 25
+    mineur_emancipe:
+      - true
+      - true
+  output:
+    majeur:
+      - true
+      - true
+
+- name: Majorité avant 1974
+  period: 1960-01
+  input:
+    age:
+      - 16
+      - 18
+      - 25
+  output:
+    majeur:
+      - false
+      - false
+      - true

--- a/tests/formulas/demographie/majeur.yaml
+++ b/tests/formulas/demographie/majeur.yaml
@@ -1,41 +1,14 @@
 - name: Cas général de majorité
   period: 2021-01
   input:
-    age:
-      - 15
-      - 16
-      - 18
-      - 25
+    age: [ 15, 16, 18, 25 ]
   output:
-    majeur:
-      - false
-      - false
-      - true
-      - true
+    majeur: [ false, false, true, true ]
 
 - name: Cas des mineurs émancipés
   period: 2021-01
   input:
-    age:
-      - 16
-      - 25
-    mineur_emancipe:
-      - true
-      - true
+    age: [ 16, 25 ]
+    mineur_emancipe: [ true, true ]
   output:
-    majeur:
-      - true
-      - true
-
-- name: Majorité avant 1974
-  period: 1960-01
-  input:
-    age:
-      - 16
-      - 18
-      - 25
-  output:
-    majeur:
-      - false
-      - false
-      - true
+    majeur: [ true, true ]

--- a/tests/formulas/garantie_pret_etudiant.yaml
+++ b/tests/formulas/garantie_pret_etudiant.yaml
@@ -16,3 +16,14 @@
     garantie_pret_etudiant_condition_nationalite: [ true, true, true, true, true ]
   output:
     garantie_pret_etudiant_eligibilite: [ false, true, true, false, false ]
+
+
+- name: Condition de majorité pour l'éligibilité à la garantie du prêt étudiant
+  period: 2021-03
+  input:
+    etudiant: true
+    mineur_emancipe: true
+    age: 16
+    garantie_pret_etudiant_condition_nationalite: true
+  output:
+    garantie_pret_etudiant_eligibilite: true


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir de 1579 (XVIᵉ siècle).
* Zones impactées :
  - `parameters/demographie/age_majorite.yaml`
* Détails :
  - Ajoute la variable `majeur` qui calcule si la personne a atteint la majorité civile par son âge on son émancipation.
  - Ajoute la variable `mineur_emancipe`.
  - Ajoute le paramètre `demographie.age_majorite` qui donne l'âge d'obtention de la majorité civile.
  - Améliore le calcul de `garantie_pret_etudiant` en utilisant une condition de majorite et non d'âge.

- - - -

Ces changements :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.

- - - -

Followup of #1489.