### PR TITLE
Ajoute l'aide mon job mon logement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 71.1.0 [#1586](https://github.com/openfisca/openfisca-france/pull/1586)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `/prestations/mon_job_mon_logement.py`
+  - `/parameters/prestations/mon_job_mon_logement.yaml`
+* Détails :
+  - Ajoute la variable `mon_job_mon_logement` qui calcule l'aide mon job mon logement d'action logement.
+
 # 71.0.0 [#1623](https://github.com/openfisca/openfisca-france/pull/1623)
 
 * Amélioration technique.

--- a/openfisca_france/model/prestations/mon_job_mon_logement.py
+++ b/openfisca_france/model/prestations/mon_job_mon_logement.py
@@ -1,0 +1,72 @@
+from numpy import datetime64
+
+from openfisca_france.model.base import Individu, Variable, MONTH, date, TypesActivite, TypesStatutOccupationLogement, Menage
+
+
+class date_entree_logement(Variable):
+    value_type = date
+    default_value = date(1970, 1, 1)
+    entity = Menage
+    definition_period = MONTH
+    label = "Date entrée dans le logement"
+
+
+class mon_job_mon_logement_eligibilite_logement(Variable):
+    value_type = bool
+    entity = Individu
+    definition_period = MONTH
+    label = "Eligibilité logement de l'aide mon jon mon logement"
+
+    def formula(individu, period):
+        statut_occupation_logement = individu.menage('statut_occupation_logement', period)
+        locataire = ((statut_occupation_logement == TypesStatutOccupationLogement.locataire_hlm)
+                     + (statut_occupation_logement == TypesStatutOccupationLogement.locataire_vide)
+                     + (statut_occupation_logement == TypesStatutOccupationLogement.locataire_meuble))
+        return locataire * (individu.menage('date_entree_logement', period) > datetime64(period.offset(-3, 'month').start))
+
+
+class mon_job_mon_logement_eligibilite_jeunes_actifs(Variable):
+    value_type = bool
+    entity = Individu
+    definition_period = MONTH
+    label = "Éligibilité à l'aide mon job mon logement pour les jeunes actifs"
+
+    def formula(individu, period):
+        eligibilite_activite = (individu('activite', period) == TypesActivite.actif) + individu('alternant', period)
+        smic_mensuel_brut = individu("smic_proratise", period)
+        eligibilite_salaire = (individu("salaire_de_base", period) <= smic_mensuel_brut) * (individu("salaire_de_base", period) >= smic_mensuel_brut * 0.3)
+        eligibilite_logement = individu('mon_job_mon_logement_eligibilite_logement', period)
+        eligibilite_activite_debut = individu('contrat_de_travail_debut', period) > datetime64(period.offset(-6, 'month').start)
+        elibilite_age = individu('age', period) < 25
+
+        return eligibilite_activite * eligibilite_salaire * eligibilite_logement * eligibilite_activite_debut * elibilite_age
+
+
+class mon_job_mon_logement_eligibilite(Variable):
+    value_type = bool
+    entity = Individu
+    definition_period = MONTH
+    label = "Éligibilité à l'aide mon job mon logement"
+
+    def formula(individu, period):
+        eligibilite_activite = (individu('activite', period) == TypesActivite.actif) + individu('alternant', period)
+        smic_mensuel_brut = individu("smic_proratise", period)
+        eligibilite_salaire = individu("salaire_de_base", period) <= smic_mensuel_brut * 1.5
+        eligibilite_logement = individu('mon_job_mon_logement_eligibilite_logement', period)
+        eligibilite_activite_debut = individu('contrat_de_travail_debut', period) >= datetime64(
+            period.offset(-3, 'month').start)
+
+        return eligibilite_activite * eligibilite_salaire * eligibilite_logement * eligibilite_activite_debut
+
+
+class mon_job_mon_logement(Variable):
+    value_type = float
+    entity = Individu
+    definition_period = MONTH
+    label = "Montant de l'aide mon job mon logement"
+    reference = ["https://www.actionlogement.fr/aide-mon-job-mon-logement"]
+
+    def formula(individu, period, parameters):
+        montant = parameters(period).prestations.mon_job_mon_logement.montant
+        eligibilite = individu('mon_job_mon_logement_eligibilite', period) + individu('mon_job_mon_logement_eligibilite_jeunes_actifs', period)
+        return montant * eligibilite

--- a/openfisca_france/parameters/prestations/mon_job_mon_logement.yaml
+++ b/openfisca_france/parameters/prestations/mon_job_mon_logement.yaml
@@ -1,0 +1,8 @@
+montant:
+  description: Montant de l'aide mon job mon logement
+  reference:
+    - https://www.actionlogement.fr/aide-mon-job-mon-logement
+  unit: currency
+  values:
+    2021-02-18:
+      value: 1000

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "71.0.0",
+    version = "71.1.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/mon_job_mon_logement.yaml
+++ b/tests/formulas/mon_job_mon_logement.yaml
@@ -1,0 +1,26 @@
+- name: Éligibilité à l'aide mon job mon logement
+  period: 2021-07
+  input:
+    activite: ["actif", "etudiant", "inactif", "actif", "actif", "actif"]
+    alternant: [false, true, false, false, false, false]
+    salaire_de_base: [1554.58, 1554.58, 1554.58, 1555, 1554.58, 3000.]
+    statut_occupation_logement: ['locataire_meuble', 'locataire_vide', 'locataire_hlm', 'non_renseigne', 'locataire_vide', 'locataire_vide']
+    date_entree_logement: [2021-07-01, 2021-07-01, 2021-07-01, 2021-07-01, 2021-04-01, 2021-07-01]
+    contrat_de_travail_debut: [2021-07-01, 2021-07-01, 2021-07-01, 2021-07-01, 2021-07-01, 2021-04-01]
+    age: [ 26, 26, 26, 26, 26, 26 ]
+
+  output:
+    mon_job_mon_logement: [1000, 1000, 0, 0, 0, 0]
+
+- name: Éligibilité à l'aide mon job mon logement jeunes actifs
+  period: 2021-07
+  input:
+    activite: ["actif", "etudiant", "inactif", "actif", "actif", "actif", "actif"]
+    alternant: [false, true, false, false, false, false, false]
+    salaire_de_base: [1554.58, 1554.58, 1554.58, 1555, 1554.58, 3000., 1554.58]
+    statut_occupation_logement: ['locataire_meuble', 'locataire_vide', 'locataire_hlm', 'non_renseigne', 'locataire_vide', 'locataire_vide', 'locataire_vide']
+    date_entree_logement: [2021-07-01, 2021-07-01, 2021-07-01, 2021-07-01, 2021-04-01, 2021-07-01, 2021-07-01]
+    contrat_de_travail_debut: [2021-07-01, 2021-07-01, 2021-07-01, 2021-07-01, 2021-07-01, 2021-07-01, 2021-03-01]
+    age: [20, 20, 20, 20, 20, 20, 26]
+  output:
+    mon_job_mon_logement: [1000, 1000, 0, 0, 0, 0, 0]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées :
- `/prestations/mon_job_mon_logement.py`
- `/parameters/prestations/mon_job_mon_logement.yaml`
* Détails :
  - Ajoute la variable `mon_job_mon_logement` qui calcule l'aide mon job mon logement d'action logement.

- - - -

Ces changements :
- Ajoute une variable `mon_job_mon_logement` qui calcule l'aide.
- Ajoute les variables `mon_job_mon_logement_eligibilite`, `mon_job_mon_logement_eligibilite_jeunes_actifs`, `mon_job_mon_logement_eligibilite_logement` qui vérifie l'éligibilité à l'aide `mon_job_mon_logement`.
- Ajoute une variable `date_entree_logement` pour récupérer la date d'entrée du ménage dans un logement. Cette variable est nécessaire pour calculer `mon_job_mon_logement`.

- - - -

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
