### PR TITLE
Résoudre les fails de récupération de cache sur la CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }} # Cache the entire build Python environment
+          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }} # Cache the entire build Python environment
       - name: Build package
         if: steps.restore-build.outputs.cache-hit != 'true'
         run: make build
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: dist
-          key: ${{ env.pythonLocation }}-build-release-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-release-${{ hashFiles('setup.py') }}
 
   lint-files:
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
       - run: make check-syntax-errors
       - run: make check-style
       - name: Lint Python files
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
       - run: |
           shopt -s globstar
           openfisca test tests/**/*.py
@@ -93,7 +93,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
       - name: Split YAML tests
         id: yaml-test
         env:
@@ -119,7 +119,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
       - name: Test the Web API
         run: "${GITHUB_WORKSPACE}/.github/test-api.sh"
 
@@ -177,13 +177,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
       - name: Cache build release
         id: restore-build-release
         uses: actions/cache@v2
         with:
           path: dist
-          key: ${{ env.pythonLocation }}-build-release-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-release-${{ hashFiles('setup.py') }}
       - name: Upload a Python package to PyPi
         run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
       - name: Publish a git tag

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.7.12
       - name: Cache build
         id: restore-build
         uses: actions/cache@v2
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.7.12
       - name: Cache build
         id: restore-build
         uses: actions/cache@v2
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.7.12
       - name: Cache build
         id: restore-build
         uses: actions/cache@v2
@@ -87,7 +87,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.7.12
       - name: Cache build
         id: restore-build
         uses: actions/cache@v2
@@ -113,7 +113,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.7.12
       - name: Cache build
         id: restore-build
         uses: actions/cache@v2
@@ -133,7 +133,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.7.12
       - name: Check version number has been properly updated
         run: "${GITHUB_WORKSPACE}/.github/is-version-number-acceptable.sh"
 
@@ -153,7 +153,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.7.12
       - id: stop-early
         run: if "${GITHUB_WORKSPACE}/.github/has-functional-changes.sh" ; then echo "::set-output name=status::success" ; fi
 
@@ -171,7 +171,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.7.12
       - name: Cache build
         id: restore-build
         uses: actions/cache@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }} # Cache the entire build Python environment
+          key: ${{ github.ref }}${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }} # Cache the entire build Python environment
       - name: Build package
         if: steps.restore-build.outputs.cache-hit != 'true'
         run: make build
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: dist
-          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-release-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}${{ env.pythonLocation }}-build-release-${{ hashFiles('setup.py') }}
 
   lint-files:
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
       - run: make check-syntax-errors
       - run: make check-style
       - name: Lint Python files
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
       - run: |
           shopt -s globstar
           openfisca test tests/**/*.py
@@ -93,7 +93,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
       - name: Split YAML tests
         id: yaml-test
         env:
@@ -119,7 +119,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
       - name: Test the Web API
         run: "${GITHUB_WORKSPACE}/.github/test-api.sh"
 
@@ -177,13 +177,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}${{ env.pythonLocation }}-build-${{ hashFiles('setup.py') }}
       - name: Cache build release
         id: restore-build-release
         uses: actions/cache@v2
         with:
           path: dist
-          key: ${{ github.ref }}-${{ env.pythonLocation }}-build-release-${{ hashFiles('setup.py') }}
+          key: ${{ github.ref }}${{ env.pythonLocation }}-build-release-${{ hashFiles('setup.py') }}
       - name: Upload a Python package to PyPi
         run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
       - name: Publish a git tag


### PR DESCRIPTION
**Problèmes :**

1. Problème de cold-start. La première exécution du workflow sur une nouvelle branche qui ne modifie pas le `setup.py` fait appel au dernier cache du `build` sur la `master`.  Le cache de la dernière exécution sur la `master`est restauré et par conséquent le `build` qui contient les modifications de la nouvelle branche n'est pas exécuté.

2. La version de Python entre le `build` et les `tests` changent parfois de `3.7.11` à `3.7.12`, ce qui change la clé du cache et par conséquent les jobs de test n'arrivent pas à récupérer le bon cache.

**Solutions :**

1. Rajouter le nom de la branche à la clé de cache pour s'assurer qu'on récupère toujours le bon `build`.

2. Préciser le patch de la version Python à utiliser `3.7.12`

**Détails:**

*  Correction d'un bug sur la CI
* Zones impactées : onfiguration de l'intégration continue.
* Détails :
  - Rajoute le nom de la branche à la référence du cache dans le `build`
  - Précise le patch de la version Python

