### PR TITLE
Affine les paramètres passés aux fonctions appelés par des formules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+### 70.0.2 [#1647](https://github.com/openfisca/openfisca-france/pull/1647)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées :
+  * `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py`
+  * `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py`
+  * `openfisca_france/model/revenus/activite/salarie.py`
+* Détails :
+  - En tout et pour tout, il y avait 3 fonctions appelées par des formules OpenFisca, qui recevaient la racine des paramètres en argument.
+  - Or, ces 3 fonctions n'utilisent chacune qu'une partie bien spécifique de l'arbre des paramètres.
+  - Ce patch modifie l'appel de ces 3 fonctions afin de leur fournir uniquement la partie spécifique de l'arbre qui les concerne.
+  - Cela facilite la détection automatique des paramètres précisément utilisés par chaque formule.
+
 # 70.0.0 [#1640](https://github.com/openfisca/openfisca-france/pull/1640)
 *  Amélioration technique.
 *  Périodes concernées : toutes.

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -129,8 +129,7 @@ class credit_impot_competitivite_emploi(Variable):
         jeune_entreprise_innovante = individu('jeune_entreprise_innovante', period)  # noqa F841
         smic_proratise = individu('smic_proratise', period)
         stagiaire = individu('stagiaire', period)
-        parameters = parameters(period)
-        taux_cice = taux_exo_cice(assiette_allegement, smic_proratise, parameters)
+        taux_cice = taux_exo_cice(assiette_allegement, smic_proratise, parameters(period).prelevements_sociaux.reductions_cotisations_sociales.cice)
         credit_impot_competitivite_emploi = taux_cice * assiette_allegement  # En updatant la formule (>2019) il faudra passer le parametre à null
         non_cumul = not_(stagiaire)
         association = individu('entreprise_est_association_non_lucrative', period)
@@ -484,7 +483,6 @@ def compute_allegement_progressif(individu, period, parameters, variable_name, c
         return compute_function(individu, up_to_this_month, parameters) - cumul
 
 
-def taux_exo_cice(assiette_allegement, smic_proratise, parameters):
-    cice = parameters.prelevements_sociaux.reductions_cotisations_sociales.cice
+def taux_exo_cice(assiette_allegement, smic_proratise, cice):
     taux_cice = ((assiette_allegement / (smic_proratise + 1e-16)) <= cice.plafond_smic) * cice.taux
     return taux_cice

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
@@ -65,7 +65,7 @@ class contribution_exceptionnelle_solidarite(Variable):
         supplement_familial_traitement = individu('supplement_familial_traitement', period)
         # Assujettis
         parameters = parameters(period)
-        seuil_assujetissement_fds = compute_seuil_fds(parameters)
+        seuil_assujetissement_fds = compute_seuil_fds(parameters.prelevements_sociaux.cotisations_sociales.fds)
         concernes = (
             (categorie_salarie == TypesCategorieSalarie.public_titulaire_etat)
             + (categorie_salarie == TypesCategorieSalarie.public_titulaire_territoriale)
@@ -308,11 +308,10 @@ class rafp_employeur(Variable):
         return - rafp_employeur
 
 
-def compute_seuil_fds(parameters):
+def compute_seuil_fds(fds):
     '''
     Calcule le seuil mensuel d'assujetissement à la contribution au fond de solidarité
     '''
-    fds = parameters.prelevements_sociaux.cotisations_sociales.fds
     pt_ind_mensuel = fds.valeur_annuelle_point_fp / 12
     seuil_mensuel = math.floor((pt_ind_mensuel * fds.indice_majore_de_reference))  # TODO improve
     return seuil_mensuel

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -888,7 +888,7 @@ class supplement_familial_traitement(Variable):
         indice_maj_min = P.IM_min
         indice_maj_max = P.IM_max
 
-        traitement_brut_mensuel_min = _traitement_brut_mensuel(indice_maj_min, _P)
+        traitement_brut_mensuel_min = _traitement_brut_mensuel(indice_maj_min, _P.fonc.IM_100)
         plancher_mensuel_1 = part_fixe
         plancher_mensuel_2 = part_fixe + traitement_brut_mensuel_min * pct_variable_2
         plancher_mensuel_3 = part_fixe + traitement_brut_mensuel_min * pct_variable_3
@@ -901,7 +901,7 @@ class supplement_familial_traitement(Variable):
             + plancher_mensuel_supp * max_(0, fonc_nbenf - 3)
             )
 
-        traitement_brut_mensuel_max = _traitement_brut_mensuel(indice_maj_max, _P)
+        traitement_brut_mensuel_max = _traitement_brut_mensuel(indice_maj_max, _P.fonc.IM_100)
         plafond_mensuel_1 = part_fixe
         plafond_mensuel_2 = part_fixe + traitement_brut_mensuel_max * pct_variable_2
         plafond_mensuel_3 = part_fixe + traitement_brut_mensuel_max * pct_variable_3
@@ -930,9 +930,8 @@ class supplement_familial_traitement(Variable):
         return sft
 
 
-def _traitement_brut_mensuel(indice_maj, law):
-    Indice_majore_100_annuel = law.fonc.IM_100
-    traitement_brut = Indice_majore_100_annuel * indice_maj / 100 / 12
+def _traitement_brut_mensuel(indice_maj, indice_majore_100_annuel):
+    traitement_brut = indice_majore_100_annuel * indice_maj / 100 / 12
     return traitement_brut
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "70.0.1",
+    version = "70.0.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : 
  * `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py`
  * `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py`
  * `openfisca_france/model/revenus/activite/salarie.py`
* Détails :
  - En tout et pour tout, il y avait 3 fonctions appelées par des formules OpenFisca, qui recevaient la racine des paramètres en argument.
  - Or, ces 3 fonctions n'utilisent chacune qu'une partie bien spécifique de l'arbre des paramètres.
  - Ce patch modifie l'appel de ces 3 fonctions afin de leur fournir uniquement la partie spécifique de l'arbre qui les concerne.
  - Cela facilite la détection automatique des paramètres précisément utilisés par chaque formule.

- - - -

Ces changements :

- Modifient des formules, sans en changer les calculs.
