### PR TITLE
Ajoute les limites d'abattement sur les salaires et pensions pour 2020 et 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### 117.0.1 [#1838](https://github.com/openfisca/openfisca-france/pull/1838)
+
+* Évolution du système socio-fiscal
+* Périodes concernées : du 01/01/2020 au 31/12/2021
+* Zones impactées :
+  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/max.yaml`
+  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/min.yaml`
+  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min.yaml`
+  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min.yaml`
+* Détails :
+  - Mise à jour des montants minimum et maximum d'abattement pour les traitements et salaires et pour les pensions
+  - Ajout de références législatives
+
 ## 117.0.0 [#1880](https://github.com/openfisca/openfisca-france/pull/1880)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/max.yaml
@@ -82,6 +82,10 @@ values:
     value: 3812
   2019-01-01:
     value: 3850
+  2020-01-01:
+    value: 3858
+  2021-01-01:
+    value: 3912
 metadata:
   unit: currency
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/max.yaml
@@ -84,11 +84,18 @@ values:
     value: 3850
   2020-01-01:
     value: 3858
+    reference:
+      title: Art. 2 de la loi no 2020-1721 du 29 décembre 2020 de finances pour 2021
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042753593
+      details: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
   2021-01-01:
     value: 3912
+    reference:
+      title: Art. 2 de la loi no 2021-1900 du 30 décembre 2021 de finances pour 2022
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044637653
+      details: Revalorisation de (10 225 / 10 084) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
 metadata:
   unit: currency
   reference:
-  - href: https://www.ipp.eu/baremes-ipp/impot-sur-le-revenu/calcul_revenus_imposables/deductions/
-  - href: http://bofip.impots.gouv.fr/bofip/7458-PGP#7458-PGP_Plafond_de_labattement_33
-  - href: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000034597100&cidTexte=LEGITEXT000006069577
+    title: Art. 158, 5, a, al. 2 du Code général des impôts
+    href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000045768992

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/min.yaml
@@ -48,6 +48,10 @@ values:
     value: 389
   2019-01-01:
     value: 393
+  2020-01-01:
+    value: 394
+  2021-01-01:
+    value: 400
 metadata:
   unit: currency
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/min.yaml
@@ -50,11 +50,18 @@ values:
     value: 393
   2020-01-01:
     value: 394
+    reference:
+      title: Art. 2 de la loi no 2020-1721 du 29 décembre 2020 de finances pour 2021
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042753593
+      details: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
   2021-01-01:
     value: 400
+    reference:
+      title: Art. 2 de la loi no 2021-1900 du 30 décembre 2021 de finances pour 2022
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044637653
+      details: Revalorisation de (10 225 / 10 084) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
 metadata:
   unit: currency
   reference:
-  - href: https://www.ipp.eu/baremes-ipp/impot-sur-le-revenu/calcul_revenus_imposables/deductions/
-  - href: http://bofip.impots.gouv.fr/bofip/7458-PGP#7458-PGP_Plafond_de_labattement_33
-  - href: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000034597100&cidTexte=LEGITEXT000006069577
+    title: Art. 158, 5, a, al. 3 du Code général des impôts
+    href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000045768992

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/max.yaml
@@ -86,9 +86,21 @@ values:
     value: 12627
   2020-01-01:
     value: 12652
+    reference:
+      title: Art. 2 de la loi no 2020-1721 du 29 décembre 2020 de finances pour 2021
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042753593
+      details: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
   2021-01-01:
     value: 12829
+    reference:
+      title: Art. 2 de la loi no 2021-1900 du 30 décembre 2021 de finances pour 2022
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044637653
+      details: Revalorisation de (10 225 / 10 084) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
 metadata:
   unit: currency
   reference:
-    title: Barèmes IPP - https://www.ipp.eu/wp-content/uploads/2017/07/baremes-ipp-impot-revenu-income-tax.xlsx
+    title: Art. 83, 3°, al. 2 du Code général des impôts
+    href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043662712/
+
+
+

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/max.yaml
@@ -84,6 +84,10 @@ values:
     value: 12502
   2019-01-01:
     value: 12627
+  2020-01-01:
+    value: 12652
+  2021-01-01:
+    value: 12829
 metadata:
   unit: currency
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min.yaml
@@ -56,6 +56,10 @@ values:
     value: 437
   2019-01-01:
     value: 441
+  2020-01-01:
+    value: 442
+  2021-01-01:
+    value: 448
 metadata:
   unit: currency
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min.yaml
@@ -58,9 +58,18 @@ values:
     value: 441
   2020-01-01:
     value: 442
+    reference:
+      title: Art. 2 de la loi no 2020-1721 du 29 décembre 2020 de finances pour 2021
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042753593
+      details: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
   2021-01-01:
     value: 448
+    reference:
+      title: Art. 2 de la loi no 2021-1900 du 30 décembre 2021 de finances pour 2022
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044637653
+      details: Revalorisation de (10 225 / 10 084) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
 metadata:
   unit: currency
   reference:
-    href: https://www.ipp.eu/outils/baremes-ipp/
+    title: Art. 83, 3°, al. 3 et 4 du Code général des impôts
+    href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043662712/

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '117.0.0',
+    version = '117.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/2020 au 31/12/2022.
* Zones impactées : 
  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/max.yaml` ;
  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/min.yaml` ;
  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min.yaml` ;
  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min.yaml` ;
* Détails :
  - Mise à jour des montants minimum et maximum d'abattement pour les traitements et salaires et pour les pensions (cf. #1837)

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
