### PR TITLE
aspa n'existe pas avant 2006

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# 64.0.1 [#1626](https://github.com/openfisca/openfisca-france/pull/1626)
+
+* Changement mineur.
+* Périodes concernées : jusqu'au 31/12/2005
+* Zones impactées : /model/prestations/minima_sociaux/asi_aspa.py
+* Détails : L'aspa n'existe pas avant 2006
+
 # 64.0.0 [#1622](https://github.com/openfisca/openfisca-france/pull/1622)
 
 * Évolution du système socio-fiscal. | Amélioration technique.

--- a/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/asi_aspa.py
@@ -279,7 +279,7 @@ class aspa(Variable):
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
-    def formula(famille, period, parameters):
+    def formula_2006_01_01(famille, period, parameters):
         maries = famille('maries', period)
         en_couple = famille('en_couple', period)
         asi_aspa_nb_alloc = famille('asi_aspa_nb_alloc', period)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "64.0.0",
+    version = "64.0.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : jusqu'au 31/12/2005
* Zones impactées : /model/prestations/minima_sociaux/asi_aspa.py
* Détails :
  - L'aspa n'existe pas avant 2006
