### PR TITLE
Retire de la CI le déploiement obsolète de l'API Web

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -190,15 +190,6 @@ jobs:
         run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
       - name: Publish a git tag
         run: "${GITHUB_WORKSPACE}/.github/publish-git-tag.sh"
-      - name: Add SSH key & Deploy the Web API
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: |
-          mkdir -p /home/runner/.ssh
-          ssh-keyscan fr.openfisca.org >> /home/runner/.ssh/known_hosts
-          echo "${{ secrets.FRANCE_API_DEPLOY_KEY }}" > /home/runner/.ssh/france_api_deploy
-          chmod 600 /home/runner/.ssh/france_api_deploy
-          ssh -i /home/runner/.ssh/france_api_deploy -o StrictHostKeyChecking=no deploy-api@fr.openfisca.org
 
   check-api-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -141,7 +141,7 @@ jobs:
 
   # GitHub Actions does not have a halt job option, to stop from deploying if no functional changes were found.
   # We build a separate job to substitute the halt option.
-  # The `deploy` job is dependent on the output of the `check-for-functional-changes`job.
+  # The `deploy` job is dependent on the output of the `check-for-functional-changes` job.
   check-for-functional-changes:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [#1733](https://github.com/openfisca/openfisca-france/pull/1733)
+### 80.4.8 [#1733](https://github.com/openfisca/openfisca-france/pull/1733)
 
 * Correction d'un crash.
 * Périodes concernées : toutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### [#1733](https://github.com/openfisca/openfisca-france/pull/1733)
+
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées : `.github/workflows/workflow.yml`
+* Détails :
+  - Corrige le statut du déploiement d'`openfisca-france`.
+    * Supprime de GitHub Action un mode de déploiement obsolète pour l'API Web.
+
 ### 80.4.7 [#1719](https://github.com/openfisca/openfisca-france/pull/1719)
 
 * Amélioration technique.
@@ -8,7 +17,7 @@
   - `openfisca_france/parameters/prestations/minima_sociaux/aah/`
   - `openfisca_france/model/prestations/minima_sociaux/aah.py`
 * Détails :
-- Améliore le calcul de l'AAH
+  - Améliore le calcul de l'AAH
 
 ### 80.4.6 [#1731](https://github.com/openfisca/openfisca-france/pull/1731)
 
@@ -18,9 +27,9 @@
   - `openfisca_france/model/prestations/`
   - `tests/formulas/`
 * Détails :
-- Mets à jour le chèque énergie et ajoute l'aide exceptionnelle de 2021
-- Améliore le calcul de la paje
-- Améliore le calcul de l'aspa
+  - Mets à jour le chèque énergie et ajoute l'aide exceptionnelle de 2021
+  - Améliore le calcul de la paje
+  - Améliore le calcul de l'aspa
 
 ### 80.4.5 [#1730](https://github.com/openfisca/openfisca-france/pull/1730)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "80.4.7",
+    version = "80.4.8",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Fixes #1724 (selon ce qui est décrit par [ce commentaire](https://github.com/openfisca/openfisca-france/issues/1724#issuecomment-994837562))

* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `.github/workflows/workflow.yml`
* Détails :
  - Corrige le statut du déploiement d'`openfisca-france`.
    * Supprime de GitHub Action un mode de déploiement obsolète pour l'API Web.

- - - -

Question complémentaire 🙂 :
Chers reviewers,  À l'issue du merge de cette PR, pensez-vous qu'il faille conserver le `secrets.FRANCE_API_DEPLOY_KEY` des Settings d'openfisca-france ? J'envisage de le supprimer.

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
