### PR TITLE
Corrige l'ARS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 111.1.0 [#1806](https://github.com/openfisca/openfisca-france/pull/1806)
+
+* Évolution du système socio-fiscal. Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées : `prestations/prestations_familiales/ars.py`.
+* Détails :
+  - Corrige les conditions en termes d'âge des enfants. Avant, tous les enfants ayant 5 ans en septembre était comptés. Les enfants ayant 18 ans en septembre étaient aussi comptés (alors qu'éligibilité jusqu'à 17 ans), et les montants majorés étaient définis en fonction de l'âge de septembre au lieu de décembre
+  - Corrige la formule de l'ARS différentielle : la déduction d'aide due à ce dispositif était divisée par le nombre d'enfants (dans la loi, cette division est mentionnée, mais pour la réduction due PAR enfant, pas pour la réduction totale).
+
 # 111.0.0 [#1803](https://github.com/openfisca/openfisca-france/pull/1803)
 
 * Amélioration technique. 

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -20,8 +20,6 @@ class ars(Variable):
         base_ressources = famille('prestations_familiales_base_ressources', janvier)
         ars = parameters(septembre).prestations_sociales.prestations_familiales.education_presence_parentale.ars
         # TODO: convention sur la mensualisation
-        # On tient compte du fait qu'en cas de léger dépassement du plafond, une allocation dégressive
-        # (appelée allocation différentielle), calculée en fonction des revenus, peut être versée.
 
         bmaf = parameters(septembre).prestations_sociales.prestations_familiales.bmaf.bmaf
 

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -35,12 +35,12 @@ class ars(Variable):
         #     6 ans en janvier N+1 car normalement, n'entrent en CP que les enfants atteignant 6 ans l'année de la rentrée. D'ailleurs, le site de la Cnaf évoque l'âge de six ans au 31/12 : https://www.caf.fr/allocataires/droits-et-prestations/s-informer-sur-les-aides/enfance-et-jeunesse/l-allocation-de-rentree-scolaire-ars
         #   - Les majorations dépendent de l'âge au 31/12. Donc, au total, on détermine l'éligibilité des enfants à l'ARS et leur catégorie en termes de montant en fonction de leur âge en décembre.
         #   - Exception : la fin de l'éligibilité à l'ARS intervient après 17 ans, lorsque cet âge est dépassé non pas au 31/12, mais au 15/09 de l'année de la rentrée scolaire. Condition moins restrictive. On ajoute les enfants dus à cette moindre restriction, sans prendre en compte la subtilité du 15/09 (on inclut les enfants n'ayant pas atteint 18 ans au 30/09)
-        enf_primaire = nb_enf(famille, decembre, ars.age_entree_primaire, ars.age_entree_college - 1)
-        enf_college = nb_enf(famille, decembre, ars.age_entree_college, ars.age_entree_lycee - 1)
-        enf_lycee_moins_18_ans_decembre = nb_enf(famille, decembre, ars.age_entree_lycee, ars.age_sortie_lycee - 1)
-        age_mois_decembre_i = famille.members('age_mois', decembre)
+        enf_primaire = nb_enf(famille, decembre, ars.ars_cond.age_entree_primaire, ars.ars_cond.age_entree_college - 1)
+        enf_college = nb_enf(famille, decembre, ars.ars_cond.age_entree_college, ars.ars_cond.age_entree_lycee - 1)
+        enf_lycee_moins_18_ans_decembre = nb_enf(famille, decembre, ars.ars_cond.age_entree_lycee, ars.ars_cond.age_sortie_lycee - 1)
+        age_en_mois_decembre_i = famille.members('age_en_mois', decembre)
         autonomie_financiere_i = famille.members('autonomie_financiere', decembre)
-        enf_lycee_eligible_18_ans_decembre_i = (age_mois_decembre_i <= 12 * 18 + 2 & age_mois_decembre_i >= 12 * 18 & not_(autonomie_financiere_i))
+        enf_lycee_eligible_18_ans_decembre_i = (age_en_mois_decembre_i <= 12 * ars.ars_cond.age_sortie_lycee + 2 & age_en_mois_decembre_i >= 12 * ars.ars_cond.age_sortie_lycee & not_(autonomie_financiere_i))
         enf_lycee_eligible_18_ans_decembre = famille.sum(enf_lycee_eligible_18_ans_decembre_i, role = Famille.ENFANT)
         enf_lycee = enf_lycee_moins_18_ans_decembre + enf_lycee_eligible_18_ans_decembre
 

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -15,14 +15,14 @@ class ars(Variable):
         Allocation de rentrée scolaire brute de CRDS
         '''
         janvier = period.first_month
-        septembre = period.start.offset('first-of', 'year').offset(9, 'month').period('month')
-        decembre = period.start.offset('first-of', 'year').offset(12, 'month').period('month')
-        af_nbenf = famille('af_nbenf', septembre)
+        octobre = period.start.offset('first-of', 'year').offset(9, 'month').period('month')
+        decembre = period.start.offset('first-of', 'year').offset(11, 'month').period('month')
+        af_nbenf = famille('af_nbenf', octobre)
         base_ressources = famille('prestations_familiales_base_ressources', janvier)
-        ars = parameters(septembre).prestations_sociales.prestations_familiales.education_presence_parentale.ars
+        ars = parameters(octobre).prestations_sociales.prestations_familiales.education_presence_parentale.ars
         # TODO: convention sur la mensualisation
 
-        bmaf = parameters(septembre).prestations_sociales.prestations_familiales.bmaf.bmaf
+        bmaf = parameters(octobre).prestations_sociales.prestations_familiales.bmaf.bmaf
 
         # Condition sur l'âge
         # Art. R543-2 :
@@ -40,8 +40,10 @@ class ars(Variable):
         enf_lycee_moins_18_ans_decembre = nb_enf(famille, decembre, ars.ars_cond.age_entree_lycee, ars.ars_cond.age_sortie_lycee - 1)
         age_en_mois_decembre_i = famille.members('age_en_mois', decembre)
         autonomie_financiere_i = famille.members('autonomie_financiere', decembre)
-        enf_lycee_eligible_18_ans_decembre_i = (age_en_mois_decembre_i <= 12 * ars.ars_cond.age_sortie_lycee + 2 & age_en_mois_decembre_i >= 12 * ars.ars_cond.age_sortie_lycee & not_(autonomie_financiere_i))
-        enf_lycee_eligible_18_ans_decembre = famille.sum(enf_lycee_eligible_18_ans_decembre_i, role = Famille.ENFANT)
+        enf_lycee_eligible_18_ans_decembre = famille.sum(
+            ((age_en_mois_decembre_i <= 12 * ars.ars_cond.age_sortie_lycee + 2) * (age_en_mois_decembre_i >= 12 * ars.ars_cond.age_sortie_lycee) * not_(autonomie_financiere_i)),
+            role = Famille.ENFANT
+            )
         enf_lycee = enf_lycee_moins_18_ans_decembre + enf_lycee_eligible_18_ans_decembre
 
         # Plafond en fonction du nb d'enfants A CHARGE (Cf. article R543)

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -15,6 +15,7 @@ class ars(Variable):
         '''
         janvier = period.first_month
         septembre = period.start.offset('first-of', 'year').offset(9, 'month').period('month')
+        decembre = period.start.offset('first-of', 'year').offset(12, 'month').period('month')
         af_nbenf = famille('af_nbenf', septembre)
         base_ressources = famille('prestations_familiales_base_ressources', janvier)
         ars = parameters(septembre).prestations_sociales.prestations_familiales.education_presence_parentale.ars
@@ -23,16 +24,26 @@ class ars(Variable):
         # (appelée allocation différentielle), calculée en fonction des revenus, peut être versée.
 
         bmaf = parameters(septembre).prestations_sociales.prestations_familiales.bmaf.bmaf
-        # On doit prendre l'âge en septembre
-        enf_05 = nb_enf(famille, septembre, ars.ars_cond.age_entree_primaire - 1, ars.ars_cond.age_entree_primaire - 1)  # 5 ans et 6 ans avant le 31 décembre
-        # enf_05 = 0
-        # Un enfant scolarisé qui n'a pas encore atteint l'âge de 6 ans
-        # avant le 1er février 2012 peut donner droit à l'ARS à condition qu'il
-        # soit inscrit à l'école primaire. Il faudra alors présenter un
-        # certificat de scolarité.
-        enf_primaire = enf_05 + nb_enf(famille, septembre, ars.ars_cond.age_entree_primaire, ars.ars_cond.age_entree_college - 1)
-        enf_college = nb_enf(famille, septembre, ars.ars_cond.age_entree_college, ars.ars_cond.age_entree_lycee - 1)
-        enf_lycee = nb_enf(famille, septembre, ars.ars_cond.age_entree_lycee, ars.ars_cond.age_sortie_lycee)
+
+        # Condition sur l'âge
+        # Art. R543-2 :
+        # "Ouvre droit à l'allocation de rentrée scolaire chaque enfant à charge qui atteindra son sixième anniversaire avant le
+        # 1er février de l'année suivant celle de la rentrée scolaire."
+        # "L'allocation reste due, lors de chaque rentrée scolaire, pour tout enfant qui n'a pas atteint l'âge de dix-huit ans révolus au 15 septembre de l'année considérée."
+        # "Le montant de l'allocation de rentrée scolaire est majoré, d'une part, lorsque l'enfant atteint ses onze ans, et, d'autre part, lorsque l'enfant atteint ses quinze ans, au cours de l'année civile de la rentrée scolaire."
+        # Ce que l'on fait :
+        #   - On donne éligibilité à l'ARS aux enfants à partir de ceux ayant 6 ans au 31/12. On n'ajoute pas ceux atteingant
+        #     6 ans en janvier N+1 car normalement, n'entrent en CP que les enfants atteignant 6 ans l'année de la rentrée. D'ailleurs, le site de la Cnaf évoque l'âge de six ans au 31/12 : https://www.caf.fr/allocataires/droits-et-prestations/s-informer-sur-les-aides/enfance-et-jeunesse/l-allocation-de-rentree-scolaire-ars
+        #   - Les majorations dépendent de l'âge au 31/12. Donc, au total, on détermine l'éligibilité des enfants à l'ARS et leur catégorie en termes de montant en fonction de leur âge en décembre.
+        #   - Exception : la fin de l'éligibilité à l'ARS intervient après 17 ans, lorsque cet âge est dépassé non pas au 31/12, mais au 15/09 de l'année de la rentrée scolaire. Condition moins restrictive. On ajoute les enfants dus à cette moindre restriction, sans prendre en compte la subtilité du 15/09 (on inclut les enfants n'ayant pas atteint 18 ans au 30/09)
+        enf_primaire = nb_enf(famille, decembre, ars.age_entree_primaire, ars.age_entree_college - 1)
+        enf_college = nb_enf(famille, decembre, ars.age_entree_college, ars.age_entree_lycee - 1)
+        enf_lycee_moins_18_ans_decembre = nb_enf(famille, decembre, ars.age_entree_lycee, ars.age_sortie_lycee-1)
+        age_mois_decembre_i = famille.members('age_mois', decembre)
+        autonomie_financiere_i = famille.members('autonomie_financiere', decembre)
+        enf_lycee_eligible_18_ans_decembre_i = (age_mois_decembre_i <= 12*18 + 2 & age_mois_decembre_i >= 12*18 & not_(autonomie_financiere_i))
+        enf_lycee_eligible_18_ans_decembre = famille.sum(enf_lycee_eligible_18_ans_decembre_i, role = Famille.ENFANT)
+        enf_lycee = enf_lycee_moins_18_ans_decembre + enf_lycee_eligible_18_ans_decembre
 
         arsnbenf = enf_primaire + enf_college + enf_lycee
 

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -54,8 +54,7 @@ class ars(Variable):
             + ars.ars_m.taux_lycee * enf_lycee
             )
 
-        # Forme de l'ARS  en fonction des enfants a*n - (rev-plaf)/n
-        # ars_diff = (ars_plaf_res + arsbase - base_ressources) / arsnbenf
-        ars_montant = (arsnbenf > 0) * max_(0, arsbase - max_(0, (base_ressources - ars_plaf_res) / max_(1, arsnbenf)))
+        # Montant de l'ARS, avec ARS différentielle si les ressources sont supérieures au plafond (voir art. R543-6-1 du CSS)
+        ars_montant = max_(0, arsbase - max_(0, (base_ressources - ars_plaf_res)))
 
         return ars_montant * (ars_montant >= ars.montant_minimum_verse)

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -1,3 +1,4 @@
+from numpy import logical_not as not_
 from openfisca_france.model.base import *
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf
 
@@ -36,14 +37,12 @@ class ars(Variable):
         #   - Exception : la fin de l'éligibilité à l'ARS intervient après 17 ans, lorsque cet âge est dépassé non pas au 31/12, mais au 15/09 de l'année de la rentrée scolaire. Condition moins restrictive. On ajoute les enfants dus à cette moindre restriction, sans prendre en compte la subtilité du 15/09 (on inclut les enfants n'ayant pas atteint 18 ans au 30/09)
         enf_primaire = nb_enf(famille, decembre, ars.age_entree_primaire, ars.age_entree_college - 1)
         enf_college = nb_enf(famille, decembre, ars.age_entree_college, ars.age_entree_lycee - 1)
-        enf_lycee_moins_18_ans_decembre = nb_enf(famille, decembre, ars.age_entree_lycee, ars.age_sortie_lycee-1)
+        enf_lycee_moins_18_ans_decembre = nb_enf(famille, decembre, ars.age_entree_lycee, ars.age_sortie_lycee - 1)
         age_mois_decembre_i = famille.members('age_mois', decembre)
         autonomie_financiere_i = famille.members('autonomie_financiere', decembre)
-        enf_lycee_eligible_18_ans_decembre_i = (age_mois_decembre_i <= 12*18 + 2 & age_mois_decembre_i >= 12*18 & not_(autonomie_financiere_i))
+        enf_lycee_eligible_18_ans_decembre_i = (age_mois_decembre_i <= 12 * 18 + 2 & age_mois_decembre_i >= 12 * 18 & not_(autonomie_financiere_i))
         enf_lycee_eligible_18_ans_decembre = famille.sum(enf_lycee_eligible_18_ans_decembre_i, role = Famille.ENFANT)
         enf_lycee = enf_lycee_moins_18_ans_decembre + enf_lycee_eligible_18_ans_decembre
-
-        arsnbenf = enf_primaire + enf_college + enf_lycee
 
         # Plafond en fonction du nb d'enfants A CHARGE (Cf. article R543)
         ars_plaf_res = ars.ars_plaf.plafond_ressources * (1 + af_nbenf * ars.ars_plaf.majoration_par_enf_supp)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name = "OpenFisca-France",
-    version = "111.0.0",
+    version = "111.1.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal. Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `prestations/prestations_familiales/ars.py`.
* Détails :
  - Corrige les conditions en termes d'âge des enfants. Avant, tous les enfants ayant 5 ans en septembre était comptés. Les enfants ayant 18 ans en septembre étaient aussi comptés (alors qu'éligibilité jusqu'à 17 ans), et les montants majorés étaient définis en fonction de l'âge de septembre au lieu de décembre
  - Corrige la formule de l'ARS différentielle : la déduction d'aide due à ce dispositif était divisée par le nombre d'enfants (dans la loi, cette division est mentionnée, mais pour la réduction due PAR enfant, pas pour la réduction totale).

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.