### PR TITLE
Corrige le format des références dans les metadata de l'ARE afin que les dates soient à l'intérieur.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 104.0.1 [#1792](https://github.com/openfisca/openfisca-france/pull/1792)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/parameters/chomage/allocation_retour_emploi/`.
+* Détails :
+  - Corrige le format des références dans les metadata de l'ARE afin que les dates soient à l'intérieur.
+
 # 104.0.0 [#1711](https://github.com/openfisca/openfisca-france/pull/1711)
 
 * Évolution du système socio-fiscal

--- a/openfisca_france/parameters/chomage/allocation_retour_emploi/montant_minimum_hors_mayotte.yaml
+++ b/openfisca_france/parameters/chomage/allocation_retour_emploi/montant_minimum_hors_mayotte.yaml
@@ -30,7 +30,7 @@ values:
 metadata:
   ux_name: Montant minimum journalier
   unit: currency
-  2021-07-01:
-    reference:
+  reference:
+    2021-07-01:
       - https://www.service-public.fr/particuliers/actualites/A15021
       - https://www.unedic.org/indemnisation/vos-questions-sur-indemnisation-assurance-chomage/comment-est-calculee-mon-allocation-chomage

--- a/openfisca_france/parameters/chomage/allocation_retour_emploi/montant_minimum_mayotte.yaml
+++ b/openfisca_france/parameters/chomage/allocation_retour_emploi/montant_minimum_mayotte.yaml
@@ -10,8 +10,8 @@ values:
 metadata:
   ux_name: Montant minimum journalier
   unit: currency
-  2021-07-01:
-    reference:
+  reference:
+    2021-07-01:
       - https://www.service-public.fr/particuliers/actualites/A15021
       - https://www.unedic.org/espace-presse/actualites/les-allocations-dassurance-chomage-sont-revalorisees-de-060-partir-du-1er
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-France",
-    version = "104.0.0",
+    version = "104.0.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/parameters/chomage/allocation_retour_emploi/`.
* Détails :
  - Corrige la structure des références dans les metadata.
