### PR TITLE
Ajoute la revalorisation du plafond de base de la CSS pour Avril 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 80.3.3 [#1713](https://github.com/openfisca/openfisca-france/pull/1713)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/04/2021.
+* Zones impactées : `openfisca_france\parameters\cs\cmu\plafond_base.yaml`.
+* Détails :
+  - Ajoute le montant du plafond de base de la Complementaire Santé Solidaire revalorisé pour Avril 2021
+
 ### 80.3.2 [#1715](https://github.com/openfisca/openfisca-france/pull/1715)
 
 * Changement mineur.

--- a/openfisca_france/parameters/cs/cmu/plafond_base.yaml
+++ b/openfisca_france/parameters/cs/cmu/plafond_base.yaml
@@ -32,5 +32,8 @@ values:
   2018-04-01:
     value: 8810.23
   2019-04-01:
-    value: 8951.00
+    value: 8951.0
     reference: https://www.legifrance.gouv.fr/eli/arrete/2019/3/20/SSAS1908400A/jo/article_1
+  2021-04-01:
+    value: 9041.0
+    reference: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043306326

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "80.3.2",
+    version = "80.3.3",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/04/2021.
* Zones impactées : `openfisca_france\parameters\cs\cmu\plafond_base.yaml`.
* Détails :
  - Ajoute le montant du plafond de base de la Complementaire Santé Solidaire revalorisé pour Avril 2021