### PR TITLE
Corrige et rationalise certaines variables de revenus du capital

### DIFF
--- a/.github/get_pypi_info.py
+++ b/.github/get_pypi_info.py
@@ -34,7 +34,7 @@ def replace_in_file(filepath: str, info: dict):
     meta = meta.replace('PYPI_SHA256', info['sha256'])
     with open(filepath, 'wt') as fout:
         fout.write(meta)
-    print(f'File {filepath} has been updated with informations from PyPi.')  # noqa: T001
+    print(f'File {filepath} has been updated with informations from PyPi.')  # noqa: T201
 
 
 if __name__ == '__main__':
@@ -43,5 +43,5 @@ if __name__ == '__main__':
     parser.add_argument('-f', '--filename', type=str, default='.conda/meta.yaml', help='Path to meta.yaml, with filename')
     args = parser.parse_args()
     info = get_info(args.package)
-    print('Information of the last published PyPi package :', info)  # noqa: T001
+    print('Information of the last published PyPi package :', info)  # noqa: T201
     replace_in_file(args.filename, info)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 116.7.0 [#1844](https://github.com/openfisca/openfisca-france/pull/1844)
+
+* Correction de législation.
+* Périodes concernées : toutes.
+* Zones impactées:
+   - `mesures.py`.
+   - `prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py`
+   - `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py`
+* Détails :
+  - Corrige des variables de bases taxables de revenus du capital
+  - Rationalise et corrige la variable `plus_values_base_large`
+
 ### 116.6.1 [#1831](https://github.com/openfisca/openfisca-france/pull/1831)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -156,6 +156,10 @@ class plus_values_base_large(Variable):
         calcul du revenu disponible, afin de n'oublier aucun revenu. Elle vaut la somme de assiette_csg_plus_values et rfr_plus_values_hors_rni,
         où l'on enlève les cases communes entre ces deux variables, et où l'on ajoute les variables présentes dans 'revenu_categoriel_plus_values', mais pas présente
         dans assiette_csg_plus_values
+        Attention, on n'ajoute pas en revanche 3SA car de notre compréhension, il s'agit de plus-values qui avaient bénéficié
+        de reports d'imposition, report qui a expiré. Ce qui veut dire que ces revenus n'avaient pas été imposés lors de leur
+        réalisation (ils le sont maintenant), mais avaient été comptés dans le RFR. Donc, il s'agit de revenus qui ne font pas parti
+        du revenu courant de cette année. 
         Attention : pour les variables de 'revenu_categoriel_plus_values' ajoutées, elles peuvent représenter des montants nets, alors qu'il faudrait le brut. Améliorer ce point
         '''
 
@@ -165,11 +169,12 @@ class plus_values_base_large(Variable):
         f3vg = foyer_fiscal('f3vg', period)
         f3we = foyer_fiscal('f3we', period)
         f3vz = foyer_fiscal('f3vz', period)
+        f3vt = foyer_fiscal('f3vt', period)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        intersection_v1_v2 = f3vg + f3we + f3vz + rpns_pvce
+        intersection_v1_v2 = f3vg + f3we + f3vz + rpns_pvce + f3vt
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2
 
@@ -183,15 +188,15 @@ class plus_values_base_large(Variable):
 
         f3we = foyer_fiscal('f3we', period)
         f3vz = foyer_fiscal('f3vz', period)
-        f3sb = foyer_fiscal('f3sb', period)
         f3vl = foyer_fiscal('f3vl', period)
         f3wb = foyer_fiscal('f3wb', period)
+        f3vt = foyer_fiscal('f3vt', period)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        intersection_v1_v2 = f3we + f3vz + rpns_pvce
-        ajouts_de_rev_cat_pv = f3sb + f3vl + f3wb
+        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt
+        ajouts_de_rev_cat_pv = f3vl + f3wb
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2 + ajouts_de_rev_cat_pv
 
@@ -205,50 +210,28 @@ class plus_values_base_large(Variable):
 
         f3we = foyer_fiscal('f3we', period)
         f3vz = foyer_fiscal('f3vz', period)
-        f3sb = foyer_fiscal('f3sb', period)
         f3wb = foyer_fiscal('f3wb', period)
+        f3vt = foyer_fiscal('f3vt', period)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        intersection_v1_v2 = f3we + f3vz + rpns_pvce
-        ajouts_de_rev_cat_pv = f3sb + f3wb
+        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt
+        ajouts_de_rev_cat_pv = f3wb
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2 + ajouts_de_rev_cat_pv
 
     def formula_2018_01_01(foyer_fiscal, period):
         '''
         Cf. docstring période précédente
+        Pour 2018 et 2019, assiette_csg_plus_values est inclus dans rfr_plus_values_hors_rni
         '''
+        f3wb = foyer_fiscal('f3wb', period)
 
-        v1_assiette_csg_plus_values = foyer_fiscal('assiette_csg_plus_values', period)
-        v2_rfr_plus_values_hors_rni = foyer_fiscal('rfr_plus_values_hors_rni', period)
+        rfr_plus_values_hors_rni = foyer_fiscal('rfr_plus_values_hors_rni', period)
+        ajouts_de_rev_cat_pv = f3wb
 
-        f3ua = foyer_fiscal('f3ua', period)
-        f3vg = foyer_fiscal('f3vg', period)
-        f3we = foyer_fiscal('f3we', period)
-        f3vz = foyer_fiscal('f3vz', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
-        f3sj = foyer_fiscal('f3sj', period)
-        f3tj = foyer_fiscal('f3tj', period)
-        f3sk = foyer_fiscal('f3sk', period)
-        f3vm = foyer_fiscal('f3vm', period)
-        f3vt = foyer_fiscal('f3vt', period)
-        f3wi = foyer_fiscal('f3wi', period)
-        f3wj = foyer_fiscal('f3wj', period)
-        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
-        f3pi = foyer_fiscal('f3pi', period)
-
-        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
-
-        intersection_v1_v2 = f3vg + f3ua + f3vz + f3we + rpns_pvce + f3sj + f3sk + f3vm + f3vt + f3wi + f3wj + f3pi + f3tj + f3vd + f3vi + f3vf
-
-        return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2
+        return rfr_plus_values_hors_rni + ajouts_de_rev_cat_pv
 
 
 class revenus_nets_du_capital(Variable):

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -159,7 +159,7 @@ class plus_values_base_large(Variable):
         Attention, on n'ajoute pas en revanche 3SA car de notre compréhension, il s'agit de plus-values qui avaient bénéficié
         de reports d'imposition, report qui a expiré. Ce qui veut dire que ces revenus n'avaient pas été imposés lors de leur
         réalisation (ils le sont maintenant), mais avaient été comptés dans le RFR. Donc, il s'agit de revenus qui ne font pas parti
-        du revenu courant de cette année. 
+        du revenu courant de cette année.
         Attention : pour les variables de 'revenu_categoriel_plus_values' ajoutées, elles peuvent représenter des montants nets, alors qu'il faudrait le brut. Améliorer ce point
         '''
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2014,7 +2014,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3sa + f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + f3wi + f3wj + rpns_pvce
+        return f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + f3wi + f3wj + rpns_pvce
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
         '''
@@ -2038,6 +2038,7 @@ class rfr_plus_values_hors_rni(Variable):
         f3we = foyer_fiscal('f3we', period)
         f3wi = foyer_fiscal('f3wi', period)
         f3wj = foyer_fiscal('f3wj', period)
+        f3pi = foyer_fiscal('f3pi', period)
 
         f3vi = foyer_fiscal.sum(f3vi_i)
         f3vd = foyer_fiscal.sum(f3vd_i)
@@ -2046,7 +2047,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3sa + f3vg + f3ua + f3sj + f3sk + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3tj
+        return f3vg + f3ua + f3sj + f3sk + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3tj + f3pi
 
     def formula_2019_01_01(foyer_fiscal, period, parameters):
         '''
@@ -2071,7 +2072,6 @@ class rfr_plus_values_hors_rni(Variable):
         f3wi = foyer_fiscal('f3wi', period)
         f3wj = foyer_fiscal('f3wj', period)
         f3an = foyer_fiscal('f3an', period)
-        f3bn = foyer_fiscal('f3bn', period)
         f3pi = foyer_fiscal('f3pi', period)
 
         f3vi = foyer_fiscal.sum(f3vi_i)
@@ -2081,7 +2081,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3sa + f3vg + f3ua + f3sj + f3sk + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3tj + f3an - f3bn + f3pi
+        return f3vg + f3ua + f3sj + f3sk + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3tj + f3an + f3pi
 
 
 class iai(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1988,7 +1988,6 @@ class rfr_plus_values_hors_rni(Variable):
         '''
         Plus-values 2016 et + entrant dans le calcul du revenu fiscal de référence
         '''
-        f3sa = foyer_fiscal('f3sa', period)
         f3sj = foyer_fiscal('f3sj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3tz = foyer_fiscal('f3tz', period)
@@ -2020,7 +2019,6 @@ class rfr_plus_values_hors_rni(Variable):
         '''
         Plus-values réalisées sur année 2018 entrant dans le calcul du revenu fiscal de référence.
         '''
-        f3sa = foyer_fiscal('f3sa', period)
         f3vg = foyer_fiscal('f3vg', period)
         f3ua = foyer_fiscal('f3ua', period)
         f3sj = foyer_fiscal('f3sj', period)
@@ -2053,7 +2051,6 @@ class rfr_plus_values_hors_rni(Variable):
         '''
         Plus-values 2019 et + entrant dans le calcul du revenu fiscal de référence.
         '''
-        f3sa = foyer_fiscal('f3sa', period)
         f3vg = foyer_fiscal('f3vg', period)
         f3ua = foyer_fiscal('f3ua', period)
         f3sj = foyer_fiscal('f3sj', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -131,16 +131,16 @@ class plus_values_prelevement_forfaitaire_unique_ir(Variable):
     definition_period = YEAR
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
-        f3sa = foyer_fiscal('f3sa', period)
+        f3sb = foyer_fiscal('f3sb', period)
         f3ua = foyer_fiscal('f3ua', period)
         f3va = foyer_fiscal('f3va', period)
         f3vg = foyer_fiscal('f3vg', period)
         f3tj = foyer_fiscal('f3tj', period)
 
-        return f3sa + max_(0, f3ua - f3va) + f3vg + f3tj
+        return f3sb + max_(0, f3ua - f3va) + f3vg + f3tj
 
     def formula_2019_01_01(foyer_fiscal, period, parameters):
-        f3sa = foyer_fiscal('f3sa', period)
+        f3sb = foyer_fiscal('f3sb', period)
         f3ua = foyer_fiscal('f3ua', period)
         f3va = foyer_fiscal('f3va', period)
         f3vg = foyer_fiscal('f3vg', period)
@@ -148,9 +148,8 @@ class plus_values_prelevement_forfaitaire_unique_ir(Variable):
         f3tk = foyer_fiscal('f3tk', period)
         f3vt = foyer_fiscal('f3vt', period)
         f3an = foyer_fiscal('f3an', period)
-        f3bn = foyer_fiscal('f3bn', period)
 
-        return f3sa + max_(0, f3ua - f3va) + f3vg + max_(0, f3tj - f3tk) + f3vt + f3an - f3bn
+        return f3sb + max_(0, f3ua - f3va) + f3vg + max_(0, f3tj - f3tk) + f3vt + f3an
 
 
 class prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -144,13 +144,14 @@ class assiette_csg_plus_values(Variable):
         f3sl = foyer_fiscal('f3sl', period)
         f3va_2014 = foyer_fiscal('f3va_2014', period)
         f3we = foyer_fiscal('f3we', period)
+        f3vt = foyer_fiscal('f3vt', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
 
-        return f3vg + f3sg + f3sl + f3va_2014 + f3vz + f3we + rpns_pvce
+        return f3vg + f3sg + f3sl + f3va_2014 + f3vz + f3we + f3vt + rpns_pvce
 
     def formula_2015_01_01(foyer_fiscal, period, parameters):
         '''
@@ -164,13 +165,14 @@ class assiette_csg_plus_values(Variable):
         f3va_2016_i = foyer_fiscal.members('f3va_2016', period)
         f3va_2016 = foyer_fiscal.sum(f3va_2016_i)
         f3we = foyer_fiscal('f3we', period)
+        f3vt = foyer_fiscal('f3vt', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
 
-        return f3vg + f3sg + f3sl + f3va_2016 + f3vz + f3we + rpns_pvce
+        return f3vg + f3sg + f3sl + f3va_2016 + f3vz + f3we + f3vt + rpns_pvce
 
     def formula_2017_01_01(foyer_fiscal, period, parameters):
         '''
@@ -184,13 +186,14 @@ class assiette_csg_plus_values(Variable):
         f3va = foyer_fiscal('f3va', period)
         f3we = foyer_fiscal('f3we', period)
         f3ua = foyer_fiscal('f3ua', period)
+        f3vt = foyer_fiscal('f3vt', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
 
-        return f3vg + f3sg + f3sl + f3va + f3ua + f3vz + f3we + rpns_pvce
+        return f3vg + f3sg + f3sl + f3va + f3ua + f3vz + f3we + f3vt + rpns_pvce
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
 
@@ -240,7 +243,6 @@ class assiette_csg_plus_values(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         f3pi = foyer_fiscal('f3pi', period)
         f3an = foyer_fiscal('f3an', period)
-        f3bn = foyer_fiscal('f3bn', period)
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
         f3vd = foyer_fiscal.sum(f3vd_i)
@@ -250,7 +252,7 @@ class assiette_csg_plus_values(Variable):
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
 
-        return f3vg + f3ua + f3vz + f3we + rpns_pvce + f3sj + f3sk + f3vm + f3vt + f3wi + f3wj + f3pi + f3tj + f3an - f3bn + f3vd + f3vi + f3vf
+        return f3vg + f3ua + f3vz + f3we + rpns_pvce + f3sj + f3sk + f3vm + f3vt + f3wi + f3wj + f3pi + f3tj + f3an + f3vd + f3vi + f3vf
 
 
 class assiette_csg_revenus_capital(Variable):

--- a/openfisca_france/scripts/performance/measure_spiral_performances.py
+++ b/openfisca_france/scripts/performance/measure_spiral_performances.py
@@ -87,7 +87,7 @@ def test_revenu_disponible():
             simulation.calculate('revenu_disponible', 2018)
 
     result, delta = run_test()
-    print('{:2.6f} s'.format(delta / NB_RUN))  # noqa T001
+    print('{:2.6f} s'.format(delta / NB_RUN))  # noqa T201
 
 
 def test_spiral():
@@ -103,19 +103,19 @@ def test_spiral():
             simulation.calculate('logement_social_eligible', '2018-12')
 
     result, delta = run_test()
-    print('{:2.6f} s'.format(delta / NB_RUN))  # noqa T001
+    print('{:2.6f} s'.format(delta / NB_RUN))  # noqa T201
 
 
-print('Premier test revenu disponible')  # noqa T001
+print('Premier test revenu disponible')  # noqa T201
 test_revenu_disponible()
-print('Second test revenu disponible')  # noqa T001
+print('Second test revenu disponible')  # noqa T201
 test_revenu_disponible()
-print('3e test revenu disponible')  # noqa T001
+print('3e test revenu disponible')  # noqa T201
 test_revenu_disponible()
 
-print('Premier test ciblé spirale')  # noqa T001
+print('Premier test ciblé spirale')  # noqa T201
 test_spiral()
-print('Second test ciblé spirale')  # noqa T001
+print('Second test ciblé spirale')  # noqa T201
 test_spiral()
-print('3e test ciblé spirale')  # noqa T001
+print('3e test ciblé spirale')  # noqa T201
 test_spiral()

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,9 @@ setup(
             ],
         'dev': [
             'autopep8 ==1.5.7',
-            'flake8 >=3.8.0,<3.10.0',
-            'flake8-print',
-            'flake8-quotes',
+            'flake8 >= 4.0.0, < 5.0.0',
+            'flake8-print >= 5.0.0, < 6.0.0',
+            'flake8-quotes >= 3.3.1, < 6.0.0',
             'pytest >= 5.0.0, < 7.0.0',
             'scipy >= 0.17',  # Only used to test de_net_a_brut reform
             'requests >= 2.8',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '116.6.1',
+    version = '116.7.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -256,7 +256,7 @@
   absolute_error_margin: 1
   input:
     f2dc: 20000
-    f3sa: 30000
+    f3sb: 30000 # Correspond à f3sa apres abattement. Pas besoin de spécifier f3sa car jamais utilisée dans OFF (vu que ces revenus sont juste utilisés pour l'IR, pour leur montant après abattement, mais n'entrent pas dans les revenus courants : voir explications dans docstring de plus_values_base_large)
     f3vg: 40000
     f3vd: 50000
     interets_plan_epargne_logement_moins_de_12_ans_ouvert_a_partir_de_2018: 60000
@@ -264,11 +264,11 @@
     rsa: 0
   output:
     prelevements_sociaux_revenus_capital: -41280
-    revenus_nets_du_capital: 270000 - 41280
+    revenus_nets_du_capital: (270000 - 30000) - 41280 # car les revenus associés à 3SA et 3SB ne sont pas dans les revenus courants : voir docstring de plus_values_base_large
     prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs: -28160 #-(22000*0.128) 3VD est un gain taxé forfaitairement au taux de 18% et non au PFU
     taxation_plus_values_hors_bareme: 9000 #50000 * 0.18
     impots_directs: -28160 - 9000
-    revenu_disponible: 270000 - 41280 - 28160 - 9000
+    revenu_disponible: (270000 - 30000) - 41280 - 28160 - 9000 # car les revenus associés à 3SA et 3SB ne sont pas dans les revenus courants : voir docstring de plus_values_base_large
 
 - name: plus_values_immobilières_2018
   description: Montant d'impôt et revenu disponible pour les plus-values immobilières (3VZ)


### PR DESCRIPTION
* Correction de législation.
* Périodes concernées : toutes.
* Zones impactées:
   - `mesures.py`.
   - `prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py`
   - `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py`
* Détails :
  - Corrige des variables de bases taxables de revenus du capital
  - Rationalise et corrige la variable `plus_values_base_large`