### PR TITLE
tar.gz sur PyPi en plus du .whl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 99.0.1 [#1778](https://github.com/openfisca/openfisca-france/pull/1778)
+
+* Amélioration technique. 
+* Périodes concernées : aucune.
+* Zones impactées : build.
+* Détails :
+  - Pour pouvoir publier sur Conda-Forge, publie une archive des sources en tar.gz sur PyPi en plus du .whl.
+
 # 99.0.0 [#1761](https://github.com/openfisca/openfisca-france/pull/1761)
 
 * Amélioration technique. 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ build: clean deps
 	@# of OpenFisca-France, the same we put in the hands of users and reusers.
 	python setup.py bdist_wheel
 	find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
+	@# Build also the tar.gz
+	python setup.py bdist
 	pip install openfisca-core[web-api]
 
 check-syntax-errors:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "99.0.0",
+    version = "99.0.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
Bonjour,

Ce changement mineur permet de publier une archive tar.gz sur PyPi comme c'est le cas pour OpenFisca-Core.

Ceci permettra de la réutiliser pour publier OpenFisca-France sur Conda-Forge pour Anaconda. https://github.com/openfisca/openfisca-core/issues/1039

* Amélioration technique.
* Périodes concernées : aucune.
* Zones impactées : aucune.
* Détails :
  - Pour pouvoir publier sur Conda-Forge, publie une archive des sources en tar.gz sur PyPi en plus du .whl.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (Makefile).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
