### PR TITLE
Corrige 'ref' en 'href' dans les références de paramètres.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 80.3.4 [#1720](https://github.com/openfisca/openfisca-france/pull/1720)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/reduction_maximale/`.
+* Détails :
+  - Corrige des références de paramètres qui contenaient par erreur l'attribut "ref" au lieu de "href".
+
 ### 80.3.3 [#1713](https://github.com/openfisca/openfisca-france/pull/1713)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/reduction_maximale/entreprises_de_20_salaries_et_plus.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/reduction_maximale/entreprises_de_20_salaries_et_plus.yaml
@@ -24,12 +24,12 @@ metadata:
   reference:
     2021-01-01:
       title: Article D241-7 du Code de la Sécurité Sociale
-      ref: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042869486/2020-12-30/
+      href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042869486/2020-12-30/
     2020-01-01:
     - title: Décret 2020-2 du 02/01/2020, art. 2
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000039749436&idArticle=&categorieLien=id
     - title: Article D241-7 du Code de la Sécurité Sociale
-      ref: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041460935/2020-01-01/
+      href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041460935/2020-01-01/
     2019-01-01: 
     - title: Décret 2018-1356 du 28/12/2018, art. 1 et 4
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000037884638&categorieLien=id

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/reduction_maximale/entreprises_de_moins_de_20_salaries.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/reduction_maximale/entreprises_de_moins_de_20_salaries.yaml
@@ -28,12 +28,12 @@ metadata:
     - title: Décret n° 2020-1719 du 28 décembre 2020, art. 2
       href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000042748822
     - title: Article D241-7 du Code de la Sécurité Sociale
-      ref: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042869486/2020-12-30/
+      href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042869486/2020-12-30/
     2020-01-01:
     - title: Décret 2020-2 du 02/01/2020, art. 2
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000039749436&idArticle=&categorieLien=id
     - title: Article D241-7 du Code de la Sécurité Sociale
-      ref: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041460935/2020-01-01/
+      href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041460935/2020-01-01/
     2019-01-01: 
     - title: Décret 2018-1356 du 28/12/2018, art. 1 et 4
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000037884638&categorieLien=id

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "80.3.3",
+    version = "80.3.4",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/reduction_maximale/`.
* Détails :
  - Corrige des références de paramètres qui contenaient par erreur l'attribut "ref" au lieu de "href".
