### PR TITLE
Ajoute une condition d'éligibilité sur l'âge des alternants pour le repas à un euro du crous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 74.1.0 [#1636](https://github.com/openfisca/openfisca-france/pull/1636)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2021.
+* Zones impactées :
+  - `model/prestations/alimentation.py`
+  - `parameters/crous_repas_un_euro.yaml`.
+  - `model/prestations/education.py`.
+* Détails :
+  - Ajoute une condition d'éligibilité pour les détenteurs d'une carte des métiers pour la variable `crous_repas_un_euro_eligibilite`.
+
 # 74.0.1 [#1668](https://github.com/openfisca/openfisca-france/pull/1668)
 
 * Changement mineur.

--- a/openfisca_france/model/prestations/alimentation.py
+++ b/openfisca_france/model/prestations/alimentation.py
@@ -23,5 +23,6 @@ class crous_repas_un_euro_eligibilite(Variable):
 
     def formula_2021_07(individu, period):
         enseignement_superieur = individu('scolarite', period) == TypesScolarite.enseignement_superieur
+        detention_carte_des_metiers = individu('detention_carte_des_metiers', period)
         boursier = individu('boursier', period)
-        return boursier * enseignement_superieur
+        return boursier * (enseignement_superieur + detention_carte_des_metiers)

--- a/openfisca_france/model/prestations/education.py
+++ b/openfisca_france/model/prestations/education.py
@@ -366,3 +366,18 @@ class mention_baccalaureat(Variable):
     documentation = '''
     En cas de multiples baccalauréats, meilleure mention obtenue.
     '''
+
+
+class detention_carte_des_metiers(Variable):
+    value_type = bool
+    label = "Détention carte des métiers"
+    entity = Individu
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+    reference = [
+        "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000024410525/2011-07-30/",
+        "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031088014/"
+        ]
+
+    def formula(individu, period, parameters):
+        return individu('alternant', period) * (individu('age', period) < parameters(period).prestations.carte_des_metiers.age_maximal)

--- a/openfisca_france/parameters/prestations/carte_des_metiers.yaml
+++ b/openfisca_france/parameters/prestations/carte_des_metiers.yaml
@@ -1,0 +1,10 @@
+age_maximal:
+  reference:
+    - https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000024410525/2011-07-30/
+    - https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031088014/
+  description: Âge maximal des alternants pour lequel le repas à un euro peut être pris en charge par le crous.
+  unit: year
+  values:
+    2011-07-28:
+      value: 26
+

--- a/openfisca_france/parameters/prestations/carte_des_metiers.yaml
+++ b/openfisca_france/parameters/prestations/carte_des_metiers.yaml
@@ -7,4 +7,3 @@ age_maximal:
   values:
     2011-07-28:
       value: 26
-

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "74.0.1",
+    version = "74.1.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/crous_repas_un_euro.yaml
+++ b/tests/formulas/crous_repas_un_euro.yaml
@@ -1,6 +1,17 @@
 - name: Covid-19 - Deux repas par jour au Crous à 1 € pour tous les étudiants.
   period: 2021-01
   input:
-    scolarite: [enseignement_superieur, lycee]
+    scolarite: [enseignement_superieur, non_renseigne]
   output:
     crous_repas_un_euro_eligibilite: [true, false]
+
+
+- name: Covid-19 - Deux repas par jour au Crous à 1 € pour tous les étudiants.
+  period: 2021-08
+  input:
+    boursier: [true, true, true, false]
+    scolarite: [enseignement_superieur, non_renseigne, non_renseigne, enseignement_superieur]
+    alternant: [false, true, true, false]
+    age: [26, 26, 25, 26]
+  output:
+    crous_repas_un_euro_eligibilite: [true, false, true, false]

--- a/tests/formulas/crous_repas_un_euro.yaml
+++ b/tests/formulas/crous_repas_un_euro.yaml
@@ -5,7 +5,6 @@
   output:
     crous_repas_un_euro_eligibilite: [true, false]
 
-
 - name: Covid-19 - Deux repas par jour au Crous à 1 € pour tous les étudiants.
   period: 2021-08
   input:


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2021.
* Zones impactées :
 - `model/prestations/alimentation.py`
 - `parameters/crous_repas_un_euro.yaml`.
 - `model/prestations/education.py`
* Détails :
  - Ajoute une condition d'éligibilité sur l'âge des alternants pour l'aide `crous_repas_un_euro_eligibilite`.

- - - -
- Corrigent ou améliorent un calcul déjà existant.
- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

