### PR TITLE
Fiabilise le Livret d'épargne populaire pour les jeunes

### DIFF
--- a/openfisca_france/model/patrimoine/livret_epargne_populaire.py
+++ b/openfisca_france/model/patrimoine/livret_epargne_populaire.py
@@ -1,5 +1,4 @@
-from openfisca_france.model.base import *
-
+from openfisca_france.model.base import Individu, Variable, min_, max_, not_, MONTH
 from numpy import ceil
 
 
@@ -31,13 +30,15 @@ class livret_epargne_populaire_eligibilite(Variable):
     value_type = bool
     entity = Individu
     label = "Eligibilité au livret d'épargne populaire"
+    reference = "https://www.service-public.fr/particuliers/vosdroits/F2367"
     definition_period = MONTH
 
     def formula(individu, period, parameters):
         rfr = individu.foyer_fiscal('rfr', period.n_2)
         plafond = individu('livret_epargne_populaire_plafond', period)
+        independent = not_(individu('enfant_a_charge', period.this_year))
 
-        return rfr <= plafond
+        return independent * (rfr <= plafond)
 
 
 class livret_epargne_populaire_taux(Variable):

--- a/tests/patrimoine/livret_epargne_populaire/eligibilite.yml
+++ b/tests/patrimoine/livret_epargne_populaire/eligibilite.yml
@@ -1,15 +1,9 @@
 - period: month:2019-05
   input:
     rfr:
-      2017: 9
-    livret_epargne_populaire_plafond: 10
+      2017: [9, 9, 11]
+    livret_epargne_populaire_plafond: [10, 10, 10]
+    enfant_a_charge:
+      2019: [true, false, false]
   output:
-    livret_epargne_populaire_eligibilite: true
-
-- period: month:2019-05
-  input:
-    rfr:
-      2017: 11
-    livret_epargne_populaire_plafond: 10
-  output:
-    livret_epargne_populaire_eligibilite: false
+    livret_epargne_populaire_eligibilite: [false, true, false]


### PR DESCRIPTION
* Évolution du système socio-fiscal
* Périodes concernées : toutes.
* Zones impactées : `model/patrimoine/livret_epargne_populaire.py`.
* Détails :
  - Corrige l'éligibilité des jeunes toujours rattachés au foyer fiscal parental
- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
