### PR TITLE
Limite le dispositif repas à 1€ aux étudiants boursiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 73.1.2 [#1664](https://github.com/openfisca/openfisca-france/pull/1664)
+### 73.1.3 [#1658](https://github.com/openfisca/openfisca-france/pull/1658)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/07/2021.
+* Zones impactées : `prestations/alimentation.py`.
+* Détails :
+  - Limite le dispositif repas à 1€ aux étudiants boursiers
+
+### 73.1.2 [#1664](https://github.com/openfisca/openfisca-france/pull/1664)
 
 * Changement mineur.
 * Périodes concernées : toutes
@@ -8,7 +16,7 @@
 * Détails :
   -  Corrige quelques erreurs dans certains parametres, ayant trait aux unités (unités manquantes).
 
-## 73.1.1 [#1665](https://github.com/openfisca/openfisca-france/pull/1665)
+### 73.1.1 [#1665](https://github.com/openfisca/openfisca-france/pull/1665)
 
 * Changement mineur.
 * Périodes concernées : toutes.
@@ -46,7 +54,7 @@
   - Regroupe les deux jobs `lint_python_files` et `lint_yaml_files` dans un seul job.
   - Rend le job `check-version-and-changelog` dépendant de tous les autres jobs.
 
-## 72.1.1 [#1657](https://github.com/openfisca/openfisca-france/pull/1657)
+### 72.1.1 [#1657](https://github.com/openfisca/openfisca-france/pull/1657)
 
 * Changement mineur.
 * Périodes concernées : à partir du 01/01/2019.

--- a/openfisca_france/model/prestations/alimentation.py
+++ b/openfisca_france/model/prestations/alimentation.py
@@ -8,7 +8,7 @@ class crous_repas_un_euro_eligibilite(Variable):
     entity = Individu
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
-    reference = "https://www.etudiant.gouv.fr/fr/le-repas-au-crous-passe-1-euro-pour-tous-les-etudiants-2314"
+    reference = "https://www.etudiant.gouv.fr/sites/default/files/2021-01/le-repas-un-euro-4977.pdf"
     documentation = '''
     Suite à la crise Covid-19, tous les étudiants, boursiers ou non, peuvent bénéficier
     de deux repas par jour au tarif de 1 euro.

--- a/openfisca_france/model/prestations/alimentation.py
+++ b/openfisca_france/model/prestations/alimentation.py
@@ -18,5 +18,10 @@ class crous_repas_un_euro_eligibilite(Variable):
     et jusqu’au début de la semaine du 25 janvier.
     '''
 
-    def formula_2021_01(individu, period, parameters):
+    def formula_2021_01(individu, period):
         return individu('scolarite', period) == TypesScolarite.enseignement_superieur
+
+    def formula_2021_07(individu, period):
+        enseignement_superieur = individu('scolarite', period) == TypesScolarite.enseignement_superieur
+        boursier = individu('boursier', period)
+        return boursier * enseignement_superieur

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "73.1.2",
+    version = "73.1.3",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/07/2021.
* Zones impactées : `prestations/alimentation.py`.
* Détails :
  - Limite le dispositif repas à 1€ aux étudiants boursiers

- - - -
Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
