### PR TITLE
Fix Numpy warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### 56.0.1 [#1580](https://github.com/openfisca/openfisca-france/pull/1580) 
+
+* Amélioration technique 
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `model/prelevements_obligatoires/impot_revenu/ir.py`
+  - `model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py`
+  - `model/prestations/minima_sociaux/aah.py`
+  - `model/prestations/minima_sociaux/asi_aspa.py`
+  - `model/prestations/prestations_familiales/af.py`
+  - `model/prestations/prestations_familiales/base_ressource.py`
+  
+* Détails :
+  - Enlève les opérateurs unaires '+' en tête des formules qui génèrent des `DeprecationWarning` Numpy sur `openfisca-france-local`
+  
+
 # 56.0.0 [#1549](https://github.com/openfisca/openfisca-france/pull/1549) 
 
 * Évolution du système socio-fiscal non rétrocompatible

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -3075,13 +3075,13 @@ class abat_spe(Variable):
 
         # Vecteur de foyers eligibles aux abattements spéciaux
         foyers_eligibles = (
-            + (((age_declarant >= 65) | declarant_invalide) & (age_declarant > 0))
+            (((age_declarant >= 65) | declarant_invalide) & (age_declarant > 0))
             + (((age_conjoint >= 65) | conjoint_invalide) & (age_conjoint > 0))
             )
 
         # Vecteur de montants d'abattement pour personnes âges ou invalides
         as_inv = (
-            + foyers_eligibles
+            foyers_eligibles
             * (
                 (
                     + abattement_age_ou_invalidite.montant_1
@@ -3090,7 +3090,7 @@ class abat_spe(Variable):
                 + (
                     + abattement_age_ou_invalidite.montant_2
                     * (
-                        + (revenu_net_global > abattement_age_ou_invalidite.plafond_1)
+                        (revenu_net_global > abattement_age_ou_invalidite.plafond_1)
                         & (revenu_net_global <= abattement_age_ou_invalidite.plafond_2)
                         )
                     )
@@ -3099,7 +3099,7 @@ class abat_spe(Variable):
 
         # Vecteur de montants d'abattement pour enfants à charge
         as_enf = (
-            + nombre_enfants
+            nombre_enfants
             * abattement_enfant_marie.montant
             )
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
@@ -265,7 +265,7 @@ class formation_profession_liberale(Variable):
         bareme.multiply_thresholds(plafond_securite_sociale_annuel)
         categorie_non_salarie = individu('categorie_non_salarie', period)
         assiette = (
-            + (categorie_non_salarie == TypesCategorieNonSalarie.profession_liberale)
+            (categorie_non_salarie == TypesCategorieNonSalarie.profession_liberale)
             ) * individu('rpns_individu', period)
         return -bareme.calc(assiette)
 
@@ -319,7 +319,7 @@ class retraite_complementaire_profession_liberale(Variable):
         bareme.multiply_thresholds(plafond_securite_sociale_annuel)
         categorie_non_salarie = individu('categorie_non_salarie', period)
         assiette = (
-            + (categorie_non_salarie == TypesCategorieNonSalarie.profession_liberale)
+            (categorie_non_salarie == TypesCategorieNonSalarie.profession_liberale)
             ) * individu('rpns_individu', period)
         return -bareme.calc(assiette)
 
@@ -341,6 +341,6 @@ class vieillesse_profession_liberale(Variable):
         bareme.multiply_thresholds(plafond_securite_sociale_annuel)
         categorie_non_salarie = individu('categorie_non_salarie', period)
         assiette = (
-            + (categorie_non_salarie == TypesCategorieNonSalarie.profession_liberale)
+            (categorie_non_salarie == TypesCategorieNonSalarie.profession_liberale)
             ) * individu('rpns_individu', period)
         return -bareme.calc(assiette)

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -356,7 +356,7 @@ class eligibilite_caah(Variable):
         salaire_net = individu('salaire_net', annee_precedente, options = [ADD])
 
         return (
-            + (taux_incapacite >= taux_incapacite_min)
+            (taux_incapacite >= taux_incapacite_min)
             * ((aah > 0) | (benef_asi > 0))
             * not_(locataire_foyer)
             * (salaire_net == 0)

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -247,7 +247,7 @@ class asi(Variable):
         # Montant mensuel servi (sous réserve d'éligibilité)
         montant_servi_asi = max_(diff, 0)
         return montant_servi_asi * (
-            + individu.has_role(Famille.DEMANDEUR) * demandeur_eligible_asi * (elig1 + elig2 / 2 + elig3 / 2)
+            individu.has_role(Famille.DEMANDEUR) * demandeur_eligible_asi * (elig1 + elig2 / 2 + elig3 / 2)
             + individu.has_role(Famille.CONJOINT) * conjoint_eligible_asi * (elig1 + elig2 / 2 + elig3 / 2)
             )
 

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -241,7 +241,7 @@ class af_complement_degressif(Variable):
         depassement_mensuel = depassement_helper(famille, period, parameters, af_nbenf)
 
         return (
-            + not_(eligibilite_dom)
+            not_(eligibilite_dom)
             * (depassement_mensuel > 0)
             * max_(0, af - depassement_mensuel)
             )

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -139,7 +139,7 @@ class rev_coll(Variable):
 
         # TODO: ajouter les revenus de l'étranger etr*0.9
         return (
-            + revenu_categoriel_foncier
+            revenu_categoriel_foncier
             + pensions_alimentaires_versees  # négatif
             + rente_viagere_titre_onereux_net
             + rev_cat_rvcm
@@ -277,22 +277,22 @@ class abattements_speciaux_prestations_familiales(Variable):
 
         # Vecteur de foyers eligibles aux abattements spéciaux
         foyers_eligibles = (
-            + (((date_naissance_declarant < dateLimite) | declarant_invalide) & (age_declarant > 0))
+            (((date_naissance_declarant < dateLimite) | declarant_invalide) & (age_declarant > 0))
             + (((date_naissance_conjoint < dateLimite) | conjoint_invalide) & (age_conjoint > 0))
             )
 
         # Vecteur de montants d'abattement pour personnes âges ou invalides
         abattement_special_personne_agee_invalide = (
-            + foyers_eligibles
+            foyers_eligibles
             * (
                 (
-                    + abattement_age_ou_invalidite.montant_1
+                    abattement_age_ou_invalidite.montant_1
                     * (revenu_net_global <= abattement_age_ou_invalidite.plafond_1)
                     )
                 + (
-                    + abattement_age_ou_invalidite.montant_2
+                    abattement_age_ou_invalidite.montant_2
                     * (
-                        + (revenu_net_global > abattement_age_ou_invalidite.plafond_1)
+                        (revenu_net_global > abattement_age_ou_invalidite.plafond_1)
                         & (revenu_net_global <= abattement_age_ou_invalidite.plafond_2)
                         )
                     )
@@ -301,7 +301,7 @@ class abattements_speciaux_prestations_familiales(Variable):
 
         # Vecteur de montants d'abattement pour enfants à charge
         abattement_special_enfants_a_charge = (
-            + nombre_enfants
+            nombre_enfants
             * abattement_enfant_marie.montant
             )
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "56.0.0",
+    version = "56.0.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
closes #1403

* Amélioration technique 
* Périodes concernées : toutes.
* Zones impactées :
  - `model/prelevements_obligatoires/impot_revenu/ir.py`
  - `model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py`
  - `model/prestations/minima_sociaux/aah.py`
  - `model/prestations/minima_sociaux/asi_aspa.py`
  - `model/prestations/prestations_familiales/af.py`
  - `model/prestations/prestations_familiales/base_ressource.py`
* Détails :
  - Enlève les opérateurs unaires '+' des formules qui génèrent les warnings Numpy.



- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.
