### PR TITLE
ajoute des valeurs aux smic horaire brut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 73.0.1 [#]()
+### 73.0.1 [#1642](https://github.com/openfisca/openfisca-france/pull/1642)
 
 * Changement mineur.
 * Périodes concernées : 1995 - 2001

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 73.0.1 [#]()
+
+* Changement mineur.
+* Périodes concernées : 1995 - 2001
+* Zones impactées :
+  * `parameters/marche_travail/salaire_minimum/smic_h_b.yaml`
+* Détails :
+  - Ajoute quelques années au SMIC horaire brut
+
 # 73.0.0 [#1661](https://github.com/openfisca/openfisca-france/pull/1661) [#1567](https://github.com/openfisca/openfisca-france/pull/1567)
 
 * Évolution du système socio-fiscal **non rétrocompatible** | Correction d'un crash.
@@ -134,7 +143,7 @@
 
 * Évolution du système socio-fiscal **non rétrocompatible** | Amélioration technique
 * Périodes concernées : toutes.
-* Zones impactées : 
+* Zones impactées :
   - `model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py`
   - `model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/preprocessing.py`
   - `parameters/prelevements_sociaux/cotisations_regime_assurance_chomage`
@@ -168,7 +177,7 @@
 * Amélioration technique **non rétrocompatible**
 * Périodes concernées : toutes.
 * Zones impactées : toutes
-* Détails : 
+* Détails :
   - Harmonisation du dossier `parameters.prelevements_sociaux.cotisations_regime_assurance_chomage` :
     * Arborescence selon le modèle IPP
     * Nouveau formatage des fichiers .yaml
@@ -181,7 +190,7 @@
 * Changement mineur.
 * Périodes concernées : toutes.
 * Zones impactées : `parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/formation`.
-* Détails : 
+* Détails :
   * Ajout de ";" manquants aux `official_journal_date` multiples.
 
 Ces changements modifient des éléments non fonctionnels (metadata `official_journal_date` de paramètres).
@@ -219,7 +228,7 @@ Ces changements :
 
 * Changement mineur.
 * Périodes concernées : toutes
-* Zones impactées : 
+* Zones impactées :
   - Presque l'ensemble des fichiers présents dans : `openfisca-france/openfisca_france/model/`
 * Détails :
   - Configure les variables par mois pour qu'elles fonctionnent avec un input annuel.
@@ -244,7 +253,7 @@ Ces changements :
 * Amélioration technique **non rétrocompatible**
 * Périodes concernées : toutes.
 * Zones impactées : toutes
-* Détails : 
+* Détails :
   - Harmonisation du dossier `parameters.prelevements_sociaux.pss` :
     * Arborescence selon le modèle IPP
     * Nouveau formatage des fichiers .yaml
@@ -350,7 +359,7 @@ Ces changements :
 
 * Amélioration technique **non rétrocompatible**
 * Périodes concernées : toutes.
-* Zones impactées : 
+* Zones impactées :
   - `parameters`
   - `parameters.cotsoc`
 * Détails :

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic_h_b.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic_h_b.yaml
@@ -3,6 +3,20 @@ reference: Décret n° 2016-1818 du 22 décembre 2016 portant relèvement du sal
   de croissance - Article 1
 unit: currency
 values:
+  1995-07-01:
+    value: 36.98
+  1996-05-01:
+    value: 37.72
+  1996-07-01:
+    value: 37.91
+  1997-07-01:
+    value: 39.43
+  1998-07-01:
+    value: 40.22
+  1999-07-01:
+    value: 40.72
+  2000-07-01:
+    value: 42.02
   2001-07-01:
     value: 6.67
   2002-07-01:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "73.0.0",
+    version = "73.0.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
### 69.0.2 [#1642](https://github.com/openfisca/openfisca-france/pull/1642)

* Changement mineur.
* Périodes concernées : 1995 - 2001
* Zones impactées :
  * `parameters/marche_travail/salaire_minimum/smic_h_b.yaml`
* Détails :
  - Ajoute quelques années au SMIC horaire brut
  - Les valeurs sont en francs avant 2001
  - Elles sont prises des barèmes IPP: https://www.ipp.eu/ipp-tax-and-benefit-tables/en/labour-market/salaire_minimum/smic
  - Je m'arrête à 1995 car je souhaite faire tourner les données ERFS et elles commencent en 1996