### PR TITLE
Revalorisation du seuil de non recouvrement et ajout de références

### DIFF
--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/autres/nr_seuil.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/autres/nr_seuil.yaml
@@ -8,8 +8,14 @@ values:
     value: 22
   2017-01-01:
     value: 23
+  2021-01-01:
+    value: 24
 metadata:
   unit: currency
   reference:
     2017-01-01:
       href: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000035671411&cidTexte=LEGITEXT000006073189&categorieLien=id&dateTexte=
+    2021-01-01:
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038929179
+documentation: |-
+  Notes: Seuil calculé au regard du plafond de la sécurité sociale mensuel et arrondi à l'euro supérieur.

--- a/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/montant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/montant.yaml
@@ -136,7 +136,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000041835211
     2021-04-01:
       title: Décret 2021-527 du 29/04/2021 - art. 1
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043459535#:~:text=Le%20montant%20mensuel%20de%20l,du%20mois%20d'avril%202021.
+      href: https://www.legifrance.gouv.fr/eli/decret/2021/4/29/SSAA2110847D/jo/article_1
     2022-04-01:
     - title: Décret 2022-700 du 26/04/2022 - art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045668702

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/plafond_ressources_0_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/plafond_ressources_0_enfant.yaml
@@ -93,8 +93,8 @@ metadata:
     2021-01-01:
     - title: Article L755-16 du Code de la sécurité sociale
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000034109980
-    - title: Arrêté du 14/12/2020, art. 3
-      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042694990
+    - title: Arrêté du 14/12/2020, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042694988
     - title: Circulaire DSS/2B/2020/226 du 14/12/2020, p.210
       href: https://solidarites-sante.gouv.fr/fichiers/bo/2020/20-12/ste_20200012_0000_0050.pdf
     2022-01-01:

--- a/tests/formulas/rsa.yaml
+++ b/tests/formulas/rsa.yaml
@@ -596,16 +596,16 @@
     rsa: 826.40 - 200
 
 - name: RSA avec revenu d'apprenti
-  period: 2021-04
+  period: 2021-01
   absolute_error_margin: 0.03
   input:
     famille:
       parents: [personne1]
       aide_logement:
-        2021-04: 250
-        2021-03: 250
-        2021-02: 250
         2021-01: 250
+        2020-12: 250
+        2020-11: 250
+        2020-10: 250
     foyer_fiscal:
       declarants: [personne1]
     menage:
@@ -615,32 +615,31 @@
       personne1:
         date_naissance: 1980-01-01
         remuneration_apprenti:
-          2021-04: 960
-          2021-03: 960
-          2021-02: 960
           2021-01: 960
+          2020-12: 960
+          2020-11: 960
+          2020-10: 960
         salaire_imposable:
-          2021-04: 0
-          2021-03: 0
-          2021-02: 0
           2021-01: 0
+          2020-12: 0
+          2020-11: 0
+          2020-10: 0
   output:
-    rsa_forfait_logement: 67.84
     rsa_base_ressources: 960
     rsa: 0
 
 
 - name: RSA avec revenu d'apprenti - la condition d'accès est remplie sur les 3 ans qui précèdent la demande soit les 3214 heures d'activité
-  period: 2021-04
+  period: 2021-01
   absolute_error_margin: 0.03
   input:
     famille:
       parents: [personne1]
       aide_logement:
-        2021-04: 120
-        2021-03: 120
-        2021-02: 120
         2021-01: 120
+        2020-12: 120
+        2020-11: 120
+        2020-10: 120
     foyer_fiscal:
       declarants: [personne1]
     menage:
@@ -650,17 +649,16 @@
       personne1:
         date_naissance: 2000-01-01
         remuneration_apprenti:
-          2021-04: 943
-          2021-03: 943
-          2021-02: 943
           2021-01: 943
+          2020-12: 943
+          2020-11: 943
+          2020-10: 943
         rsa_jeune_condition_heures_travail_remplie: true
         salaire_imposable:
-          2021-04: 0
-          2021-03: 0
-          2021-02: 0
           2021-01: 0
+          2020-12: 0
+          2020-11: 0
+          2020-10: 0
   output:
-    rsa_forfait_logement: 67.84
     rsa_base_ressources: 943
     rsa: 0


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/2021.
* Zones impactées : 
  - `parameters/prestations_sociales/aides_logement/allocations_logement/autres/nr_seuil.yaml`
  - `parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/plafond_ressources_0_enfant.yaml`
  - `tests/formulas/rsa.yaml`
  
* Détails :
  - Revalorisation du seuil de non recouvrement de l'AL.
  - Correction de la date des 2 cas de tests RSA.