### PR TITLE
Corrige règle de cumul complément familial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 111.2.0 [#1808](https://github.com/openfisca/openfisca-france/pull/1808)
+
+* Évolution du système socio-fiscal. Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées : `prestations/prestations_familiales/cf.py`.
+* Détails :
+  - Corrige les règles de cumul entre CF et les autres prestations
+
 ## 111.1.0 [#1806](https://github.com/openfisca/openfisca-france/pull/1806)
 
 * Évolution du système socio-fiscal. Correction d'un crash.

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -325,6 +325,8 @@ class cf(Variable):
         L'allocation de base de la paje n'est pas cumulable avec le complément familial
         '''
         paje_base = famille('paje_base', period)
+        paje_clca = famille('paje_clca', period)
+        paje_prepare = famille('paje_prepare', period)
         apje_avant_cumul = famille('apje_avant_cumul', period)
         ape_avant_cumul = famille('ape_avant_cumul', period)
         cf_montant = famille('cf_montant', period)
@@ -332,6 +334,8 @@ class cf(Variable):
 
         cf_brut = (
             not_(paje_base)
+            * not_(paje_clca)
+            * not_(paje_prepare)
             * (apje_avant_cumul <= cf_montant)
             * (ape_avant_cumul <= cf_montant)
             * cf_montant

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -322,7 +322,7 @@ class cf(Variable):
 
     def formula(famille, period, parameters):
         '''
-        L'allocation de base de la paje n'est pas cumulable avec le complément familial
+        Pour les règles de non-cumul, voir notamment les art. L532-1 et L532-2 du CSS
         '''
         paje_base = famille('paje_base', period)
         paje_clca = famille('paje_clca', period)

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -322,7 +322,7 @@ class cf(Variable):
 
     def formula(famille, period, parameters):
         '''
-        Pour les règles de non-cumul, voir notamment les art. L532-1 et L532-2 du CSS
+        Pour les règles de non-cumul du CF avec les autres prestations, voir notamment les art. L532-1 et L532-2 du CSS
         '''
         paje_base = famille('paje_base', period)
         paje_clca = famille('paje_clca', period)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name = "OpenFisca-France",
-    version = "111.1.0",
+    version = "111.2.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal. Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `prestations/prestations_familiales/cf.py`.
* Détails :
  - Corrige les règles de cumul entre CF et les autres prestations

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.