### PR TITLE
Harmonisation - Impôt sur le Revenu - Prélèvement Forfaitaire Libératoire (Partie 2) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# 116.0.0 [#1824](https://github.com/openfisca/openfisca-france/pull/1824)
+
+* Périodes concernées : après 2018-01-01
+* Zones impactées: 
+- `parameters.impot_revenu.prelevement_forfaitaire_unique_ir`
+- `parameters.taxation_capital.prelevement_forfaitaire.partir_2018`
+* Détails : 
+  - Fusionne les doublons du PFU dans l'IR avec ceux qui sont dans Taxation du capital, sur le modèle IPP
+
 # 115.0.0 [#1823](https://github.com/openfisca/openfisca-france/pull/1823)
 
 * Périodes concernées : toutes.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -161,7 +161,7 @@ class prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_eta
     definition_period = YEAR
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
-        P = parameters(period).impot_revenu.prelevement_forfaitaire_unique_ir
+        P = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018
 
         # Revenus des valeurs et capitaux mobiliers hors assurance-vie et hors produits d'épargne solidaire ou des états non-coopératifs
         #   Note : Les revenus d'assurance-vie, de l'épargne solidaire et des produits des états non-coopératifs ont été ajoutés dans les variables f2ee et f2dh (cf. docstring de ces varables pour une explication), d'où le fait qu'on soustrait ici ces variables de revenus_capitaux_prelevement_forfaitaire_unique_ir
@@ -193,7 +193,7 @@ class prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_eta
             + plus_values_prelevement_forfaitaire_unique_ir
             )
 
-        return -assiette_pfu_hors_assurance_vie * P.taux
+        return -assiette_pfu_hors_assurance_vie * P.taux_prelevement_forfaitaire_rev_capital_eligibles_pfu_interets_dividendes_etc
 
 
 class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
@@ -203,7 +203,8 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
     definition_period = YEAR
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
-        P1 = parameters(period).impot_revenu.prelevement_forfaitaire_unique_ir
+        P1_taux = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018.taux_prelevement_forfaitaire_rev_capital_eligibles_pfu_interets_dividendes_etc
+        P1_taux_reduit_av = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018.taux_prelevement_produits_assurance_vie_non_eligibles_prelevement_forfaitaire_unique
         P2 = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
@@ -215,9 +216,9 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
         abattement_residuel = max_(P2.abat_assvie * (1 + maries_ou_pacses) - f2ch, 0)
         abattement_residuel2 = max_(abattement_residuel - f2vv, 0)
         pfu_ir_sur_assurance_vie = -(
-            (f2zz * P1.taux)
-            + (max_(f2vv - abattement_residuel, 0) * P1.taux_reduit_av)
-            + (max_(f2ww - abattement_residuel2, 0) * P1.taux)
+            (f2zz * P1_taux)
+            + (max_(f2vv - abattement_residuel, 0) * P1_taux_reduit_av)
+            + (max_(f2ww - abattement_residuel2, 0) * P1_taux)
             )
 
         return pfu_ir_sur_assurance_vie

--- a/openfisca_france/parameters/impot_revenu/prelevement_forfaitaire_unique_ir/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/prelevement_forfaitaire_unique_ir/index.yaml
@@ -1,1 +1,0 @@
-description: Partie du prélèvement forfaitaire unique (PFU) au titre de l'impôt sur le revenu

--- a/openfisca_france/parameters/impot_revenu/prelevement_forfaitaire_unique_ir/seuil_taux_reduit_av.yaml
+++ b/openfisca_france/parameters/impot_revenu/prelevement_forfaitaire_unique_ir/seuil_taux_reduit_av.yaml
@@ -1,9 +1,0 @@
-description: Seuil pour bénéficier du taux réduit sur les produits d'assurance-vie
-values:
-  2018-01-01:
-    value: 150000
-metadata:
-  unit: /1
-  reference:
-    title: https://www.ipp.eu/outils/baremes-ipp/ (hors parser des barèmes)
-  last_review: "2021-10-12"

--- a/openfisca_france/parameters/impot_revenu/prelevement_forfaitaire_unique_ir/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/prelevement_forfaitaire_unique_ir/taux.yaml
@@ -1,9 +1,0 @@
-description: Taux
-values:
-  2018-01-01:
-    value: 0.128
-metadata:
-  unit: /1
-  reference:
-    href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036428175/
-  last_review: "2021-10-12"

--- a/openfisca_france/parameters/impot_revenu/prelevement_forfaitaire_unique_ir/taux_reduit_av.yaml
+++ b/openfisca_france/parameters/impot_revenu/prelevement_forfaitaire_unique_ir/taux_reduit_av.yaml
@@ -1,9 +1,0 @@
-description: Taux réduit des produits d'assurance-vie soumis au nouveau régime (revenus perçus à compter de 2018, au titre de primes versées à compter du 27 septembre 2017, pour des contrats souscrits à partir du 26 septembre 1997)
-values:
-  2018-01-01:
-    value: 0.075
-metadata:
-  unit: /1
-  reference:
-    title: https://www.ipp.eu/outils/baremes-ipp/ (hors parser des barèmes)
-  last_review: "2021-10-12"

--- a/openfisca_france/parameters/taxation_capital/prelevement_forfaitaire/partir_2018/taux_prelevement_forfaitaire_rev_capital_eligibles_pfu_interets_dividendes_etc.yaml
+++ b/openfisca_france/parameters/taxation_capital/prelevement_forfaitaire/partir_2018/taux_prelevement_forfaitaire_rev_capital_eligibles_pfu_interets_dividendes_etc.yaml
@@ -1,14 +1,16 @@
-description: Prélèvement forfaitaire unique (PFU), Prélèvements libératoires sur les revenus des valeurs mobilières (2018 - )
+description: Taux du prélèvement forfaitaire unique (PFU), Prélèvements libératoires sur les revenus des valeurs mobilières (2018 - )
 values:
   2018-01-01:
     value: 0.128
 metadata:
-  ux_name: Prélèvement forfaitaire unique (PFU) 
+  ux_name: Taux du PFU
   unit: /1
   reference:
     2018-01-01:
-      title: Loi 2017-1837 du 30/12/2017 - art. 28 (modif art 125 A, 125-0 A, 200 A et art 117 quater du CGI)
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036377422&cidTexte=JORFTEXT000036339197
+      - title: Loi 2017-1837 du 30/12/2017 - art. 28 (modif art 125 A, 125-0 A, 200 A et art 117 quater du CGI)
+        href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036377422&cidTexte=JORFTEXT000036339197
+      - title: Article 117 quater du Code général des impôts
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036428175/
   official_journal_date:
     2018-01-01: 2017-12-31
   notes:

--- a/openfisca_france/parameters/taxation_capital/prelevement_forfaitaire/partir_2018/taux_prelevement_produits_assurance_vie_non_eligibles_prelevement_forfaitaire_unique.yaml
+++ b/openfisca_france/parameters/taxation_capital/prelevement_forfaitaire/partir_2018/taux_prelevement_produits_assurance_vie_non_eligibles_prelevement_forfaitaire_unique.yaml
@@ -1,14 +1,16 @@
-description: Produits d'assurance-vie non-éligibles au PFU, Prélèvements libératoires sur les revenus des valeurs mobilières (2018 - )
+description: Taux réduit, pour les produits d'assurance-vie non-éligibles au PFU, Prélèvements libératoires sur les revenus des valeurs mobilières (2018 - )
 values:
   2018-01-01:
     value: 0.075
 metadata:
-  ux_name: Produits d'assurance-vie non-éligibles au PFU
+  ux_name: Taux réduit du PFU
   unit: /1
   reference:
     2018-01-01:
-      title: Loi 2017-1837 du 30/12/2017 - art. 28 (modif art 125 A, 125-0 A, 200 A et art 117 quater du CGI)
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036377422&cidTexte=JORFTEXT000036339197
+      - title: Loi 2017-1837 du 30/12/2017 - art. 28 (modif art 125 A, 125-0 A, 200 A et art 117 quater du CGI)
+        href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036377422&cidTexte=JORFTEXT000036339197
+      - title: Article 117 quater du Code général des impôts
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036428175/
   official_journal_date:
     2018-01-01: 2017-12-31
   notes:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name = "OpenFisca-France",
-    version = "115.0.0",
+    version = "116.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.fr",
     classifiers = [


### PR DESCRIPTION
* Amélioration technique. 
* Périodes concernées : après 2018-01-01
* Zones impactées : 
- `parameters.impot_revenu.prelevement_forfaitaire_unique_ir`
- `parameters.taxation_capital.prelevement_forfaitaire.partir_2018`
* Détails : 
  - Fusionne les doublons du PFU dans l'IR avec ceux qui sont dans Taxation du capital, sur le modèle IPP