### PR TITLE
Met à jour l'aide `carte_sncf_eleve_apprenti`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 116.13.0 [#1858](https://github.com/openfisca/openfisca-france/pull/1858)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/model/prestations/transport.py`.
+* Détails :
+  - Limite l'éligibilité de l'aide `carte_sncf_eleve_apprenti` aux résidents de la métropole.
+
 ## 116.12.0 [#1857](https://github.com/openfisca/openfisca-france/pull/1857)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/transport.py
+++ b/openfisca_france/model/prestations/transport.py
@@ -1,4 +1,5 @@
 from openfisca_france.model.base import Variable, Individu, MONTH, set_input_dispatch_by_period, set_input_divide_by_period
+from openfisca_france.model.caracteristiques_socio_demographiques.logement import TypesLieuResidence
 
 
 class pret_formation_permis_eligibilite(Variable):
@@ -80,4 +81,6 @@ class carte_sncf_eleve_apprenti_eligibilite(Variable):
         eligibilite_apprenti = (age_apprenti > age) * individu('apprenti', period)
         eligibilite_etudiant = (age_etudiant > age) * individu('etudiant', period)
 
-        return eligibilite_apprenti + eligibilite_etudiant
+        residence_metropole = individu.menage('residence', period) == TypesLieuResidence.metropole
+
+        return (eligibilite_apprenti + eligibilite_etudiant) * residence_metropole

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '116.12.0',
+    version = '116.13.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/carte_sncf_eleve_apprenti.yaml
+++ b/tests/formulas/carte_sncf_eleve_apprenti.yaml
@@ -1,7 +1,8 @@
 - period: 2021-09
   input:
-    apprenti: [true, true, true, true, false, false, false, false]
-    etudiant: [true, true, false, false, true, true, false, false]
-    age: [16, 30, 20, 25, 25, 30, 20, 30]
+    apprenti: [true, true, true, true, false, false, false, false, true]
+    etudiant: [true, true, false, false, true, true, false, false, true]
+    age: [16, 30, 20, 25, 25, 30, 20, 30, 20]
+    depcom: ["75111", "75111", "75111", "75111", "75111", "75111", "75111", "75111", "97101"]
   output:
-    carte_sncf_eleve_apprenti_eligibilite: [true, false, true, false, true, false, false, false]
+    carte_sncf_eleve_apprenti_eligibilite: [true, false, true, false, true, false, false, false, false]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/prestations/transport.py`.
* Détails :
  - Limite l'éligibilité de l'aide `carte_sncf_eleve_apprenti` aux résidents de la métropole.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
