### PR TITLE
Edit divide period prelevement forfaitaire unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Périodes concernées : toutes. 
 * Zones impactées : `model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique`.
 * Détails :
-  - Ajout du set_input_divide_by_period sur la class revenus_capitaux_prelevement_forfaitaire_unique_ir
+  - Ajout du set_input_divide_by_period sur la classe revenus_capitaux_prelevement_forfaitaire_unique_ir
   
 ## 52.1.1 [#1530](https://github.com/openfisca/openfisca-france/pull/1530)
 * Changement mineur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 52.1.2 [#1531](https://github.com/openfisca/openfisca-france/pull/1531)
+* Amélioration technique. 
+* Périodes concernées : toutes. 
+* Zones impactées : `model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique`.
+* Détails :
+  - Ajout du set_input_divide_by_period sur la class revenus_capitaux_prelevement_forfaitaire_unique_ir
+  
 ## 52.1.1 [#1530](https://github.com/openfisca/openfisca-france/pull/1530)
 * Changement mineur.
 * Périodes concernées : toutes.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -100,6 +100,7 @@ class revenus_capitaux_prelevement_forfaitaire_unique_ir(Variable):
     entity = FoyerFiscal
     label = "Revenus des valeurs et capitaux mobiliers soumis au prélèvement forfaitaire unique (partie impôt sur le revenu)"
     definition_period = MONTH
+    set_input = set_input_divide_by_period
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
         '''


### PR DESCRIPTION
* Amélioration technique. 
* Périodes concernées : toutes. 
* Zones impactées : `model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique`.
* Détails :
  - Ajout du set_input_divide_by_period sur la classe revenus_capitaux_prelevement_forfaitaire_unique_ir