### PR TITLE
Supprime l'information de rétro-compatibilité python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ L'ensembles des endpoints sont décrits dans la [documentation Swagger](https://
 
 Ce paquet requiert [Python 3.7](https://www.python.org/downloads/release/python-370/) et [pip](https://pip.pypa.io/en/stable/installing/).
 
-> La rétro-compatibilité avec Python 2.7 est maintenue pour le moment, mais cessera le 1er janvier 2019.
-
-
 Plateformes supportées :
 - distributions GNU/Linux (en particulier Debian and Ubuntu) ;
 - Mac OS X ;


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/2019
* Zones impactées : `README.md`
* Détails :
  - Supprime l'information de rétro-compatibilité à Python 2.7

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
