### PR TITLE
Correction d'une faute de frappe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 62.0.1 [#1617](https://github.com/openfisca/openfisca-france/pull/1617)
+
+* Changement mineur.
+* Périodes concernées : toutes
+* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`.
+* Détails : 
+  - Corrige une faute de frappe
+  - Supprime des fichiers inutiles
+  - Met à jour la documentation avec la syntaxe CircleCI 2.0
+
 ## 62.0.0 [#1608](https://github.com/openfisca/openfisca-france/pull/1608)
 
 * Amélioration technique : Corrige ou améliore un calcul déjà existant.
@@ -27,11 +37,8 @@
 * Périodes concernées : toutes.
 * Zones impactées : `parameters`.
 * Détails :
-  - Dans les metadonnées des paramètres, renommage de `date_parution_jo` en `official_journal_date`
-
-Ces changements (effacez les lignes ne correspondant pas à votre cas) :
-
-- Modifient l'API publique d'OpenFisca France, mais seulement dans les metadata et ce sont des corrections.
+  - Dans les metadonnées des paramètres, renommage de `date_parution_jo` en `official_journal_date`.
+  - Modifie l'API publique d'OpenFisca France, mais seulement dans les metadata et ce sont des corrections.
 
 ### 61.0.1 [#1609](https://github.com/openfisca/openfisca-france/pull/1609)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Certaines règles sont communes à tous les dépôts OpenFisca et sont détaill�
 
 Les évolutions d'OpenFisca-France doivent pouvoir être comprises par des réutilisateurs qui n'interviennent pas nécessairement sur le code. Le Changelog, rédigé en français, se doit donc d'être le plus explicite possible.
 
-Chaque évolution sera documentée par les élements suivants :
+Chaque évolution sera documentée par les éléments suivants :
 
 - Sur la première ligne figure en guise de titre le numéro de version, et un lien vers la Pull Request introduisant le changement. Le niveau de titre doit correspondre au niveau d'incrémentation de la version.
 
@@ -61,18 +61,7 @@ Certaines interventions sur OpenFica concernent à la fois [OpenFica-Core](https
 
 C'est par exemple le cas lorsqu'une version à paraître de Core contient un changement non-rétrocompatible, et que l'on souhaite s'assurer qu'il est possible d'adapter France à cette nouvelle version.
 
-Dans ce cas, il peut être pertinent de faire tourner les tests d'OpenFisca-France en se basant sur une version non-publiée de Core, disponible sur une branche spécifique. Pour ce faire, éditer le fichier `circle.yml` comme suit :
-
-```diff
-(...)
-dependencies:
-  override:
-    - pip install --upgrade pip wheel  # pip >= 8.0 needed to be compatible with "manylinux" wheels, used by numpy >= 1.11
-    - pip install twine
-+    - pip install --editable git+https://github.com/openfisca/openfisca-core.git@SPECIFIC_BRANCH_NAME#egg=OpenFisca-Core
-    - pip install .[test] --upgrade
-(...)
-```
+Dans ce cas, il peut être pertinent d'exécuter les tests d'OpenFisca-France en se basant sur une version non-publiée de Core, disponible sur une branche spécifique. Pour ce faire, éditer le fichier [`.circleci/config.yml`](https://github.com/openfisca/openfisca-france/blob/9c44a5e2d44e1319c64326e7c528b2ac37cbfc05/.circleci/config.yml#L26).
 
 Bien sûr, une fois la version spécifique de core publiée, **ce changement doit être reverté** avant le merge de la pull request sur France.
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -3000,7 +3000,7 @@ class rpns_imposables(Variable):
 
         majo_cga = max_(0, cga_taux2 * (ntimp + rpns_frag))  # Pour ne pas avoir à majorer les déficits
         # total 6
-        revevenus_non_salaries = rpns_frag + rpns_mrag + frag_fore + coupe_bois + atimp + ntimp + majo_cga - def_agri
+        revenus_non_salaries = rpns_frag + rpns_mrag + frag_fore + coupe_bois + atimp + ntimp + majo_cga - def_agri
 
         # revenu net après abatement
         # total 7
@@ -3009,7 +3009,7 @@ class rpns_imposables(Variable):
         exon_ncn = max_(0, mncn_timp - mncn_mvct) - mncn_timp  # ajout artificiel
 
         return (
-            revevenus_non_salaries + rev_ns_mi + rpns_pvct + exon_acc + exon_ncn
+            revenus_non_salaries + rev_ns_mi + rpns_pvct + exon_acc + exon_ncn
             + abic_impm - abic_defm + alnp_imps + cncn_aimp - rpns_mvct_pro - rpns_mvct_agr - rpns_mvct_nonpro
             )
 

--- a/pat_sal_harmonisation_cotsoc_d51a4555d.txt
+++ b/pat_sal_harmonisation_cotsoc_d51a4555d.txt
@@ -1,2 +1,0 @@
-WARNING:openfisca_core.scripts:Several country packages detected : `openfisca_france, openfisca_france_dotations_locales`. Using `openfisca_france` by default. To use another package, please use the --country-package option.
-WARNING:openfisca_core.scripts:Several country packages detected : `openfisca_france, openfisca_france_dotations_locales`. Using `openfisca_france` by default. To use another package, please use the --country-package option.

--- a/pat_sal_master_f59d01ec9.txt
+++ b/pat_sal_master_f59d01ec9.txt
@@ -1,2 +1,0 @@
-WARNING:openfisca_core.scripts:Several country packages detected : `openfisca_france, openfisca_france_dotations_locales`. Using `openfisca_france` by default. To use another package, please use the --country-package option.
-WARNING:openfisca_core.scripts:Several country packages detected : `openfisca_france, openfisca_france_dotations_locales`. Using `openfisca_france` by default. To use another package, please use the --country-package option.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "62.0.0",
+    version = "62.0.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`.
* Détails : Dans la formule de calcul de "rnps_imposable", une des clés semble avoir une faute de frappe (revevenus_non_salaries)
Cette clé est uniquement dans cette formule.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas)  corrigent ou améliorent un calcul déjà existant.


