### PR TITLE
cotisations_taxes_professions_liberales : Ajout de valeurs manquantes et de last_review.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 116.7.3 [#1835](https://github.com/openfisca/openfisca-france/pull/1835)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/`.
+* Détails :
+  - Modification de la valeur de certains paramètres
+  - Ajout de last_review
+  - Ajout de references législatives
+
 ### 116.7.2 [#1848](https://github.com/openfisca/openfisca-france/pull/1848)
 
 * Correction d'un crash.
@@ -80,7 +90,7 @@
 * Amélioration technique.
 * Périodes concernées : À partir de 2018
 * Zones impactées : `tests/formulas/taxation_capital.yaml`
-* Détails : 
+* Détails :
 - Ajoute un cas de concernant la taxation de l'assurance vie.
 
 ## 116.2.0 [#1832](https://github.com/openfisca/openfisca-france/pull/1832)
@@ -99,16 +109,16 @@
 * Changement mineur
 * Périodes concernées :  à partir du 01/06/2009
 * Zones impactées : `parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rmi/rmi_cond/patrimoine`
-* Détails : J'ai ajouté les références législatives et le last_review 
-  
+* Détails : J'ai ajouté les références législatives et le last_review
+
 ### 116.1.1 [#1807](https://github.com/openfisca/openfisca-france/pull/1807)
 * Amélioration technique.
 * Zones impactées : `/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/`
-* Détails : 
-- Ajoute last review 
-- Ajoute références vers les valeurs 
-- Ajoute des références législatives pour les valeurs concernées 
-  
+* Détails :
+- Ajoute last review
+- Ajoute références vers les valeurs
+- Ajoute des références législatives pour les valeurs concernées
+
 ## 116.1.0 [#1826](https://github.com/openfisca/openfisca-france/pull/1826)
 
 * Évolution du système socio-fiscal.
@@ -122,10 +132,10 @@
 # 116.0.0 [#1824](https://github.com/openfisca/openfisca-france/pull/1824)
 
 * Périodes concernées : après 2018-01-01
-* Zones impactées: 
+* Zones impactées:
 - `parameters.impot_revenu.prelevement_forfaitaire_unique_ir`
 - `parameters.taxation_capital.prelevement_forfaitaire.partir_2018`
-* Détails : 
+* Détails :
   - Fusionne les doublons du PFU dans l'IR avec ceux qui sont dans Taxation du capital, sur le modèle IPP
 
 # 115.0.0 [#1823](https://github.com/openfisca/openfisca-france/pull/1823)
@@ -139,16 +149,16 @@ git log --oneline 6d3d89b5d70c9^..68333e8282d9e | grep "variable_name"
 
 # 114.0.0 [#1818](https://github.com/openfisca/openfisca-france/pull/1818)
 
-* Amélioration technique. 
+* Amélioration technique.
 * Périodes concernées : toutes.
-* Zones impactées : 
+* Zones impactées :
 - `parameters/taxation_capital/`
 - `model/prelevements_obligatoires/isf`
 * Détails :
-  - Supprime les doublons générés dans les PRs : 
+  - Supprime les doublons générés dans les PRs :
       - #1815 ,
       -  #1816
-      - et #1817 
+      - et #1817
   - Adapte les formules
 * Guide pour la migration: Vous pouvez chercher où sont passés vos fichiers avec la commande suivante:
 git log --oneline 98b434c2c3c67fa5^..16095f417480157 | grep "variable_name"
@@ -164,9 +174,9 @@ git log --oneline 98b434c2c3c67fa5^..16095f417480157 | grep "variable_name"
 
 ### 113.0.3 [#1817](https://github.com/openfisca/openfisca-france/pull/1817)
 
-* Amélioration technique. 
+* Amélioration technique.
 * Périodes concernées : toutes.
-* Zones impactées : 
+* Zones impactées :
 - `parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018`
 * Détails:
   - Ajout des fichiers issus des barèmes-ipp, aucune modification du code existant
@@ -174,19 +184,19 @@ git log --oneline 98b434c2c3c67fa5^..16095f417480157 | grep "variable_name"
 
 ### 113.0.2 [#1816](https://github.com/openfisca/openfisca-france/pull/1816)
 
-* Amélioration technique. 
+* Amélioration technique.
 * Périodes concernées : toutes.
-* Zones impactées : 
+* Zones impactées :
 - `parameters/taxation_capital/impot_solidarite_fortune_isf_1989_2017`
 * Détails :
   - Ajout des fichiers issus des barèmes-ipp, aucune modification du code existant
   - Les doublons générés dans cette PR seront supprimés dans une PR à venir
- 
+
 ### 113.0.1 [#1815](https://github.com/openfisca/openfisca-france/pull/1815)
 
-* Amélioration technique. 
+* Amélioration technique.
 * Périodes concernées : toutes.
-* Zones impactées : 
+* Zones impactées :
 - `parameters/taxation_capital/impot_grandes_fortunes_1982_1986`
 * Détails :
   - Ajout des fichiers issus des barèmes-ipp, aucune modification du code existant
@@ -194,9 +204,9 @@ git log --oneline 98b434c2c3c67fa5^..16095f417480157 | grep "variable_name"
 
 # 113.0.0 [#1804](https://github.com/openfisca/openfisca-france/pull/1804)
 
-* Amélioration technique. 
+* Amélioration technique.
 * Périodes concernées : toutes.
-* Zones impactées : 
+* Zones impactées :
 - `parameters/taxation_capital/prelevement_forfaitaire`
 - `parameters/taxation_capital/pfl_av`.
 - `parameters/taxation_capital/pfl`.
@@ -242,9 +252,9 @@ git log --oneline 13335ed5de72dfd^..7b19d7a4d879cd741d1 | grep "variable_name"
 
 # 111.0.0 [#1803](https://github.com/openfisca/openfisca-france/pull/1803)
 
-* Amélioration technique. 
+* Amélioration technique.
 * Périodes concernées : toutes.
-* Zones impactées : 
+* Zones impactées :
 - `parameters/taxation_capital/prelevements_sociaux`.
 * Détails :
   - Harmonisation des fichiers avec les barèmes-ipp
@@ -279,9 +289,9 @@ git log --oneline 7f9b9894cbb4beed2^..4fa92d17e8299 | grep "variable_name"
 
 # 110.0.0 [#1800](https://github.com/openfisca/openfisca-france/pull/1800)
 
-* Amélioration technique. 
+* Amélioration technique.
 * Périodes concernées : toutes.
-* Zones impactées : 
+* Zones impactées :
 - `parameters/prestations_sociales/aides_jeunes`.
 * Détails :
   - Harmonisation des fichiers avec les barèmes-ipp

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_independants_artisans_commercants/deces_ac/artisans/sous_pss.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_independants_artisans_commercants/deces_ac/artisans/sous_pss.yaml
@@ -17,7 +17,6 @@ values:
   2015-01-01:
     value: 0.013
 metadata:
-  last_review: 2022-04-04
   ux_name: Taux Artisan
   description_en: SSCs for disability and death benefits (sales retailers and craftsmen)
   ipp_csv_id: id_art_0_1

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_independants_artisans_commercants/deces_ac/artisans/sous_pss.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_independants_artisans_commercants/deces_ac/artisans/sous_pss.yaml
@@ -17,6 +17,7 @@ values:
   2015-01-01:
     value: 0.013
 metadata:
+  last_review: 2022-04-04
   ux_name: Taux Artisan
   description_en: SSCs for disability and death benefits (sales retailers and craftsmen)
   ipp_csv_id: id_art_0_1

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/cipav.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/cipav.yaml
@@ -60,9 +60,6 @@ metadata:
     2017-04-01: "2017-03-10"
     2018-01-01: "2017-12-31"
     2021-06-14: "2021-06-13"
-  notes:
-    2017-04-01:
-    - title: Depuis le 1er janvier 2017, la CFP est unifiée pour tous les artisans (en et hors Alsace)
 documentation: |-
   Notes :
   (i) L’auto-entrepreneur bénéficie d’un régime simplifié de calcul et de paiement des cotisations et contributions sociales obligatoires.
@@ -75,6 +72,3 @@ documentation: |-
   de retraite de base
   de la retraite complémentaire obligatoire
   du régime invalidité et décès
-  (ii) Les auto-entrepreneurs sont dispensés de contribution à la formation professionnelle jusqu'en 2011.
-  Sources :
-  Cotisation des indépendants "auto-entrepreneurs" : D. 131-6-1 du Code de la sécurité sociale jusqu'en 2017 ; devient D. 131-5-1 avec le Décret 2017-1894

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/cipav.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/cipav.yaml
@@ -12,7 +12,10 @@ values:
     value: 0.225
   2018-01-01:
     value: 0.22
+  2021-06-14:
+    value: 0.222
 metadata:
+  last_review: "2022-04-05"
   ux_name: Taux - CIPAV
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_plib_ca
@@ -41,8 +44,13 @@ metadata:
       href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
       title: Décret 2017-301 du 08/03/2017
     2018-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
+    - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
       title: Décret 2017-1894 du 30/12/2017, art. 1
+    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041918199/2020-05-25/#LEGIARTI000041918199
+      title: Décret n°2020-621 du 22 mai 2020 - art. 1
+    2021-06-14:
+      href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041918199/2020-05-25/#LEGIARTI000041918199
+      title: Décret n°2021-755 du 12 juin 2021 - art. 1
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"
@@ -52,6 +60,7 @@ metadata:
     2016-01-01: "2014-12-19"
     2017-04-01: "2017-03-10"
     2018-01-01: "2017-12-31"
+    2021-06-14: "2021-06-13"
   notes:
     2017-04-01:
     - title: Depuis le 1er janvier 2017, la CFP est unifiée pour tous les artisans (en et hors Alsace)

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/cipav.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/cipav.yaml
@@ -36,8 +36,10 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
       title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
     2017-04-01:
-      href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000034161060/2017-03-11/
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000034161060/2017-03-11/
       title: Décret 2017-301 du 08/03/2017, art. 4, 1°
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000034163589/2017-03-11
+      title: Article D131-6-1, b) du Code de la sécurité sociale
     2018-01-01:
     - href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036456533/2018-01-01
       title: Décret n° 2017-1894 du 30 décembre 2017 - art. 1

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/cipav.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/cipav.yaml
@@ -39,6 +39,10 @@ metadata:
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000034161060/2017-03-11/
       title: Décret 2017-301 du 08/03/2017, art. 4, 1°
     2018-01-01:
+    - href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036456533/2018-01-01
+      title: Décret n° 2017-1894 du 30 décembre 2017 - art. 1
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036466353/2018-01-01
+      title: Article D131-5-1, b) du Code de la sécurité sociale
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000041911701/2020-05-25/
       title: Décret n°2020-621 du 22 mai 2020 - art. 1
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041918199/2020-05-25

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/cipav.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/cipav.yaml
@@ -15,7 +15,7 @@ values:
   2021-06-14:
     value: 0.222
 metadata:
-  last_review: "2022-04-06"
+  last_review: "2022-04-11"
   ux_name: Taux - CIPAV
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_plib_ca
@@ -26,8 +26,6 @@ metadata:
       title: Décret 2008-1348 du 18/12/2008
     - href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000019951825
       title: Décret 2008-1349 du 18/12/2008
-    2011-01-01:
-      title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
     2013-01-01:
       href: https://www.legifrance.gouv.fr/eli/decret/2012/12/28/2012-1551/jo/texte
       title: Décret 2012-1551 du 28/12/2012
@@ -37,15 +35,10 @@ metadata:
     2015-01-01:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
       title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
-    2016-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
-      title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
     2017-04-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
-      title: Décret 2017-301 du 08/03/2017
+      href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000034161060/2017-03-11/
+      title: Décret 2017-301 du 08/03/2017, art. 4, 1°
     2018-01-01:
-    - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
-      title: Décret 2017-1894 du 30/12/2017, art. 1
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000041911701/2020-05-25/
       title: Décret n°2020-621 du 22 mai 2020 - art. 1
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041918199/2020-05-25
@@ -55,14 +48,11 @@ metadata:
       title: Décret n°2021-755 du 12 juin 2021 - art. 1
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043656794/2021-06-14
       title: Article D613-4, b) du Code de la sécurité sociale
-
   official_journal_date:
     2009-01-01: "2008-12-19"
-    2011-01-01: "2010-12-30"
     2013-01-01: "2012-12-30"
     2014-01-01: "2013-12-31"
     2015-01-01: "2014-12-19"
-    2016-01-01: "2014-12-19"
     2017-04-01: "2017-03-10"
     2018-01-01: "2017-12-31"
     2021-06-14: "2021-06-13"
@@ -84,5 +74,3 @@ documentation: |-
   (ii) Les auto-entrepreneurs sont dispensés de contribution à la formation professionnelle jusqu'en 2011.
   Sources :
   Cotisation des indépendants "auto-entrepreneurs" : D. 131-6-1 du Code de la sécurité sociale jusqu'en 2017 ; devient D. 131-5-1 avec le Décret 2017-1894
-  Contribution à la formation professionnelle des artisans : 1609 quatervicies B du CGI, puis L. 6331-48 du Code du travail
-  Contribution à la formation professionnelle des commerçants et professions libérales : L. 6331-48 du Code du travail

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/cipav.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/cipav.yaml
@@ -15,7 +15,7 @@ values:
   2021-06-14:
     value: 0.222
 metadata:
-  last_review: "2022-04-05"
+  last_review: "2022-04-06"
   ux_name: Taux - CIPAV
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_plib_ca
@@ -46,11 +46,16 @@ metadata:
     2018-01-01:
     - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
       title: Décret 2017-1894 du 30/12/2017, art. 1
-    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041918199/2020-05-25/#LEGIARTI000041918199
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000041911701/2020-05-25/
       title: Décret n°2020-621 du 22 mai 2020 - art. 1
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041918199/2020-05-25
+      title: Article D613-4, b) du Code de la sécurité sociale
     2021-06-14:
-      href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041918199/2020-05-25/#LEGIARTI000041918199
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043650438/2021-06-14/
       title: Décret n°2021-755 du 12 juin 2021 - art. 1
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043656794/2021-06-14
+      title: Article D613-4, b) du Code de la sécurité sociale
+
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/servi.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/servi.yaml
@@ -13,7 +13,7 @@ values:
   2018-01-01:
     value: 0.22
 metadata:
-  last_review: "2022-04-05"
+  last_review: "2022-04-06"
   ux_name: Taux - Prestations de service
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_ser_ca
@@ -44,10 +44,12 @@ metadata:
     2018-01-01:
     - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
       title: Décret 2017-1894 du 30/12/2017, art. 1
-    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041918199/2020-05-25/#LEGIARTI000041918199
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000041911701/2020-05-25/
       title: Décret n°2020-621 du 22 mai 2020 - art. 1
-    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043656794/2021-06-14/
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043650438/2021-06-14/
       title: Décret n°2021-755 du 12 juin 2021 - art. 1
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043656794/2021-06-14
+      title: Article D613-4, d) du Code de la sécurité sociale
 
 
   official_journal_date:

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/servi.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/servi.yaml
@@ -56,9 +56,6 @@ metadata:
     2016-01-01: "2014-12-19"
     2017-04-01: "2017-03-10"
     2018-01-01: "2017-12-31"
-  notes:
-    2017-04-01:
-    - title: Depuis le 1er janvier 2017, la CFP est unifiée pour tous les artisans (en et hors Alsace)
 documentation: |-
   Notes :
   (i) L’auto-entrepreneur bénéficie d’un régime simplifié de calcul et de paiement des cotisations et contributions sociales obligatoires.

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/servi.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/servi.yaml
@@ -13,6 +13,7 @@ values:
   2018-01-01:
     value: 0.22
 metadata:
+  last_review: "2022-04-05"
   ux_name: Taux - Prestations de service
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_ser_ca
@@ -41,8 +42,14 @@ metadata:
       href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
       title: Décret 2017-301 du 08/03/2017
     2018-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
+    - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
       title: Décret 2017-1894 du 30/12/2017, art. 1
+    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041918199/2020-05-25/#LEGIARTI000041918199
+      title: Décret n°2020-621 du 22 mai 2020 - art. 1
+    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043656794/2021-06-14/
+      title: Décret n°2021-755 du 12 juin 2021 - art. 1
+
+
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/servi.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/servi.yaml
@@ -13,7 +13,7 @@ values:
   2018-01-01:
     value: 0.22
 metadata:
-  last_review: "2022-04-06"
+  last_review: "2022-04-11"
   ux_name: Taux - Prestations de service
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_ser_ca
@@ -24,8 +24,6 @@ metadata:
       title: Décret 2008-1348 du 18/12/2008
     - href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000019951825
       title: Décret 2008-1349 du 18/12/2008
-    2011-01-01:
-      title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
     2013-01-01:
       href: https://www.legifrance.gouv.fr/eli/decret/2012/12/28/2012-1551/jo/texte
       title: Décret 2012-1551 du 28/12/2012
@@ -39,22 +37,17 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
       title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
     2017-04-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
-      title: Décret 2017-301 du 08/03/2017
+      href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000034161060/2017-03-11/
+      title: Décret 2017-301 du 08/03/2017, art. 4, 1°
     2018-01-01:
-    - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
-      title: Décret 2017-1894 du 30/12/2017, art. 1
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000041911701/2020-05-25/
       title: Décret n°2020-621 du 22 mai 2020 - art. 1
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043650438/2021-06-14/
       title: Décret n°2021-755 du 12 juin 2021 - art. 1
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043656794/2021-06-14
       title: Article D613-4, d) du Code de la sécurité sociale
-
-
   official_journal_date:
     2009-01-01: "2008-12-19"
-    2011-01-01: "2010-12-30"
     2013-01-01: "2012-12-30"
     2014-01-01: "2013-12-31"
     2015-01-01: "2014-12-19"
@@ -79,5 +72,3 @@ documentation: |-
   (ii) Les auto-entrepreneurs sont dispensés de contribution à la formation professionnelle jusqu'en 2011.
   Sources :
   Cotisation des indépendants "auto-entrepreneurs" : D. 131-6-1 du Code de la sécurité sociale jusqu'en 2017 ; devient D. 131-5-1 avec le Décret 2017-1894
-  Contribution à la formation professionnelle des artisans : 1609 quatervicies B du CGI, puis L. 6331-48 du Code du travail
-  Contribution à la formation professionnelle des commerçants et professions libérales : L. 6331-48 du Code du travail

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/servi.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/servi.yaml
@@ -37,8 +37,10 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
       title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
     2017-04-01:
-      href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000034161060/2017-03-11/
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000034161060/2017-03-11/
       title: Décret 2017-301 du 08/03/2017, art. 4, 1°
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000034163589/2017-03-11
+      title: Article D131-6-1, d) du Code de la sécurité sociale
     2018-01-01:
     - href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036456533/2018-01-01
       title: Décret n° 2017-1894 du 30 décembre 2017 - art. 1

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/servi.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/servi.yaml
@@ -40,8 +40,10 @@ metadata:
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000034161060/2017-03-11/
       title: Décret 2017-301 du 08/03/2017, art. 4, 1°
     2018-01-01:
-    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000041911701/2020-05-25/
-      title: Décret n°2020-621 du 22 mai 2020 - art. 1
+    - href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036456533/2018-01-01
+      title: Décret n° 2017-1894 du 30 décembre 2017 - art. 1
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036466353/2018-01-01
+      title: Article D131-5-1, d) du Code de la sécurité sociale
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043650438/2021-06-14/
       title: Décret n°2021-755 du 12 juin 2021 - art. 1
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043656794/2021-06-14

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/vente.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/vente.yaml
@@ -15,7 +15,7 @@ values:
   2018-01-01:
     value: 0.128
 metadata:
-  last_review: "2022-04-06"
+  last_review: "2022-04-11"
   ux_name: Taux - Vente
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_av_ca
@@ -26,8 +26,6 @@ metadata:
       title: Décret 2008-1348 du 18/12/2008
     - href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000019951825
       title: Décret 2008-1349 du 18/12/2008
-    2011-01-01:
-      title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
     2013-01-01:
       href: https://www.legifrance.gouv.fr/eli/decret/2012/12/28/2012-1551/jo/texte
       title: Décret 2012-1551 du 28/12/2012
@@ -41,11 +39,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
       title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
     2017-04-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
-      title: Décret 2017-301 du 08/03/2017
+      href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000034161060/2017-03-11/
+      title: Décret 2017-301 du 08/03/2017, art. 4, 1°
     2018-01-01:
-    - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
-      title: Décret 2017-1894 du 30/12/2017, art. 1
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000041911701/2020-05-25/
       title: Décret n°2020-621 du 22 mai 2020 - art. 1
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043650438/2021-06-14/
@@ -54,7 +50,6 @@ metadata:
       title: Article D613-4, a) du Code de la sécurité sociale
   official_journal_date:
     2009-01-01: "2008-12-19"
-    2011-01-01: "2010-12-30"
     2013-01-01: "2012-12-30"
     2014-01-01: "2013-12-31"
     2015-01-01: "2014-12-19"
@@ -79,5 +74,3 @@ documentation: |-
   (ii) Les auto-entrepreneurs sont dispensés de contribution à la formation professionnelle jusqu'en 2011.
   Sources :
   Cotisation des indépendants "auto-entrepreneurs" : D. 131-6-1 du Code de la sécurité sociale jusqu'en 2017 ; devient D. 131-5-1 avec le Décret 2017-1894
-  Contribution à la formation professionnelle des artisans : 1609 quatervicies B du CGI, puis L. 6331-48 du Code du travail
-  Contribution à la formation professionnelle des commerçants et professions libérales : L. 6331-48 du Code du travail

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/vente.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/vente.yaml
@@ -15,7 +15,7 @@ values:
   2018-01-01:
     value: 0.128
 metadata:
-  last_review: "2022-04-05"
+  last_review: "2022-04-06"
   ux_name: Taux - Vente
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_av_ca
@@ -46,10 +46,12 @@ metadata:
     2018-01-01:
     - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
       title: Décret 2017-1894 du 30/12/2017, art. 1
-    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041918199/2020-05-25/#LEGIARTI000041918199
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000041911701/2020-05-25/
       title: Décret n°2020-621 du 22 mai 2020 - art. 1
-    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043656794/2021-06-14/
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043650438/2021-06-14/
       title: Décret n°2021-755 du 12 juin 2021 - art. 1
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043656794/2021-06-14
+      title: Article D613-4, a) du Code de la sécurité sociale
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/vente.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/vente.yaml
@@ -58,9 +58,6 @@ metadata:
     2016-01-01: "2014-12-19"
     2017-04-01: "2017-03-10"
     2018-01-01: "2017-12-31"
-  notes:
-    2017-04-01:
-    - title: Depuis le 1er janvier 2017, la CFP est unifiée pour tous les artisans (en et hors Alsace)
 documentation: |-
   Notes :
   (i) L’auto-entrepreneur bénéficie d’un régime simplifié de calcul et de paiement des cotisations et contributions sociales obligatoires.

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/vente.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/vente.yaml
@@ -15,6 +15,7 @@ values:
   2018-01-01:
     value: 0.128
 metadata:
+  last_review: "2022-04-05"
   ux_name: Taux - Vente
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_av_ca
@@ -43,8 +44,12 @@ metadata:
       href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
       title: Décret 2017-301 du 08/03/2017
     2018-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
+    - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
       title: Décret 2017-1894 du 30/12/2017, art. 1
+    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000041918199/2020-05-25/#LEGIARTI000041918199
+      title: Décret n°2020-621 du 22 mai 2020 - art. 1
+    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000043656794/2021-06-14/
+      title: Décret n°2021-755 du 12 juin 2021 - art. 1
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/vente.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/vente.yaml
@@ -42,8 +42,10 @@ metadata:
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000034161060/2017-03-11/
       title: Décret 2017-301 du 08/03/2017, art. 4, 1°
     2018-01-01:
-    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000041911701/2020-05-25/
-      title: Décret n°2020-621 du 22 mai 2020 - art. 1
+    - href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036456533/2018-01-01
+      title: Décret n° 2017-1894 du 30 décembre 2017 - art. 1
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036466353/2018-01-01
+      title: Article D131-5-1, a) du Code de la sécurité sociale
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043650438/2021-06-14/
       title: Décret n°2021-755 du 12 juin 2021 - art. 1
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043656794/2021-06-14

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/vente.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/cotisations_prestations/vente.yaml
@@ -39,8 +39,10 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
       title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
     2017-04-01:
-      href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000034161060/2017-03-11/
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000034161060/2017-03-11/
       title: Décret 2017-301 du 08/03/2017, art. 4, 1°
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000034163589/2017-03-11
+      title: Article D131-6-1, a) du Code de la sécurité sociale
     2018-01-01:
     - href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036456533/2018-01-01
       title: Décret n° 2017-1894 du 30 décembre 2017 - art. 1

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_alsace_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_alsace_chiffre_affaires.yaml
@@ -35,14 +35,9 @@ metadata:
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"
-    2013-01-01: "2012-12-30"
-    2014-01-01: "2013-12-31"
-    2015-01-01: "2014-12-19"
-    2016-01-01: "2014-12-19"
-    2017-04-01: "2017-03-10"
-    2018-01-01: "2017-12-31"
+    2017-01-01: "2017-03-10"
   notes:
-    2017-04-01:
+    2017-01-01:
     - title: Depuis le 1er janvier 2017, la CFP est unifiée pour tous les artisans (en et hors Alsace)
 documentation: |-
   Notes :

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_alsace_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_alsace_chiffre_affaires.yaml
@@ -7,6 +7,7 @@ values:
   2017-04-01:
     value: 0.003
 metadata:
+  last_review: "2022-04-07"
   ux_name: Taux - Prestation de services (artisans) Alsace
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_art_form_als_ca
@@ -35,8 +36,13 @@ metadata:
       href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
       title: Décret 2017-301 du 08/03/2017
     2018-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
-      title: Décret 2017-1894 du 30/12/2017, art. 1
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000033760722/2017-01-01/
+      title: LOI n° 2016-1917 du 29 décembre 2016 de finances pour 2017 - article 50
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
+      title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
+      title: Article L6331-48 du code du travail
+
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_alsace_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_alsace_chiffre_affaires.yaml
@@ -4,10 +4,10 @@ values:
     value: null
   2011-01-01:
     value: 0.00176
-  2017-04-01:
+  2017-01-01:
     value: 0.003
 metadata:
-  last_review: "2022-04-07"
+  last_review: "2022-04-12"
   ux_name: Taux - Prestation de services (artisans) Alsace
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_art_form_als_ca
@@ -19,30 +19,19 @@ metadata:
     - href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000019951825
       title: Décret 2008-1349 du 18/12/2008
     2011-01-01:
-      title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
-    2013-01-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2012/12/28/2012-1551/jo/texte
-      title: Décret 2012-1551 du 28/12/2012
-    2014-01-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2013/12/27/2013-1290/jo/texte
-      title: Décret 2013-1290 du 27/12/2013
-    2015-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
-      title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
-    2016-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
-      title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
-    2017-04-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
-      title: Décret 2017-301 du 08/03/2017
-    2018-01-01:
-    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000033760722/2017-01-01/
-      title: LOI n° 2016-1917 du 29 décembre 2016 de finances pour 2017 - article 50
-    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
+    - title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
+      note: lien indisponible
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023363626/2011-01-01
+      title: Article 1609 quatervicies B du Code général des impôts
+    2017-01-01:
+    - href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000033760722/2017-01-01
+      title: LOI n° 2016-1917 du 29 décembre 2016 de finances pour 2017 - article 103
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000033814192/2017-01-01/
+      title: Article 1609 quatervicies B du Code général des impôts
+    - href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000044794656/2022-01-01
       title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
       title: Article L6331-48 du code du travail
-
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_alsace_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_alsace_chiffre_affaires.yaml
@@ -20,7 +20,6 @@ metadata:
       title: Décret 2008-1349 du 18/12/2008
     2011-01-01:
     - title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
-      note: lien indisponible
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023363626/2011-01-01
       title: Article 1609 quatervicies B du Code général des impôts
     2017-01-01:

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_hors_alsace_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_hors_alsace_chiffre_affaires.yaml
@@ -5,7 +5,7 @@ values:
   2011-01-01:
     value: 0.003
 metadata:
-  last_review: "2022-04-07"
+  last_review: "2022-04-12"
   ux_name: Taux - Prestation de services (artisans) hors Alsace
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_art_form_ca
@@ -17,43 +17,20 @@ metadata:
     - href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000019951825
       title: Décret 2008-1349 du 18/12/2008
     2011-01-01:
-      title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
-    2013-01-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2012/12/28/2012-1551/jo/texte
-      title: Décret 2012-1551 du 28/12/2012
-    2014-01-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2013/12/27/2013-1290/jo/texte
-      title: Décret 2013-1290 du 27/12/2013
-    2015-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
-      title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
-    2016-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
-      title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
-    2017-04-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
-      title: Décret 2017-301 du 08/03/2017
-    2018-01-01:
-    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000033760722/2017-01-01/
-      title: LOI n° 2016-1917 du 29 décembre 2016 de finances pour 2017 - article 50
-    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
+    - title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
+      note: lien indisponible
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023363626/2011-01-01
+      title: Article 1609 quatervicies B du Code général des impôts
+    - href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000044794656/2022-01-01
       title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
-      title: Article L6331-48, 1° du code du travail
+      title: Article L6331-48 du code du travail
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"
-    2013-01-01: "2012-12-30"
-    2014-01-01: "2013-12-31"
-    2015-01-01: "2014-12-19"
-    2016-01-01: "2014-12-19"
-    2017-04-01: "2017-03-10"
-    2018-01-01: "2017-12-31"
-  notes:
-    2017-04-01:
-    - title: Depuis le 1er janvier 2017, la CFP est unifiée pour tous les artisans (en et hors Alsace)
 documentation: |-
   Notes :
+  Depuis le 1er janvier 2017, la CFP est unifiée pour tous les artisans (en et hors Alsace)
   (i) L’auto-entrepreneur bénéficie d’un régime simplifié de calcul et de paiement des cotisations et contributions sociales obligatoires.
   Chaque mois ou chaque trimestre, selon son choix, il doit calculer et payer l’ensemble de ses charges sociales personnelles en fonction de son chiffre d’affaires réalisé au cours de cette période selon les pourcentages indiqués
   Les charges sociales ainsi calculées sont définitives et ne feront pas l’objet de régularisation contrairement aux modalités de calcul classiques.

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_hors_alsace_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_hors_alsace_chiffre_affaires.yaml
@@ -18,7 +18,6 @@ metadata:
       title: Décret 2008-1349 du 18/12/2008
     2011-01-01:
     - title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
-      note: lien indisponible
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023363626/2011-01-01
       title: Article 1609 quatervicies B du Code général des impôts
     - href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000044794656/2022-01-01

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_hors_alsace_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/artisans_hors_alsace_chiffre_affaires.yaml
@@ -5,6 +5,7 @@ values:
   2011-01-01:
     value: 0.003
 metadata:
+  last_review: "2022-04-07"
   ux_name: Taux - Prestation de services (artisans) hors Alsace
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_art_form_ca
@@ -33,8 +34,12 @@ metadata:
       href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
       title: Décret 2017-301 du 08/03/2017
     2018-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
-      title: Décret 2017-1894 du 30/12/2017, art. 1
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000033760722/2017-01-01/
+      title: LOI n° 2016-1917 du 29 décembre 2016 de finances pour 2017 - article 50
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
+      title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
+      title: Article L6331-48, 1° du code du travail
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/professions_liberales_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/professions_liberales_chiffre_affaires.yaml
@@ -17,25 +17,10 @@ metadata:
     - href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000019951825
       title: Décret 2008-1349 du 18/12/2008
     2011-01-01:
-      title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
-    2013-01-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2012/12/28/2012-1551/jo/texte
-      title: Décret 2012-1551 du 28/12/2012
-    2014-01-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2013/12/27/2013-1290/jo/texte
-      title: Décret 2013-1290 du 27/12/2013
-    2015-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
-      title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
-    2016-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
-      title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
-    2017-04-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
-      title: Décret 2017-301 du 08/03/2017
-    2018-01-01:
-    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000033760722/2017-01-01/
-      title: LOI n° 2016-1917 du 29 décembre 2016 de finances pour 2017 - article 50
+    - title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
+      note: lien indisponible
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023382168/2011-01-01/
+      title: Article L6331-48 du Code du travail
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
       title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
@@ -43,15 +28,6 @@ metadata:
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"
-    2013-01-01: "2012-12-30"
-    2014-01-01: "2013-12-31"
-    2015-01-01: "2014-12-19"
-    2016-01-01: "2014-12-19"
-    2017-04-01: "2017-03-10"
-    2018-01-01: "2017-12-31"
-  notes:
-    2017-04-01:
-    - title: Depuis le 1er janvier 2017, la CFP est unifiée pour tous les artisans (en et hors Alsace)
 documentation: |-
   Notes :
   (i) L’auto-entrepreneur bénéficie d’un régime simplifié de calcul et de paiement des cotisations et contributions sociales obligatoires.
@@ -64,8 +40,4 @@ documentation: |-
   de retraite de base
   de la retraite complémentaire obligatoire
   du régime invalidité et décès
-  (ii) Les auto-entrepreneurs sont dispensés de contribution à la formation professionnelle jusqu'en 2011.
-  Sources :
-  Cotisation des indépendants "auto-entrepreneurs" : D. 131-6-1 du Code de la sécurité sociale jusqu'en 2017 ; devient D. 131-5-1 avec le Décret 2017-1894
-  Contribution à la formation professionnelle des artisans : 1609 quatervicies B du CGI, puis L. 6331-48 du Code du travail
-  Contribution à la formation professionnelle des commerçants et professions libérales : L. 6331-48 du Code du travail
+  (ii) attention en 2018-01-01, il y a un changement dans l'Article L6331-48 du code du travail qui modifie les régles des valeurs

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/professions_liberales_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/professions_liberales_chiffre_affaires.yaml
@@ -18,7 +18,6 @@ metadata:
       title: Décret 2008-1349 du 18/12/2008
     2011-01-01:
     - title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
-      note: lien indisponible
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023382168/2011-01-01/
       title: Article L6331-48 du Code du travail
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/professions_liberales_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/professions_liberales_chiffre_affaires.yaml
@@ -5,6 +5,7 @@ values:
   2011-01-01:
     value: 0.002
 metadata:
+  last_review: "2022-04-07"
   ux_name: Taux - Professions libérales
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_plib_form_ca
@@ -33,8 +34,12 @@ metadata:
       href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
       title: Décret 2017-301 du 08/03/2017
     2018-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
-      title: Décret 2017-1894 du 30/12/2017, art. 1
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000033760722/2017-01-01/
+      title: LOI n° 2016-1917 du 29 décembre 2016 de finances pour 2017 - article 50
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
+      title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
+      title: Article L6331-48 du code du travail
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/professions_liberales_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/professions_liberales_chiffre_affaires.yaml
@@ -39,4 +39,5 @@ documentation: |-
   de retraite de base
   de la retraite complémentaire obligatoire
   du régime invalidité et décès
-  (ii) attention en 2018-01-01, il y a un changement dans l'Article L6331-48 du code du travail qui modifie les régles des valeurs
+  (ii) attention en 2018-01-01, il y a un changement dans l'Article L6331-48 du code du travail qui redefini la division entre les différents taux entre les travailleurs indépendants
+   à partir de l'article 50-0 du code général des impôts, et non plus directement dans le texte lui même.

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/servicecom_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/servicecom_chiffre_affaires.yaml
@@ -17,25 +17,10 @@ metadata:
     - href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000019951825
       title: Décret 2008-1349 du 18/12/2008
     2011-01-01:
-      title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
-    2013-01-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2012/12/28/2012-1551/jo/texte
-      title: Décret 2012-1551 du 28/12/2012
-    2014-01-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2013/12/27/2013-1290/jo/texte
-      title: Décret 2013-1290 du 27/12/2013
-    2015-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
-      title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
-    2016-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
-      title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
-    2017-04-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
-      title: Décret 2017-301 du 08/03/2017
-    2018-01-01:
-    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000033760722/2017-01-01/
-      title: LOI n° 2016-1917 du 29 décembre 2016 de finances pour 2017 - article 50
+    - title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
+      note: lien indisponible
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023382168/2011-01-01/
+      title: Article L6331-48 du Code du travail
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
       title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
@@ -43,15 +28,6 @@ metadata:
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"
-    2013-01-01: "2012-12-30"
-    2014-01-01: "2013-12-31"
-    2015-01-01: "2014-12-19"
-    2016-01-01: "2014-12-19"
-    2017-04-01: "2017-03-10"
-    2018-01-01: "2017-12-31"
-  notes:
-    2017-04-01:
-    - title: Depuis le 1er janvier 2017, la CFP est unifiée pour tous les artisans (en et hors Alsace)
 documentation: |-
   Notes :
   (i) L’auto-entrepreneur bénéficie d’un régime simplifié de calcul et de paiement des cotisations et contributions sociales obligatoires.
@@ -64,8 +40,4 @@ documentation: |-
   de retraite de base
   de la retraite complémentaire obligatoire
   du régime invalidité et décès
-  (ii) Les auto-entrepreneurs sont dispensés de contribution à la formation professionnelle jusqu'en 2011.
-  Sources :
-  Cotisation des indépendants "auto-entrepreneurs" : D. 131-6-1 du Code de la sécurité sociale jusqu'en 2017 ; devient D. 131-5-1 avec le Décret 2017-1894
-  Contribution à la formation professionnelle des artisans : 1609 quatervicies B du CGI, puis L. 6331-48 du Code du travail
-  Contribution à la formation professionnelle des commerçants et professions libérales : L. 6331-48 du Code du travail
+  (ii) attention en 2018-01-01, il y a un changement dans l'Article L6331-48 du code du travail qui modifie les régles des valeurs

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/servicecom_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/servicecom_chiffre_affaires.yaml
@@ -5,6 +5,7 @@ values:
   2011-01-01:
     value: 0.002
 metadata:
+  last_review: "2022-04-07"
   ux_name: Taux - Prestation de services (commerçants)
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_servcom_form_ca
@@ -33,8 +34,12 @@ metadata:
       href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
       title: Décret 2017-301 du 08/03/2017
     2018-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
-      title: Décret 2017-1894 du 30/12/2017, art. 1
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000033760722/2017-01-01/
+      title: LOI n° 2016-1917 du 29 décembre 2016 de finances pour 2017 - article 50
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
+      title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
+      title: Article L6331-48 du code du travail
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/servicecom_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/servicecom_chiffre_affaires.yaml
@@ -18,7 +18,6 @@ metadata:
       title: Décret 2008-1349 du 18/12/2008
     2011-01-01:
     - title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
-      note: lien indisponible
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023382168/2011-01-01/
       title: Article L6331-48 du Code du travail
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/servicecom_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/servicecom_chiffre_affaires.yaml
@@ -39,4 +39,3 @@ documentation: |-
   de retraite de base
   de la retraite complémentaire obligatoire
   du régime invalidité et décès
-  (ii) attention en 2018-01-01, il y a un changement dans l'Article L6331-48 du code du travail qui modifie les régles des valeurs

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/ventecom_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/ventecom_chiffre_affaires.yaml
@@ -5,6 +5,7 @@ values:
   2011-01-01:
     value: 0.001
 metadata:
+  last_review: "2022-04-07"
   ux_name: Taux - Vente (commerçants)
   description_en: Self-employed specific scheme (auto-entrepreneurs)
   ipp_csv_id: auto_vente_form_ca
@@ -33,8 +34,12 @@ metadata:
       href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
       title: Décret 2017-301 du 08/03/2017
     2018-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036456533&cidTexte=JORFTEXT000036342439
-      title: Décret 2017-1894 du 30/12/2017, art. 1
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000033760722/2017-01-01/
+      title: LOI n° 2016-1917 du 29 décembre 2016 de finances pour 2017 - article 50
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
+      title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
+      title: Article L6331-48 du code du travail
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/ventecom_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/ventecom_chiffre_affaires.yaml
@@ -17,25 +17,10 @@ metadata:
     - href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000019951825
       title: Décret 2008-1349 du 18/12/2008
     2011-01-01:
-      title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
-    2013-01-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2012/12/28/2012-1551/jo/texte
-      title: Décret 2012-1551 du 28/12/2012
-    2014-01-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2013/12/27/2013-1290/jo/texte
-      title: Décret 2013-1290 du 27/12/2013
-    2015-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
-      title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
-    2016-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000029921990&cidTexte=JORFTEXT000029920824
-      title: Décret 2014-1531 du 17/12/2014, art. 4, 1°
-    2017-04-01:
-      href: https://www.legifrance.gouv.fr/eli/decret/2017/3/8/2017-301/jo/texte
-      title: Décret 2017-301 du 08/03/2017
-    2018-01-01:
-    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000033760722/2017-01-01/
-      title: LOI n° 2016-1917 du 29 décembre 2016 de finances pour 2017 - article 50
+    - title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
+      note: lien indisponible
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023382168/2011-01-01/
+      title: Article L6331-48 du Code du travail
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
       title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
@@ -43,15 +28,6 @@ metadata:
   official_journal_date:
     2009-01-01: "2008-12-19"
     2011-01-01: "2010-12-30"
-    2013-01-01: "2012-12-30"
-    2014-01-01: "2013-12-31"
-    2015-01-01: "2014-12-19"
-    2016-01-01: "2014-12-19"
-    2017-04-01: "2017-03-10"
-    2018-01-01: "2017-12-31"
-  notes:
-    2017-04-01:
-    - title: Depuis le 1er janvier 2017, la CFP est unifiée pour tous les artisans (en et hors Alsace)
 documentation: |-
   Notes :
   (i) L’auto-entrepreneur bénéficie d’un régime simplifié de calcul et de paiement des cotisations et contributions sociales obligatoires.
@@ -64,8 +40,4 @@ documentation: |-
   de retraite de base
   de la retraite complémentaire obligatoire
   du régime invalidité et décès
-  (ii) Les auto-entrepreneurs sont dispensés de contribution à la formation professionnelle jusqu'en 2011.
-  Sources :
-  Cotisation des indépendants "auto-entrepreneurs" : D. 131-6-1 du Code de la sécurité sociale jusqu'en 2017 ; devient D. 131-5-1 avec le Décret 2017-1894
-  Contribution à la formation professionnelle des artisans : 1609 quatervicies B du CGI, puis L. 6331-48 du Code du travail
-  Contribution à la formation professionnelle des commerçants et professions libérales : L. 6331-48 du Code du travail
+  (ii) attention en 2018-01-01, il y a un changement dans l'Article L6331-48 du code du travail qui modifie les régles des valeurs

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/ventecom_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/ventecom_chiffre_affaires.yaml
@@ -18,7 +18,6 @@ metadata:
       title: Décret 2008-1349 du 18/12/2008
     2011-01-01:
     - title: Loi 2010-1657 du 29/12/2010 de finances pour 2011, art. 137
-      note: lien indisponible
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023382168/2011-01-01/
       title: Article L6331-48 du Code du travail
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/ventecom_chiffre_affaires.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/auto_entrepreneur/formation_professionnelle/ventecom_chiffre_affaires.yaml
@@ -39,4 +39,3 @@ documentation: |-
   de retraite de base
   de la retraite complémentaire obligatoire
   du régime invalidité et décès
-  (ii) attention en 2018-01-01, il y a un changement dans l'Article L6331-48 du code du travail qui modifie les régles des valeurs

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
@@ -21,10 +21,6 @@ metadata:
       title: Loi 2012-958 du 16/08/2012 (LFR pour 2012), art. 38
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000026294815/2012-08-18/
       title: Article L6331-48 du Code du travail
-    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
-      title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
-    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
-      title: Article L6331-48, 1° du code du travail
   official_journal_date:
     1992-01-01: "1992-01-04"
     2012-08-18: "2012-08-17"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
@@ -25,7 +25,6 @@ metadata:
       title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
       title: Article L6331-48, 1° du code du travail
-
   official_journal_date:
     1992-01-01: "1992-01-04"
     2012-08-18: "2012-08-17"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
@@ -5,6 +5,7 @@ values:
   2012-08-18:
     value: 0.0025
 metadata:
+  last_view: "2022-04-05"
   ux_name: Taux (sous PSS)
   description_en: Contribution to lifelong professional training (professionals)
   ipp_csv_id: form_plib_0_1
@@ -14,8 +15,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006657767&cidTexte=JORFTEXT000000721454
       title: Loi 91-1405 du 31/12/1991, art. 32
     2012-08-18:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290023&cidTexte=JORFTEXT000026288927
+    - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290023&cidTexte=JORFTEXT000026288927
       title: Loi 2012-958 du 16/08/2012 (LFR pour 2012), art. 38
+    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000044981898/2022-01-01/
+      title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
+
   official_journal_date:
     1992-01-01: "1992-01-04"
     2012-08-18: "2012-08-17"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
@@ -12,9 +12,9 @@ metadata:
   unit: /1
   reference:
     1992-01-01:
-    -  href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006657767&cidTexte=JORFTEXT000000721454
+    - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006657767&cidTexte=JORFTEXT000000721454
       title: Loi 91-1405 du 31/12/1991, art. 32
-    -  href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006651549/1992-01-04
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006651549/1992-01-04
       title: Article L953-1 du Code du travail
     2012-08-18:
     - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290023&cidTexte=JORFTEXT000026288927

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
@@ -5,7 +5,7 @@ values:
   2012-08-18:
     value: 0.0025
 metadata:
-  last_view: "2022-04-06"
+  last_review: "2022-04-06"
   ux_name: Taux (sous PSS)
   description_en: Contribution to lifelong professional training (professionals)
   ipp_csv_id: form_plib_0_1

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
@@ -5,7 +5,7 @@ values:
   2012-08-18:
     value: 0.0025
 metadata:
-  last_view: "2022-04-05"
+  last_view: "2022-04-06"
   ux_name: Taux (sous PSS)
   description_en: Contribution to lifelong professional training (professionals)
   ipp_csv_id: form_plib_0_1
@@ -17,8 +17,10 @@ metadata:
     2012-08-18:
     - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290023&cidTexte=JORFTEXT000026288927
       title: Loi 2012-958 du 16/08/2012 (LFR pour 2012), art. 38
-    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000044981898/2022-01-01/
+    - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
       title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
+      title: Article L6331-48, 1° du code du travail
 
   official_journal_date:
     1992-01-01: "1992-01-04"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales/formation_pl/sous_pss.yaml
@@ -12,11 +12,15 @@ metadata:
   unit: /1
   reference:
     1992-01-01:
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006657767&cidTexte=JORFTEXT000000721454
+    -  href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006657767&cidTexte=JORFTEXT000000721454
       title: Loi 91-1405 du 31/12/1991, art. 32
+    -  href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006651549/1992-01-04
+      title: Article L953-1 du Code du travail
     2012-08-18:
     - href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026290023&cidTexte=JORFTEXT000026288927
       title: Loi 2012-958 du 16/08/2012 (LFR pour 2012), art. 38
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000026294815/2012-08-18/
+      title: Article L6331-48 du Code du travail
     - href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000044794656/2022-01-01/
       title: LOI n°2021-1900 du 30 décembre 2021 - art. 121
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044981898/2022-01-01
@@ -29,4 +33,4 @@ documentation: |-
   Note :
   Depuis 2005, supplément de 0,9 % si leur conjoint a le statut de conjoint collaborateur.
   Sources :
-  Article article L. 953-1 du Code du travail, puis (depuis 2012) article L. 6331-48 du Code du travail
+  Article article L. 953-1 du Code du travail (depuis 2005), puis article L. 6331-48 du Code du travail (depuis 2008).

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '116.7.2',
+    version = '116.7.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir de 2021.
* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/cotisations_taxes_professions_liberales`.
* Détails :
  - last_review + reference :  auto_entrepreneur.cotisations_prestations
Il y a un changement de valeur dans: auto_entrepreneur.cotisations_prestations.cipav en  2021-06-14
  - last_review + reference : auto_entrepreneur.formation_professionnelle
  - last_reviw + reference: formation_pl
Question pour formation_pl.sous_pss :  Depuis 2005, supplément de 0,9 % si leur conjoint a le statut de conjoint collaborateur. cela ne semble pas être pris en compte et est juste en note.

