### PR TITLE
Parameters metadata fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,12 @@
 # Changelog
 
-## 73.1.0 [#1662](https://github.com/openfisca/openfisca-france/pull/1662)
+## 73.1.1 [#1665](https://github.com/openfisca/openfisca-france/pull/1665)
 
-* Évolution du système socio-fiscal.
+* Changement mineur.
 * Périodes concernées : toutes.
-* Zones impactées :
-  - `model/caracteristiques_socio_demographiques/demographie.py`
+* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general`.
 * Détails :
-  - Ajoute une variable Enum pour le régime de sécurité sociale.
+  - Correction d'erreurs sur les `unit` dans les metadata de paramètres YAML.
 
 ### 73.0.1 [#1642](https://github.com/openfisca/openfisca-france/pull/1642)
 

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/cnav/salarie/vieillesse_deplafonnee.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/cnav/salarie/vieillesse_deplafonnee.yaml
@@ -1,5 +1,4 @@
 description: Taux salarié de la Cotisation déplafonnée de sécurité sociale (SS) du régime général pour la branche assurance vieillesse (CNAV) (2004-2016)
-unit: /1
 brackets:
 - rate:
     2004-07-01:

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/mmid/taux.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/mmid/taux.yaml
@@ -16,8 +16,8 @@ metadata:
   ux_name: Barème salarié
   last_review:
     2019-01-01
-  unit_rate: /1
-  unit_threshold: SMIC
+  rate_unit: /1
+  threshold_unit: SMIC
   reference:
     2019-01-01:
       title: Loi 2017-1836 du 30/12/2017 (LFSS pour 2018), art. 9

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/mmid_am/maladie_alsace_moselle.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/mmid_am/maladie_alsace_moselle.yaml
@@ -1,5 +1,4 @@
 description: Barème salarié des cotisations du régime local d'assurance maladie d'Alsace et Moselle (depuis 1967)
-unit: /1
 brackets:
 - rate:
     1946-07-01:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "73.1.0",
+    version = "73.1.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general`.
* Détails :
  - Correction d'erreurs sur les `unit` dans les metadata de paramètres YAML.
