### PR TITLE
Calcule le montant de l'aide Mobili-jeune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 51.16.0 [#1516](https://github.com/openfisca/openfisca-france/pull/1516)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/07/2012.
+* Zones impactées :
+  * `prestations/mobili_jeune.py`
+  * `parameters/prestations/mobili_jeune.yaml`
+* Détails :
+  - Ajoute la variable `mobili_jeune` qui calcule le montant de l'aide Mobili-jeune.
+
 ## 51.15.0 [#1493](https://github.com/openfisca/openfisca-france/pull/1493)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/mobili_jeune.py
+++ b/openfisca_france/model/prestations/mobili_jeune.py
@@ -12,7 +12,7 @@ class mobili_jeune(Variable):
     definition_period = MONTH
     reference = "https://www.actionlogement.fr/l-aide-mobili-jeune"
 
-    def formula(individu, period, parameters):
+    def formula_2012_07(individu, period, parameters):
         loyer = individu.menage('loyer', period)
         charges_locatives = individu.menage('charges_locatives', period)
         apl = individu.famille('apl', period)
@@ -35,7 +35,7 @@ class mobili_jeune_eligibilite_employeur(Variable):
     definition_period = MONTH
     reference = "https://www.actionlogement.fr/l-aide-mobili-jeune"
 
-    def formula(individu, period):
+    def formula_2012_07(individu, period):
         secteur_prive_non_agricole = (
             individu("categorie_salarie", period) == TypesCategorieSalarie.prive_non_cadre
             ) * (

--- a/openfisca_france/model/prestations/mobili_jeune.py
+++ b/openfisca_france/model/prestations/mobili_jeune.py
@@ -1,7 +1,31 @@
 from openfisca_france.model.base import (
     Variable, Individu, MONTH,
-    TypesCategorieSalarie, TypesSecteurActivite, TypesStatutOccupationLogement
+    TypesCategorieSalarie, TypesSecteurActivite, TypesStatutOccupationLogement,
+    min_, where,
     )
+
+
+class mobili_jeune(Variable):
+    value_type = float
+    label = "Montant de l'aide au logement mobili-jeune"
+    entity = Individu
+    definition_period = MONTH
+    reference = "https://www.actionlogement.fr/l-aide-mobili-jeune"
+
+    def formula(individu, period, parameters):
+        loyer = individu.menage('loyer', period)
+        charges_locatives = individu.menage('charges_locatives', period)
+        apl = individu.famille('apl', period)
+
+        reste_a_charge = loyer + charges_locatives - apl
+
+        eligibilite = individu('mobili_jeune_eligibilite', period)
+
+        return where(
+            reste_a_charge >= parameters(period).prestations.mobili_jeune.montant.minimum,
+            eligibilite * min_(reste_a_charge, parameters(period).prestations.mobili_jeune.montant.maximum),
+            0,
+            )
 
 
 class mobili_jeune_eligibilite_employeur(Variable):

--- a/openfisca_france/parameters/prestations/mobili_jeune.yaml
+++ b/openfisca_france/parameters/prestations/mobili_jeune.yaml
@@ -5,3 +5,17 @@ age_maximum:
   values:
     2012-07-01:
       value: 30
+
+montant:
+  maximum:
+    description: Montant maximum de l'aide mobili-jeune
+    reference: https://www.actionlogement.fr/l-aide-mobili-jeune
+    unit: currency
+    values:
+      2012-07-01: 100
+  minimum:
+    description: Montant minimum de l'aide mobili-jeune en-dessous duquel aucune aide n'est versée
+    reference: https://www.actionlogement.fr/l-aide-mobili-jeune
+    unit: currency
+    values:
+      2012-07-01: 10

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "51.15.0",
+    version = "51.16.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/mobili_jeune.yaml
+++ b/tests/formulas/mobili_jeune.yaml
@@ -8,3 +8,14 @@
     statut_occupation_logement: ['locataire_meuble', 'locataire_vide', 'locataire_hlm', 'locataire_foyer', 'locataire_foyer', 'non_renseigne']
   output:
     mobili_jeune_eligibilite: [true, false, false, false, false, false]
+
+- name: Montant de l'aide au logement mobili-jeune
+  description: Cas donnés sur actionlogement.fr/l-aide-mobili-jeune
+  period: 2021-03
+  input:
+    age: [ 18, 18, 18, 18 ]
+    mobili_jeune_eligibilite: [ true, true, true, false ]
+    loyer: [ 350, 350, 250, 350 ]
+    apl: [ 220, 280, 245, 220 ]
+  output:
+    mobili_jeune: [ 100, 70, 0, 0 ]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/07/2012.
* Zones impactées :
  * `prestations/mobili_jeune.py`
  * `parameters/prestations/mobili_jeune.yaml`
* Détails :
  - Ajoute la variable `mobili_jeune` qui calcule le montant de l'aide Mobili-jeune.

- - - -

Ces changements :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
