### PR TITLE
Correction prelevements sociaux independants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 112.0.0 [#1805](https://github.com/openfisca/openfisca-france/pull/1805)
+
+* Amélioration technique.
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `openfisca_france/model/mesures.py`
+  - `openfisca_france/model/prestations/visale.py`
+  - `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py`
+  - `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py`
+  - `tests/formulas/travail_non_salarie/artisan_commercant_profession_liberale.yaml`
+* Détails :
+  - Divise la variable csg_non_salarie en deux variables : csg_dedutible_non_salarie et csg_imposable_non_salarie. En effet il existe bien une part déductible et une part imposable de la csg pour les revenus des travailleurs non salariés mais elle n'était pas codé jusque maintenant.
+  - Adapte les variables qui appelaient la variable csg_non_salarie.
+  - Supprime un double compte des cotisations_sociales_non_salarie. Celles-ci étaient ôtées de rpns_imposable alors que les revenus imposables des non salariés sont directement renseignés après cotisations.
+
 ## 111.2.0 [#1808](https://github.com/openfisca/openfisca-france/pull/1808)
 
 * Évolution du système socio-fiscal. Correction d'un crash.

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -102,11 +102,11 @@ class revenus_nets_du_travail(Variable):
         salaire_net = individu('salaire_net', period, options = [ADD])
         # Non salariés
         revenu_non_salarie = individu('rpns_imposables', period, options = [ADD])
-        csg_non_salarie = individu('csg_non_salarie', period)
+        csg_imposable_non_salarie = individu('csg_imposable_non_salarie', period)
         crds_non_salarie = individu('crds_non_salarie', period)
         revenu_non_salarie_net = (
             revenu_non_salarie
-            + csg_non_salarie
+            + csg_imposable_non_salarie
             + crds_non_salarie
             )
         return salaire_net + revenu_non_salarie_net

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -98,21 +98,14 @@ class revenus_nets_du_travail(Variable):
     definition_period = YEAR
 
     def formula(individu, period):
-        '''
-        Note : pour les revenus non-salariés, on prend rpns_imposables, auquel on enlève les cotisations sociales
-               et la CSG-CRDS. En effet, les variables formant la variable cotisations_non_salarie utilisent
-               comme base rpns_imposables, ce qui suggère que rpns_imposables est avant tout prélèvement
-        '''
         # Salariés
         salaire_net = individu('salaire_net', period, options = [ADD])
         # Non salariés
         revenu_non_salarie = individu('rpns_imposables', period, options = [ADD])
-        cotisations_non_salarie = individu('cotisations_non_salarie', period)
         csg_non_salarie = individu('csg_non_salarie', period)
         crds_non_salarie = individu('crds_non_salarie', period)
         revenu_non_salarie_net = (
             revenu_non_salarie
-            + cotisations_non_salarie
             + csg_non_salarie
             + crds_non_salarie
             )

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -340,33 +340,36 @@ class revenus_travail_super_bruts_menage(Variable):
         '''
         Revenus du travail super bruts du ménage :
         avant CSG-CRDS, cotisations salariales et patronales
-        Note : pour les revenus non-salariés, on prend rpns_imposables, auquel on n'ajoute ni les cotisations sociales,
-               ni la CSG-CRDS. En effet, les variables formant la variable cotisations_non_salarie utilisent
-               comme base rpns_imposables, ce qui suggère que rpns_imposables est avant tout prélèvement
         '''
         salaire_net_i = menage.members('salaire_net', period, options = [ADD])
         rpns_i = menage.members('rpns_imposables', period)
         csg_imposable_salaire_i = menage.members('csg_imposable_salaire', period, options = [ADD])
         csg_deductible_salaire_i = menage.members('csg_deductible_salaire', period, options = [ADD])
+        csg_deductible_non_salarie_i = menage.members('csg_deductible_non_salarie', period, options = [ADD])
         crds_salaire_i = menage.members('crds_salaire', period, options = [ADD])
         cotisations_employeur_i = menage.members('cotisations_employeur', period, options = [ADD])
         cotisations_salariales_i = menage.members('cotisations_salariales', period, options = [ADD])
+        cotisations_non_salarie_i = menage.members('cotisations_non_salarie', period, options = [ADD])
 
         salaire_net = menage.sum(salaire_net_i)
         rpns = menage.sum(rpns_i)
         csg_imposable_salaire = menage.sum(csg_imposable_salaire_i)
         csg_deductible_salaire = menage.sum(csg_deductible_salaire_i)
+        csg_deductible_non_salarie = menage.sum(csg_deductible_non_salarie_i)
         crds_salaire = menage.sum(crds_salaire_i)
         cotisations_employeur = menage.sum(cotisations_employeur_i)
         cotisations_salariales = menage.sum(cotisations_salariales_i)
+        cotisations_non_salarie = menage.sum(cotisations_non_salarie_i)
 
         return (
             salaire_net
             + rpns
             - cotisations_employeur  # On veut ajouter le montant de cotisations. Vu que ce montant est négatif, on met un "moins". Idem pour les autres items ci-dessous
             - cotisations_salariales  # On veut ajouter le montant de cotisations. Vu que ce montant est négatif, on met un "moins". Idem pour les autres items ci-dessous
+            - cotisations_non_salarie
             - csg_imposable_salaire
             - csg_deductible_salaire
+            - csg_deductible_non_salarie
             - crds_salaire
             )
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -340,7 +340,7 @@ class assiette_csg_crds_non_salarie(Variable):
         return assiette_cotisation
 
 
-class csg_non_salarie(Variable):
+class csg_imposable_non_salarie(Variable):
     value_type = float
     entity = Individu
     label = "Assiette CSG des personnes non salariées"
@@ -349,7 +349,19 @@ class csg_non_salarie(Variable):
     def formula(individu, period, parameters):
         assiette_csg_crds_non_salarie = individu('assiette_csg_crds_non_salarie', period)
         csg = parameters(period).prelevements_sociaux.contributions_sociales.csg.activite
-        taux = csg.deductible.taux + csg.imposable.taux
+        taux = csg.imposable.taux
+        return - taux * assiette_csg_crds_non_salarie
+
+class csg_deductible_non_salarie(Variable):
+    value_type = float
+    entity = Individu
+    label = "Assiette CSG des personnes non salariées"
+    definition_period = YEAR
+
+    def formula(individu, period, parameters):
+        assiette_csg_crds_non_salarie = individu('assiette_csg_crds_non_salarie', period)
+        csg = parameters(period).prelevements_sociaux.contributions_sociales.csg.activite
+        taux = csg.deductible.taux
         return - taux * assiette_csg_crds_non_salarie
 
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -352,6 +352,7 @@ class csg_imposable_non_salarie(Variable):
         taux = csg.imposable.taux
         return - taux * assiette_csg_crds_non_salarie
 
+
 class csg_deductible_non_salarie(Variable):
     value_type = float
     entity = Individu

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py
@@ -17,7 +17,8 @@ class csg(Variable):
         csg_deductible_chomage = individu('csg_deductible_chomage', period, options = [ADD])
         csg_imposable_retraite = individu('csg_imposable_retraite', period, options = [ADD])
         csg_deductible_retraite = individu('csg_deductible_retraite', period, options = [ADD])
-        csg_non_salarie = individu('csg_non_salarie', period, options = [ADD])
+        csg_imposable_non_salarie = individu('csg_imposable_non_salarie', period, options = [ADD])
+        csg_deductible_non_salarie = individu('csg_deductible_non_salarie', period, options = [ADD])
         # CSG sur revenus du capital, définie à l'échelle du foyer fiscal, mais projetée sur le déclarant principal
         csg_revenus_capital = individu.foyer_fiscal('csg_revenus_capital', period)
         csg_revenus_capital_projetee = csg_revenus_capital * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
@@ -29,7 +30,8 @@ class csg(Variable):
             + csg_deductible_chomage
             + csg_imposable_retraite
             + csg_deductible_retraite
-            + csg_non_salarie
+            + csg_imposable_non_salarie
+            + csg_deductible_non_salarie
             + csg_revenus_capital_projetee
             )
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
@@ -11,6 +11,9 @@ from openfisca_france.model.base import *
 # - les cotisations minimales
 # - la gestion de la temporatité
 
+# Il manque également le régime micro social qui consiste en un forfait unique couvrant l'ensemble des cotisations ainsi que la csg et la crds
+# https://www.legifrance.gouv.fr/codes/section_lc/LEGITEXT000006073189/LEGISCTA000037051840/#LEGISCTA000037051840
+
 
 log = logging.getLogger(__name__)
 

--- a/openfisca_france/model/prestations/visale.py
+++ b/openfisca_france/model/prestations/visale.py
@@ -169,7 +169,6 @@ class visale_base_ressources_individuelle(Variable):
 
         ressources_individu_annuelles = [
             'rpns_imposables',
-            'cotisations_non_salarie',
             'csg_non_salarie',
             'crds_non_salarie',
             ]

--- a/openfisca_france/model/prestations/visale.py
+++ b/openfisca_france/model/prestations/visale.py
@@ -169,7 +169,7 @@ class visale_base_ressources_individuelle(Variable):
 
         ressources_individu_annuelles = [
             'rpns_imposables',
-            'csg_non_salarie',
+            'csg_imposable_non_salarie',
             'crds_non_salarie',
             ]
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name = "OpenFisca-France",
-    version = "111.2.0",
+    version = "112.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [

--- a/tests/formulas/travail_non_salarie/artisan_commercant_profession_liberale.yaml
+++ b/tests/formulas/travail_non_salarie/artisan_commercant_profession_liberale.yaml
@@ -16,7 +16,8 @@
     maladie_maternite_profession_liberale: 0
     vieillesse_profession_liberale: 0
     assiette_csg_crds_non_salarie: 10000 + 700 + 497 + .1775 * 10000 +215
-    csg_non_salarie: -.075 * (10000 + 700 + 497 + .1775 * 10000 +215)
+    csg_imposable_non_salarie: -.024 * (10000 + 700 + 497 + .1775 * 10000 +215)
+    csg_deductible_non_salarie: -.051 * (10000 + 700 + 497 + .1775 * 10000 +215)
     crds_non_salarie: -.005 * (10000 + 700 + 497 + .1775 * 10000 +215)
     revenus_nets_du_travail: 10000 - (.075 + .005) * (10000 + 700 + 497 + .1775 * 10000 + 215) - (700 + 497 + 0.1775 * 10000 + 130 + 29 + 215)
 
@@ -39,7 +40,8 @@
     maladie_maternite_profession_liberale: 0
     vieillesse_profession_liberale: 0
     assiette_csg_crds_non_salarie: 10000 + 700 + 497 + .1775 * 10000 + 215
-    csg_non_salarie: -.075 * (10000 + 700 + 497 + .1775 * 10000 + 215)
+    csg_imposable_non_salarie: -.024 * (10000 + 700 + 497 + .1775 * 10000 + 215)
+    csg_deductible_non_salarie: -.051 * (10000 + 700 + 497 + .1775 * 10000 + 215)
     crds_non_salarie: -.005 * (10000 + 700 + 497 + .1775 * 10000 + 215)
     revenus_nets_du_travail: 10000 - (.075 + .005) * (10000 + 700 + 497 + .1775 * 10000 + 215) - (700 + 497 + 0.1775 * 10000 + 130 + 25 + 215)
 
@@ -62,7 +64,8 @@
     maladie_maternite_profession_liberale: 0
     vieillesse_profession_liberale: 0
     assiette_csg_crds_non_salarie: 10000 + 700 + 289 + .1775 * 10000
-    csg_non_salarie: -.092 * (10000 + 700 + 289 + .1775 * 10000)
+    csg_imposable_non_salarie: -.024 * (10000 + 700 + 289 + .1775 * 10000)
+    csg_deductible_non_salarie: -.068 * (10000 + 700 + 289 + .1775 * 10000)
     crds_non_salarie: -.005 * (10000 + 700 + 289 + .1775 * 10000)
     revenus_nets_du_travail: 10000 - (.092 + .005) * (10000 + 700 + 289 + .1775 * 10000) - (700 + 289 + 0.1775 * 10000 + 130 + 25)
 
@@ -86,7 +89,8 @@
     maladie_maternite_profession_liberale: -427
     vieillesse_profession_liberale: -823
     assiette_csg_crds_non_salarie: (10000 + 823 + 427 + 0 + 215)
-    csg_non_salarie: -.075 * (10000 + 823 + 427 + 0 + 215)
+    csg_imposable_non_salarie: -.024 * (10000 + 823 + 427 + 0 + 215)
+    csg_deductible_non_salarie: -.051 * (10000 + 823 + 427 + 0 + 215)
     crds_non_salarie: -.005 * (10000 + 823 + 427 + 0 + 215)
     revenus_nets_du_travail: 10000 - (.075 + .005) * (10000 + 823 + 427 + 0 + 215) - (823 + 427 + 25 + 215)
 
@@ -109,6 +113,7 @@
     maladie_maternite_profession_liberale: -264
     vieillesse_profession_liberale: -823
     assiette_csg_crds_non_salarie: (10000 + 823 + 264 + 0)
-    csg_non_salarie: -.092 * (10000 + 823 + 264 + 0)
+    csg_imposable_non_salarie: -.024 * (10000 + 823 + 264 + 0)
+    csg_deductible_non_salarie: -.068 * (10000 + 823 + 264 + 0)
     crds_non_salarie: -.005 * (10000 + 823 + 264 + 0)
     revenus_nets_du_travail: 10000 - (.092 + .005) * (10000 + 823 + 264 + 0) - (823 + 264 + 25)

--- a/tests/formulas/travail_non_salarie/artisan_commercant_profession_liberale.yaml
+++ b/tests/formulas/travail_non_salarie/artisan_commercant_profession_liberale.yaml
@@ -19,7 +19,7 @@
     csg_imposable_non_salarie: -.024 * (10000 + 700 + 497 + .1775 * 10000 +215)
     csg_deductible_non_salarie: -.051 * (10000 + 700 + 497 + .1775 * 10000 +215)
     crds_non_salarie: -.005 * (10000 + 700 + 497 + .1775 * 10000 +215)
-    revenus_nets_du_travail: 10000 - (.075 + .005) * (10000 + 700 + 497 + .1775 * 10000 + 215) - (700 + 497 + 0.1775 * 10000 + 130 + 29 + 215)
+    revenus_nets_du_travail: 10000 - (.024 + .005) * (10000 + 700 + 497 + .1775 * 10000 + 215)
 
 
 - name: Commerçant sous PSS
@@ -43,7 +43,7 @@
     csg_imposable_non_salarie: -.024 * (10000 + 700 + 497 + .1775 * 10000 + 215)
     csg_deductible_non_salarie: -.051 * (10000 + 700 + 497 + .1775 * 10000 + 215)
     crds_non_salarie: -.005 * (10000 + 700 + 497 + .1775 * 10000 + 215)
-    revenus_nets_du_travail: 10000 - (.075 + .005) * (10000 + 700 + 497 + .1775 * 10000 + 215) - (700 + 497 + 0.1775 * 10000 + 130 + 25 + 215)
+    revenus_nets_du_travail: 10000 - (.024 + .005) * (10000 + 700 + 497 + .1775 * 10000 + 215)
 
 
 - name: Commerçant sous PSS
@@ -67,7 +67,7 @@
     csg_imposable_non_salarie: -.024 * (10000 + 700 + 289 + .1775 * 10000)
     csg_deductible_non_salarie: -.068 * (10000 + 700 + 289 + .1775 * 10000)
     crds_non_salarie: -.005 * (10000 + 700 + 289 + .1775 * 10000)
-    revenus_nets_du_travail: 10000 - (.092 + .005) * (10000 + 700 + 289 + .1775 * 10000) - (700 + 289 + 0.1775 * 10000 + 130 + 25)
+    revenus_nets_du_travail: 10000 - (.024 + .005) * (10000 + 700 + 289 + .1775 * 10000)
 
 
 - name: Profession libérale
@@ -92,7 +92,7 @@
     csg_imposable_non_salarie: -.024 * (10000 + 823 + 427 + 0 + 215)
     csg_deductible_non_salarie: -.051 * (10000 + 823 + 427 + 0 + 215)
     crds_non_salarie: -.005 * (10000 + 823 + 427 + 0 + 215)
-    revenus_nets_du_travail: 10000 - (.075 + .005) * (10000 + 823 + 427 + 0 + 215) - (823 + 427 + 25 + 215)
+    revenus_nets_du_travail: 10000 - (.024 + .005) * (10000 + 823 + 427 + 0 + 215)
 
 - name: Profession libérale
   description: Profession libérale sous PSS
@@ -116,4 +116,4 @@
     csg_imposable_non_salarie: -.024 * (10000 + 823 + 264 + 0)
     csg_deductible_non_salarie: -.068 * (10000 + 823 + 264 + 0)
     crds_non_salarie: -.005 * (10000 + 823 + 264 + 0)
-    revenus_nets_du_travail: 10000 - (.092 + .005) * (10000 + 823 + 264 + 0) - (823 + 264 + 25)
+    revenus_nets_du_travail: 10000 - (.024 + .005) * (10000 + 823 + 264 + 0)


### PR DESCRIPTION
* Amélioration technique.
* Périodes concernées : toutes.
* Zones impactées : 
  - `openfisca_france/model/mesures.py`
  - `openfisca_france/model/prestations/visale.py`
  - `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py`
  - `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py`
  - `tests/formulas/travail_non_salarie/artisan_commercant_profession_liberale.yaml`
 
* Détails :
  - Divise la variable `csg_non_salarie` en deux variables : `csg_dedutible_non_salarie` et `csg_imposable_non_salarie`. En effet il existe bien une part déductible et une part imposable de la csg pour les revenus des travailleurs non salariés mais elle n'était pas codé jusque maintenant.
  - Adapte les variables qui appelaient la variable `csg_non_salarie`.
  - Supprime un double compte des `cotisations_sociales_non_salarie`. Celles-ci étaient ôtées de `rpns_imposable` alors que les revenus imposables des non salariés sont directement renseignés après cotisations. 

- - - -

- Modifient l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.

- - - -
