### PR TITLE
Étend l'aide aux jeunes diplômés anciens boursiers à fin 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+##
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/07/2021
+* Zones impactées : `model/covid19/jeunes.py`
+* Détails :
+  - Applique une mise à jour de la réglementation.
+  - Reporte la date limite de dépôt du dossier de demande de l'aide à fin 2021.
 
 ### 55.0.0 [#1477](https://github.com/openfisca/openfisca-france/pull/1477)
 

--- a/openfisca_france/model/covid19/jeunes.py
+++ b/openfisca_france/model/covid19/jeunes.py
@@ -35,7 +35,7 @@ class aide_jeunes_diplomes_anciens_boursiers_eligibilite(Variable):
     entity = Individu
     label = "Éligibilité à l'aide jeunes diplômés et anciens boursiers"
     definition_period = MONTH
-    end = "2021-06-30"
+    end = "2021-12-31"
     reference = "https://www.pole-emploi.fr/candidat/mes-droits-aux-aides-et-allocati/allocations-et-aides--les-repons/aides-financieres-aux-jeunes-dip.html"
     documentation = '''
     Conditions non modélisées :
@@ -83,7 +83,7 @@ class aide_jeunes_diplomes_anciens_boursiers_montant(Variable):
     entity = Individu
     label = "Montant de l'aide jeunes diplômés et anciens boursiers"
     definition_period = MONTH
-    end = "2021-06-30"
+    end = "2021-12-31"
     reference = "https://www.pole-emploi.fr/candidat/mes-droits-aux-aides-et-allocati/allocations-et-aides--les-repons/aides-financieres-aux-jeunes-dip.html"
 
     def formula_2021_02_05(individu, period, parameters):


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/07/2021
* Zones impactées : `model/covid19/jeunes.py`
* Détails :
  - Applique une mise à jour de la réglementation.
  - Reporte la date limite de dépôt du dossier de demande de l'aide à fin 2021.

P.S : Je n'ai pas vu d'évolution des règles d'éligibilité.
- - - -

Ces changements :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable) : ils réactivent une variable éteinte depuis le 1er juillet.
- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

