### PR TITLE
Suppression d'une date qui n'a rien à faire là.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 80.4.2 [#1727](https://github.com/openfisca/openfisca-france/pull/1727)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_contribution_supplementaire/plus_de_250_entre_3_et_4pc.yaml`.
+* Détails :
+  - Suppression d'une date dupliquée.
+  - 
 ### 80.4.1 [#1726](https://github.com/openfisca/openfisca-france/pull/1726)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_contribution_supplementaire/plus_de_250_entre_3_et_4pc.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_contribution_supplementaire/plus_de_250_entre_3_et_4pc.yaml
@@ -14,7 +14,6 @@ metadata:
       - title: art.22, LOI n° 2012-354 du 14 mars 2012 de finances rectificative pour 2012
         href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000025509790
     2011-01-01:
-      2011-01-01:
       - title: Article 230H - II-3º du CGI
         href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000024430161/2011-07-31
       - title: art.23, Loi n° 2011-900 du 29 juillet 2011 de finances rectificative pour 2011

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "80.4.1",
+    version = "80.4.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_contribution_supplementaire/plus_de_250_entre_3_et_4pc.yaml`.
* Détails :
  - Correction d'une erreur de copier/coller : une date était dupliquée.
