### PR TITLE
Corrige les end date de 8 cotisations touchees par fusion agirc arrco

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 74.1.4 [#1681](https://github.com/openfisca/openfisca-france/pull/1681)
+
+* Changement mineur.
+* Périodes concernées : jusqu'au 31/12/2018 (inclus) à partir du 21/12/2018 (inclus)
+* Zones impactées : model/prelevements_obligatoires/prelevements_sociaux/travail_prive.py.
+* Détails :
+  - Erreur dans l'end_date de 8 cotisation sociales concernées par la fusion Agirc Arrco (agff, agirc, arrco, cet, employeur et salarié)
+
 ### 74.1.3 [#1674](https://github.com/openfisca/openfisca-france/pull/1674)
 
 * Amélioration technique.

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_prive.py
@@ -218,7 +218,7 @@ class agff_salarie(Variable):
     label = "Cotisation retraite AGFF tranche A (salarié)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
-    end = '2018-12-21'
+    end = '2018-12-31'
     # AGFF: Association pour la gestion du fonds de financement (sous-entendu des départs entre 60 et 65 ans)
 
     def formula(individu, period, parameters):
@@ -239,7 +239,7 @@ class agff_employeur(Variable):
     label = "Cotisation retraite AGFF tranche A (employeur)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
-    end = '2018-12-21'
+    end = '2018-12-31'
     # TODO: améliorer pour gérer mensuel/annuel
 
     def formula(individu, period, parameters):
@@ -300,7 +300,7 @@ class agirc_gmp_salarie(Variable):
     label = "Cotisation AGIRC pour la garantie minimale de points (GMP,  salarié)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
-    end = '2018-12-21'
+    end = '2018-12-31'
     # TODO: gestion annuel/mensuel
 
     def formula(individu, period, parameters):
@@ -332,7 +332,7 @@ class agirc_gmp_employeur(Variable):
     label = "Cotisation AGIRC pour la garantie minimale de points (GMP, employeur)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
-    end = '2018-12-21'
+    end = '2018-12-31'
     # TODO: gestion annuel/mensuel
 
     def formula(individu, period, parameters):
@@ -364,7 +364,7 @@ class agirc_salarie(Variable):
     label = "Cotisation AGIRC tranche B (salarié)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
-    end = '2018-12-21'
+    end = '2018-12-31'
 
     def formula(individu, period, parameters):
         cotisation = apply_bareme(
@@ -385,7 +385,7 @@ class agirc_employeur(Variable):
     label = "Cotisation AGIRC tranche B (employeur)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
-    end = '2018-12-21'
+    end = '2018-12-31'
 
     def formula(individu, period, parameters):
         cotisation = apply_bareme(
@@ -502,7 +502,7 @@ class arrco_salarie(Variable):
     label = "Cotisation ARRCO tranche 1 (salarié)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
-    end = '2018-12-21'
+    end = '2018-12-31'
     # TODO: check gestion mensuel/annuel
 
     def formula(individu, period, parameters):
@@ -543,7 +543,7 @@ class arrco_employeur(Variable):
     label = "Cotisation ARRCO tranche 1 (employeur)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
-    end = '2018-12-21'
+    end = '2018-12-31'
     # TODO: check gestion mensuel/annuel
 
     def formula(individu, period, parameters):
@@ -743,7 +743,7 @@ class cotisation_exceptionnelle_temporaire_salarie(Variable):
     label = "Cotisation_exceptionnelle_temporaire (salarie)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
-    end = '2018-12-21'
+    end = '2018-12-31'
 
     def formula(individu, period, parameters):
         cotisation = apply_bareme(
@@ -763,7 +763,7 @@ class cotisation_exceptionnelle_temporaire_employeur(Variable):
     label = "Cotisation exceptionnelle temporaire (employeur)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
-    end = '2018-12-21'
+    end = '2018-12-31'
 
     def formula(individu, period, parameters):
         cotisation = apply_bareme(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "74.1.3",
+    version = "74.1.4",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : jusqu'au 31/12/2018 (inclus) à partir du 21/12/2018 (inclus)
* Zones impactées : `model/prelevements_obligatoires/prelevements_sociaux/travail_prive.py`.
* Détails :
  - Erreur dans l'end_date de 8 cotisation sociales concernées par la fusion Agirc Arrco (agff, agirc, arrco, cet, employeur et salarié)

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
