### PR TITLE
Ne valide pas le YAML en cas de push

### DIFF
--- a/.github/workflows/validate_yaml.yml
+++ b/.github/workflows/validate_yaml.yml
@@ -2,7 +2,7 @@ name: Validate YAML
 
 on:
   - pull_request
-  - push
+  # - push
   - workflow_dispatch
 
 jobs:


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `.github/workflows/validate_yaml.yml`.
* Détails :
  - Ne valide pas le YAML en cas de push, mais seulement en cas de pull request.
