### PR TITLE
Correction caractéristiques variables handicap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 116.7.2 [#1848](https://github.com/openfisca/openfisca-france/pull/1848)
+
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées : `caracteristiques_socio_demographiques/capacite_travail.py`.
+* Détails :
+  - Ajoute `is_period_size_independent` pour `taux_capacite_travail` et `taux_incapacite`: sans cet argument, on avait des problèmes dans nos survey scenarios quand on rentrait cette variable en input. Ex: si on entrait 0.8, pour chaque mois de l'année des années, on avait 12*0.8, pour les mois de l'année d'après, on avait 12*12*0.8, etc. Et ce malgré le `set_input_dispatch_by_period`.
+
 ### 116.7.1 [#1847](https://github.com/openfisca/openfisca-france/pull/1847)
 
 * Correction d'une erreur de législation

--- a/openfisca_france/model/caracteristiques_socio_demographiques/capacite_travail.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/capacite_travail.py
@@ -7,6 +7,7 @@ class taux_capacite_travail(Variable):
     entity = Individu
     label = "Taux de capacité de travail, appréciée par la commission des droits et de l'autonomie des personnes handicapées (CDAPH)"
     definition_period = MONTH
+    is_period_size_independent = True
     set_input = set_input_dispatch_by_period
 
 
@@ -17,4 +18,5 @@ class taux_incapacite(Variable):
     definition_period = MONTH
     reference = 'https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=BD54F4B28313142C87FC8B96013E0441.tplgfr44s_1?idArticle=LEGIARTI000023097719&cidTexte=LEGITEXT000006073189&dateTexte=20190312'
     documentation = "Taux d'incapacité retenu pour l'Allocation Adulte Handicapé (AAH)."
+    is_period_size_independent = True
     set_input = set_input_dispatch_by_period

--- a/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
+++ b/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
@@ -164,7 +164,7 @@ class rsa_activite(Variable):
     set_input = set_input_divide_by_period
 
     def formula_2009_06_01(famille, period):
-        rsa = famille('rsa', period, period)
+        rsa = famille('rsa', period)
         rsa_base_ressources = famille('rsa_base_ressources', period)
         rsa_socle = famille('rsa_socle', period)
         rsa_forfait_logement = famille('rsa_forfait_logement', period)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '116.7.1',
+    version = '116.7.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `caracteristiques_socio_demographiques/capacite_travail.py`.
* Détails :
  - Ajoute `is_period_size_independent` pour `taux_capacite_travail` et `taux_incapacite`: sans cet argument, on avait des problèmes dans nos survey scenarios quand on rentrait cette variable en input. Ex: si on entrait 0.8, pour chaque mois de l'année des années, on avait 12*0.8, pour les mois de l'année d'après, on avait 12*12*0.8, etc. Et ce malgré le `set_input_dispatch_by_period`.