### PR TITLE
Renommage de date_parution_jo en official_journal_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 61.0.2 [#1609](https://github.com/openfisca/openfisca-france/pull/1611)
+### 61.0.2 [#1611](https://github.com/openfisca/openfisca-france/pull/1611)
 
 * Changement mineur.
 * Périodes concernées : toutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 61.0.2 [#1609](https://github.com/openfisca/openfisca-france/pull/1611)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `parameters`.
+* Détails :
+  - Dans les metadonnées des paramètres, renommage de `date_parution_jo` en `official_journal_date`
+
+Ces changements (effacez les lignes ne correspondant pas à votre cas) :
+
+- Modifient l'API publique d'OpenFisca France, mais seulement dans les metadata et ce sont des corrections.
+
 ### 61.0.1 [#1609](https://github.com/openfisca/openfisca-france/pull/1609)
 
 * Correction d'un crash.

--- a/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage.yaml
@@ -68,7 +68,7 @@ metadata:
       title: Décret 72-1208 du 27/12/1972
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000695977&categorieLien=id
     1972-07-01: Loi 71-576 et loi 71-578, art. 3 du 16/07/1971
-  date_parution_jo:
+  official_journal_date:
     2019-01-01: 2018-09-06
     2014-01-01: 2013-12-29; 2012-03-15
     2013-01-01: 2012-03-15

--- a/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_250.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_250.yaml
@@ -66,7 +66,7 @@ metadata:
       title: Décret 72-1208 du 27/12/1972
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000695977&categorieLien=id
     1972-07-01: Loi 71-576 et loi 71-578, art. 3 du 16/07/1971
-  date_parution_jo:
+  official_journal_date:
     2019-01-01: 2018-09-06
     2014-01-01: 2013-12-29; 2012-03-15
     2013-01-01: 2012-03-15

--- a/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_add.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_add.yaml
@@ -31,7 +31,7 @@ metadata:
     2004-01-01:
       title: Loi 2004-1484 du 30/12/2005 (LF pour 2005), art. 37
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006322119&cidTexte=JORFTEXT000000789373
-  date_parution_jo:
+  official_journal_date:
     2014-01-01: 2013-12-29; 2012-03-15
     2006-01-01: 2004-12-31
     2005-01-01: 2004-12-31

--- a/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_alsace_moselle.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_alsace_moselle.yaml
@@ -68,7 +68,7 @@ metadata:
       title: Décret 72-1208 du 27/12/1972
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000695977&categorieLien=id
     1972-07-01: Loi 71-576 et loi 71-578, art. 3 du 16/07/1971
-  date_parution_jo:
+  official_journal_date:
     2019-01-01: 2018-09-06
     2014-01-01: 2013-12-29; 2012-03-15
     2013-01-01: 2012-03-15

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "61.0.1",
+    version = "61.0.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `parameters`.
* Détails :
  - Dans les metadonnées des paramètres, renommage de `date_parution_jo` en `official_journal_date`

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient l'API publique d'OpenFisca France, mais seulement dans les metadata et ce sont des corrections.
