### PR TITLE
Retire le doublon pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,4 @@ check-style:
 test: clean check-syntax-errors check-style
 	@# Launch tests from openfisca_france/tests directory (and not .) because TaxBenefitSystem must be initialized
 	@# before parsing source files containing formulas.
-	pytest
 	openfisca test --country-package openfisca_france tests


### PR DESCRIPTION
Closes #1644 

* Amélioration technique.
* Zones impactées : `Makefile`.
* Détails :
  - Retire les doublons des tests Python dans `make test` en retirant l'appel à `pytest`.