### PR TITLE
Corrige le calcul bourse_criteres_sociaux_echelon suite au refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 51.16.1 [#1517](https://github.com/openfisca/openfisca-france/pull/1517)
+
+* Changement mineur.
+* Zones impactées : `prestations/enseignement_superieur/bourse_criteres_sociaux.py`.
+* Détails :
+  - Corrige le calcul de l'échelon des bourses sur critères sociaux.
+
 ## 51.16.0 [#1516](https://github.com/openfisca/openfisca-france/pull/1516)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/enseignement_superieur/bourse_criteres_sociaux.py
+++ b/openfisca_france/model/prestations/enseignement_superieur/bourse_criteres_sociaux.py
@@ -313,4 +313,6 @@ class bourse_criteres_sociaux_echelon(Variable):
                 base_ressources <= plafond_echelon_0bis,
                 ],
             [7, 6, 5, 4, 3, 2, 1, 0])
-        return where(bourse_criteres_sociaux_eligibilite, echelon, -1)
+
+        eligible = individu('bourse_criteres_sociaux_eligibilite', period)
+        return where(eligible, echelon, -1)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "51.16.0",
+    version = "51.16.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/bourses_superieur/bourse_criteres_sociaux.yaml
+++ b/tests/formulas/bourses_superieur/bourse_criteres_sociaux.yaml
@@ -68,11 +68,11 @@
 
 - period: 2021-03
   input:
-    bourse_criteres_sociaux_eligibilite: [true, true, true, true, true]
-    bourse_criteres_sociaux_base_ressources: [0, 1000, 1000, 1000, 30351]
-    bourse_criteres_sociaux_points_de_charge: [0, 0, 17, 18, 8]
+    bourse_criteres_sociaux_eligibilite: [true, true, true, true, true, false]
+    bourse_criteres_sociaux_base_ressources: [0, 1000, 1000, 1000, 30351, 30351]
+    bourse_criteres_sociaux_points_de_charge: [0, 0, 17, 18, 8, 8]
   output:
-    bourse_criteres_sociaux_echelon: [7, 6, 7, 7, 2]
+    bourse_criteres_sociaux_echelon: [7, 6, 7, 7, 2, -1]
 
 - period: 2021-03
   input:


### PR DESCRIPTION
* Changement mineur.
* Zones impactées : `prestations/enseignement_superieur/bourse_criteres_sociaux.py`.
* Détails :
  - Corrige le calcul de l'échelon des bourses sur critères sociaux.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
