### PR TITLE
Configure la variable "indemnites_compensatrices_conges_payes" par mois.

### DIFF
--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -233,6 +233,7 @@ class indemnites_compensatrices_conges_payes(Variable):
     entity = Individu
     label = "indemnites_compensatrices_conges_payes"
     definition_period = MONTH
+    set_input = set_input_divide_by_period
 
 
 class indemnite_fin_contrat_due(Variable):


### PR DESCRIPTION
Configure la variable "indemnites_compensatrices_conges_payes" par mois, pour qu'elle fonctionne avec un input annuel.
