### PR TITLE
Restructure la configuration CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           paths:
             - dist
 
-  test-python: # Python tests are separated from YAML tests, because the latter take longer. This would allow Python tests to use any other available container and yield it, once finished, to another job instead of counting only on the two containers assigned to the YAML tests.
+  test_python: # Python tests are separated from YAML tests, because the latter take longer. This would allow Python tests to use any other available container and yield it, once finished, to another job instead of counting only on the two containers assigned to the YAML tests.
     docker:
       - image: python:3.7
 
@@ -52,7 +52,7 @@ jobs:
           name: Run Python tests
           command: pytest `circleci tests glob "tests/**/[^_]*.py" | circleci tests split`
 
-  test-yaml:
+  test_yaml:
     parallelism: 2  # Speed up the yaml tests, while letting two containers available for other jobs.
     docker:
       - image: python:3.7
@@ -165,10 +165,10 @@ workflows:
   build_and_deploy:
     jobs:
       - build
-      - test-python:
+      - test_python:
           requires:
             - build
-      - test-yaml:
+      - test_yaml:
           requires:
              - build
       - test_api:
@@ -180,15 +180,15 @@ workflows:
       - check_version_and_changelog:
           requires:
             - build
-            - test-python
-            - test-yaml
+            - test_python
+            - test_yaml
             - lint_files
       - deploy:
           requires:
             - check_version_and_changelog
             - build
-            - test-python
-            - test-yaml
+            - test_python
+            - test_yaml
             - test_api
             - lint_files
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           paths:
             - dist
 
-  test-python:
+  test-python: # Python tests are separated from YAML tests, because the latter take longer. This would allow Python tests to use any other available container and yield it, once finished, to another job instead of counting only on the two containers assigned to the YAML tests.
     docker:
       - image: python:3.7
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,25 @@ jobs:
 
       - run:
           name: Run tests
-          command: |
-            pytest `circleci tests glob "tests/**/[^_]*.py" | circleci tests split`
-            openfisca test `circleci tests glob "tests/**/*.{yaml,yml}" | circleci tests split`
+          command: openfisca test `circleci tests glob "tests/**/*.{yaml,yml}" | circleci tests split`
+
+  test-python:
+    docker:
+      - image: python:3.7
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+
+      - run:
+          name: Avtivate virtualenv
+          command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
+
+      - run:
+          name: Run Python tests
+          command: pytest `circleci tests glob "tests/**/[^_]*.py" | circleci tests split`
 
   lint_yaml_files:
     docker:
@@ -155,6 +171,9 @@ workflows:
     jobs:
       - check_version_and_changelog
       - build
+      - test-python:
+          requires:
+            - build
       - test_api:
           requires:
             - build
@@ -169,6 +188,7 @@ workflows:
             - check_version_and_changelog
             - build
             - test_api
+            - test-python
             - lint_yaml_files
             - lint_python_files
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,45 @@ jobs:
           paths:
             - /tmp/venv/openfisca_france
 
+  lint_files:
+    docker:
+      - image: python:3.7
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+
+      - run:
+          name: Activate virtualenv
+          command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
+
+      - run: make check-syntax-errors
+
+      - run: make check-style
+
+      - run:
+          name: Lint Python files
+          command: .circleci/lint-changed-python-files.sh
+
+      - run:
+          name: Lint YAML tests
+          command: .circleci/lint-changed-yaml-tests.sh
+
+  check_version_and_changelog:
+    docker:
+      - image: python:3.7
+
+    steps:
+      - checkout
+
+      - run:
+          name: Check version number has been properly updated
+          command: |
+            git fetch
+            .circleci/is-version-number-acceptable.sh
+
   build:
     docker:
       - image: python:3.7
@@ -113,43 +152,7 @@ jobs:
 
       - run:
           name: Test the Web API
-          command: |
-            .circleci/test-api.sh
-
-  lint_files:
-    docker:
-      - image: python:3.7
-
-    steps:
-      - checkout
-
-      - restore_cache:
-          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
-
-      - run:
-          name: Activate virtualenv
-          command: |
-            echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
-
-      - run:
-          name: Lint files
-          command: |
-            make check-syntax-errors check-style
-            .circleci/lint-changed-python-files.sh
-            .circleci/lint-changed-yaml-tests.sh
-
-  check_version_and_changelog:
-    docker:
-      - image: python:3.7
-
-    steps:
-      - checkout
-
-      - run:
-          name: Check version number has been properly updated
-          command: |
-            git fetch
-            .circleci/is-version-number-acceptable.sh
+          command: .circleci/test-api.sh
 
   deploy:
     docker:
@@ -190,6 +193,9 @@ workflows:
   build_and_deploy:
     jobs:
       - install
+      - lint_files:
+          requires:
+            - install
       - build:
           requires:
             - install
@@ -202,26 +208,19 @@ workflows:
       - test_api:
            requires:
              - build
-      - lint_files:
-          requires:
-            - install
       - check_version_and_changelog:
           requires:
-            - install
-            - build
+            - lint_files
             - test_python
             - test_yaml
             - test_api
-            - lint_files
       - deploy:
           requires:
-            - check_version_and_changelog
-            - install
-            - build
+            - lint_files
             - test_python
             - test_yaml
             - test_api
-            - lint_files
+            - check_version_and_changelog
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,11 +76,6 @@ jobs:
           command: make build
 
       - save_cache:
-          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
-          paths:
-            - /tmp/venv/openfisca_france
-
-      - save_cache:
           key: v1-py3-build-{{ .Revision }}
           paths:
             - dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@
 version: 2
 jobs:
   build:
-    parallelism: 2  # Speed up the tests, while letting two containers available for other builds.
     docker:
       - image: python:3.7
 
@@ -35,10 +34,6 @@ jobs:
           paths:
             - dist
 
-      - run:
-          name: Run tests
-          command: openfisca test `circleci tests glob "tests/**/*.{yaml,yml}" | circleci tests split`
-
   test-python:
     docker:
       - image: python:3.7
@@ -56,6 +51,45 @@ jobs:
       - run:
           name: Run Python tests
           command: pytest `circleci tests glob "tests/**/[^_]*.py" | circleci tests split`
+
+  test-yaml:
+    parallelism: 2  # Speed up the yaml tests, while letting two containers available for other jobs.
+    docker:
+      - image: python:3.7
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+
+      - run:
+          name: Avtivate virtualenv
+          command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
+
+      - run:
+          name: Run YAML tests
+          command: openfisca test `circleci tests glob "tests/**/*.{yaml,yml}" | circleci tests split`
+
+  test_api:
+    docker:
+      - image: python:3.7
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+
+      - run:
+          name: Activate virtualenv
+          command: |
+            echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
+
+      - run:
+          name: Test the Web API
+          command: |
+            .circleci/test-api.sh
 
   lint_yaml_files:
     docker:
@@ -97,26 +131,6 @@ jobs:
           command: |
             make check-syntax-errors check-style
             .circleci/lint-changed-python-files.sh
-
-  test_api:
-    docker:
-      - image: python:3.7
-
-    steps:
-      - checkout
-
-      - restore_cache:
-          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
-
-      - run:
-          name: Activate virtualenv
-          command: |
-            echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
-
-      - run:
-          name: Test the Web API
-          command: |
-            .circleci/test-api.sh
 
   check_version_and_changelog:
     docker:
@@ -174,9 +188,12 @@ workflows:
       - test-python:
           requires:
             - build
-      - test_api:
+      - test-yaml:
           requires:
-            - build
+             - build
+      - test_api:
+           requires:
+             - build
       - lint_yaml_files:
           requires:
             - build
@@ -187,8 +204,9 @@ workflows:
           requires:
             - check_version_and_changelog
             - build
-            - test_api
             - test-python
+            - test-yaml
+            - test_api
             - lint_yaml_files
             - lint_python_files
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,19 +57,6 @@ jobs:
           name: Lint YAML tests
           command: .circleci/lint-changed-yaml-tests.sh
 
-  check_version_and_changelog:
-    docker:
-      - image: python:3.7
-
-    steps:
-      - checkout
-
-      - run:
-          name: Check version number has been properly updated
-          command: |
-            git fetch
-            .circleci/is-version-number-acceptable.sh
-
   build:
     docker:
       - image: python:3.7
@@ -153,6 +140,19 @@ jobs:
       - run:
           name: Test the Web API
           command: .circleci/test-api.sh
+
+  check_version_and_changelog:
+    docker:
+      - image: python:3.7
+
+    steps:
+      - checkout
+
+      - run:
+          name: Check version number has been properly updated
+          command: |
+            git fetch
+            .circleci/is-version-number-acceptable.sh
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,9 @@ workflows:
   build_and_deploy:
     jobs:
       - install
-      - build
+      - build:
+          requires:
+            - install
       - test_python:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,11 @@ jobs:
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
 
       - save_cache:
+          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+          paths:
+            - /tmp/venv/openfisca_france
+
+      - save_cache:
           key: v1-py3-build-{{ .Revision }}
           paths:
             - dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,6 @@ jobs:
           paths:
             - /tmp/venv/openfisca_france
 
-      - save_cache:
-          key: v1-py3-build-{{ .Revision }}
-          paths:
-            - dist
-
   build:
     docker:
       - image: python:3.7
@@ -52,6 +47,11 @@ jobs:
           command: |
             make build
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
+
+      - save_cache:
+          key: v1-py3-build-{{ .Revision }}
+          paths:
+            - dist
 
   test_python: # Python tests are separated from YAML tests, because the latter take longer. This would allow Python tests to use any other available container and yield it, once finished, to another job instead of counting only on the two containers assigned to the YAML tests.
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - run:
-          name: Avtivate virtualenv
+          name: Activate virtualenv
           command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
 
       - run:
@@ -64,7 +64,7 @@ jobs:
           key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - run:
-          name: Avtivate virtualenv
+          name: Activate virtualenv
           command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,6 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - check_version_and_changelog
       - build
       - test-python:
           requires:
@@ -178,6 +177,12 @@ workflows:
       - lint_files:
           requires:
             - build
+      - check_version_and_changelog:
+          requires:
+            - build
+            - test-python
+            - test-yaml
+            - lint_files
       - deploy:
           requires:
             - check_version_and_changelog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,11 @@ jobs:
           command: make build
 
       - save_cache:
+          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+          paths:
+            - /tmp/venv/openfisca_france
+
+      - save_cache:
           key: v1-py3-build-{{ .Revision }}
           paths:
             - dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,27 +91,7 @@ jobs:
           command: |
             .circleci/test-api.sh
 
-  lint_yaml_files:
-    docker:
-      - image: python:3.7
-
-    steps:
-      - checkout
-
-      - restore_cache:
-          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
-
-      - run:
-          name: Activate virtualenv
-          command: |
-            echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
-
-      - run:
-          name: Lint files
-          command: |
-            .circleci/lint-changed-yaml-tests.sh
-
-  lint_python_files:
+  lint_files:
     docker:
       - image: python:3.7
 
@@ -131,6 +111,7 @@ jobs:
           command: |
             make check-syntax-errors check-style
             .circleci/lint-changed-python-files.sh
+            .circleci/lint-changed-yaml-tests.sh
 
   check_version_and_changelog:
     docker:
@@ -194,10 +175,7 @@ workflows:
       - test_api:
            requires:
              - build
-      - lint_yaml_files:
-          requires:
-            - build
-      - lint_python_files:
+      - lint_files:
           requires:
             - build
       - deploy:
@@ -207,8 +185,7 @@ workflows:
             - test-python
             - test-yaml
             - test_api
-            - lint_yaml_files
-            - lint_python_files
+            - lint_files
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,10 +216,6 @@ workflows:
             - test_api
       - deploy:
           requires:
-            - lint_files
-            - test_python
-            - test_yaml
-            - test_api
             - check_version_and_changelog
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
 
       - run:
           name: Run Python tests
-          command: pytest `circleci tests glob "tests/**/[^_]*.py" | circleci tests split`
+          command: pytest `circleci tests glob "tests/**/[^_]*.py"`
 
   test_yaml:
     parallelism: 2  # Speed up the yaml tests, while letting two containers available for other jobs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
           command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
 
       - run:
+          name: Build package
           command: |
             make build
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,11 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: |
-            make install
-            # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
+          command: make install
+
+    # - run:
+      #    name: Use a specific branch of OpenFisca-Core for testing purposes
+      #    command:  pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core
 
       - save_cache:
           key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
@@ -45,9 +47,7 @@ jobs:
 
       - run:
           name: Build package
-          command: |
-            make build
-            # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
+          command: make build
 
       - save_cache:
           key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
@@ -59,7 +59,7 @@ jobs:
           paths:
             - dist
 
-  test_python: # Python tests are separated from YAML tests, because the latter take longer. This would allow Python tests to use any other available container and yield it, once finished, to another job instead of counting only on the two containers assigned to the YAML tests.
+  test_python: # Python tests are separated from YAML tests, because the latter take longer. This allows Python tests to use any other available container and yield it, once finished, to another job instead of relying only on the two containers assigned to the YAML tests.
     docker:
       - image: python:3.7
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,7 @@ workflows:
             - build
             - test_python
             - test_yaml
+            - test_api
             - lint_files
       - deploy:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # CircleCI 2.0 configuration file. See <https://circleci.com/docs/2.0/language-python/>.
 version: 2
 jobs:
-  build:
+  install:
     docker:
       - image: python:3.7
 
@@ -21,7 +21,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            make build
+            make install
             # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
 
       - save_cache:
@@ -33,6 +33,25 @@ jobs:
           key: v1-py3-build-{{ .Revision }}
           paths:
             - dist
+
+  build:
+    docker:
+      - image: python:3.7
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+
+      - run:
+          name: Activate virtualenv
+          command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
+
+      - run:
+          command: |
+            make build
+            # pip install --editable git+https://github.com/openfisca/openfisca-core.git@BRANCH_NAME#egg=OpenFisca-Core  # use a specific branch of OpenFisca-Core
 
   test_python: # Python tests are separated from YAML tests, because the latter take longer. This would allow Python tests to use any other available container and yield it, once finished, to another job instead of counting only on the two containers assigned to the YAML tests.
     docker:
@@ -164,6 +183,7 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
+      - install
       - build
       - test_python:
           requires:
@@ -176,9 +196,10 @@ workflows:
              - build
       - lint_files:
           requires:
-            - build
+            - install
       - check_version_and_changelog:
           requires:
+            - install
             - build
             - test_python
             - test_yaml
@@ -186,6 +207,7 @@ workflows:
       - deploy:
           requires:
             - check_version_and_changelog
+            - install
             - build
             - test_python
             - test_yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
           command: make build
 
       - save_cache:
-          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+          key: v2-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
           paths:
             - /tmp/venv/openfisca_france
 
@@ -93,7 +93,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+          key: v2-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - restore_cache:
           key: v1-py3-build-{{ .Revision }}
@@ -101,9 +101,6 @@ jobs:
       - run:
           name: Activate virtualenv
           command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
-
-      - run:
-          command: make install
 
       - run:
           name: Run Python tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,9 @@ jobs:
       - restore_cache:
           key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 
+      - restore_cache:
+          key: v1-py3-build-{{ .Revision }}
+
       - run:
           name: Activate virtualenv
           command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
@@ -201,7 +204,7 @@ workflows:
             - install
       - test_python:
           requires:
-            - install
+            - build
       - test_yaml:
           requires:
              - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ workflows:
             - install
       - test_python:
           requires:
-            - build
+            - install
       - test_yaml:
           requires:
              - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,9 +95,6 @@ jobs:
       - restore_cache:
           key: v2-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 
-      - restore_cache:
-          key: v1-py3-build-{{ .Revision }}
-
       - run:
           name: Activate virtualenv
           command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
@@ -115,7 +112,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+          key: v2-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - run:
           name: Activate virtualenv
@@ -133,7 +130,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+          key: v2-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - run:
           name: Activate virtualenv
@@ -168,7 +165,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
+          key: v2-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - restore_cache:
           key: v1-py3-build-{{ .Revision }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,11 +68,8 @@ jobs:
           key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - run:
-          name: Create a virtualenv
-          command: |
-            mkdir -p /tmp/venv/openfisca_france
-            python -m venv /tmp/venv/openfisca_france
-            echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
+          name: Activate virtualenv
+          command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
 
       - run:
           name: Build package
@@ -198,19 +195,22 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - build
+      - install
       - lint_files:
           requires:
-            - build
+            - install
+      - build:
+          requires:
+            - install
       - test_python:
           requires:
             - build
       - test_yaml:
           requires:
-             - build
+            - build
       - test_api:
-           requires:
-             - build
+          requires:
+            - build
       - check_version_and_changelog:
           requires:
             - lint_files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,9 @@ jobs:
           command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
 
       - run:
+          command: make install
+
+      - run:
           name: Run Python tests
           command: pytest `circleci tests glob "tests/**/[^_]*.py"`
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,11 @@ jobs:
           key: v1-py3-deps-{{ .Branch }}-{{ checksum "setup.py" }}
 
       - run:
-          name: Activate virtualenv
-          command: echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
+          name: Create a virtualenv
+          command: |
+            mkdir -p /tmp/venv/openfisca_france
+            python -m venv /tmp/venv/openfisca_france
+            echo "source /tmp/venv/openfisca_france/bin/activate" >> $BASH_ENV
 
       - run:
           name: Build package
@@ -195,13 +198,10 @@ workflows:
   version: 2
   build_and_deploy:
     jobs:
-      - install
+      - build
       - lint_files:
           requires:
-            - install
-      - build:
-          requires:
-            - install
+            - build
       - test_python:
           requires:
             - build

--- a/.circleci/lint-changed-python-files.sh
+++ b/.circleci/lint-changed-python-files.sh
@@ -4,8 +4,8 @@ last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-pa
 
 if ! changes=$(git diff-index --name-only --diff-filter=ACMR --exit-code $last_tagged_commit -- "*.py")
 then
-  echo "Hello boss, I'm linting the following changed files:"
+  echo "Linting the following Python files:"
   echo $changes
   flake8 $changes
-else echo "Could't find changed files, come visit again!"
+else echo "No changed Python files to lint"
 fi

--- a/.circleci/lint-changed-yaml-tests.sh
+++ b/.circleci/lint-changed-yaml-tests.sh
@@ -4,8 +4,8 @@ last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-pa
 
 if ! changes=$(git diff-index --name-only --diff-filter=ACMR --exit-code $last_tagged_commit -- "tests/*.yaml")
 then
-  echo "Hello boss, I'm linting the following changed files:"
+  echo "Linting the following changed YAML tests:"
   echo $changes
   yamllint $changes
-else echo "Could't find changed files, come visit again!"
+else echo "No changed YAML tests to lint"
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 72.1.2 [#1650](https://github.com/openfisca/openfisca-france/pull/1650)
+
+* Amélioration technique.
+* Zones impactées : configuration de l'intégration continue.
+* Détails :
+  - Sépare les jobs `test_python` et `test_yaml` du `build`.
+  - Sépare le job `install` du job `build`.
+  - Regroupe les deux jobs `lint_python_files` et `lint_yaml_files` dans un seul job.
+  - Rend le job `check-version-and-changelog` dépendant de tous les autres jobs.
+
 ## 72.1.1 [#1657](https://github.com/openfisca/openfisca-france/pull/1657)
 
 * Changement mineur.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "72.1.1",
+    version = "72.1.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Closes #1643 

* Amélioration technique.
* Périodes concernées : toutes.
* Zones impactées : `.circleci/config.yml`.
* Détails :
  -  Sépare les jobs `test-python` et `test-yaml` du `build`.
  -  Regroupe les deux jobs `lint_python_files` et `lint_yaml_files` dans un seul job.
  -  Rend le job `check-version-and-changelog` dépendant de tous les autres jobs.
