### PR TITLE
Limite l'éligiblite du chèque énergie aux ménages avec déclarants fiscaux

### DIFF
--- a/openfisca_france/model/prestations/cheque_energie.py
+++ b/openfisca_france/model/prestations/cheque_energie.py
@@ -82,5 +82,7 @@ class cheque_energie(Variable):
 
     def formula_2017(menage, period, parameters):
         eligible = menage('cheque_energie_eligibilite_logement', period)
+        declarant = menage.nb_persons(FoyerFiscal.DECLARANT) > 0
+
         montant = menage('cheque_energie_montant', period.this_year)
-        return eligible * montant
+        return declarant * eligible * montant

--- a/openfisca_france/model/prestations/cheque_energie.py
+++ b/openfisca_france/model/prestations/cheque_energie.py
@@ -82,7 +82,7 @@ class cheque_energie(Variable):
 
     def formula_2017(menage, period, parameters):
         eligible = menage('cheque_energie_eligibilite_logement', period)
-        declarant = menage.nb_persons(FoyerFiscal.DECLARANT) > 0
+        declarant = menage.nb_persons(FoyerFiscal.DECLARANT) > 0  # une colocation de personnes à la charge de leurs parents n'est pas éligible aux chèques énergie, par exemple
 
         montant = menage('cheque_energie_montant', period.this_year)
         return declarant * eligible * montant

--- a/tests/formulas/cheque_energie/eligibilite_logement.yaml
+++ b/tests/formulas/cheque_energie/eligibilite_logement.yaml
@@ -5,3 +5,19 @@
     statut_occupation_logement: proprietaire
   output:
     cheque_energie_eligibilite_logement: false
+
+- period: 2021-04
+  input:
+    individus:
+      _: {}
+    familles:
+      _:
+        enfants: [_]
+    menages:
+      _:
+        personne_de_reference: [_]
+    foyers_fiscaux:
+      _:
+        personnes_a_charge: [_]
+  output:
+    cheque_energie_eligibilite_logement: false


### PR DESCRIPTION

* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées : `prestations/cheque_energie.py`.
* Détails :
  - Limite l'éligiblite du chèque énergie aux ménages avec déclarants fiscaux.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
