### PR TITLE
Calcule mensuellement et annuellement la CSG et la CRDS

### DIFF
--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -295,6 +295,7 @@ class assiette_csg_crds_non_salarie(Variable):
     entity = Individu
     label = "Assiette CSG des personnes non salariées"
     definition_period = YEAR
+    set_input = set_input_divide_by_period
 
     def formula(individu, period):
         rpns_imposables = individu('rpns_imposables', period)
@@ -334,6 +335,7 @@ class csg_non_salarie(Variable):
     entity = Individu
     label = "Assiette CSG des personnes non salariées"
     definition_period = YEAR
+    set_input = set_input_divide_by_period
 
     def formula(individu, period, parameters):
         assiette_csg_crds_non_salarie = individu('assiette_csg_crds_non_salarie', period)
@@ -347,6 +349,7 @@ class crds_non_salarie(Variable):
     entity = Individu
     label = "Assiette CSG des personnes non salariées"
     definition_period = YEAR
+    set_input = set_input_divide_by_period
 
     def formula(individu, period, parameters):
         assiette_csg_crds_non_salarie = individu('assiette_csg_crds_non_salarie', period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py
@@ -9,6 +9,7 @@ class csg(Variable):
     entity = Individu
     label = "Contribution sociale généralisée"
     definition_period = YEAR
+    set_input = set_input_divide_by_period
 
     def formula(individu, period):
         csg_imposable_salaire = individu('csg_imposable_salaire', period, options = [ADD])
@@ -41,6 +42,7 @@ class crds(Variable):
     entity = Individu
     label = "Contributions au remboursement de la dette sociale"
     definition_period = YEAR
+    set_input = set_input_divide_by_period
 
     def formula(individu, period):
         # CRDS sur revenus individuels
@@ -67,6 +69,7 @@ class crds_hors_prestations(Variable):
     entity = Individu
     label = "Contributions au remboursement de la dette sociale (hors celles portant sur les prestations sociales)"
     definition_period = YEAR
+    set_input = set_input_divide_by_period
 
     def formula(individu, period):
         # CRDS sur revenus individuels


### PR DESCRIPTION
* Amélioration technique.
* Périodes concernées : toutes. 
* Zones impactées : /model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/
* Détails :
  - Ajout de set_input_divide_by_period pour les variables csg et crds

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.