### PR TITLE
Ajout de doc sur taux_effectif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 52.1.1 [#1530](https://github.com/openfisca/openfisca-france/pull/1530)
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées
+   * `/model/prelevements_obligatoires/impot_revenu/ir.py`.
+* Détails :
+  - Documentation du taux_effectif.
+
 ## 52.1.0 [#1524](https://github.com/openfisca/openfisca-france/pull/1524)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -3110,8 +3110,15 @@ class abat_spe(Variable):
 class taux_effectif(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = "taux_effectif"
+    label = "La règle du taux effectif a pour objet de maintenir intégralement la progressivité de l'impôt"
     definition_period = YEAR
+    reference = "https://bofip.impots.gouv.fr/bofip/4616-PGP.html/identifiant=BOI-IR-LIQ-20-30-30-20120912"
+    documentation = '''
+        Cette règle du « taux effectif » s'applique notamment et sous certaines conditions :
+        - aux salariés détachés à l'étranger
+        - aux fonctionnaires des organisations internationales
+        - aux contribuables soumis au régime micro-entreprise
+        '''
 
     def formula_2009_01_01(foyer_fiscal, period, parameters):
         rni = foyer_fiscal('rni', period)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "52.1.0",
+    version = "52.1.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Connected to issue #1479

* Changement mineur.
* Périodes concernées : toutes
* Zones impactées : `/model/prelevements_obligatoires/impot_revenu/ir.py`.
* Détails :
  - Ajout du libellé et de la description du taux_effectif


Ces changements  :
- Corrigent ou améliorent un calcul déjà existant.

**Attention** : cette formule ne semble pas couverte par un test. Le BOFIP présente un détail de calcul qui pourrait servir pour un test : [Exemple_dapplication](https://bofip.impots.gouv.fr/bofip/4616-PGP.html/identifiant=BOI-IR-LIQ-20-30-30-20120912#Exemple_dapplication_210)

