### PR TITLE
Corrige date_parution_jo en official_journal_date.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 80.4.3 [#1728](https://github.com/openfisca/openfisca-france/pull/1728)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/versement_transport/bareme/taux_maximal/`.
+* Détails :
+  - Corrige date_parution_jo en official_journal_date.
+
 ### 80.4.2 [#1727](https://github.com/openfisca/openfisca-france/pull/1727)
 
 * Changement mineur.
@@ -7,7 +15,7 @@
 * Zones impactées : `openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_contribution_supplementaire/plus_de_250_entre_3_et_4pc.yaml`.
 * Détails :
   - Suppression d'une date dupliquée.
-  - 
+
 ### 80.4.1 [#1726](https://github.com/openfisca/openfisca-france/pull/1726)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/versement_transport/bareme/taux_maximal/sous_pss.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/versement_transport/bareme/taux_maximal/sous_pss.yaml
@@ -18,7 +18,7 @@ metadata:
       - title: Loi 73-640 du 11/07/1973, art. 1
         href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006399843&cidTexte=JORFTEXT000000334814
       - décret 74-66 du 29/01/1974
-  date_parution_jo:
+  official_journal_date:
     1993-04-01: 1992-12-31
     1993-01-01: 1992-12-31
     1989-01-01: 1988-12-30

--- a/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/versement_transport/bareme/taux_maximal/tout_salaire.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/versement_transport/bareme/taux_maximal/tout_salaire.yaml
@@ -17,7 +17,7 @@ metadata:
     1993-04-01:
       title: Loi 92-1376 du 30/12/1992, art. 115
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006318658&cidTexte=JORFTEXT000000178406
-  date_parution_jo:
+  official_journal_date:
     1993-04-01: 1992-12-31
   notes:
     1993-04-01: Déplafonnement du versement transport

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "80.4.2",
+    version = "80.4.3",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/versement_transport/bareme/taux_maximal/`.
* Détails :
  - Corrige date_parution_jo en official_journal_date.
