### PR TITLE
Corrige la date de `mobili_jeune`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 116.12.0 [#1854](https://github.com/openfisca/openfisca-france/pull/1854)
+## 116.12.0 [#1857](https://github.com/openfisca/openfisca-france/pull/1857)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : toutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 116.12.0 [#1854](https://github.com/openfisca/openfisca-france/pull/1854)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : `model/prestations/jeunes/mobili_jeune.py`.
+* Détails :
+  - Corrige la date de formule de la variable `mobili_jeune`
+
 ## 116.11.0 [#1854](https://github.com/openfisca/openfisca-france/pull/1854)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/jeunes/mobili_jeune.py
+++ b/openfisca_france/model/prestations/jeunes/mobili_jeune.py
@@ -13,7 +13,7 @@ class mobili_jeune(Variable):
     set_input = set_input_divide_by_period
     reference = 'https://www.actionlogement.fr/l-aide-mobili-jeune'
 
-    def formula_2022_07(individu, period, parameters):
+    def formula_2022_06(individu, period, parameters):
         loyer = individu.menage('loyer', period)
         charges_locatives = individu.menage('charges_locatives', period)
         aide_logement = individu.famille('aide_logement', period)
@@ -81,7 +81,7 @@ class mobili_jeune_eligibilite(Variable):
     Avoir un reste à charge de loyer après déduction d'APL/ALS supérieur ou égal à 10€.
     '''
 
-    def formula_2022_07(individu, period, parameters):
+    def formula_2022_06(individu, period, parameters):
         condition_age = individu('age', period) < parameters(period).prestations_sociales.aides_jeunes.mobilite.mobili_jeune.age_maximum
 
         alternant = individu('alternant', period)  # sous contrat d'apprentissage ou de professionnalisation

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/mobilite/mobili_jeune/montant/maximum.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/mobilite/mobili_jeune/montant/maximum.yaml
@@ -1,7 +1,7 @@
 description: Montant maximum de l'Aide Mobili-Jeune à la mobilité pour les jeunes
 secteur_agricole:
   values:
-    2022-07-01:
+    2022-06-01:
       value: 300
 autres_secteurs:
   values:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '116.11.0',
+    version = '116.12.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/mobili_jeune.yaml
+++ b/tests/formulas/mobili_jeune.yaml
@@ -21,7 +21,7 @@
     mobili_jeune: [100, 70, 0, 0]
 
 - name: Éligibilité à l'aide au logement mobili-jeune
-  period: 2022-07
+  period: 2022-06
   input:
     age: [16, 30, 29, 29, 29, 29]
     alternant: [true, true, false, true, true, true]
@@ -33,7 +33,7 @@
 
 - name: Montant de l'aide au logement mobili-jeune
   description: Cas donnés sur actionlogement.fr/l-aide-mobili-jeune
-  period: 2022-07
+  period: 2022-06
   input:
     age: [18, 18, 18, 18, 18, 18]
     mobili_jeune_eligibilite: [true, true, true, true, true, false]


### PR DESCRIPTION
Merci de contribuer à OpenFisca ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)

* Évolution du système socio-fiscal. 
* Périodes concernées : toutes. 
* Zones impactées : `model/prestations/jeunes/mobili_jeune.py`.
* Détails :
  - Corrige la date de formule de la variable `mobili_jeune`

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
