### PR TITLE
Harmonisation - Prelevements Sociaux - contributions_assises_specifiquement_accessoires_salaire (Partie 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# 91.0.0 [#1756](https://github.com/openfisca/openfisca-france/pull/1756)
+
+* Amélioration technique. 
+* Périodes concernées : toutes.
+* Zones impactées : `parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire`.
+* Détails :
+  - Harmonisation des fichiers avec les barèmes-ipp
+  - Tous les chemins sont updatés pour ne pas casser le code
+
 # 90.0.0 [#1755](https://github.com/openfisca/openfisca-france/pull/1755)
 
 * Amélioration technique. 

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/index.yaml
@@ -1,1 +1,9 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
+description: Contributions patronales sur options et actions attribuées gratuitement (Taxes sur les accessoires du salaire)
+metadata:
+  ux_name: Employeur
+  order:
+  - taux_plein
+  - taux_reduit
+  - taux_stock_options
+  - taux_attributions_gratuites_options
+  description_en: Contribution levied on options and shares granted for free

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_attributions_gratuites_options.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_attributions_gratuites_options.yaml
@@ -1,15 +1,16 @@
-description: Taux réduit des contributions patronales sur options et actions attribuées gratuitement (Taxes sur les accessoires du salaire)
+description: Taux sur les attributions gratuites d'options des contributions patronales sur options et actions attribuées gratuitement (Taxes sur les accessoires du salaire)
 values:
-  2012-07-11:
-    value: null
-  2011-01-01:
-    value: 0.1
+  2018-01-01:
+    value: 0.2
+  2017-01-01:
+    value: 0.3
+  2015-08-08:
+    value: 0.2
   2007-10-16:
     value: null
 metadata:
-  ux_name: Taux réduit
+  ux_name: Taux attributions gratuites d'options
   unit: /1
-  ipp_csv_id: cont_opt_p_tx2
   reference:
     2018-01-01:
       title: Loi 2017-1836 du 30/12/2017 (LF pour 2018), art. 11

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_attributions_gratuites_options.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_attributions_gratuites_options.yaml
@@ -28,7 +28,7 @@ metadata:
       title: Loi 2010-1594 du 20/12/2010 (LFSS pour 2011), art. 11
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000023262236&cidTexte=JORFTEXT000023261006
     2007-10-16: Articles L 137-13 et L 137-14 du CSS, créés par la Loi 2007-1786 du 19/12/2007 (LFSS pour 2008), art. 13
-  date_parution_jo:
+  official_journal_date:
     2018-01-01: 2017-12-31
     2017-01-01: 2016-12-30
     2015-08-08: 2015-08-07

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_plein.yaml
@@ -1,5 +1,4 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
-unit: /1
+description: Taux plein des contributions patronales sur options et actions attribuées gratuitement (Taxes sur les accessoires du salaire)
 values:
   2007-10-16:
     value: 0.1
@@ -7,3 +6,54 @@ values:
     value: 0.14
   2012-07-11:
     value: 0.3
+  2015-08-08:
+    value: null
+metadata:
+  ux_name: Taux Plein
+  unit: /1
+  ipp_csv_id: cont_opt_p_tx1
+  reference:
+    2018-01-01:
+      title: Loi 2017-1836 du 30/12/2017 (LF pour 2018), art. 11
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036358460&cidTexte=JORFTEXT000036339090
+    2017-01-01:
+      title: Loi 2016-1917 du 29/12/2016 (LF pour 2017), art. 61
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000033760816&cidTexte=JORFTEXT000033734169
+    2015-08-08:
+      title: Loi 2015-990 du 06/08/2015, art. 135
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000030981962&cidTexte=JORFTEXT000030978561
+    2012-07-11:
+      title: Loi 2012-958 du 16/08/2012(LFR pour 2012), art. 31
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290011&cidTexte=JORFTEXT000026288927
+    2011-01-01:
+      title: Loi 2010-1594 du 20/12/2010 (LFSS pour 2011), art. 11
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000023262236&cidTexte=JORFTEXT000023261006
+    2007-10-16: Articles L 137-13 et L 137-14 du CSS, créés par la Loi 2007-1786 du 19/12/2007 (LFSS pour 2008), art. 13
+  date_parution_jo:
+    2018-01-01: 2017-12-31
+    2017-01-01: 2016-12-30
+    2015-08-08: 2015-08-07
+    2012-07-11: 2012-08-17
+    2011-01-01: 2012-12-21
+    2007-10-16: 2007-12-21
+  notes:
+    2017-01-01: Alignement du taux pour les options attribuées gratuitement sur celui des stock-options
+    2015-08-08: Distingue les taux pour les stock-options et les attributions gratuites d'options acquises postérieurement à la loi dite "loi Macron"
+  description_en: Contribution levied on options and shares granted for free
+documentation: |
+  Principe de la contribution sur les actions gratuites et stock-options :
+  L'attribution d'actions gratuites et de stock-options donne lieu à prélèvement de CSG et de CRDS, mais est exonérée de cotisations sociales (du moment que les périodes d'indisponibilité fiscale des fonds sont respectées)
+  Les contributions (patronale et salariale) sur les actions gratuites et stock-options permettent de réduire l'avantage au vu des régimes social et fiscal
+  dont bénéficient les actions gratuites et stock-options par rapport aux éléments de rémunération soumis aux cotisations sociales.
+  Date d'effet :
+  La date d'effet reportée plus haut correspond à la date de décision d'attribution des options et actions qui détermine le taux à appliquer pour le calcul de la contribution.
+  En pratique, la contribution est exigible le mois suivant la date de la décision d’attribution des options ou des actions.
+  Particularité :
+  La contribution patronale est recouvrée par les Urssaf. Assiette définie à l'art. 137-13 du CSS.
+  La contribution salariale est recouvrée par les Impôts. Assiette définie aux art. 80 bis et 80 quaterdecies du CGI.
+  Taux réduits :
+  Entre 2011 et 2012, le taux réduit s'appliquait sur les attributions d'actions dont la valeur annuelle par salarié est inférieure à la moitié du plafond annuel mentionné à l'article L. 241-3.
+  Sources :
+  Taux employeur : L137-13 du CSS
+  Taux employé : L137-14 du CSS
+

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_plein.yaml
@@ -29,7 +29,7 @@ metadata:
       title: Loi 2010-1594 du 20/12/2010 (LFSS pour 2011), art. 11
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000023262236&cidTexte=JORFTEXT000023261006
     2007-10-16: Articles L 137-13 et L 137-14 du CSS, créés par la Loi 2007-1786 du 19/12/2007 (LFSS pour 2008), art. 13
-  date_parution_jo:
+  official_journal_date:
     2018-01-01: 2017-12-31
     2017-01-01: 2016-12-30
     2015-08-08: 2015-08-07

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_reduit.yaml
@@ -27,7 +27,7 @@ metadata:
       title: Loi 2010-1594 du 20/12/2010 (LFSS pour 2011), art. 11
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000023262236&cidTexte=JORFTEXT000023261006
     2007-10-16: Articles L 137-13 et L 137-14 du CSS, créés par la Loi 2007-1786 du 19/12/2007 (LFSS pour 2008), art. 13
-  date_parution_jo:
+  official_journal_date:
     2018-01-01: 2017-12-31
     2017-01-01: 2016-12-30
     2015-08-08: 2015-08-07

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_stock_options.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_stock_options.yaml
@@ -24,7 +24,7 @@ metadata:
       title: Loi 2010-1594 du 20/12/2010 (LFSS pour 2011), art. 11
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000023262236&cidTexte=JORFTEXT000023261006
     2007-10-16: Articles L 137-13 et L 137-14 du CSS, créés par la Loi 2007-1786 du 19/12/2007 (LFSS pour 2008), art. 13
-  date_parution_jo:
+  official_journal_date:
     2018-01-01: 2017-12-31
     2017-01-01: 2016-12-30
     2015-08-08: 2015-08-07

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_stock_options.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/employeur/taux_stock_options.yaml
@@ -1,15 +1,12 @@
-description: Taux réduit des contributions patronales sur options et actions attribuées gratuitement (Taxes sur les accessoires du salaire)
+description: Taux sur les stock-options des contributions patronales sur options et actions attribuées gratuitement (Taxes sur les accessoires du salaire)
 values:
-  2012-07-11:
-    value: null
-  2011-01-01:
-    value: 0.1
+  2015-08-08:
+    value: 0.3
   2007-10-16:
     value: null
 metadata:
-  ux_name: Taux réduit
+  ux_name: Taux stock-options
   unit: /1
-  ipp_csv_id: cont_opt_p_tx2
   reference:
     2018-01-01:
       title: Loi 2017-1836 du 30/12/2017 (LF pour 2018), art. 11
@@ -54,4 +51,3 @@ documentation: |
   Sources :
   Taux employeur : L137-13 du CSS
   Taux employé : L137-14 du CSS
-

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/index.yaml
@@ -1,1 +1,7 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
+description: Contributions sur options et actions attribuées gratuitement (Taxes sur les accessoires du salaire)
+metadata:
+  ux_name: Options et actions
+  order:
+  - employeur
+  - salarie
+  description_en: Contribution levied on options and shares granted for free

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/salarie/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/salarie/index.yaml
@@ -1,1 +1,7 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
+description: Contributions salariales sur options et actions attribuées gratuitement (Taxes sur les accessoires du salaire)
+metadata:
+  ux_name: Salarié
+  order:
+  - taux_plein
+  - taux_reduit
+  description_en: Contribution levied on options and shares granted for free

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/salarie/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/salarie/taux_plein.yaml
@@ -1,9 +1,57 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
-unit: /1
+description: Taux plein des contributions salariales sur options et actions attribuées gratuitement (Taxes sur les accessoires du salaire)
 values:
-  2007-10-16:
-    value: 0.025
-  2011-01-01:
-    value: 0.08
   2012-07-11:
     value: 0.1
+  2011-01-01:
+    value: 0.08
+  2007-10-16:
+    value: 0.025
+metadata:
+  ux_name: Taux Plein
+  unit: /1
+  ipp_csv_id: cont_opt_s_tx1
+  reference:
+    2018-01-01:
+      title: Loi 2017-1836 du 30/12/2017 (LF pour 2018), art. 11
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036358460&cidTexte=JORFTEXT000036339090
+    2017-01-01:
+      title: Loi 2016-1917 du 29/12/2016 (LF pour 2017), art. 61
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000033760816&cidTexte=JORFTEXT000033734169
+    2015-08-08:
+      title: Loi 2015-990 du 06/08/2015, art. 135
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000030981962&cidTexte=JORFTEXT000030978561
+    2012-07-11:
+      title: Loi 2012-958 du 16/08/2012(LFR pour 2012), art. 31
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290011&cidTexte=JORFTEXT000026288927
+    2011-01-01:
+      title: Loi 2010-1594 du 20/12/2010 (LFSS pour 2011), art. 11
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000023262236&cidTexte=JORFTEXT000023261006
+    2007-10-16: Articles L 137-13 et L 137-14 du CSS, créés par la Loi 2007-1786 du 19/12/2007 (LFSS pour 2008), art. 13
+  date_parution_jo:
+    2018-01-01: 2017-12-31
+    2017-01-01: 2016-12-30
+    2015-08-08: 2015-08-07
+    2012-07-11: 2012-08-17
+    2011-01-01: 2012-12-21
+    2007-10-16: 2007-12-21
+  notes:
+    2017-01-01: Alignement du taux pour les options attribuées gratuitement sur celui des stock-options
+    2015-08-08: Distingue les taux pour les stock-options et les attributions gratuites d'options acquises postérieurement à la loi dite "loi Macron"
+  description_en: Contribution levied on options and shares granted for free
+documentation: |
+  Principe de la contribution sur les actions gratuites et stock-options :
+  L'attribution d'actions gratuites et de stock-options donne lieu à prélèvement de CSG et de CRDS, mais est exonérée de cotisations sociales (du moment que les périodes d'indisponibilité fiscale des fonds sont respectées)
+  Les contributions (patronale et salariale) sur les actions gratuites et stock-options permettent de réduire l'avantage au vu des régimes social et fiscal
+  dont bénéficient les actions gratuites et stock-options par rapport aux éléments de rémunération soumis aux cotisations sociales.
+  Date d'effet :
+  La date d'effet reportée plus haut correspond à la date de décision d'attribution des options et actions qui détermine le taux à appliquer pour le calcul de la contribution.
+  En pratique, la contribution est exigible le mois suivant la date de la décision d’attribution des options ou des actions.
+  Particularité :
+  La contribution patronale est recouvrée par les Urssaf. Assiette définie à l'art. 137-13 du CSS.
+  La contribution salariale est recouvrée par les Impôts. Assiette définie aux art. 80 bis et 80 quaterdecies du CGI.
+  Taux réduits :
+  Entre 2011 et 2012, le taux réduit s'appliquait sur les attributions d'actions dont la valeur annuelle par salarié est inférieure à la moitié du plafond annuel mentionné à l'article L. 241-3.
+  Sources :
+  Taux employeur : L137-13 du CSS
+  Taux employé : L137-14 du CSS
+

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/salarie/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/salarie/taux_plein.yaml
@@ -27,7 +27,7 @@ metadata:
       title: Loi 2010-1594 du 20/12/2010 (LFSS pour 2011), art. 11
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000023262236&cidTexte=JORFTEXT000023261006
     2007-10-16: Articles L 137-13 et L 137-14 du CSS, créés par la Loi 2007-1786 du 19/12/2007 (LFSS pour 2008), art. 13
-  date_parution_jo:
+  official_journal_date:
     2018-01-01: 2017-12-31
     2017-01-01: 2016-12-30
     2015-08-08: 2015-08-07

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/salarie/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/salarie/taux_reduit.yaml
@@ -1,7 +1,57 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
-unit: /1
+description: Taux réduit des contributions salariales sur options et actions attribuées gratuitement (Taxes sur les accessoires du salaire)
 values:
-  2011-01-01:
-    value: 0.025
   2012-07-11:
     value: null
+  2011-01-01:
+    value: 0.025
+  2007-10-16:
+    value: null
+metadata:
+  ux_name: Taux Réduit
+  unit: /1
+  ipp_csv_id: cont_opt_s_tx2
+  reference:
+    2018-01-01:
+      title: Loi 2017-1836 du 30/12/2017 (LF pour 2018), art. 11
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036358460&cidTexte=JORFTEXT000036339090
+    2017-01-01:
+      title: Loi 2016-1917 du 29/12/2016 (LF pour 2017), art. 61
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000033760816&cidTexte=JORFTEXT000033734169
+    2015-08-08:
+      title: Loi 2015-990 du 06/08/2015, art. 135
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000030981962&cidTexte=JORFTEXT000030978561
+    2012-07-11:
+      title: Loi 2012-958 du 16/08/2012(LFR pour 2012), art. 31
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290011&cidTexte=JORFTEXT000026288927
+    2011-01-01:
+      title: Loi 2010-1594 du 20/12/2010 (LFSS pour 2011), art. 11
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000023262236&cidTexte=JORFTEXT000023261006
+    2007-10-16: Articles L 137-13 et L 137-14 du CSS, créés par la Loi 2007-1786 du 19/12/2007 (LFSS pour 2008), art. 13
+  date_parution_jo:
+    2018-01-01: 2017-12-31
+    2017-01-01: 2016-12-30
+    2015-08-08: 2015-08-07
+    2012-07-11: 2012-08-17
+    2011-01-01: 2012-12-21
+    2007-10-16: 2007-12-21
+  notes:
+    2017-01-01: Alignement du taux pour les options attribuées gratuitement sur celui des stock-options
+    2015-08-08: Distingue les taux pour les stock-options et les attributions gratuites d'options acquises postérieurement à la loi dite "loi Macron"
+  description_en: Contribution levied on options and shares granted for free
+documentation: |
+  Principe de la contribution sur les actions gratuites et stock-options :
+  L'attribution d'actions gratuites et de stock-options donne lieu à prélèvement de CSG et de CRDS, mais est exonérée de cotisations sociales (du moment que les périodes d'indisponibilité fiscale des fonds sont respectées)
+  Les contributions (patronale et salariale) sur les actions gratuites et stock-options permettent de réduire l'avantage au vu des régimes social et fiscal
+  dont bénéficient les actions gratuites et stock-options par rapport aux éléments de rémunération soumis aux cotisations sociales.
+  Date d'effet :
+  La date d'effet reportée plus haut correspond à la date de décision d'attribution des options et actions qui détermine le taux à appliquer pour le calcul de la contribution.
+  En pratique, la contribution est exigible le mois suivant la date de la décision d’attribution des options ou des actions.
+  Particularité :
+  La contribution patronale est recouvrée par les Urssaf. Assiette définie à l'art. 137-13 du CSS.
+  La contribution salariale est recouvrée par les Impôts. Assiette définie aux art. 80 bis et 80 quaterdecies du CGI.
+  Taux réduits :
+  Entre 2011 et 2012, le taux réduit s'appliquait sur les attributions d'actions dont la valeur annuelle par salarié est inférieure à la moitié du plafond annuel mentionné à l'article L. 241-3.
+  Sources :
+  Taux employeur : L137-13 du CSS
+  Taux employé : L137-14 du CSS
+

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/salarie/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/cont_sur_options/salarie/taux_reduit.yaml
@@ -27,7 +27,7 @@ metadata:
       title: Loi 2010-1594 du 20/12/2010 (LFSS pour 2011), art. 11
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000023262236&cidTexte=JORFTEXT000023261006
     2007-10-16: Articles L 137-13 et L 137-14 du CSS, créés par la Loi 2007-1786 du 19/12/2007 (LFSS pour 2008), art. 13
-  date_parution_jo:
+  official_journal_date:
     2018-01-01: 2017-12-31
     2017-01-01: 2016-12-30
     2015-08-08: 2015-08-07

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/index.yaml
@@ -1,2 +1,9 @@
-description: Forfait social
-reference: https://www.ipp.eu/outils/baremes-ipp/
+description: Forfait social des contributions assises spécifiquement sur les accessoires du salaire
+metadata:
+  ux_name: Forfait social
+  order:
+  - taux_plein
+  - taux_reduit_1
+  - taux_reduit_2
+  - taux_reduit_3
+  description_en: Contribution levied on various earnings supplements ("Forfait social")

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/seuil_effectif_prevoyance_complementaire.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/seuil_effectif_prevoyance_complementaire.yaml
@@ -1,5 +1,4 @@
-description: Seuil des effectifs de l'entreprise à partir duquel les contributions patronales de prévoyance
-  complémentaire rentrent dans l'assiette du FNAL à taux réduit
+description: Seuil des effectifs de l'entreprise à partir duquel les contributions patronales de prévoyance complémentaire rentrent dans l'assiette du FNAL à taux réduit
 values:
   2009-01-01:
     value: 0.0
@@ -7,3 +6,6 @@ values:
     value: 10.0
   2016-01-01:
     value: 11.0
+metadata:
+  ux_name: Seuil des effectifs
+  unit: people

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_plein.yaml
@@ -32,7 +32,7 @@ metadata:
       title: Loi 2009-1646 du 24/12/2009 (LFSS pour 2010), art. 16
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000021530855&cidTexte=JORFTEXT000021528998
     2009-01-01: Loi 2008-1330 du 17/12/2008 (LFSS pour 2009),art. 13
-  date_parution_jo:
+  official_journal_date:
     2019-01-01: 2018-12-23
     2016-01-01: 2015-08-07
     2012-08-01: 2012-12-17

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_plein.yaml
@@ -1,6 +1,4 @@
-description: Taux plein
-reference: https://www.ipp.eu/outils/baremes-ipp/
-unit: /1
+description: Taux plein du forfait social des contributions assises spécifiquement sur les accessoires du salaire
 values:
   2009-01-01:
     value: 0.02
@@ -12,3 +10,43 @@ values:
     value: 0.08
   2012-08-01:
     value: 0.2
+metadata:
+  ux_name: Taux Plein
+  ipp_csv_id: forf_soc_tx1
+  unit: /1
+  reference:
+    2019-01-01:
+      title: Loi 2018-1203 du 22/12/2018 (LFSS pour 2019), art. 16
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000037849628&cidTexte=JORFTEXT000037847585
+    2016-01-01:
+      title: Loi 2015-990 du 06/08/2015 ("loi Macron"), art. 149
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000030982066&cidTexte=JORFTEXT000030978561
+    2012-08-01:
+      title: Loi 2012-958 du 16/08/2012 (LFR pour 2012), art. 33
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290015&cidTexte=JORFTEXT000026288927
+    2012-01-01:
+      title: Loi 2011-1906 du 21/12/2011, art. 12 (LFSS pour 2012)
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000025007614&cidTexte=JORFTEXT000025005833
+    2011-01-01: Loi 2010-1594 du 20/12/2010 (LFSS pour 2011), art. 16 et 19
+    2010-01-01:
+      title: Loi 2009-1646 du 24/12/2009 (LFSS pour 2010), art. 16
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000021530855&cidTexte=JORFTEXT000021528998
+    2009-01-01: Loi 2008-1330 du 17/12/2008 (LFSS pour 2009),art. 13
+  date_parution_jo:
+    2019-01-01: 2018-12-23
+    2016-01-01: 2015-08-07
+    2012-08-01: 2012-12-17
+    2012-01-01: 2011-12-22
+    2011-01-01: 2010-12-21
+    2010-01-01: 2009-12-27
+    2009-01-01: 2008-12-18
+  notes:
+    2019-01-01: Création du taux réduit de 10 % pour l'abondement employeur à l'acquisition des titres de l'entreprise (PEE), pour les entreprises de plus de 50 salariés.
+    2016-01-01: Création du taux réduit intermédiaire de 16 % par la loi dite "loi Macron" (art. 149) pour certains versements au PERCO.
+    2012-08-01: Création du taux réduit de 8 % pour les Scop, et sur les contributions au financement de prestations complémentaires de prévoyance non assujetties à cotisations.
+  description_en: Contribution levied on various earnings supplements ("Forfait social")
+documentation: |
+  Principe de la contribution :
+  Le forfait social est une contribution payée par l'employeur, et assise sur les gains et rémunérations assujettie à la CSG et à la CRDS mais exclus de l'assiette des cotisations sociales.
+  Références dans le CSS :
+  Art. L 137-15 à L 137-17 du CSS.

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit.yaml
@@ -1,5 +1,0 @@
-description: Taux réduit
-unit: /1
-values:
-  2009-01-01:
-    value: 0.08

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_1.yaml
@@ -24,7 +24,7 @@ metadata:
       title: Loi 2009-1646 du 24/12/2009 (LFSS pour 2010), art. 16
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000021530855&cidTexte=JORFTEXT000021528998
     2009-01-01: Loi 2008-1330 du 17/12/2008 (LFSS pour 2009),art. 13
-  date_parution_jo:
+  official_journal_date:
     2019-01-01: 2018-12-23
     2016-01-01: 2015-08-07
     2012-08-01: 2012-12-17

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_2.yaml
@@ -1,5 +1,44 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
-unit: /1
+description: Taux réduit 2 du forfait social des contributions assises spécifiquement sur les accessoires du salaire
 values:
   2016-01-01:
     value: 0.16
+metadata:
+  ux_name: Taux Réduit 2
+  ipp_csv_id: forf_soc_tx3
+  unit: /1
+  reference:
+    2019-01-01:
+      title: Loi 2018-1203 du 22/12/2018 (LFSS pour 2019), art. 16
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000037849628&cidTexte=JORFTEXT000037847585
+    2016-01-01:
+      title: Loi 2015-990 du 06/08/2015 ("loi Macron"), art. 149
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000030982066&cidTexte=JORFTEXT000030978561
+    2012-08-01:
+      title: Loi 2012-958 du 16/08/2012 (LFR pour 2012), art. 33
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290015&cidTexte=JORFTEXT000026288927
+    2012-01-01:
+      title: Loi 2011-1906 du 21/12/2011, art. 12 (LFSS pour 2012)
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000025007614&cidTexte=JORFTEXT000025005833
+    2011-01-01: Loi 2010-1594 du 20/12/2010 (LFSS pour 2011), art. 16 et 19
+    2010-01-01:
+      title: Loi 2009-1646 du 24/12/2009 (LFSS pour 2010), art. 16
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000021530855&cidTexte=JORFTEXT000021528998
+    2009-01-01: Loi 2008-1330 du 17/12/2008 (LFSS pour 2009),art. 13
+  date_parution_jo:
+    2019-01-01: 2018-12-23
+    2016-01-01: 2015-08-07
+    2012-08-01: 2012-12-17
+    2012-01-01: 2011-12-22
+    2011-01-01: 2010-12-21
+    2010-01-01: 2009-12-27
+    2009-01-01: 2008-12-18
+  notes:
+    2019-01-01: Création du taux réduit de 10 % pour l'abondement employeur à l'acquisition des titres de l'entreprise (PEE), pour les entreprises de plus de 50 salariés.
+    2016-01-01: Création du taux réduit intermédiaire de 16 % par la loi dite "loi Macron" (art. 149) pour certains versements au PERCO.
+    2012-08-01: Création du taux réduit de 8 % pour les Scop, et sur les contributions au financement de prestations complémentaires de prévoyance non assujetties à cotisations.
+  description_en: Contribution levied on various earnings supplements ("Forfait social")
+documentation: |
+  Principe de la contribution :
+  Le forfait social est une contribution payée par l'employeur, et assise sur les gains et rémunérations assujettie à la CSG et à la CRDS mais exclus de l'assiette des cotisations sociales.
+  Références dans le CSS :
+  Art. L 137-15 à L 137-17 du CSS.

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_2.yaml
@@ -24,7 +24,7 @@ metadata:
       title: Loi 2009-1646 du 24/12/2009 (LFSS pour 2010), art. 16
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000021530855&cidTexte=JORFTEXT000021528998
     2009-01-01: Loi 2008-1330 du 17/12/2008 (LFSS pour 2009),art. 13
-  date_parution_jo:
+  official_journal_date:
     2019-01-01: 2018-12-23
     2016-01-01: 2015-08-07
     2012-08-01: 2012-12-17

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_3.yaml
@@ -1,10 +1,12 @@
-description: Taux réduit 1 du forfait social des contributions assises spécifiquement sur les accessoires du salaire
+description: Taux réduit 3 du forfait social des contributions assises spécifiquement sur les accessoires du salaire
 values:
-  2012-08-01:
-    value: 0.08
+  2019-01-01:
+    value: 0.1
+  2009-01-01:
+    value: null
 metadata:
-  ux_name: Taux Réduit 1
-  ipp_csv_id: forf_soc_tx2
+  ux_name: Taux Réduit 3
+  ipp_csv_id: forf_soc_tx4
   unit: /1
   reference:
     2019-01-01:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_3.yaml
@@ -26,7 +26,7 @@ metadata:
       title: Loi 2009-1646 du 24/12/2009 (LFSS pour 2010), art. 16
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000021530855&cidTexte=JORFTEXT000021528998
     2009-01-01: Loi 2008-1330 du 17/12/2008 (LFSS pour 2009),art. 13
-  date_parution_jo:
+  official_journal_date:
     2019-01-01: 2018-12-23
     2016-01-01: 2015-08-07
     2012-08-01: 2012-12-17

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/index.yaml
@@ -1,0 +1,9 @@
+description: Contributions assises spécifiquement sur les accessoires du salaire
+metadata:
+  ux_name: Contrib. accessoires salaire
+  order:
+  - prevoyance
+  - forfait_social
+  - retraites_chapeau
+  - cont_sur_options
+  description_en: Contributions levied specifically on supplements to base salary

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/prevoyance/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/prevoyance/index.yaml
@@ -1,1 +1,6 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
+description: Taxe spéciale sur les contributions patronales de prévoyance (1996-2012)
+metadata:
+  ux_name: Prévoyance
+  order:
+  - taux
+  description_en: Special tax on employer's contributions to life-insurance contracts (1996-2012)

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/prevoyance/taux.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/prevoyance/taux.yaml
@@ -1,5 +1,4 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
-unit: /1
+description: Taxe spéciale sur les contributions patronales de prévoyance (1996-2012)
 values:
   1996-01-01:
     value: 0.06
@@ -7,3 +6,31 @@ values:
     value: 0.08
   2012-01-01:
     value: null
+metadata:
+  ux_name: Taux
+  ipp_csv_id: prev_p
+  unit: /1
+  reference:
+    2012-01-01: Circulaire Acoss du 20/02/2012
+    2011-01-01: Loi 2010-1594 du 20/12/2010, article 17-I
+    1998-01-01: Loi 97-1164de FSS du 19/12/1997
+    1996-01-01: Ordonnance 96-51 du 24/01/96
+  date_parution_jo:
+    2011-01-01: 2010-12-21
+    1998-01-01: 1997-12-23
+    1996-01-01: 1996-01-25
+  notes:
+    2012-01-01: Depuis le 01/01/2012, la taxe spécifique sur les contributions patronales de prévoyance a été remplacée par le forfait social.
+    2011-01-01: Les contributions patronales acquittées pour le financement de la prévoyance complémentaire des anciens salariés se trouvent soumises à leur tour à la taxe.
+    1998-01-01: Exonération pour les entreprises de moins de 10 salariés
+  description_en: Special tax on employer's contributions to life-insurance contracts (1996-2012)
+documentation: |
+  Champ :
+  Employeurs de plus de 9 salariés
+  Assiette :
+  Toutes les contributions versées à un organisme tiers pour financer des prestations de prévoyance complétant celles servies par les régimes de base de Sécurité sociale, même pour leur fraction assujettie aux cotisations sociales.
+  Notes :
+  Dans les entreprises de 10 salariés et plus, les contributions patronales de prévoyance sont soumises au forfait social au taux de 8%, lorsque les conditions d’exclusion de l’assiette des cotisations sociales (définie à l’article L.242-1 alinéa 1
+  du code de la Sécurité sociale) et d’assujettissement à la CSG sont réunies.
+  La taxe de 8 % auparavant due spécifiquement sur les contributions patronales de prévoyance est supprimée.
+  (Voir feuille "Forfait social")

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/prevoyance/taux.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/prevoyance/taux.yaml
@@ -15,7 +15,7 @@ metadata:
     2011-01-01: Loi 2010-1594 du 20/12/2010, article 17-I
     1998-01-01: Loi 97-1164de FSS du 19/12/1997
     1996-01-01: Ordonnance 96-51 du 24/01/96
-  date_parution_jo:
+  official_journal_date:
     2011-01-01: 2010-12-21
     1998-01-01: 1997-12-23
     1996-01-01: 1996-01-25

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/droits_certains.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/droits_certains.yaml
@@ -1,5 +1,5 @@
 description: Taux pour les retraites à droits certains de la contribution spéciale sur les contributions versées par l'employeur pour les régimes de retraites supplémentaires à prestations définies
- values:
+values:
   2020-01-01:
     value: 0.297
   2004-01-01:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/droits_certains.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/droits_certains.yaml
@@ -1,14 +1,12 @@
-description: Taux 3 de la contribution spéciale sur les contributions versées par l'employeur pour les régimes de retraites supplémentaires à prestations définies
-values:
+description: Taux pour les retraites à droits certains de la contribution spéciale sur les contributions versées par l'employeur pour les régimes de retraites supplémentaires à prestations définies
+ values:
+  2020-01-01:
+    value: 0.297
   2004-01-01:
-    value: 0.12
-  2010-01-01:
-    value: 0.24
-  2013-01-01:
-    value: 0.48
+    value: null
 metadata:
-  ux_name: Taux 3
-  ipp_csv_id: retchap_tx3
+  ux_name: Taux Retraites à droits certains
+  ipp_csv_id: etchap_droits_certains
   unit: /1
   reference:
     2020-01-01:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/droits_certains.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/droits_certains.yaml
@@ -24,7 +24,7 @@ metadata:
     2004-01-01:
       title: Loi 2003-775 du 21/08/2003, art. 115
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006758675&cidTexte=JORFTEXT000000781627
-  date_parution_jo:
+  official_journal_date:
     2013-01-01: 2012-08-17
     2010-01-01: 2009-12-27
     2004-01-01: 2003-08-22

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/index.yaml
@@ -1,1 +1,10 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
+description: Contribution spéciale sur les contributions versées par l'employeur pour les régimes de retraites supplémentaires à prestations définies
+metadata:
+  ux_name: Retraites Chapeau
+  order:
+  - taux_1
+  - taux_2
+  - taux_3
+  - majoration
+  - droits_certains
+  description_en: Special contribution on employer's contribution to defined-benefits (DB) supplementary pension schemes

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/majoration.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/majoration.yaml
@@ -1,5 +1,57 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
-unit: /1
+description: Majoration de la contribution spéciale sur les contributions versées par l'employeur pour les régimes de retraites supplémentaires à prestations définies
 values:
+  2015-11-20:
+    value: null
   2010-01-01:
     value: 0.3
+  2004-01-01:
+    value: null
+metadata:
+  ux_name: Majoration
+  ipp_csv_id: retchap_maj
+  unit: /1
+  reference:
+    2020-01-01:
+      title: Ordonnance 2019-697 du 03/07/2019
+      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000038720909&categorieLien=id
+    2015-11-20: 
+      title: Décision 2015-498 QPC du 20/11/2015
+      href: https://www.conseil-constitutionnel.fr/decision/2015/2015498QPC.htm
+    2013-01-01:
+      title: Loi 2012-958 du 16/08/2012 (LFR pour 2012), art. 32
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290013&cidTexte=JORFTEXT000026288927
+    2010-01-01:
+      title: Loi 2009-1646 du 24/12/2009 (LFSS pour 2010), art. 15
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000021530853&cidTexte=JORFTEXT000021528998
+    2004-01-01:
+      title: Loi 2003-775 du 21/08/2003, art. 115
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006758675&cidTexte=JORFTEXT000000781627
+  date_parution_jo:
+    2013-01-01: 2012-08-17
+    2010-01-01: 2009-12-27
+    2004-01-01: 2003-08-22
+  notes:
+    2020-01-01: Le texte met fin (voir Notes) aux régimes à droits aléatoires qui conditionnent les droits à l'achèvement de la carrière dans l'entreprise. 
+    2015-11-20: La majoration est jugée contraire à la constitution. La décision prend effet à la date de la décision.
+  description_en: Special contribution on employer's contribution to defined-benefits (DB) supplementary pension schemes
+documentation: |
+  Références du CSS :
+  Art. L 137-11 du CSS
+  Principe :
+  Les sommes versées par l'employeur pour le financement des régimes de retraite supplémentaire à prestations définies (régimes de retraite "chapeau")
+  ne sont pas soumises aux cotisations sociales (au sens large), ni à la CSG-CRDS, ni aux taxes sur les salaires et la main d'œuvre.
+  Ces versements ne sont pas soumis non plus au forfait social ; mais depuis 2004, ils sont soumis à une contribution spéciale à charge de l'employeur.
+  (cf. Mémento pratique PAIE Francis Lefèbvre, §6956)
+  Assiette :
+  L'employeur peut choisir l'assiette (et le taux applicable) au moment de la mise en place du régime :
+  Option 1 (Taux 1) : l'assiette est constituées par les rentes
+  Pour les rentes liquidées depuis le 22/10/2010, la contribution est due sur la totalité de la rente versée, et non plus sur la part
+  excédant 1/3 du PSS comme c'était le cas pour les rentes liquidées avant le 22/10/2010.
+  Option 2 (Taux 2 et Taux 3) : l'assiette est constituée par les primes versées pour le financement
+  Le taux 2 s'applique en cas de gestion externe du régime
+  Le taux 3 s'applique en cas de gestion interne.
+  Majoration :
+  La majoration s'applique aux rentes excédant 8 PSS
+  Taux pour les retraites à droits certains :
+  Depuis le 05/07/2019, il ne peut plus y avoir de nouveaux bénéficiaires de régimes de retraite supplémentaire à prestations définis à clauses aléatoires (comme l'achèvement de la carrière du bénéficiaire dans l'entreprise).
+  L'acquisition de droits s'arrête au 31/12/2019, sauf pour les régimes clos aux nouvelles adhésions avant le 20/05/2014. Pour ces derniers, l'acquisition de droits continue et la contribution au financement reste soumise aux contributions aux taux 1, 2 ou 3.

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/majoration.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/majoration.yaml
@@ -26,7 +26,7 @@ metadata:
     2004-01-01:
       title: Loi 2003-775 du 21/08/2003, art. 115
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006758675&cidTexte=JORFTEXT000000781627
-  date_parution_jo:
+  official_journal_date:
     2013-01-01: 2012-08-17
     2010-01-01: 2009-12-27
     2004-01-01: 2003-08-22

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/taux_1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/taux_1.yaml
@@ -1,5 +1,4 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
-unit: /1
+description: Taux 1 de la contribution spéciale sur les contributions versées par l'employeur pour les régimes de retraites supplémentaires à prestations définies
 values:
   2004-01-01:
     value: 0.08
@@ -7,3 +6,52 @@ values:
     value: 0.16
   2013-01-01:
     value: 0.32
+metadata:
+  ux_name: Taux 1
+  ipp_csv_id: retchap_tx1
+  unit: /1
+  reference:
+    2020-01-01:
+      title: Ordonnance 2019-697 du 03/07/2019
+      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000038720909&categorieLien=id
+    2015-11-20: 
+      title: Décision 2015-498 QPC du 20/11/2015
+      href: https://www.conseil-constitutionnel.fr/decision/2015/2015498QPC.htm
+    2013-01-01:
+      title: Loi 2012-958 du 16/08/2012 (LFR pour 2012), art. 32
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290013&cidTexte=JORFTEXT000026288927
+    2010-01-01:
+      title: Loi 2009-1646 du 24/12/2009 (LFSS pour 2010), art. 15
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000021530853&cidTexte=JORFTEXT000021528998
+    2004-01-01:
+      title: Loi 2003-775 du 21/08/2003, art. 115
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006758675&cidTexte=JORFTEXT000000781627
+  date_parution_jo:
+    2013-01-01: 2012-08-17
+    2010-01-01: 2009-12-27
+    2004-01-01: 2003-08-22
+  notes:
+    2020-01-01: Le texte met fin (voir Notes) aux régimes à droits aléatoires qui conditionnent les droits à l'achèvement de la carrière dans l'entreprise. 
+    2015-11-20: La majoration est jugée contraire à la constitution. La décision prend effet à la date de la décision.
+  description_en: Special contribution on employer's contribution to defined-benefits (DB) supplementary pension schemes
+documentation: |
+  Références du CSS :
+  Art. L 137-11 du CSS
+  Principe :
+  Les sommes versées par l'employeur pour le financement des régimes de retraite supplémentaire à prestations définies (régimes de retraite "chapeau")
+  ne sont pas soumises aux cotisations sociales (au sens large), ni à la CSG-CRDS, ni aux taxes sur les salaires et la main d'œuvre.
+  Ces versements ne sont pas soumis non plus au forfait social ; mais depuis 2004, ils sont soumis à une contribution spéciale à charge de l'employeur.
+  (cf. Mémento pratique PAIE Francis Lefèbvre, §6956)
+  Assiette :
+  L'employeur peut choisir l'assiette (et le taux applicable) au moment de la mise en place du régime :
+  Option 1 (Taux 1) : l'assiette est constituées par les rentes
+  Pour les rentes liquidées depuis le 22/10/2010, la contribution est due sur la totalité de la rente versée, et non plus sur la part
+  excédant 1/3 du PSS comme c'était le cas pour les rentes liquidées avant le 22/10/2010.
+  Option 2 (Taux 2 et Taux 3) : l'assiette est constituée par les primes versées pour le financement
+  Le taux 2 s'applique en cas de gestion externe du régime
+  Le taux 3 s'applique en cas de gestion interne.
+  Majoration :
+  La majoration s'applique aux rentes excédant 8 PSS
+  Taux pour les retraites à droits certains :
+  Depuis le 05/07/2019, il ne peut plus y avoir de nouveaux bénéficiaires de régimes de retraite supplémentaire à prestations définis à clauses aléatoires (comme l'achèvement de la carrière du bénéficiaire dans l'entreprise).
+  L'acquisition de droits s'arrête au 31/12/2019, sauf pour les régimes clos aux nouvelles adhésions avant le 20/05/2014. Pour ces derniers, l'acquisition de droits continue et la contribution au financement reste soumise aux contributions aux taux 1, 2 ou 3.

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/taux_1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/taux_1.yaml
@@ -26,7 +26,7 @@ metadata:
     2004-01-01:
       title: Loi 2003-775 du 21/08/2003, art. 115
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006758675&cidTexte=JORFTEXT000000781627
-  date_parution_jo:
+  official_journal_date:
     2013-01-01: 2012-08-17
     2010-01-01: 2009-12-27
     2004-01-01: 2003-08-22

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/taux_2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/taux_2.yaml
@@ -26,7 +26,7 @@ metadata:
     2004-01-01:
       title: Loi 2003-775 du 21/08/2003, art. 115
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006758675&cidTexte=JORFTEXT000000781627
-  date_parution_jo:
+  official_journal_date:
     2013-01-01: 2012-08-17
     2010-01-01: 2009-12-27
     2004-01-01: 2003-08-22

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/taux_2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/taux_2.yaml
@@ -1,5 +1,4 @@
-reference: https://www.ipp.eu/outils/baremes-ipp/
-unit: /1
+description: Taux 2 de la contribution spéciale sur les contributions versées par l'employeur pour les régimes de retraites supplémentaires à prestations définies
 values:
   2004-01-01:
     value: 0.06
@@ -7,3 +6,52 @@ values:
     value: 0.12
   2013-01-01:
     value: 0.24
+metadata:
+  ux_name: Taux 2
+  ipp_csv_id: retchap_tx2
+  unit: /1
+  reference:
+    2020-01-01:
+      title: Ordonnance 2019-697 du 03/07/2019
+      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000038720909&categorieLien=id
+    2015-11-20: 
+      title: Décision 2015-498 QPC du 20/11/2015
+      href: https://www.conseil-constitutionnel.fr/decision/2015/2015498QPC.htm
+    2013-01-01:
+      title: Loi 2012-958 du 16/08/2012 (LFR pour 2012), art. 32
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290013&cidTexte=JORFTEXT000026288927
+    2010-01-01:
+      title: Loi 2009-1646 du 24/12/2009 (LFSS pour 2010), art. 15
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000021530853&cidTexte=JORFTEXT000021528998
+    2004-01-01:
+      title: Loi 2003-775 du 21/08/2003, art. 115
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006758675&cidTexte=JORFTEXT000000781627
+  date_parution_jo:
+    2013-01-01: 2012-08-17
+    2010-01-01: 2009-12-27
+    2004-01-01: 2003-08-22
+  notes:
+    2020-01-01: Le texte met fin (voir Notes) aux régimes à droits aléatoires qui conditionnent les droits à l'achèvement de la carrière dans l'entreprise. 
+    2015-11-20: La majoration est jugée contraire à la constitution. La décision prend effet à la date de la décision.
+  description_en: Special contribution on employer's contribution to defined-benefits (DB) supplementary pension schemes
+documentation: |
+  Références du CSS :
+  Art. L 137-11 du CSS
+  Principe :
+  Les sommes versées par l'employeur pour le financement des régimes de retraite supplémentaire à prestations définies (régimes de retraite "chapeau")
+  ne sont pas soumises aux cotisations sociales (au sens large), ni à la CSG-CRDS, ni aux taxes sur les salaires et la main d'œuvre.
+  Ces versements ne sont pas soumis non plus au forfait social ; mais depuis 2004, ils sont soumis à une contribution spéciale à charge de l'employeur.
+  (cf. Mémento pratique PAIE Francis Lefèbvre, §6956)
+  Assiette :
+  L'employeur peut choisir l'assiette (et le taux applicable) au moment de la mise en place du régime :
+  Option 1 (Taux 1) : l'assiette est constituées par les rentes
+  Pour les rentes liquidées depuis le 22/10/2010, la contribution est due sur la totalité de la rente versée, et non plus sur la part
+  excédant 1/3 du PSS comme c'était le cas pour les rentes liquidées avant le 22/10/2010.
+  Option 2 (Taux 2 et Taux 3) : l'assiette est constituée par les primes versées pour le financement
+  Le taux 2 s'applique en cas de gestion externe du régime
+  Le taux 3 s'applique en cas de gestion interne.
+  Majoration :
+  La majoration s'applique aux rentes excédant 8 PSS
+  Taux pour les retraites à droits certains :
+  Depuis le 05/07/2019, il ne peut plus y avoir de nouveaux bénéficiaires de régimes de retraite supplémentaire à prestations définis à clauses aléatoires (comme l'achèvement de la carrière du bénéficiaire dans l'entreprise).
+  L'acquisition de droits s'arrête au 31/12/2019, sauf pour les régimes clos aux nouvelles adhésions avant le 20/05/2014. Pour ces derniers, l'acquisition de droits continue et la contribution au financement reste soumise aux contributions aux taux 1, 2 ou 3.

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/taux_3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/retraites_chapeau/taux_3.yaml
@@ -26,7 +26,7 @@ metadata:
     2004-01-01:
       title: Loi 2003-775 du 21/08/2003, art. 115
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006758675&cidTexte=JORFTEXT000000781627
-  date_parution_jo:
+  official_journal_date:
     2013-01-01: 2012-08-17
     2010-01-01: 2009-12-27
     2004-01-01: 2003-08-22

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "90.0.0",
+    version = "91.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Amélioration technique. 
* Périodes concernées : toutes.
* Zones impactées : `parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire`.
* Détails :
  - Harmonisation des fichiers avec les barèmes-ipp
  - Tous les chemins sont updatés pour ne pas casser le code

- - - -
Ces changements :

- Modifient l'API publique d'OpenFisca France
- Corrigent ou améliorent un calcul déjà existant.
- - - -