### PR TITLE
Mise à jour du montant de la majoration tierce personne

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 54.0.3 [#1556](https://github.com/openfisca/openfisca-france/pull/1556)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/04/2017.
+* Zones impactées :
+  - `parameters/autonomie/mtp/mtp`
+* Détails :
+  - Met à jour les montants et références de la majoration pour aide constante d'une tierce personne.
+
 ### 54.0.2 [#1460](https://github.com/openfisca/openfisca-france/pull/1460)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/autonomie/mtp/mtp.yaml
+++ b/openfisca_france/parameters/autonomie/mtp/mtp.yaml
@@ -31,6 +31,18 @@ values:
     value: 1103.08
   2016-04-01:
     value: 1104.18
+  2017-04-01:
+    value: 1107.49
+    reference: https://www.legislation.cnav.fr/Documents/circulaire_cnav_2017_13_04042017.pdf
+  2018-04-01:
+    value: 1118.57
+    reference: https://www.legislation.cnav.fr/Documents/circulaire_cnav_2018_10_05042018.pdf
+  2019-04-01:
+    value: 1121.92
+    reference: https://www.legislation.cnav.fr/Documents/circulaire_cnav_2019_15_05042019.pdf
+  2020-04-01:
+    value: 1125.29
+    reference: https://www.legislation.cnav.fr/Documents/circulaire_cnav_2020_20_03042020.pdf
   2021-04-01:
     value: 1126.41
     reference: https://www.legislation.cnav.fr/Documents/circulaire_cnav_2021_14_01042021.pdf

--- a/openfisca_france/parameters/autonomie/mtp/mtp.yaml
+++ b/openfisca_france/parameters/autonomie/mtp/mtp.yaml
@@ -31,3 +31,6 @@ values:
     value: 1103.08
   2016-04-01:
     value: 1104.18
+  2021-04-01:
+    value: 1126.41
+    reference: https://www.legislation.cnav.fr/Documents/circulaire_cnav_2021_14_01042021.pdf

--- a/openfisca_france/parameters/autonomie/mtp/mtp.yaml
+++ b/openfisca_france/parameters/autonomie/mtp/mtp.yaml
@@ -1,36 +1,52 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
+description: Montant de la majoration pour aide constante d'une tierce personne (MTP)
+reference: https://framagit.org/french-tax-and-benefit-tables/baremes-ipp-yaml/-/blob/master/parameters/prestations_sociales/prestations_etat_de_sante/perte_autonomie_personnes_agees/apa_mtp.yaml
 unit: currency
 values:
   2002-01-01:
     value: 916.31
+    reference: https://www.legifrance.gouv.fr/affichTexte.do%3bjsessionid=294A4B307D26FF213FE38A04660E9011.tpdjo12v_3?cidTexte=JORFTEXT000000399330&categorieLien=vig
   2003-01-01:
     value: 930.05
+    reference: https://www.legifrance.gouv.fr/affichTexte.do%3bjsessionid=FF934DF3E1CA8D754FF66512241B3F48.tpdjo17v_1?cidTexte=JORFTEXT000000776880&categorieLien=vig
   2004-01-01:
     value: 945.87
+    reference: https://www.legifrance.gouv.fr/affichTexte.do%3bjsessionid=2058ACFBAB20C3272E650B02EDE7E528.tpdjo17v_1?cidTexte=JORFTEXT000000611637&categorieLien=vig
   2005-01-01:
     value: 964.78
+    reference: https://www.legifrance.gouv.fr/affichTexte.do%3bjsessionid=2058ACFBAB20C3272E650B02EDE7E528.tpdjo17v_1?cidTexte=LEGITEXT000005945891&dateTexte=vig
   2006-01-01:
     value: 982.15
+    reference: https://www.legifrance.gouv.fr/affichTexte.do%3bjsessionid=2058ACFBAB20C3272E650B02EDE7E528.tpdjo17v_1?cidTexte=LEGITEXT000006053088&dateTexte=vig
   2007-01-01:
     value: 999.83
+    reference: https://www.legifrance.gouv.fr/affichTexte.do%3bjsessionid=2058ACFBAB20C3272E650B02EDE7E528.tpdjo17v_1?cidTexte=JORFTEXT000000820419&categorieLien=vig
   2008-01-01:
     value: 1010.82
+    reference: https://www.legifrance.gouv.fr/affichTexte.do%3bjsessionid=2058ACFBAB20C3272E650B02EDE7E528.tpdjo17v_1?cidTexte=LEGITEXT000017770723&dateTexte=vig
   2008-09-01:
     value: 1018.91
+    reference: https://www.legislation.cnav.fr/Pages/texte.aspx?Nom=CR_CN_2008045_12082008
   2009-04-01:
     value: 1029.1
+    reference: https://www.legislation.cnav.fr/Pages/texte.aspx?Nom=CR_CN_2009031_16042009
   2010-04-01:
     value: 1038.36
+    reference: https://www.legislation.cnav.fr/Pages/texte.aspx?Nom=CR_CN_2010043_23042010
   2011-04-01:
     value: 1060.16
+    reference: https://www.legislation.cnav.fr/Pages/texte.aspx?Nom=CR_CN_2011030_14042011
   2012-04-01:
     value: 1082.43
+    reference: https://www.legislation.cnav.fr/Pages/texte.aspx?Nom=circulaire_cnav_2012_35_17042012
   2013-04-01:
     value: 1096.5
+    reference: https://www.legislation.cnav.fr/Pages/texte.aspx?Nom=circulaire_cnav_2013_29_18042013
   2014-04-01:
     value: 1103.08
+    reference: https://www.legislation.cnav.fr/Pages/texte.aspx?Nom=circulaire_cnav_2014_028_09042014
   2016-04-01:
     value: 1104.18
+    reference: https://www.legislation.cnav.fr/Documents/circulaire_cnav_2016_21_04042016.pdf
   2017-04-01:
     value: 1107.49
     reference: https://www.legislation.cnav.fr/Documents/circulaire_cnav_2017_13_04042017.pdf

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "54.0.2",
+    version = "54.0.3",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/04/2021.
* Zones impactées : `autonomie.mtp.mtp`.
* Détails :
  - Mise à jour d'après circulaire CNAV.

- - - -

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Corrige #1554.