### PR TITLE
Update rsa.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+
+### 76.1.1 [#1654](https://github.com/openfisca/openfisca-france/pull/1654)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : openfisca_france/model/prestations/minima_sociaux/rsa.py.
+* Détails :
+  - Corrige le set_input du RSA, qui avait été initialisé par erreur lors d'un ajout en masse des set_input.
+
 ## 76.1.0 [#1508](https://github.com/openfisca/openfisca-france/pull/1508)
 
 * Évolution du système socio-fiscal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-### 76.1.1 [#1654](https://github.com/openfisca/openfisca-france/pull/1654)
+### 76.1.1 [#1686](https://github.com/openfisca/openfisca-france/pull/1686)
 
 * Changement mineur.
 * Périodes concernées : toutes.

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -576,7 +576,7 @@ class rsa(Variable):
     label = "Revenu de solidarité active"
     entity = Famille
     definition_period = MONTH
-    set_input = set_input_dispatch_by_period
+    set_input = set_input_divide_by_period
 
     def formula_2009_06(famille, period):
         montant = famille('rsa_montant', period)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "76.1.0",
+    version = "76.1.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Corrige le set_input du RSA.

* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/prestations/minima_sociaux/rsa.py`.
* Détails :
  - Corrige le set_input du RSA, qui avait été initialisé par erreur lors d'un ajout en masse des set_input.
