### PR TITLE
Corrige le format de certaines dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 51.17.3 [#1522](https://github.com/openfisca/openfisca-france/pull/1522)
+
+* Correction d'un crash.
+* Périodes concernées : à partir du 31/03/2006.
+* Zones impactées : `parameters/bourses_enseignement_superieur/criteres_sociaux/*`.
+* Détails :
+  - Corrige la déclaration de certaines dates dont les mois et jours étaient inversés.
+
 ### 51.17.2 [#1523](https://github.com/openfisca/openfisca-france/pull/1523)
 
 * Changement mineur.
@@ -8,7 +16,7 @@
    * `caracteristiques_socio_demographiques/demographie`.
    * `prelevements_obligatoires/impot_revenu/ir`.
 * Détails :
-  - Renomme `caseH`, dont le nom prêtait à confusion. Car il s'agit de l'année de naissance des enfants déclarés dans la case H, cette dernière renvoyant à la variable `nbH`. 
+  - Renomme `caseH`, dont le nom prêtait à confusion. Car il s'agit de l'année de naissance des enfants déclarés dans la case H, cette dernière renvoyant à la variable `nbH`.
 
 ### 51.17.1 [#1520](https://github.com/openfisca/openfisca-france/pull/1520)
 

--- a/openfisca_france/parameters/bourses_enseignement_superieur/criteres_sociaux/points_de_charge.yaml
+++ b/openfisca_france/parameters/bourses_enseignement_superieur/criteres_sociaux/points_de_charge.yaml
@@ -8,35 +8,35 @@ distance_domicile_familial:
     type: single_amount
   brackets:
   - threshold:
-      2006-31-03:
+      2006-03-31:
         value: 0
     amount:
-      2006-31-03:
+      2006-03-31:
         value: 0
   - threshold:
-      2006-31-03:
+      2006-03-31:
         value: 30
     amount:
-      2006-31-03:
+      2006-03-31:
         value: 1
   - threshold:
-      2006-31-03:
+      2006-03-31:
         value: 250
     amount:
-      2006-31-03:
+      2006-03-31:
         value: 2
 charges_familiales:
   points_par_enfant_a_charge:
     description: Nombre de points de charge par enfant à l'exclusion du candidat boursier pour la bourse du supérieur sur critères sociaux
     values:
-      2006-31-03:
+      2006-03-31:
         value: 1
-      2020-06-08:
+      2020-08-06:
         value: 2
   points_par_enfant_a_charge_etudiant_enseignement_superieur:
     description: Nombre de points de charge par enfant dans l'enseignement supérieur à l'exclusion du candidat boursier pour la bourse du supérieur sur critères sociaux
     values:
-      2006-31-03:
+      2006-03-31:
         value: 3
-      2020-06-08:
+      2020-08-06:
         value: 4

--- a/openfisca_france/parameters/bourses_enseignement_superieur/criteres_sociaux/seuil_ressources_etudiant_autonome.yaml
+++ b/openfisca_france/parameters/bourses_enseignement_superieur/criteres_sociaux/seuil_ressources_etudiant_autonome.yaml
@@ -1,6 +1,6 @@
 description: Seuil de ressources pour considérer l'étudiant autonome en pourcentage du SMIC net
 unit: /1
 values:
-  2006-31-03:
+  2006-03-31:
     reference: https://www.education.gouv.fr/bo/2006/15/MENS0600981C.htm
     value: 0.9

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "51.17.2",
+    version = "51.17.3",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
**Contexte** : En essayant d'appliquer une réforme de type [`asof`](https://github.com/openfisca/openfisca-survey-manager/blob/master/openfisca_survey_manager/utils.py#L121) au tax benefit system d'Openfisca-France, je suis tombée sur une erreur concernant le format de certaines dates dans le tax benefit system.

NB : Je vois qu'il y a beaucoup de travaux en cours sur d'autres branches concernant les aides pour les jeunes donc peut-être que cette MR fait doublon. Si c'est le cas désolée et n'hésitez pas à la fermer :) 

* Changement mineur.
* Périodes concernées : à partir du 31/03/2006.
* Zones impactées : `parameters/bourses_enseignement_superieur/criteres_sociaux`.
* Détails :
  - Correction du format de dates dans des paramètres liés aux bourses du supérieur

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

