### PR TITLE
Correction du format des dates dans official_journal_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 
+### 56.1.1 [1592](https://github.com/openfisca/openfisca-france/pull/1592)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/ss/salaire_sous_pss/`.
+* Détails :
+  - Correction de format de dates dans les metadata de paramètres.
+  - Erreurs détectées par le validateur Leximpact.
+
+
 ## 56.1.0 [1546](https://github.com/openfisca/openfisca-france/pull/1546)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/ss/salaire_sous_pss/cotisation_ouvriere/moins_de_65_ans.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/ss/salaire_sous_pss/cotisation_ouvriere/moins_de_65_ans.yaml
@@ -36,7 +36,7 @@ metadata:
     1948-07-01: 1948-08-24
     1937-01-01: 1935-10-31
     1936-01-01: 1935-10-31
-    1930-07-01: 12-04-1928 ; 01-05-1930
+    1930-07-01: 1928-04-12 ; 1930-05-01
   notes:
     1967-09-01: En 1967 la cotisation globale de Sécurité sociale est remplacée par des cotisations différenciées par branches
     1947-01-01: 4% sont dues au titre de la contribution spéciale instaurée par l'ordonnance du 30/12/1944

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/ss/salaire_sous_pss/cotisation_ouvriere/plus_de_65_ans.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/ss/salaire_sous_pss/cotisation_ouvriere/plus_de_65_ans.yaml
@@ -38,7 +38,7 @@ metadata:
     1948-07-01: 1948-08-24
     1937-01-01: 1935-10-31
     1936-01-01: 1935-10-31
-    1930-07-01: 12-04-1928 ; 01-05-1930
+    1930-07-01: 1928-04-12 ; 1930-05-01
   notes:
     1967-09-01: En 1967 la cotisation globale de Sécurité sociale est remplacée par des cotisations différenciées par branches
     1947-01-01: 4% sont dues au titre de la contribution spéciale instaurée par l'ordonnance du 30/12/1944

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/ss/salaire_sous_pss/cotisation_patronale.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/ss/salaire_sous_pss/cotisation_patronale.yaml
@@ -46,7 +46,7 @@ metadata:
     1948-07-01: 1948-08-24
     1937-01-01: 1935-10-31
     1936-01-01: 1935-10-31
-    1930-07-01: 12-04-1928 ; 01-05-1930
+    1930-07-01: 1928-04-12 ; 1930-05-01
   notes:
     1967-09-01: En 1967 la cotisation globale de Sécurité sociale est remplacée par des cotisations différenciées par branches
     1947-01-01: 4% sont dues au titre de la contribution spéciale instaurée par l'ordonnance du 30/12/1944

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "56.1.0",
+    version = "56.1.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/ss/salaire_sous_pss/`.
* Détails :
  - Correction de format de dates dans les metadata de paramètres.
  - Erreurs détectées par le validateur Leximpact.

- - - -

Ces changements  :

- Modifient des metadata.
