### PR TITLE
Ajout de set_input_divide_by_period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [#1532](https://github.com/openfisca/openfisca-france/pull/1532)
+### 53.0.1 [#1532](https://github.com/openfisca/openfisca-france/pull/1532)
 
 * Amélioration technique. 
 * Périodes concernées : toutes. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 51.17.0 [#1532](https://github.com/openfisca/openfisca-france/pull/1532)
+
+* Amélioration technique. 
+* Périodes concernées : toutes. 
+* Zones impactées : `/Users/sasha/Desktop/LexImpact_Code/openfisca-france/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/revenus_capitaux_prelevement_forfaitaire_unique_ir`.
+* Détails :
+  - Ajout du set_input_divide_by_period sur
+
 ## 53.0.0 [#1541](https://github.com/openfisca/openfisca-france/pull/1541) 
 
 * Changement majeur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Amélioration technique. 
 * Périodes concernées : toutes. 
-* Zones impactées : `/Users/sasha/Desktop/LexImpact_Code/openfisca-france/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/revenus_capitaux_prelevement_forfaitaire_unique_ir`.
+* Zones impactées : `model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/revenus_capitaux_prelevement_forfaitaire_unique_ir`.
 * Détails :
   - Ajout du set_input_divide_by_period sur
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## 51.17.0 [#1532](https://github.com/openfisca/openfisca-france/pull/1532)
+## [#1532](https://github.com/openfisca/openfisca-france/pull/1532)
 
 * Amélioration technique. 
 * Périodes concernées : toutes. 
-* Zones impactées : `model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/revenus_capitaux_prelevement_forfaitaire_unique_ir`.
+* Zones impactées : 
+  - `model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique`
 * Détails :
-  - Ajout du set_input_divide_by_period sur
+  - Permet la division automatique des `revenus_capitaux_prelevement_forfaitaire_unique_ir` annuels en revenus mensuels
 
 ## 53.0.0 [#1541](https://github.com/openfisca/openfisca-france/pull/1541) 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -99,7 +99,6 @@ class revenus_capitaux_prelevement_forfaitaire_unique_ir(Variable):
     value_type = float
     entity = FoyerFiscal
     set_input = set_input_divide_by_period
-    
     label = "Revenus des valeurs et capitaux mobiliers soumis au prélèvement forfaitaire unique (partie impôt sur le revenu)"
     definition_period = MONTH
     set_input = set_input_divide_by_period

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -98,6 +98,8 @@ class assurance_vie_pfu_ir(Variable):
 class revenus_capitaux_prelevement_forfaitaire_unique_ir(Variable):
     value_type = float
     entity = FoyerFiscal
+    set_input = set_input_divide_by_period
+    
     label = "Revenus des valeurs et capitaux mobiliers soumis au prélèvement forfaitaire unique (partie impôt sur le revenu)"
     definition_period = MONTH
     set_input = set_input_divide_by_period

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -98,7 +98,6 @@ class assurance_vie_pfu_ir(Variable):
 class revenus_capitaux_prelevement_forfaitaire_unique_ir(Variable):
     value_type = float
     entity = FoyerFiscal
-    set_input = set_input_divide_by_period
     label = "Revenus des valeurs et capitaux mobiliers soumis au prélèvement forfaitaire unique (partie impôt sur le revenu)"
     definition_period = MONTH
     set_input = set_input_divide_by_period

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "53.0.0",
+    version = "53.0.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Amélioration technique. 
* Périodes concernées : toutes. 
* Zones impactées : `model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/revenus_capitaux_prelevement_forfaitaire_unique_ir`.
* Détails :
  - Ajout du set_input_divide_by_period sur la class revenus_capitaux_prelevement_forfaitaire_unique_ir

- - - -
Ces changements
- Corrigent ou améliorent un calcul déjà existant.
- - - -