### PR TITLE
Ajoute case 3PI (plus-values sur instruments financiers taxables à 50%) en 2017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 116.7.1 [#1847](https://github.com/openfisca/openfisca-france/pull/1847)
+
+* Correction d'une erreur de législation
+* Périodes concernées : 2017
+* Zones impactées:
+    - `prelevements_obligatoires/impot_revenu/ir.py`.
+    - `mesures.py`
+    - `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py`.
+* Détails :
+  - Ajoute en 2017 la case 3PI, créée cette année-là, et qui était présente seulement à partir de 2018
+
 ## 116.7.0 [#1844](https://github.com/openfisca/openfisca-france/pull/1844)
 
 * Correction de législation.

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -221,6 +221,28 @@ class plus_values_base_large(Variable):
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2 + ajouts_de_rev_cat_pv
 
+    def formula_2017_01_01(foyer_fiscal, period):
+        '''
+        Cf. docstring période précédente
+        '''
+
+        v1_assiette_csg_plus_values = foyer_fiscal('assiette_csg_plus_values', period)
+        v2_rfr_plus_values_hors_rni = foyer_fiscal('rfr_plus_values_hors_rni', period)
+
+        f3we = foyer_fiscal('f3we', period)
+        f3vz = foyer_fiscal('f3vz', period)
+        f3wb = foyer_fiscal('f3wb', period)
+        f3vt = foyer_fiscal('f3vt', period)
+        f3pi = foyer_fiscal('f3pi', period)
+
+        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
+        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
+
+        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt + f3pi
+        ajouts_de_rev_cat_pv = f3wb
+
+        return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2 + ajouts_de_rev_cat_pv
+
     def formula_2018_01_01(foyer_fiscal, period):
         '''
         Cf. docstring période précédente

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1905,7 +1905,7 @@ class rfr_plus_values_hors_rni(Variable):
     label = 'Plus-values hors RNI entrant dans le calcul du revenu fiscal de référence (PV au barème, PV éxonérées ..)'
     definition_period = YEAR
 
-    def formula_2011_01_01(foyer_fiscal, period, parameters):
+    def formula_2011_01_01(foyer_fiscal, period):
         '''
         Plus-values 2011 entrant dans le calcul du revenu fiscal de référence
         '''
@@ -1927,7 +1927,7 @@ class rfr_plus_values_hors_rni(Variable):
 
         return f3vc + f3vd + f3vf + f3vg + f3vi + f3vl + f3vm + f3vp + f3vy + f3vz + rpns_pvce
 
-    def formula_2012_01_01(foyer_fiscal, period, parameters):
+    def formula_2012_01_01(foyer_fiscal, period):
         '''
         Plus-values 2012 entrant dans le calcul du revenu fiscal de référence
         '''
@@ -1956,7 +1956,7 @@ class rfr_plus_values_hors_rni(Variable):
 
         return f3sa_2012 + f3sj + f3sk + f3vc + f3vd + f3vf + f3vg + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz + f3we + rpns_pvce
 
-    def formula_2013_01_01(foyer_fiscal, period, parameters):
+    def formula_2013_01_01(foyer_fiscal, period):
         '''
         Plus-values 2013-2016 entrant dans le calcul du revenu fiscal de référence
         '''
@@ -1984,7 +1984,7 @@ class rfr_plus_values_hors_rni(Variable):
 
         return f3sj + f3sk + f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + rpns_pvce
 
-    def formula_2016_01_01(foyer_fiscal, period, parameters):
+    def formula_2016_01_01(foyer_fiscal, period):
         '''
         Plus-values 2016 et + entrant dans le calcul du revenu fiscal de référence
         '''
@@ -2015,7 +2015,7 @@ class rfr_plus_values_hors_rni(Variable):
 
         return f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + f3wi + f3wj + rpns_pvce
 
-    def formula_2017_01_01(foyer_fiscal, period, parameters):
+    def formula_2017_01_01(foyer_fiscal, period):
         '''
         Plus-values 2017 et + entrant dans le calcul du revenu fiscal de référence
         '''
@@ -2047,8 +2047,7 @@ class rfr_plus_values_hors_rni(Variable):
 
         return f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3pi
 
-
-    def formula_2018_01_01(foyer_fiscal, period, parameters):
+    def formula_2018_01_01(foyer_fiscal, period):
         '''
         Plus-values réalisées sur année 2018 entrant dans le calcul du revenu fiscal de référence.
         '''
@@ -2080,7 +2079,7 @@ class rfr_plus_values_hors_rni(Variable):
 
         return f3vg + f3ua + f3sj + f3sk + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3tj + f3pi
 
-    def formula_2019_01_01(foyer_fiscal, period, parameters):
+    def formula_2019_01_01(foyer_fiscal, period):
         '''
         Plus-values 2019 et + entrant dans le calcul du revenu fiscal de référence.
         '''

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1825,43 +1825,7 @@ class taxation_plus_values_hors_bareme(Variable):
 
     def formula_2017_01_01(foyer_fiscal, period, parameters):
         '''
-        Taxation des plus values (hors bareme)
-        '''
-        f3sj = foyer_fiscal('f3sj', period)
-        f3sk = foyer_fiscal('f3sk', period)
-        f3vm = foyer_fiscal('f3vm', period)
-        f3vt = foyer_fiscal('f3vt', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
-        f3wi = foyer_fiscal('f3wi', period)
-        f3wj = foyer_fiscal('f3wj', period)
-        f3pi = foyer_fiscal('f3pi', period)
-        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
-
-        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
-        plus_values = parameters(period).impot_revenu.calcul_impot_revenu.pv.plus_values
-
-        return round_(
-            plus_values.pvce * rpns_pvce
-            + plus_values.pea.taux_avant_2_ans * f3vm
-            + plus_values.pea.taux_posterieur * f3vt
-            + plus_values.taux2 * f3vd
-            + plus_values.taux3 * f3vi
-            + plus_values.taux4 * f3vf
-            + plus_values.taux_plus_values_bspce * f3sj
-            + plus_values.taux_plus_values_bspce_conditionnel * f3sk
-            + plus_values.taux_plus_values_report * f3wi
-            + plus_values.taux_plus_values_report_conditionnel * f3wj
-            + plus_values.taux_plus_values_entc * f3pi
-            )
-
-    def formula_2018_01_01(foyer_fiscal, period, parameters):
-        '''
-        Taxation des plus-values (hors imposition au barÃ¨me), en excluant celles imposées au PFU
+        Taxation des plus-values (hors imposition au barÃ¨me), en excluant, à partir de 2018, celles imposées au PFU
         (qui sont à impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py)
         '''
         f3vd_i = foyer_fiscal.members('f3vd', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1823,6 +1823,42 @@ class taxation_plus_values_hors_bareme(Variable):
             + plus_values.taux_plus_values_report_conditionnel * f3wj
             )
 
+    def formula_2017_01_01(foyer_fiscal, period, parameters):
+        '''
+        Taxation des plus values (hors bareme)
+        '''
+        f3sj = foyer_fiscal('f3sj', period)
+        f3sk = foyer_fiscal('f3sk', period)
+        f3vm = foyer_fiscal('f3vm', period)
+        f3vt = foyer_fiscal('f3vt', period)
+        f3vd_i = foyer_fiscal.members('f3vd', period)
+        f3vi_i = foyer_fiscal.members('f3vi', period)
+        f3vf_i = foyer_fiscal.members('f3vf', period)
+        f3wi = foyer_fiscal('f3wi', period)
+        f3wj = foyer_fiscal('f3wj', period)
+        f3pi = foyer_fiscal('f3pi', period)
+        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
+
+        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
+        f3vd = foyer_fiscal.sum(f3vd_i)
+        f3vi = foyer_fiscal.sum(f3vi_i)
+        f3vf = foyer_fiscal.sum(f3vf_i)
+        plus_values = parameters(period).impot_revenu.calcul_impot_revenu.pv.plus_values
+
+        return round_(
+            plus_values.pvce * rpns_pvce
+            + plus_values.pea.taux_avant_2_ans * f3vm
+            + plus_values.pea.taux_posterieur * f3vt
+            + plus_values.taux2 * f3vd
+            + plus_values.taux3 * f3vi
+            + plus_values.taux4 * f3vf
+            + plus_values.taux_plus_values_bspce * f3sj
+            + plus_values.taux_plus_values_bspce_conditionnel * f3sk
+            + plus_values.taux_plus_values_report * f3wi
+            + plus_values.taux_plus_values_report_conditionnel * f3wj
+            + plus_values.taux_plus_values_entc * f3pi
+            )
+
     def formula_2018_01_01(foyer_fiscal, period, parameters):
         '''
         Taxation des plus-values (hors imposition au barÃ¨me), en excluant celles imposées au PFU
@@ -2014,6 +2050,39 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
         return f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + f3wi + f3wj + rpns_pvce
+
+    def formula_2017_01_01(foyer_fiscal, period, parameters):
+        '''
+        Plus-values 2017 et + entrant dans le calcul du revenu fiscal de référence
+        '''
+        f3sj = foyer_fiscal('f3sj', period)
+        f3sk = foyer_fiscal('f3sk', period)
+        f3tz = foyer_fiscal('f3tz', period)
+        f3vc = foyer_fiscal('f3vc', period)
+        f3vd_i = foyer_fiscal.members('f3vd', period)
+        f3vf_i = foyer_fiscal.members('f3vf', period)
+        f3vi_i = foyer_fiscal.members('f3vi', period)
+        f3vm = foyer_fiscal('f3vm', period)
+        f3vp = foyer_fiscal('f3vp', period)
+        f3vq = foyer_fiscal('f3vq', period)
+        f3vr = foyer_fiscal('f3vr', period)
+        f3vt = foyer_fiscal('f3vt', period)
+        f3vy = foyer_fiscal('f3vy', period)
+        f3vz = foyer_fiscal('f3vz', period)
+        f3we = foyer_fiscal('f3we', period)
+        f3wi = foyer_fiscal('f3wi', period)
+        f3wj = foyer_fiscal('f3wj', period)
+        f3pi = foyer_fiscal('f3pi', period)
+
+        f3vi = foyer_fiscal.sum(f3vi_i)
+        f3vd = foyer_fiscal.sum(f3vd_i)
+        f3vf = foyer_fiscal.sum(f3vf_i)
+
+        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
+        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
+
+        return f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3pi
+
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
         '''

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -187,13 +187,14 @@ class assiette_csg_plus_values(Variable):
         f3we = foyer_fiscal('f3we', period)
         f3ua = foyer_fiscal('f3ua', period)
         f3vt = foyer_fiscal('f3vt', period)
+        f3pi = foyer_fiscal('f3pi', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
 
-        return f3vg + f3sg + f3sl + f3va + f3ua + f3vz + f3we + f3vt + rpns_pvce
+        return f3vg + f3sg + f3sl + f3va + f3ua + f3vz + f3we + f3vt + f3pi + rpns_pvce
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
 

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -573,7 +573,7 @@ class f3pi(Variable):
     unit = 'currency'
     entity = FoyerFiscal
     label = 'Profits sur instruments financiers réalisés dans des ETNC ou paradis fiscaux'
-    # start_date = date(2018, 1, 1)
+    # start_date = date(2017, 1, 1)
     definition_period = YEAR
 
 

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/pv/plus_values.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/pv/plus_values.yaml
@@ -172,7 +172,7 @@ taux_plus_values_bspce_conditionnel:
 taux_plus_values_entc:
   description: Taux forfaitaire d'imposition sur les profits sur instruments financiers dans des ETNC
   values:
-    2018-01-01:
+    2017-01-01:
       value: 0.5
   metadata:
     unit: /1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '116.7.0',
+    version = '116.7.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Correction d'une erreur de législation
* Périodes concernées : 2017
* Zones impactées:
    - `prelevements_obligatoires/impot_revenu/ir.py`.
    - `mesures.py`
    - `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py`.
* Détails :
  - Ajoute en 2017 la case 3PI, créée cette année-là, et qui était présente seulement à partir de 2018