### PR TITLE
Mets à jour le départ 18-25 ans

### DIFF
--- a/openfisca_france/parameters/prestations/depart1825.yml
+++ b/openfisca_france/parameters/prestations/depart1825.yml
@@ -1,0 +1,56 @@
+plafond_ressources:
+  description: Montant maximal des ressources de la famille pour bénéficier de la prise en charge du séjour pour les bénéficiaires de Départ 18-25.
+  reference: https://www.ancv.com/actualites/le-magazine/depart-1825-un-nouveau-programme-pour-les-jeunes-de-18-25-ans
+  unit: currency
+  base:
+    2014-09-05:
+      value: 17000
+    2021-01-01:
+      value: 17280 # Date approximative
+  par_demi_part_supplementaire:
+    2014-09-05:
+      value: 4320
+age:
+  description: Fourchette d'âges pour laquelle le séjour peut être pris en charge pour les bénéficiaires de Départ 18-25.
+  reference: https://www.ancv.com/actualites/le-magazine/depart-1825-un-nouveau-programme-pour-les-jeunes-de-18-25-ans
+  unit: year
+  minimum:
+    2014-09-05:
+      value: 18
+  maximum:
+    2014-09-05:
+      value: 25
+montant_maximum:
+  unit: currency
+  values:
+    2014-09-05:
+      value: 150
+    2021-01-01:
+      value: 200
+    2021-06-14:
+      value: 300
+    2021-10-01:
+      value: 200
+proportion_maximum:
+  description: Part maximale du montant du séjour prise en charge pour les bénéficiaires de Départ 18-25.
+  unit: /1
+  values:
+    2014-09-05:
+      value: .50
+      reference: https://www.ancv.com/sites/default/files/20140905_depart_1825.pdf
+    2021-01-01:
+      value: .75
+      reference: https://programme-depart-1825.com
+    2021-06-14:
+      value: .90
+      reference: https://www.service-public.fr/particuliers/actualites/A14868
+    2021-10-01:
+      value: .75
+      reference: https://www.service-public.fr/particuliers/actualites/A14868
+reste_a_charge_minimum:
+  description: Montant minimum du coût du séjour à régler pour les bénéficiaires de Départ 18-25.
+  reference: https://www.ancv.com/actualites/le-magazine/depart-1825-un-nouveau-programme-pour-les-jeunes-de-18-25-ans
+  unit: currency
+  values:
+    2014-09-05:
+      value: 50

--- a/tests/formulas/depart1825.yaml
+++ b/tests/formulas/depart1825.yaml
@@ -1,0 +1,49 @@
+- period: 2021-03
+  input:
+    nbptr:
+      2019: [1, 1.5]
+  output:
+    depart1825_plafond_ressources: [17280, 21600]
+
+- period: 2021-03
+  input:
+    rfr:
+      2019: 100
+    depart1825_plafond_ressources: [120]
+  output:
+    depart1825_eligibilite_financiere: [true]
+
+- period: 2021-03
+  input:
+    activite: [etudiant, etudiant, inactif, inactif, actif]
+    boursier: [true, false, true, true, true]
+    alternant: [false, false, true, false, false]
+    garantie_jeunes: [0, 0, 0, 1, 0]
+  output:
+    depart1825_eligibilite_statut: [true, false, true, true, false]
+
+- period: 2021-03
+  input:
+    age: [18, 18, 18]
+    depart1825_eligibilite_statut: [true, false, false]
+    depart1825_eligibilite_financiere: [false, true, false]
+  output:
+    depart1825_eligibilite: [true, true, false]
+
+- period: 2021-03
+  input:
+    depart1825_eligibilite: [true, false]
+  output:
+    depart1825_montant_maximum: [200, 0]
+
+- period: 2021-07
+  input:
+    depart1825_eligibilite: [true, false]
+  output:
+    depart1825_montant_maximum: [300, 0]
+
+- period: 2021-10
+  input:
+    depart1825_eligibilite: [true, false]
+  output:
+    depart1825_montant_maximum: [200, 0]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées :  | à partir du 14/06/2021. jusqu'au 31/09/2021.
* Zones impactées :  openfisca_france/parameters/prestations/depart1825.yml tests/formulas/depart1825.yaml
* Détails :
Mise à jour des paramètres de calcul pour le départ 18-25 ans

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.
- - - -

- [ x ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ x ] Documentez votre contribution avec des références législatives.
- [ x ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
