### PR TITLE
Ajout de set_input manquants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 69.0.2 [#1645](https://github.com/openfisca/openfisca-france/pull/1645)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py`.
+* Détails :
+  - Ajout des set_input manquants empêchant la saisie de montant annuels.
+
 ### 69.0.1 [#1638](https://github.com/openfisca/openfisca-france/pull/1638)
 
 * Changement mineur.

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -404,6 +404,7 @@ class agirc_arrco_salarie(Variable):
     entity = Individu
     label = "Cotisation AGIRC-ARRCO (après la fusion, salarié)"
     definition_period = MONTH
+    set_input = set_input_divide_by_period
 
     def formula_2019_01_01(individu, period, parameters):
         cotisation = apply_bareme(
@@ -422,6 +423,7 @@ class agirc_arrco_employeur(Variable):
     entity = Individu
     label = "Cotisation AGIRC-ARRCO (après la fusion, employeur)"
     definition_period = MONTH
+    set_input = set_input_divide_by_period
 
     def formula_2019_01_01(individu, period, parameters):
         cotisation = apply_bareme(
@@ -634,6 +636,7 @@ class contribution_equilibre_general_salarie(Variable):
     entity = Individu
     label = "Contribution d'équilibre général (salarie)"
     definition_period = MONTH
+    set_input = set_input_divide_by_period
 
     def formula_2019_01_01(individu, period, parameters):
 
@@ -653,6 +656,7 @@ class contribution_equilibre_general_employeur(Variable):
     entity = Individu
     label = "Contribution d'équilibre général (employeur)"
     definition_period = MONTH
+    set_input = set_input_divide_by_period
 
     def formula_2019_01_01(individu, period, parameters):
 
@@ -691,6 +695,7 @@ class cotisation_equilibre_technique_salarie(Variable):
     entity = Individu
     label = "Cotisation d'équilibre technique (salarie)"
     definition_period = MONTH
+    set_input = set_input_divide_by_period
 
     def formula_2019_01_01(individu, period, parameters):
 
@@ -713,6 +718,7 @@ class cotisation_equilibre_technique_employeur(Variable):
     entity = Individu
     label = "Cotisation d'équilibre technique (employeur)"
     definition_period = MONTH
+    set_input = set_input_divide_by_period
 
     def formula_2019_01_01(individu, period, parameters):
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "69.0.1",
+    version = "69.0.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py`.
* Détails :
  - Ajout des set_input manquants empêchant la saisie de montant annuels.

- - - -

Ces changements :

- Ajoutent une fonctionnalité
