### PR TITLE
Ajoute la gratuité d'entrée aux musées et monuments nationaux et la liste des pays des l'Union européenne

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,6 @@
 # Changelog
 
-## 51.7.0 [#1498](https://github.com/openfisca/openfisca-france/pull/1498)
-
-* Évolution du système socio-fiscal.
-* Périodes concernées : à partir de 1579 (XVIᵉ siècle).
-* Zones impactées :
-  - `parameters/demographie/age_majorite.yaml`
-* Détails :
-  - Ajoute la variable `majeur` qui calcule si la personne a atteint la majorité civile par son âge on son émancipation.
-  - Ajoute la variable `mineur_emancipe`.
-  - Ajoute le paramètre `demographie.age_majorite` qui donne l'âge d'obtention de la majorité civile.
-  - Améliore le calcul de `garantie_pret_etudiant` en utilisant une condition de majorite et non d'âge.
-
-### 51.6.1 [#1500](https://github.com/openfisca/openfisca-france/pull/1500)
-
-* Évolution du système socio-fiscal.
-* Périodes concernées : à partir du 16/02/2021.
-* Zones impactées :
-  - `parameters/prestations/garantie_pret_etudiant/montant_max.yaml`
-* Détails :
-  - Mise à jour du montant maximum du prêt étudiant garanti par l'État.
-
-## 51.6.0 [#1499](https://github.com/openfisca/openfisca-france/pull/1499)
+## 51.7.0 [#1499](https://github.com/openfisca/openfisca-france/pull/1499)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/1958.
@@ -34,6 +13,27 @@
   - Ajoute la variable `gratuite_musees_monuments`, qui indique l'éligibilité à la gratuité d'accès aux musées et monuments nationaux pour les jeunes résident·e·s de l'Union européenne.
   - Ajoute la variable `resident_ue`, qui calcule la résidence dans un pays de l'Union européenne à partir de la `nationalite` et peut être écrasée si l'information est obtenue de manière plus précise.
   - Ajoute le paramètre `geopolitique.ue`, qui donne l'évolution de la liste des pays de l'Union européenne de 1958 à 2021.
+
+### 51.6.1 [#1500](https://github.com/openfisca/openfisca-france/pull/1500)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 16/02/2021.
+* Zones impactées :
+  - `parameters/prestations/garantie_pret_etudiant/montant_max.yaml`
+* Détails :
+  - Mise à jour du montant maximum du prêt étudiant garanti par l'État.
+
+## 51.6.0 [#1498](https://github.com/openfisca/openfisca-france/pull/1498)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir de 1579 (XVIᵉ siècle).
+* Zones impactées :
+  - `parameters/demographie/age_majorite.yaml`
+* Détails :
+  - Ajoute la variable `majeur` qui calcule si la personne a atteint la majorité civile par son âge on son émancipation.
+  - Ajoute la variable `mineur_emancipe`.
+  - Ajoute le paramètre `demographie.age_majorite` qui donne l'âge d'obtention de la majorité civile.
+  - Améliore le calcul de `garantie_pret_etudiant` en utilisant une condition de majorite et non d'âge.
 
 ## 51.5.0 [#1489](https://github.com/openfisca/openfisca-france/pull/1489)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,6 @@
 # Changelog
 
-### 51.6.1 [#1500](https://github.com/openfisca/openfisca-france/pull/1500)
-
-* Évolution du système socio-fiscal.
-* Périodes concernées : à partir du 16/02/2021.
-* Zones impactées :
-  - `parameters/prestations/garantie_pret_etudiant/montant_max.yaml`
-* Détails :
-  - Mise à jour du montant maximum du prêt étudiant garanti par l'État.
-
-## 51.6.0 [#1498](https://github.com/openfisca/openfisca-france/pull/1498)
+## 51.7.0 [#1498](https://github.com/openfisca/openfisca-france/pull/1498)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir de 1579 (XVIᵉ siècle).
@@ -20,6 +11,29 @@
   - Ajoute la variable `mineur_emancipe`.
   - Ajoute le paramètre `demographie.age_majorite` qui donne l'âge d'obtention de la majorité civile.
   - Améliore le calcul de `garantie_pret_etudiant` en utilisant une condition de majorite et non d'âge.
+
+### 51.6.1 [#1500](https://github.com/openfisca/openfisca-france/pull/1500)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 16/02/2021.
+* Zones impactées :
+  - `parameters/prestations/garantie_pret_etudiant/montant_max.yaml`
+* Détails :
+  - Mise à jour du montant maximum du prêt étudiant garanti par l'État.
+
+## 51.6.0 [#1499](https://github.com/openfisca/openfisca-france/pull/1499)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/1958.
+* Zones impactées :
+  - `parameters/geopolitique/ue.yaml`
+  - `parameters/divers/gratuite_musees_monuments.yaml`
+  - `model/demographie.py`
+  - `model/divers/gratuite_musees_monuments.py`
+* Détails :
+  - Ajoute la variable `gratuite_musees_monuments`, qui indique l'éligibilité à la gratuité d'accès aux musées et monuments nationaux pour les jeunes résident·e·s de l'Union européenne.
+  - Ajoute la variable `resident_ue`, qui calcule la résidence dans un pays de l'Union européenne à partir de la `nationalite` et peut être écrasée si l'information est obtenue de manière plus précise.
+  - Ajoute le paramètre `geopolitique.ue`, qui donne l'évolution de la liste des pays de l'Union européenne de 1958 à 2021.
 
 ## 51.5.0 [#1489](https://github.com/openfisca/openfisca-france/pull/1489)
 

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -321,6 +321,22 @@ class ressortissant_eee(Variable):
         return sum([nationalite == str.encode(etat_membre) for etat_membre in parameters(period).geopolitique.eee])  # TOOPTIMIZE: string encoding into bytes array should be done at load time
 
 
+'''
+La résidence est supposée par la nationalité.
+Si la résidence est déterminée d'une autre manière plus précise, écraser cette variable en la définissant plutôt qu'en la laissant calculer par la nationalité.
+'''
+class resident_ue(Variable):
+    value_type = bool
+    default_value = True
+    entity = Individu
+    label = "Individu résidant dans pays membre de l'Union européenne (UE)."
+    definition_period = MONTH
+
+    def formula(individu, period, parameters):
+        nationalite = individu('nationalite', period)
+        return sum([ nationalite == str.encode(etat_membre) for etat_membre in parameters(period).geopolitique.ue ])  #TOOPTIMIZE: string encoding into bytes array should be done at load time
+
+
 class residence_continue_annees(Variable):
     value_type = float
     entity = Individu

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -321,13 +321,11 @@ class ressortissant_eee(Variable):
         return sum([nationalite == str.encode(etat_membre) for etat_membre in parameters(period).geopolitique.eee])  # TOOPTIMIZE: string encoding into bytes array should be done at load time
 
 
-'''
-La résidence est supposée par la nationalité.
-Si la résidence est déterminée d'une autre manière plus précise, écraser cette variable en la définissant plutôt qu'en la laissant calculer par la nationalité.
-'''
-
-
 class resident_ue(Variable):
+    '''
+    La résidence est supposée par la nationalité.
+    Si la résidence est déterminée d'une autre manière plus précise, écraser cette variable en la définissant plutôt qu'en la laissant calculer par la nationalité.
+    '''
     value_type = bool
     default_value = True
     entity = Individu

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -325,6 +325,8 @@ class ressortissant_eee(Variable):
 La résidence est supposée par la nationalité.
 Si la résidence est déterminée d'une autre manière plus précise, écraser cette variable en la définissant plutôt qu'en la laissant calculer par la nationalité.
 '''
+
+
 class resident_ue(Variable):
     value_type = bool
     default_value = True
@@ -334,7 +336,7 @@ class resident_ue(Variable):
 
     def formula(individu, period, parameters):
         nationalite = individu('nationalite', period)
-        return sum([ nationalite == str.encode(etat_membre) for etat_membre in parameters(period).geopolitique.ue ])  #TOOPTIMIZE: string encoding into bytes array should be done at load time
+        return sum([nationalite == str.encode(etat_membre) for etat_membre in parameters(period).geopolitique.ue])  # TOOPTIMIZE: string encoding into bytes array should be done at load time
 
 
 class residence_continue_annees(Variable):

--- a/openfisca_france/model/divers/gratuite_musees_monuments.py
+++ b/openfisca_france/model/divers/gratuite_musees_monuments.py
@@ -1,0 +1,17 @@
+from openfisca_france.model.base import *
+
+
+class gratuite_musees_monuments(Variable):
+    value_type = bool
+    label = "Accès gratuit aux musées et monuments nationaux"
+    entity = Individu
+    definition_period = MONTH
+    reference = "https://www.service-public.fr/particuliers/vosdroits/F20348"
+
+    def formula(individu, period, parameters):
+        age = individu('age', period)
+        condition_age = (age >= parameters(period).divers.gratuite_musees_monuments.age_min) * (age <= parameters(period).divers.gratuite_musees_monuments.age_max)
+
+        condition_nationalite = individu('resident_ue', period)
+
+        return condition_age * condition_nationalite

--- a/openfisca_france/parameters/divers/gratuite_musees_monuments.yaml
+++ b/openfisca_france/parameters/divers/gratuite_musees_monuments.yaml
@@ -1,0 +1,11 @@
+age_min:
+  description: Âge à partir duquel l'accès aux musées et monuments nationaux est gratuit pour les résidents de l'Union européenne.
+  reference: https://www.service-public.fr/particuliers/vosdroits/F20348
+  values:
+    2007-05-01: 18  # cette date est approximative, la mesure a été adoptée sous la présidence Sarkozy
+
+age_max:
+  description: Âge jusqu'auquel l'accès aux musées et monuments nationaux est gratuit pour les résidents de l'Union européenne.
+  reference: https://www.service-public.fr/particuliers/vosdroits/F20348
+  values:
+    2007-05-01: 25  # cette date est approximative, la mesure a été adoptée sous la présidence Sarkozy

--- a/openfisca_france/parameters/divers/gratuite_musees_monuments.yaml
+++ b/openfisca_france/parameters/divers/gratuite_musees_monuments.yaml
@@ -2,10 +2,14 @@ age_min:
   description: Âge à partir duquel l'accès aux musées et monuments nationaux est gratuit pour les résidents de l'Union européenne.
   reference: https://www.service-public.fr/particuliers/vosdroits/F20348
   values:
-    2007-05-01: 18  # cette date est approximative, la mesure a été adoptée sous la présidence Sarkozy
+    2009-04-04:
+      value: 18
+      reference: https://www.culture.gouv.fr/Nous-connaitre/Decouvrir-le-ministere/Histoire-du-ministere/Ressources-documentaires/Discours-de-ministres/Discours-de-ministres-depuis-1998/Frederic-Mitterrand-2009-2012/Communiques-2009-2012/Frederic-Mitterrand-etend-la-gratuite-des-musees-et-des-monuments-nationaux-a-tous-les-jeunes-qui-resident-dans-l-Union-Europeenne-quelle-que-soit
 
 age_max:
   description: Âge jusqu'auquel l'accès aux musées et monuments nationaux est gratuit pour les résidents de l'Union européenne.
   reference: https://www.service-public.fr/particuliers/vosdroits/F20348
   values:
-    2007-05-01: 25  # cette date est approximative, la mesure a été adoptée sous la présidence Sarkozy
+    2009-04-04:
+      value: 25
+      reference: https://www.culture.gouv.fr/Nous-connaitre/Decouvrir-le-ministere/Histoire-du-ministere/Ressources-documentaires/Discours-de-ministres/Discours-de-ministres-depuis-1998/Frederic-Mitterrand-2009-2012/Communiques-2009-2012/Frederic-Mitterrand-etend-la-gratuite-des-musees-et-des-monuments-nationaux-a-tous-les-jeunes-qui-resident-dans-l-Union-Europeenne-quelle-que-soit

--- a/openfisca_france/parameters/geopolitique/ue.yaml
+++ b/openfisca_france/parameters/geopolitique/ue.yaml
@@ -1,0 +1,22 @@
+description: Liste des pays membres de l'Union européenne (UE ou EU en anglais), par date de ratification des traités d'adhésion.
+reference: https://fr.wikipedia.org/wiki/Élargissement_de_l%27Union_européenne#Chronologie
+unit: ISO 3166-1 alpha-2
+values:
+  1958-01-01:
+    value: [ BE, DE, FR, IT, LU, NL ]
+  1973-01-01:
+    value: [ BE, DE, DK, FR, IE, IT, LU, NL, UK ]
+  1981-01-01:
+    value: [ BE, DE, DK, FR, GR, IE, IT, LU, NL, UK ]
+  1986-01-01:
+    value: [ BE, DE, DK, ES, FR, GR, IE, IT, LU, NL, PT, UK ]
+  1995-01-01:
+    value: [ AT, BE, DE, DK, ES, FI, FR, GR, IE, IT, LU, NL, PT, SE, UK ]
+  2004-01-01:
+    value: [ AT, BE, CY, CZ, DE, DK, EE, ES, FI, FR, GR, HU, IE, IT, LT, LV, LU, MT, NL, PL, PT, SE, SK, SV, UK ]
+  2007-01-01:
+    value: [ AT, BE, BG, CY, CZ, DE, DK, EE, ES, FI, FR, GR, HU, IE, IT, LT, LV, LU, MT, NL, PL, PT, RO, SE, SK, SV, UK ]
+  2013-01-01:
+    value: [ AT, BE, BG, CY, CZ, DE, DK, EE, ES, FI, FR, GR, HR, HU, IE, IT, LT, LV, LU, MT, NL, PL, PT, RO, SE, SK, SV, UK ]
+  2021-01-01:
+    value: [ AT, BE, BG, CY, CZ, DE, DK, EE, ES, FI, FR, GR, HR, HU, IE, IT, LT, LV, LU, MT, NL, PL, PT, RO, SE, SK, SV ]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "51.6.1",
+    version = "51.7.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/divers/gratuite_musees_monuments.yaml
+++ b/tests/formulas/divers/gratuite_musees_monuments.yaml
@@ -1,0 +1,17 @@
+- name: Condition d'âge pour l'accès gratuit aux musées nationaux
+  period: 2021-03
+  input:
+    age: [ 16, 18, 25, 26 ]
+    nationalite: [ FR, FR, FR, FR ]
+  output:
+    gratuite_musees_monuments: [ false, true, true, false ]
+
+
+- name: Condition de résidence pour l'accès gratuit aux musées nationaux
+  period: 2021-03
+  input:
+    age: [ 19, 19, 19, 19, 19, 19 ]
+    nationalite: [ FR, DE, UK, CH, LI, NZ ]
+  output:
+    gratuite_musees_monuments: [ true, true, false, false, false, false ]
+

--- a/tests/formulas/divers/gratuite_musees_monuments.yaml
+++ b/tests/formulas/divers/gratuite_musees_monuments.yaml
@@ -6,7 +6,6 @@
   output:
     gratuite_musees_monuments: [ false, true, true, false ]
 
-
 - name: Condition de résidence pour l'accès gratuit aux musées nationaux
   period: 2021-03
   input:
@@ -14,4 +13,3 @@
     nationalite: [ FR, DE, UK, CH, LI, NZ ]
   output:
     gratuite_musees_monuments: [ true, true, false, false, false, false ]
-

--- a/tests/formulas/nationalite.yaml
+++ b/tests/formulas/nationalite.yaml
@@ -11,3 +11,17 @@
     nationalite: [ AT, BE, BG, CY, CZ, DE, DK, EE, ES, FI, FR, GR, HR, HU, IE, IS, IT, LI, LU, LV, MT, NL, 'NO', PL, PT, RO, SE, SI, SK, UK, CH, RU ]
   output:
     ressortissant_eee: [ true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false ]
+
+- name: Appartenance à l'UE
+  period: 2021-03
+  input:
+    nationalite: [ AT, 'NO', UK, CH, NZ ]
+  output:
+    resident_ue: [ true, false, false, false, false ]
+
+- name: Appartenance à l'UE avant le Brexit
+  period: 2020-03
+  input:
+    nationalite: [ AT, UK ]
+  output:
+    resident_ue: [ true, true ]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/1958.
* Zones impactées :
  - `parameters/geopolitique/ue.yaml`
  - `parameters/divers/gratuite_musees_monuments.yaml`
  - `model/demographie.py`
  - `model/divers/gratuite_musees_monuments.py`
* Détails :
  - Ajoute la variable `gratuite_musees_monuments`, qui indique l'éligibilité à la gratuité d'accès aux musées et monuments nationaux pour les jeunes résident·e·s de l'Union européenne.
  - Ajoute la variable `resident_ue`, qui calcule la résidence dans un pays de l'Union européenne à partir de la `nationalite` et peut être écrasée si l'information est obtenue de manière plus précise.
  - Ajoute le paramètre `geopolitique.ue`, qui donne l'évolution de la liste des pays de l'Union européenne de 1958 à 2021.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).

- - - -

:warning: L'espace de nommage retenu est `divers`, ce qui n'est pas très satisfaisant, mais je n'ai pas su trouver mieux : je ne crois pas que la gratuité d'accès aux musées et monuments nationaux puisse être considérée comme une prestation sociale. Je suis preneur de suggestions d'améliorations.
