### PR TITLE
Renomme caseH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 51.17.2 [#1523](https://github.com/openfisca/openfisca-france/pull/1523)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées
+   * `caracteristiques_socio_demographiques/demographie`.
+   * `prelevements_obligatoires/impot_revenu/ir`.
+* Détails :
+  - Renomme `caseH`, dont le nom prêtait à confusion. Car il s'agit de l'année de naissance des enfants déclarés dans la case H, cette dernière renvoyant à la variable `nbH`. 
+
 ### 51.17.1 [#1520](https://github.com/openfisca/openfisca-france/pull/1520)
 
 * Changement mineur.

--- a/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/demographie.py
@@ -130,19 +130,13 @@ class caseG(Variable):
     # que l'on remplt et l'autre une case que l'on coche
 
 
-class caseH(Variable):
-    cerfa_field = "H"
+class annee_naissance_pac_alterne(Variable):
     value_type = int
     is_period_size_independent = True
     entity = FoyerFiscal
     label = "Année de naissance des enfants à charge en garde alternée"
     definition_period = YEAR
-
-
-# il ne s'agit pas à proprement parlé de la case H, les cases permettant d'indiquer l'année de naissance
-#    se rapportent bien à nbH mais ne sont pas nommées, choisissons nous de laisser cerfa_field = 'H' pour caseH ?
-#    De plus les caseH peuvent être multiples puisqu'il peut y avoir plusieurs enfants? donc faut-il les nommer caseH1, caseH2...caseH6 (les 6 présentes dans la déclaration) ?
-#    il faut aussi créer les cases F, G, R et I qui donnent également les années de naissances des PAC
+    # Il s'agit de l'année de naissance associé aux PAC déclarés dans nbH. Il peut y avoir plusieurs années de naissance si nbH>1. On ne le prend pas en compte
 
 
 class caseK(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1168,7 +1168,7 @@ class ir_plaf_qf(Variable):
         caseE = foyer_fiscal('caseE', period)
         caseF = foyer_fiscal('caseF', period)
         caseG = foyer_fiscal('caseG', period)
-        caseH = foyer_fiscal('caseH', period)
+        annee_naissance_pac_alterne = foyer_fiscal('annee_naissance_pac_alterne', period)
         caseK = foyer_fiscal('caseK', period)
         caseN = foyer_fiscal('caseN', period)
         caseP = foyer_fiscal('caseP', period)
@@ -1193,7 +1193,7 @@ class ir_plaf_qf(Variable):
         B3 = plafond_qf.celib
 
         condition61 = celibataire_ou_divorce & caseT
-        condition63 = (celibataire_ou_divorce | (veuf & not_(jeune_veuf))) & not_(caseN) & (nb_pac == 0) & (caseK | caseE) & (caseH < int(period.start.year) - 25)
+        condition63 = (celibataire_ou_divorce | (veuf & not_(jeune_veuf))) & not_(caseN) & (nb_pac == 0) & (caseK | caseE) & (annee_naissance_pac_alterne < int(period.start.year) - 25)
 
         B = B1 * condition61 + \
             B2 * (not_(condition61 | condition63)) + \
@@ -1211,7 +1211,7 @@ class ir_plaf_qf(Variable):
         condition62caa0 = (celibataire_ou_divorce | (veuf & not_(jeune_veuf)))
         condition62caa1 = (nb_pac == 0) & (caseP | caseG | caseF | caseW)
         condition62caa2 = caseP & ((nbF - nbG > 0) | (nbH - nbI > 0))
-        condition62caa3 = not_(caseN) & (caseE | caseK) & (caseH >= 1981)
+        condition62caa3 = not_(caseN) & (caseE | caseK) & (annee_naissance_pac_alterne >= 1981)
         condition62caa = condition62caa0 & (condition62caa1 | condition62caa2 | condition62caa3)
         # marié pacs
         condition62cab = (maries_ou_pacses | jeune_veuf) & caseS & not_(caseP | caseF)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "51.17.1",
+    version = "51.17.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées
   * `caracteristiques_socio_demographiques/demographie`.
   * `prelevements_obligatoires/impot_revenu/ir`.
* Détails :
  - Renomme `caseH`, dont le nom prêtait à confusion. Car il s'agit de l'année de naissance des enfants déclarés dans la case H, cette dernière renvoyant à la variable `nbH`. 