### PR TITLE
Vérifier la version de l'API déployée

### DIFF
--- a/.github/check-api-version.py
+++ b/.github/check-api-version.py
@@ -1,7 +1,7 @@
 import requests
-import sys
 import pkg_resources  # part of setuptools
 import json
+import sys
 
 package_version = pkg_resources.require("openfisca-france")[0].version
 

--- a/.github/check-api-version.py
+++ b/.github/check-api-version.py
@@ -1,5 +1,4 @@
 import requests
-import re
 import sys
 import pkg_resources  # part of setuptools
 import json

--- a/.github/check-api-version.py
+++ b/.github/check-api-version.py
@@ -1,0 +1,12 @@
+import requests
+import re
+import sys
+import pkg_resources  # part of setuptools
+
+package_version = pkg_resources.require("openfisca-france")[0].version
+
+response_API = requests.get('https://fr.openfisca.org/legislation/swagger')
+data = response_API.text
+api_package_version = re.search('countryPackageVersion":"(.*)","entities', data).group(1)
+
+sys.stdout.write(str(api_package_version == package_version))

--- a/.github/check-api-version.py
+++ b/.github/check-api-version.py
@@ -10,4 +10,7 @@ response_API = requests.get('https://fr.openfisca.org/api/latest/spec')
 data = json.loads(response_API.text)
 api_package_version = data['info']['version']
 
-sys.stdout.write(str(api_package_version == package_version))
+sys.stdout.write("API package version: {}\nLocal package version: {}\n".format(api_package_version, package_version))
+
+if api_package_version != package_version:
+    sys.exit("The version of the API deployed on fr.openfisca.org/api/latest/spec does not match the local package version.")

--- a/.github/check-api-version.py
+++ b/.github/check-api-version.py
@@ -2,11 +2,12 @@ import requests
 import re
 import sys
 import pkg_resources  # part of setuptools
+import json
 
 package_version = pkg_resources.require("openfisca-france")[0].version
 
-response_API = requests.get('https://fr.openfisca.org/legislation/swagger')
-data = response_API.text
-api_package_version = re.search('countryPackageVersion":"(.*)","entities', data).group(1)
+response_API = requests.get('https://fr.openfisca.org/api/latest/spec')
+data = json.loads(response_API.text)
+api_package_version = data['info']['version']
 
 sys.stdout.write(str(api_package_version == package_version))

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -142,7 +142,7 @@ jobs:
   # The `deploy` job is dependent on the output of the `check-for-functional-changes`job.
   check-for-functional-changes:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
+    if: github.ref == 'refs/heads/api-version' # Only triggered for the `master` branch
     needs: [ check-version-and-changelog ]
     outputs:
       status: ${{ steps.stop-early.outputs.status }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -209,6 +209,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.7.12
+      - name: Cache build
+        id: restore-build
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ github.ref }}${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
       - name: Check api version
         id: check-api-version
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -217,5 +217,4 @@ jobs:
           key: ${{ github.ref }}${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
       - name: Check api version
         id: check-api-version
-        run: |
-          python ${GITHUB_WORKSPACE}/.github/check-api-version.py
+        run: python ${GITHUB_WORKSPACE}/.github/check-api-version.py

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -212,10 +212,4 @@ jobs:
       - name: Check api version
         id: check-api-version
         run: |
-          output=$(python "${GITHUB_WORKSPACE}/.github/check-api-version.py")
-          echo "::set-output name=version-match::$output"
-      - name: Check on failure
-        if: steps.check-api-version.outputs.version-match != 'True'
-        run: |
-          echo "The api package version and the pypi package version do not match"
-          exit 1
+          python check-api-version.py

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -100,10 +100,10 @@ jobs:
           CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           CI_NODE_INDEX: ${{ matrix.ci_node_index }}
         run: |
-            echo "TEST_FILES_SUBLIST=$(python "${GITHUB_WORKSPACE}/.github/split_tests.py" ${CI_NODE_TOTAL} ${CI_NODE_INDEX})" >> $GITHUB_ENV
+          echo "TEST_FILES_SUBLIST=$(python "${GITHUB_WORKSPACE}/.github/split_tests.py" ${CI_NODE_TOTAL} ${CI_NODE_INDEX})" >> $GITHUB_ENV
       - name: Run YAML test
         run: |
-            openfisca test ${TEST_FILES_SUBLIST}
+          openfisca test ${TEST_FILES_SUBLIST}
 
   test-api:
     runs-on: ubuntu-latest
@@ -197,3 +197,30 @@ jobs:
           echo "${{ secrets.FRANCE_API_DEPLOY_KEY }}" > /home/runner/.ssh/france_api_deploy
           chmod 600 /home/runner/.ssh/france_api_deploy
           ssh -i /home/runner/.ssh/france_api_deploy -o StrictHostKeyChecking=no deploy-api@fr.openfisca.org
+
+  check-api-version:
+    runs-on: ubuntu-latest
+    needs: [ deploy ]
+    outputs:
+      version-match: ${{ steps.check-api-version.outputs.version-match }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Cache build
+        id: restore-build
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
+      - name: Check api version
+        id: check-api-version
+        run: |
+          output=$(python "${GITHUB_WORKSPACE}/.github/check-api-version.py")
+          echo "::set-output name=version-match::$output"
+      - name: Check on failure
+        if: steps.check-api-version.outputs.version-match != 'True'
+        run: |
+          exit 1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -142,7 +142,7 @@ jobs:
   # The `deploy` job is dependent on the output of the `check-for-functional-changes`job.
   check-for-functional-changes:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/api-version' # Only triggered for the `master` branch
+    if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
     needs: [ check-version-and-changelog ]
     outputs:
       status: ${{ steps.stop-early.outputs.status }}
@@ -200,7 +200,7 @@ jobs:
 
   check-api-version:
     runs-on: ubuntu-latest
-    needs: [ check-for-functional-changes ]
+    needs: [ deploy ]
     outputs:
       version-match: ${{ steps.check-api-version.outputs.version-match }}
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -212,4 +212,4 @@ jobs:
       - name: Check api version
         id: check-api-version
         run: |
-          python check-api-version.py
+          python ${GITHUB_WORKSPACE}/.github/check-api-version.py

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -200,7 +200,7 @@ jobs:
 
   check-api-version:
     runs-on: ubuntu-latest
-    needs: [ build ]
+    needs: [ deploy ]
     outputs:
       version-match: ${{ steps.check-api-version.outputs.version-match }}
     steps:
@@ -223,4 +223,5 @@ jobs:
       - name: Check on failure
         if: steps.check-api-version.outputs.version-match != 'True'
         run: |
+          echo "The api package version and the pypi package version do not match"
           exit 1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -200,7 +200,7 @@ jobs:
 
   check-api-version:
     runs-on: ubuntu-latest
-    needs: [ deploy ]
+    needs: [ build ]
     outputs:
       version-match: ${{ steps.check-api-version.outputs.version-match }}
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -200,7 +200,7 @@ jobs:
 
   check-api-version:
     runs-on: ubuntu-latest
-    needs: [ deploy ]
+    needs: [ check-for-functional-changes ]
     outputs:
       version-match: ${{ steps.check-api-version.outputs.version-match }}
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -208,13 +208,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
-      - name: Cache build
-        id: restore-build
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
+          python-version: 3.7.12
       - name: Check api version
         id: check-api-version
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-### 74.1.3-beta.1 [#1673](https://github.com/openfisca/openfisca-france/pull/1673)
-
-* Amélioration technique.
-* Zones impactées : configuration de l'intégration continue.
-* Détails :
-  - Ajoute la vérification de la version du package de l'api web
-
 ### 74.1.2 [#1673](https://github.com/openfisca/openfisca-france/pull/1673)
 
 * Évolution du système socio-fiscal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 74.1.3 [#1674](https://github.com/openfisca/openfisca-france/pull/1674)
+
+* Amélioration technique.
+* Zones impactées : configuration de l'intégration continue.
+  * Détails :
+  - Ajoute la vérification de la version du package de l'api web
+
 ### 74.1.2 [#1673](https://github.com/openfisca/openfisca-france/pull/1673)
 
 * Évolution du système socio-fiscal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 74.1.3-beta.1 [#1673](https://github.com/openfisca/openfisca-france/pull/1673)
+
+* Amélioration technique.
+* Zones impactées : configuration de l'intégration continue.
+* Détails :
+  - Ajoute la vérification de la version du package de l'api web
+
 ### 74.1.2 [#1673](https://github.com/openfisca/openfisca-france/pull/1673)
 
 * Évolution du système socio-fiscal

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "74.1.2",
+    version = "74.1.3-beta.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "74.1.3-beta.1",
+    version = "74.1.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "74.1.2",
+    version = "74.1.3",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Related to #1663 

**Problème:**

L'API n'est pas mise à jour après le publication du package.

**Solution proposée:**

Ajouter un test automatisé pour vérifier que la version de l'API déployée est bien celle qui vient d'être publiée avec GitHub Actions.

**Détails:**

* Amélioration technique.
* Zones impactées : configuration de l'intégration continue.
* Détails :
  - Ajoute la vérification de la version du package de l'api web