### PR TITLE
Ajoute l'exonération TO-DE du secteur agricole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-##
+## 144.2.0 [#1861](https://github.com/openfisca/openfisca-france/pull/1861)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : toutes.
@@ -13,14 +13,14 @@
   - Ajoute des caractéristiques du salarié : `contrat_duree_determinee_type`, `taches_salarie_type` et `travailleur_occasionnel_agricole`
   - Adapte `allegement_cotisation_allocations_familiales` et ajoute `allegement_cotisation_allocations_familiales_base` pour le non cumul avec `allegement_fillon`
 
-# 144.0.0 [#2041](https://github.com/openfisca/openfisca-france/pull/2041)
+## 144.1.0 [#2041](https://github.com/openfisca/openfisca-france/pull/2041)
 
 * Amélioration technique.
 * Périodes concernées : à partir du 01/01/2008.
 * Zones impactées :
-  - `/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/decote/seuil.yaml`
-  - `/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`
-  - `/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/quotient_familial/`
+  - `parameters/impot_revenu/calcul_impot_revenu/plaf_qf/decote/seuil.yaml`
+  - `model/prelevements_obligatoires/impot_revenu/ir.py`
+  - `parameters/impot_revenu/calcul_impot_revenu/plaf_qf/quotient_familial/`
 * Détails :
   - Ajout d'une valeur nulle pour un paramètre de la décote qui est remplacé par d'autres paramètres à partir des revenus 2014
   - Modification de la variable nbptr suite à des changements de paramètres en 2008 :
@@ -109,7 +109,7 @@
 * Périodes concernées : toutes.
 * Zones impactées : `parameters`.
 * Détails :
-  -  Nettoie les paramètres YAML afin que leur structure et l'ordre de leurs champs soit uniformes
+  - Nettoie les paramètres YAML afin que leur structure et l'ordre de leurs champs soit uniformes
   - Corrige le champ order de `parameters/geopolitique/index.yaml`
 
 # 143.0.0 [#2001](https://github.com/openfisca/openfisca-france/pull/2001)
@@ -134,17 +134,17 @@
 * Changement mineur.
 * Périodes concernées : toutes. | jusqu'au JJ/MM/AAAA. | à partir du JJ/MM/AAAA.
 * Zones impactées :
-     * `parameters/prelevements_sociaux/contributions_sociales/crds`.
-     *  `prelevements_sociaux/contributions_sociales/csg`
-     *  `prestations_sociales/prestations_familiales/education_presence_parentale/aeeh`
-     *  `prestations_sociales/prestations_familiales/petite_enfance/paje`
-     *  `prestations_sociales/prestations_familiales/prestations_generales/af`
-     *  `prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/complement_familial`
+  - `parameters/prelevements_sociaux/contributions_sociales/crds`.
+  -  `prelevements_sociaux/contributions_sociales/csg`
+  -  `prestations_sociales/prestations_familiales/education_presence_parentale/aeeh`
+  -  `prestations_sociales/prestations_familiales/petite_enfance/paje`
+  -  `prestations_sociales/prestations_familiales/prestations_generales/af`
+  -  `prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/complement_familial`
 
 * Détails
-    - Modifie les labels pour les rendre plus explicites
-    - Rectifie des erreurs de labels
-    - Ajoute des références, notamment les articles codifiés.
+  - Modifie les labels pour les rendre plus explicites
+  - Rectifie des erreurs de labels
+  - Ajoute des références, notamment les articles codifiés.
 
 ### 142.0.3 [#2025](https://github.com/openfisca/openfisca-france/pull/2025)
 
@@ -186,30 +186,30 @@
 * Changement mineur.
 * Périodes concernées : toutes
 * Zones impactées :
-   - `impot_revenu/prelevements_forfaitaires/`
-   - `prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_taxe`
-   - `prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa`
-   - `prelevements_sociaux/autres_taxes_participations_assises_salaires/construction`
-   - `prelevements_sociaux/autres_taxes_participations_assises_salaires/fin_syndic`
-   - `prelevements_sociaux/autres_taxes_participations_assises_salaires/contribution_unique_formation`
-   - `prelevements_sociaux/autres_taxes_participations_assises_salaires/fnal`
-   - `prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social`
-   - `prelevements_sociaux/cotisations_secteur_public/mmid`
-   - `prelevements_sociaux/cotisations_securite_sociale_regime_general/cnav`
-   - `prelevements_sociaux/regimes_complementaires_retraite_secteur_prive`
-   - `prestations_sociales/aides_logement/reduction_loyer_solidarite`
-   - `prelevements_sociaux/contributions_sociales/crds`
-   - `prelevements_sociaux/reductions_cotisations_sociales/alleg_gen/mmid`
-   - `prelevements_sociaux/reductions_cotisations_sociales/allegement_cotisation_allocations_familiales`
-   - `prelevements_sociaux/reductions_cotisations_sociales/fillon`
-   - `prestations_sociales/prestations_etat_de_sante/invalidite/aah`
-   - `prestations_sociales/prestations_etat_de_sante/invalidite/asi`
-   - `prestations_sociales/prestations_familiales/bmaf`
-   - `prestations_sociales/prestations_familiales/education_presence_parentale/aeeh`
-   - `prestations_sociales/prestations_familiales/education_presence_parentale/ars`
-   - `prestations_sociales/prestations_familiales/petite_enfance/paje`
-   - `prestations_sociales/prestations_familiales/prestations_generales/af`
-   - `prestations_sociales/prestations_familiales/prestations_generales/cf`
+  - `parameters/impot_revenu/prelevements_forfaitaires/`
+  - `parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_taxe`
+  - `parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/csa`
+  - `parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/construction`
+  - `parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/fin_syndic`
+  - `parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/contribution_unique_formation`
+  - `parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/fnal`
+  - `parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social`
+  - `parameters/prelevements_sociaux/cotisations_secteur_public/mmid`
+  - `parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/cnav`
+  - `parameters/prelevements_sociaux/regimes_complementaires_retraite_secteur_prive`
+  - `parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite`
+  - `parameters/prelevements_sociaux/contributions_sociales/crds`
+  - `parameters/prelevements_sociaux/reductions_cotisations_sociales/alleg_gen/mmid`
+  - `parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_cotisation_allocations_familiales`
+  - `parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon`
+  - `parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah`
+  - `parameters/prestations_sociales/prestations_etat_de_sante/invalidite/asi`
+  - `parameters/prestations_sociales/prestations_familiales/bmaf`
+  - `parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh`
+  - `parameters/prestations_sociales/prestations_familiales/education_presence_parentale/ars`
+  - `parameters/prestations_sociales/prestations_familiales/petite_enfance/paje`
+  - `parameters/prestations_sociales/prestations_familiales/prestations_generales/af`
+  - `parameters/prestations_sociales/prestations_familiales/prestations_generales/cf`
 * Détails :
   - Change des labels (ux_name et description) pour corriger des erreurs ou préciser le sens.
   - Ajoute des références :
@@ -317,10 +317,11 @@
 * Évolution du système socio-fiscal.
 * Périodes concernées : 2022
 * Zones impactées :
-   - `openfisca-france\openfisca_france\model\prestations\minima_sociaux\per.py`.
-   - `openfisca_france\parameters\prestations_sociales\solidarite_insertion\minima_sociaux\per`
+  - `openfisca-france\openfisca_france\model\prestations\minima_sociaux\per.py`.
+  - `openfisca_france\parameters\prestations_sociales\solidarite_insertion\minima_sociaux\per`
 * Détails :
   - Ajout de la prime exceptionnelle de rentrée versée en 2022
+
 ### 138.1.5 [#1995](https://github.com/openfisca/openfisca-france/pull/1995)
 
 * Changement mineur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+##
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py`
+  - `model/revenus/activite/salarie.py`
+  - `parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode`
+* Détails :
+  - Ajoute à partir de 2019 l'exonération pour travailleur occasionnel demandeur d'emploi (TO-DE) du secteur agricole `exoneration_cotisations_employeur_tode` et la référence dans `exonerations_et_allegements`
+  - Ajoute des caractéristiques du salarié : `contrat_duree_determinee_type`, `taches_salarie_type` et `travailleur_occasionnel_agricole`
+  - Adapte `allegement_cotisation_allocations_familiales` et ajoute `allegement_cotisation_allocations_familiales_base` pour le non cumul avec `allegement_fillon`
+
 # 144.0.0 [#2041](https://github.com/openfisca/openfisca-france/pull/2041)
 
 * Amélioration technique.
@@ -15,7 +28,6 @@
       - Création d'une part supplémentaire de quotient familial d'un veuf avec personne à charge
       - Cette modification était déjà prise en compte dans le calcul car les paramètres étaient à 0 pour les périodes ou ils n'éxistaient pas. Cette PR remplace les 0 par des null ce qui nécéssite de faire un changement de formule en 2008.
   - Ajout de métadonnées pour certains paramètres du calcul du quotient familial de l'IR
-
 
 # 144.0.0 [#1717](https://github.com/openfisca/openfisca-france/pull/1717)
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -320,8 +320,8 @@ class allegement_fillon(Variable):
         apprenti = individu('apprenti', period)
         allegement_mode_recouvrement = individu('allegement_fillon_mode_recouvrement', period)
         exoneration_cotisations_employeur_jei = individu('exoneration_cotisations_employeur_jei', period)
-
-        non_cumulee = not_(exoneration_cotisations_employeur_jei)
+        exoneration_cotisations_employeur_tode = individu('exoneration_cotisations_employeur_tode', period)
+        non_cumulee = not_(exoneration_cotisations_employeur_jei) + not_(exoneration_cotisations_employeur_tode)
 
         # switch on 3 possible payment options
         allegement = switch_on_allegement_mode(

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -321,7 +321,7 @@ class allegement_fillon(Variable):
         allegement_mode_recouvrement = individu('allegement_fillon_mode_recouvrement', period)
         exoneration_cotisations_employeur_jei = individu('exoneration_cotisations_employeur_jei', period)
         exoneration_cotisations_employeur_tode = individu('exoneration_cotisations_employeur_tode', period)
-        non_cumulee = not_(exoneration_cotisations_employeur_jei) + not_(exoneration_cotisations_employeur_tode)
+        non_cumulee = not_(exoneration_cotisations_employeur_jei + exoneration_cotisations_employeur_tode)
 
         # switch on 3 possible payment options
         allegement = switch_on_allegement_mode(

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -432,7 +432,7 @@ class allegement_cotisation_allocations_familiales_base(Variable):
         return allegement * not_(stagiaire) * not_(apprenti) * non_cumulee
 
 
-def compute_allegement_cotisation_allocations_familiales(individu, period, parameters):
+def compute_allegement_cotisation_allocations_familiales_base(individu, period, parameters):
     '''
         La réduction du taux de la cotisation d’allocations familiales
     '''
@@ -482,7 +482,7 @@ class allegement_cotisation_maladie_base(Variable):
         return allegement
 
 
-def compute_allegement_cotisation_maladie(individu, period, parameters):
+def compute_allegement_cotisation_maladie_base(individu, period, parameters):
     '''
         Le calcul de l'allègement de cotisation maladie sur les bas et moyens salaires (Ex-CICE).
     '''

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -399,6 +399,21 @@ class allegement_cotisation_allocations_familiales(Variable):
     set_input = set_input_divide_by_period
 
     def formula_2015_01_01(individu, period, parameters):
+        allegement_cotisation_allocations_familiales_base = individu('allegement_cotisation_allocations_familiales_base', period)
+        # Si l'employeur fait le choix de la TO-DE alors celle-ci remplace l'allègement de cotisation des allocations familiales.
+        choix_exoneration_cotisations_employeur_agricole = individu('choix_exoneration_cotisations_employeur_agricole', period)
+        return allegement_cotisation_allocations_familiales_base * not_(choix_exoneration_cotisations_employeur_agricole)
+
+
+class allegement_cotisation_allocations_familiales_base(Variable):
+    value_type = float
+    label = "Allègement des cotisations d'allocations familiales sur les bas et moyens salaires"
+    entity = Individu
+    reference = 'https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-dallocations-famil/la-reduction-du-taux-de-la-cotis.html'
+    definition_period = MONTH
+    set_input = set_input_divide_by_period
+
+    def formula_2015_01_01(individu, period, parameters):
         stagiaire = individu('stagiaire', period)
         apprenti = individu('apprenti', period)
         allegement_mode_recouvrement =\
@@ -411,7 +426,7 @@ class allegement_cotisation_allocations_familiales(Variable):
         allegement = switch_on_allegement_mode(
             individu, period, parameters,
             allegement_mode_recouvrement,
-            'allegement_cotisation_allocations_familiales',
+            'allegement_cotisation_allocations_familiales_base',
             )
 
         return allegement * not_(stagiaire) * not_(apprenti) * non_cumulee
@@ -440,13 +455,28 @@ class allegement_cotisation_maladie(Variable):
     reference = 'https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037947559'
 
     def formula_2019_01_01(individu, period, parameters):
+        allegement_cotisation_maladie_base = individu('allegement_cotisation_maladie_base', period)
+        # Si l'employeur fait le choix de la TO-DE alors celle-ci remplace l'allègement de cotisation maladie.
+        choix_exoneration_cotisations_employeur_agricole = individu('choix_exoneration_cotisations_employeur_agricole', period)
+        return allegement_cotisation_maladie_base * not_(choix_exoneration_cotisations_employeur_agricole)
+
+
+class allegement_cotisation_maladie_base(Variable):
+    value_type = float
+    entity = Individu
+    definition_period = MONTH
+    set_input = set_input_divide_by_period
+    label = 'Allègement des cotisations employeur d’assurance maladie sur les bas et moyens salaires (Ex-CICE)'
+    reference = 'https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037947559'
+
+    def formula_2019_01_01(individu, period, parameters):
         # propose 3 modes de paiement possibles
         allegement_mode_recouvrement = individu('allegement_cotisation_maladie_mode_recouvrement', period)
 
         allegement = switch_on_allegement_mode(
             individu, period, parameters,
             allegement_mode_recouvrement,
-            'allegement_cotisation_maladie',
+            'allegement_cotisation_maladie_base',
             )
 
         return allegement

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -117,13 +117,9 @@ class exoneration_cotisations_employeur_tode(Variable):
         salaire_de_base = individu('salaire_de_base', period)
         smic_proratise = individu('smic_proratise', period)
 
-        # 1,2 × C/0,40 × (1,6 × montant mensuel du SMIC/ rémunération mensuelle brute hors heures supplémentaires et complémentaires-1)
-        # où "La rémunération mensuelle brute correspond à celle retenue pour le calcul des cotisations de la réduction générale des cotisations patronales (réduction Fillon)."
-        # d'après : https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels?p_p_id=com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_TnUJJSlWXJvY&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_TnUJJSlWXJvY_read_more=2
-
         parameters_tode = parameters(period).prelevements_sociaux.reductions_cotisations_sociales.agricole.tode
         coefficient_degressivite = parameters_tode.plafond - parameters_tode.seuil
-        exoneration_degressive = parameters_tode.seuil * (assiette_exoneration / coefficient_degressivite) * (parameters_tode.plafond * smic_proratise / salaire_de_base)
+        exoneration_degressive = parameters_tode.seuil * (assiette_exoneration / coefficient_degressivite) * (parameters_tode.plafond * smic_proratise / salaire_de_base - 1)
 
         sous_plancher = salaire_de_base <= (parameters_tode.seuil * smic_proratise)
         sous_plafond = salaire_de_base < (parameters_tode.plafond * smic_proratise)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -19,8 +19,8 @@ class exoneration_cotisations_employeur_tode_eligibilite(Variable):
     entity = Individu
     label = "Éligibilité à l'exonération de cotisations employeur agricole pour travailleur occasionnel demandeur d'emploi (TO-DE)"
     reference = [
-        "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037947610/",
-        "https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels"
+        'https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037947610/',
+        'https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels'
         ]
     definition_period = MONTH
     set_input = set_input_divide_by_period
@@ -36,13 +36,13 @@ class exoneration_cotisations_employeur_tode_eligibilite(Variable):
         Entreprises de travaux agricoles, ruraux et forestiers (ETARF).
     '''
 
-    def formula_2019(individu, period):   
+    def formula_2019(individu, period):
         # employeur relevant de la MSA
-        secteur_agricole = individu("secteur_activite_employeur", period) == TypesSecteurActivite.agricole
-        regime_agricole = individu("regime_securite_sociale", period) == RegimeSecuriteSociale.regime_agricole
-        
+        secteur_agricole = individu('secteur_activite_employeur', period) == TypesSecteurActivite.agricole
+        regime_agricole = individu('regime_securite_sociale', period) == RegimeSecuriteSociale.regime_agricole
+
         # salarié travailleur occasionnel agricole
-        travailleur_occasionnel_agricole = individu("travailleur_occasionnel_agricole", period)
+        travailleur_occasionnel_agricole = individu('travailleur_occasionnel_agricole', period)
 
         return (secteur_agricole + regime_agricole) * travailleur_occasionnel_agricole
 
@@ -52,50 +52,50 @@ class exoneration_cotisations_employeur_tode(Variable):
     entity = Individu
     label = "Exonération de cotisations employeur agricole pour travailleur occasionnel demandeur d'emploi (TO-DE)"
     reference = [
-        "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037947610/", 
-        "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038026966"
+        'https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037947610/',
+        'https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038026966'
         ]
     definition_period = MONTH
     set_input = set_input_divide_by_period
     documentation = '''
         Exonération de cotisations et contributions employeur sur les bas salaires.
 
-        Non modélisé (2022): 
+        Non modélisé (2022):
         La durée maximale d’application de l’exonération TO-DE est fixée à 119 jours
         consécutifs ou non, par employeur, par salarié et par année civile.
     '''
 
     def formula_2019(individu, period, parameters):
         # l'individu est le travailleur occasionnel
-        eligible = individu("exoneration_cotisations_employeur_tode_eligibilite", period)
+        eligible = individu('exoneration_cotisations_employeur_tode_eligibilite', period)
 
         # cotisations assurances sociales agricoles (ASA) - identiques régime général
-        mmid_employeur = individu("mmid_employeur", period)
-        allegement_cotisation_maladie = individu("allegement_cotisation_maladie", period)  # si rémunération <= 2.5 smic
+        mmid_employeur = individu('mmid_employeur', period)
+        allegement_cotisation_maladie = individu('allegement_cotisation_maladie', period)  # si rémunération <= 2.5 smic
         cotisations_asa = mmid_employeur + allegement_cotisation_maladie
 
         # cotisations allocations familiales
-        famille = individu("famille", period)
+        famille = individu('famille', period)
 
         # cotisations accident du travail et des maladies professionnelles
-        accident_du_travail = individu("accident_du_travail", period)
+        accident_du_travail = individu('accident_du_travail', period)
 
         # contribution à l’allocation logement
-        fnal = individu("fnal", period)
+        fnal = individu('fnal', period)
 
         # cotisation vieillesse
-        vieillesse_deplafonnee_employeur = individu("vieillesse_deplafonnee_employeur", period)
-        vieillesse_plafonnee_employeur = individu("vieillesse_plafonnee_employeur", period)    
+        vieillesse_deplafonnee_employeur = individu('vieillesse_deplafonnee_employeur', period)
+        vieillesse_plafonnee_employeur = individu('vieillesse_plafonnee_employeur', period)
 
         # contribution à la retraite complémentaire et CEG
-        agirc_arrco_employeur = individu("agirc_arrco_employeur", period)
-        contribution_equilibre_general_employeur = individu("contribution_equilibre_general_employeur", period)
-        
+        agirc_arrco_employeur = individu('agirc_arrco_employeur', period)
+        contribution_equilibre_general_employeur = individu('contribution_equilibre_general_employeur', period)
+
         # contribution de solidarité pour l’autonomie
-        contribution_solidarite_autonomie = individu("contribution_solidarite_autonomie", period)
+        contribution_solidarite_autonomie = individu('contribution_solidarite_autonomie', period)
 
         # contribution au titre de l’assurance chômage
-        chomage_employeur = individu("chomage_employeur", period)      
+        chomage_employeur = individu('chomage_employeur', period)
 
         assiette_exoneration = (
             cotisations_asa
@@ -104,7 +104,7 @@ class exoneration_cotisations_employeur_tode(Variable):
             + fnal
             + vieillesse_deplafonnee_employeur
             + vieillesse_plafonnee_employeur
-            + agirc_arrco_employeur 
+            + agirc_arrco_employeur
             + contribution_equilibre_general_employeur
             + contribution_solidarite_autonomie
             + chomage_employeur
@@ -114,17 +114,17 @@ class exoneration_cotisations_employeur_tode(Variable):
         # Puis dégressive : 1,2 × C/0,40 × (1,6 × montant mensuel du SMIC/ rémunération mensuelle brute hors heures supplémentaires et complémentaires-1)
         # Devient nulle à 1.6 SMIC
 
-        salaire_de_base = individu("salaire_de_base", period)
-        smic_proratise = individu("smic_proratise", period)
-        
+        salaire_de_base = individu('salaire_de_base', period)
+        smic_proratise = individu('smic_proratise', period)
+
         # 1,2 × C/0,40 × (1,6 × montant mensuel du SMIC/ rémunération mensuelle brute hors heures supplémentaires et complémentaires-1)
         # où "La rémunération mensuelle brute correspond à celle retenue pour le calcul des cotisations de la réduction générale des cotisations patronales (réduction Fillon)."
         # d'après : https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels?p_p_id=com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_TnUJJSlWXJvY&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_TnUJJSlWXJvY_read_more=2
-        
+
         parameters_tode = parameters(period).prelevements_sociaux.reductions_cotisations_sociales.agricole.tode
         coefficient_degressivite = parameters_tode.plafond - parameters_tode.seuil
         exoneration_degressive = parameters_tode.seuil * (assiette_exoneration / coefficient_degressivite) * (parameters_tode.plafond * smic_proratise / salaire_de_base)
-        
+
         sous_plancher = salaire_de_base <= (parameters_tode.seuil * smic_proratise)
         sous_plafond = salaire_de_base < (parameters_tode.plafond * smic_proratise)
         exoneration = where(sous_plancher, assiette_exoneration, sous_plafond * exoneration_degressive)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -74,27 +74,16 @@ class exoneration_cotisations_employeur_tode(Variable):
         allegement_cotisation_maladie = individu('allegement_cotisation_maladie', period)  # si rémunération <= 2.5 smic
         cotisations_asa = mmid_employeur + allegement_cotisation_maladie
 
-        # cotisations allocations familiales
         famille = individu('famille', period)
-
-        # cotisations accident du travail et des maladies professionnelles
         accident_du_travail = individu('accident_du_travail', period)
-
-        # contribution à l’allocation logement
         fnal = individu('fnal', period)
 
-        # cotisation vieillesse
         vieillesse_deplafonnee_employeur = individu('vieillesse_deplafonnee_employeur', period)
         vieillesse_plafonnee_employeur = individu('vieillesse_plafonnee_employeur', period)
-
-        # contribution à la retraite complémentaire et CEG
         agirc_arrco_employeur = individu('agirc_arrco_employeur', period)
         contribution_equilibre_general_employeur = individu('contribution_equilibre_general_employeur', period)
 
-        # contribution de solidarité pour l’autonomie
         contribution_solidarite_autonomie = individu('contribution_solidarite_autonomie', period)
-
-        # contribution au titre de l’assurance chômage
         chomage_employeur = individu('chomage_employeur', period)
 
         assiette_exoneration = (

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -46,12 +46,12 @@ class exoneration_cotisations_employeur_tode(Variable):
         
         # employeur relevant de la MSA
         secteur_agricole = individu('secteur_activite_employeur', period) == TypesSecteurActivite.agricole
-        msa = individu("regime_securite_sociale", period) == RegimeSecuriteSociale.regime_agricole
+        regime_agricole = individu("regime_securite_sociale", period) == RegimeSecuriteSociale.regime_agricole
         
         # salarié travailleur occasionnel agricole
         travailleur_occasionnel_agricole = individu("travailleur_occasionnel_agricole", period)
 
-        eligible = secteur_agricole * msa * travailleur_occasionnel_agricole
+        eligible = (secteur_agricole + regime_agricole) * travailleur_occasionnel_agricole
 
         # cotisations assurances sociales
         mmid_employeur = individu("mmid_employeur", period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -122,7 +122,8 @@ class exoneration_cotisations_employeur_tode(Variable):
         # d'après : https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels?p_p_id=com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_TnUJJSlWXJvY&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_TnUJJSlWXJvY_read_more=2
         
         parameters_tode = parameters(period).prelevements_sociaux.reductions_cotisations_sociales.agricole.tode
-        exoneration_degressive = parameters_tode.seuil * (assiette_exoneration / 0.4) * (parameters_tode.plafond * smic_proratise / salaire_de_base)
+        coefficient_degressivite = parameters_tode.plafond - parameters_tode.seuil
+        exoneration_degressive = parameters_tode.seuil * (assiette_exoneration / coefficient_degressivite) * (parameters_tode.plafond * smic_proratise / salaire_de_base)
         
         sous_plancher = salaire_de_base <= (parameters_tode.seuil * smic_proratise)
         sous_plafond = salaire_de_base < (parameters_tode.plafond * smic_proratise)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -28,33 +28,46 @@ class exoneration_cotisations_employeur_tode(Variable):
         consécutifs ou non, par employeur, par salarié et par année civile.
     '''
 
-    def formula_2019(individu, period, parameter):
+    def formula_2019(individu, period, parameters):
         # Exonération totale à 1.2 SMIC
         # Puis dégressive : 1,2 × C/0,40 × (1,6 × montant mensuel du SMIC/ rémunération mensuelle brute hors heures supplémentaires et complémentaires-1)
         # Devient nulle à 1.6 SMIC
         
         eligible = 1
 
-        agirc_arrco_employeur = individu('agirc_arrco_employeur', period)
-        chomage_employeur = individu("chomage_employeur", period)
-        vieillesse_deplafonnee_employeur = individu("vieillesse_deplafonnee_employeur", period)
-        vieillesse_plafonnee_employeur = individu("vieillesse_plafonnee_employeur", period)
-        accident_du_travail = individu("accident_du_travail", period)
-        contribution_solidarite_autonomie = individu("contribution_solidarite_autonomie", period)
+        # cotisations assurances sociales
         mmid_employeur = individu("mmid_employeur", period)
+
+        # cotisations allocations familiales
         famille = individu("famille", period)
+
+        # cotisations accident du travail et des maladies professionnelles
+        accident_du_travail = individu("accident_du_travail", period)
+
+        # contribution à l’allocation logement
         fnal = individu("fnal", period)
 
+        # contribution à la retraite complémentaire
+        agirc_arrco_employeur = individu('agirc_arrco_employeur', period)
+        # ? vieillesse_deplafonnee_employeur = individu("vieillesse_deplafonnee_employeur", period)
+        # ? vieillesse_plafonnee_employeur = individu("vieillesse_plafonnee_employeur", period)
+        
+        # contribution de solidarité pour l’autonomie
+        contribution_solidarite_autonomie = individu("contribution_solidarite_autonomie", period)
+
+        # contribution au titre de l’assurance chômage
+        chomage_employeur = individu("chomage_employeur", period)      
+
         assiette_exoneration = (
-            agirc_arrco_employeur 
-            + chomage_employeur
-            + vieillesse_deplafonnee_employeur
-            + vieillesse_plafonnee_employeur
-            + accident_du_travail
-            + contribution_solidarite_autonomie
-            + mmid_employeur
+            mmid_employeur
             + famille
+            + accident_du_travail
             + fnal
+            + agirc_arrco_employeur 
+            # ? + vieillesse_deplafonnee_employeur
+            # ? + vieillesse_plafonnee_employeur
+            + contribution_solidarite_autonomie
+            + chomage_employeur
             )
 
         salaire_de_base = individu("salaire_de_base", period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -37,7 +37,7 @@ class exoneration_cotisations_employeur_tode_eligibilite(Variable):
 
     def formula_2019(individu, period):   
         # employeur relevant de la MSA
-        secteur_agricole = individu('secteur_activite_employeur', period) == TypesSecteurActivite.agricole
+        secteur_agricole = individu("secteur_activite_employeur", period) == TypesSecteurActivite.agricole
         regime_agricole = individu("regime_securite_sociale", period) == RegimeSecuriteSociale.regime_agricole
         
         # salarié travailleur occasionnel agricole
@@ -60,25 +60,17 @@ class exoneration_cotisations_employeur_tode(Variable):
         Non modélisé (2022): 
         La durée maximale d’application de l’exonération TO-DE est fixée à 119 jours
         consécutifs ou non, par employeur, par salarié et par année civile.
-
-        Employeurs MSA sauf ces employeurs d'après 
-        https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels :
-        Coopératives d'utilisation de matériel agricole (CUMA).
-        Coopératives de transformation, conditionnement et commercialisation.
-        Entreprises paysagistes.
-        Structures exerçant des activités de tourisme à la ferme.
-        Entreprises de service (Crédit agricole, Groupama, caisses de MSA, groupements professionnels agricoles, Chambres d'agriculture…).
-        Artisans ruraux.
-        Entreprises de travail temporaire (ETT) et les entreprises de travail temporaire d'insertion (ETTI).
-        Entreprises de travaux agricoles, ruraux et forestiers (ETARF).
     '''
 
     def formula_2019(individu, period, parameters):
         # l'individu est l'exploitant agricole ? le travailleur occasionnel ?
         eligible = individu("exoneration_cotisations_employeur_tode_eligibilite", period)
 
-        # cotisations assurances sociales
+        # cotisations assurances sociales agricoles (ASA)
+        # identiques régime général
         mmid_employeur = individu("mmid_employeur", period)
+        allegement_cotisation_maladie = individu("allegement_cotisation_maladie", period)  # si rémunération <= 2.5 smic
+        cotisations_asa = mmid_employeur + allegement_cotisation_maladie
 
         # cotisations allocations familiales
         famille = individu("famille", period)
@@ -89,10 +81,13 @@ class exoneration_cotisations_employeur_tode(Variable):
         # contribution à l’allocation logement
         fnal = individu("fnal", period)
 
-        # contribution à la retraite complémentaire
+        # cotisation vieillesse
+        vieillesse_deplafonnee_employeur = individu("vieillesse_deplafonnee_employeur", period)
+        vieillesse_plafonnee_employeur = individu("vieillesse_plafonnee_employeur", period)    
+
+        # contribution à la retraite complémentaire et CEG
         agirc_arrco_employeur = individu("agirc_arrco_employeur", period)
-        # ? vieillesse_deplafonnee_employeur = individu("vieillesse_deplafonnee_employeur", period)
-        # ? vieillesse_plafonnee_employeur = individu("vieillesse_plafonnee_employeur", period)
+        contribution_equilibre_general_employeur = individu("contribution_equilibre_general_employeur", period)
         
         # contribution de solidarité pour l’autonomie
         contribution_solidarite_autonomie = individu("contribution_solidarite_autonomie", period)
@@ -101,13 +96,14 @@ class exoneration_cotisations_employeur_tode(Variable):
         chomage_employeur = individu("chomage_employeur", period)      
 
         assiette_exoneration = (
-            mmid_employeur
+            cotisations_asa
             + famille
             + accident_du_travail
             + fnal
+            + vieillesse_deplafonnee_employeur
+            + vieillesse_plafonnee_employeur
             + agirc_arrco_employeur 
-            # ? + vieillesse_deplafonnee_employeur
-            # ? + vieillesse_plafonnee_employeur
+            + contribution_equilibre_general_employeur
             + contribution_solidarite_autonomie
             + chomage_employeur
             )

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -25,27 +25,33 @@ class exoneration_cotisations_employeur_tode(Variable):
     definition_period = MONTH
     set_input = set_input_divide_by_period
     documentation = '''
-        Non modélisé (2022): La durée maximale d’application de l’exonération TO-DE est fixée à 119 jours
+        Non modélisé (2022): 
+        La durée maximale d’application de l’exonération TO-DE est fixée à 119 jours
         consécutifs ou non, par employeur, par salarié et par année civile.
+
+        Employeurs MSA sauf ces employeurs d'après 
+        https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels :
+        Coopératives d'utilisation de matériel agricole (CUMA).
+        Coopératives de transformation, conditionnement et commercialisation.
+        Entreprises paysagistes.
+        Structures exerçant des activités de tourisme à la ferme.
+        Entreprises de service (Crédit agricole, Groupama, caisses de MSA, groupements professionnels agricoles, Chambres d'agriculture…).
+        Artisans ruraux.
+        Entreprises de travail temporaire (ETT) et les entreprises de travail temporaire d'insertion (ETTI).
+        Entreprises de travaux agricoles, ruraux et forestiers (ETARF).
     '''
 
     def formula_2019(individu, period, parameters):
         # l'individu est l'exploitant agricole ? le travailleur occasionnel ?
         
         # employeur relevant de la MSA
-        regime_securite_sociale = individu("regime_securite_sociale", period)
-        # sauf ces employeurs d'après https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels :
-        # Coopératives d'utilisation de matériel agricole (CUMA).
-        # Coopératives de transformation, conditionnement et commercialisation.
-        # Entreprises paysagistes.
-        # Structures exerçant des activités de tourisme à la ferme.
-        # Entreprises de service (Crédit agricole, Groupama, caisses de MSA, groupements professionnels agricoles, Chambres d'agriculture…).
-        # Artisans ruraux.
-        # Entreprises de travail temporaire (ETT) et les entreprises de travail temporaire d'insertion (ETTI).
-        # Entreprises de travaux agricoles, ruraux et forestiers (ETARF).
-
+        secteur_agricole = individu('secteur_activite_employeur', period) == TypesSecteurActivite.agricole
+        msa = individu("regime_securite_sociale", period) == RegimeSecuriteSociale.regime_agricole
         
-        eligible = regime_securite_sociale == RegimeSecuriteSociale.regime_agricole
+        # salarié travailleur occasionnel agricole
+        travailleur_occasionnel_agricole = individu("travailleur_occasionnel_agricole", period)
+
+        eligible = secteur_agricole * msa * travailleur_occasionnel_agricole
 
         # cotisations assurances sociales
         mmid_employeur = individu("mmid_employeur", period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -114,7 +114,27 @@ class exoneration_cotisations_employeur_tode(Variable):
         sous_plafond = salaire_de_base < (parameters_tode.plafond * smic_proratise)
         exoneration = where(sous_plancher, assiette_exoneration, sous_plafond * exoneration_degressive)
 
-        return eligible * exoneration
+        # non cumul avec l'allègement général de cotisations employeur sur les bas salaires (Fillon)
+        choix_exoneration_cotisations_employeur_agricole = individu('choix_exoneration_cotisations_employeur_agricole', period)
+
+        return choix_exoneration_cotisations_employeur_agricole * eligible * exoneration
+
+
+class choix_exoneration_cotisations_employeur_agricole(Variable):
+    value_type = bool
+    default_value = False
+    entity = Individu
+    label = "L'employeur agricole choisit une exonération de cotisations employeur spécifique au secteur agricole"
+    reference = 'https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels'
+    definition_period = MONTH
+    set_input = set_input_divide_by_period
+    documentation = '''
+    Pour un travailleur occasionnel, l'employeur agricole a le choix
+    entre la réduction générale de cotisations sur les bas salaires (Fillon)
+    et la TO-DE.
+    La TO-DE est plus avantageuse mais à son arrêt au 12.2022,
+    la réduction Fillon sera applicable.
+    '''
 
 
 class exoneration_cotisations_employeur_geographiques(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -101,18 +101,18 @@ class exoneration_cotisations_employeur_tode(Variable):
             + chomage_employeur
             )
 
-        # Exonération totale à 1.2 SMIC
+        # Exonération totale à <= 1.2 SMIC
         # Puis dégressive : 1,2 × C/0,40 × (1,6 × montant mensuel du SMIC/ rémunération mensuelle brute hors heures supplémentaires et complémentaires-1)
-        # Devient nulle à 1.6 SMIC
+        # Devient nulle à >= 1.6 SMIC
 
         salaire_de_base = individu('salaire_de_base', period)
         smic_proratise = individu('smic_proratise', period)
 
         parameters_tode = parameters(period).prelevements_sociaux.reductions_cotisations_sociales.agricole.tode
-        coefficient_degressivite = parameters_tode.plafond - parameters_tode.seuil
-        exoneration_degressive = parameters_tode.seuil * (assiette_exoneration / coefficient_degressivite) * (parameters_tode.plafond * smic_proratise / salaire_de_base - 1)
+        coefficient_degressivite = parameters_tode.plafond - parameters_tode.plafond_exoneration_integrale
+        exoneration_degressive = parameters_tode.plafond_exoneration_integrale * (assiette_exoneration / coefficient_degressivite) * (parameters_tode.plafond * smic_proratise / salaire_de_base - 1)
 
-        sous_plancher = salaire_de_base <= (parameters_tode.seuil * smic_proratise)
+        sous_plancher = salaire_de_base <= (parameters_tode.plafond_exoneration_integrale * smic_proratise)
         sous_plafond = salaire_de_base < (parameters_tode.plafond * smic_proratise)
         exoneration = where(sous_plancher, assiette_exoneration, sous_plafond * exoneration_degressive)
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -23,13 +23,17 @@ class exoneration_cotisations_employeur_tode(Variable):
         ]
     definition_period = MONTH
     set_input = set_input_divide_by_period
+    documentation = '''
+        Non modélisé (2022): La durée maximale d’application de l’exonération TO-DE est fixée à 119 jours
+        consécutifs ou non, par employeur, par salarié et par année civile.
+    '''
 
     def formula_2019(individu, period, parameter):
         # Exonération totale à 1.2 SMIC
         # Puis dégressive : 1,2 × C/0,40 × (1,6 × montant mensuel du SMIC/ rémunération mensuelle brute hors heures supplémentaires et complémentaires-1)
         # Devient nulle à 1.6 SMIC
         
-        eligible = 0
+        eligible = 1
 
         agirc_arrco_employeur = individu('agirc_arrco_employeur', period)
         chomage_employeur = individu("chomage_employeur", period)
@@ -57,10 +61,12 @@ class exoneration_cotisations_employeur_tode(Variable):
         smic_proratise = individu("smic_proratise", period)
         
         # 1,2 × C/0,40 × (1,6 × montant mensuel du SMIC/ rémunération mensuelle brute hors heures supplémentaires et complémentaires-1)
+        # où "La rémunération mensuelle brute correspond à celle retenue pour le calcul des cotisations de la réduction générale des cotisations patronales (réduction Fillon)."
+        # d'après : https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels?p_p_id=com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_TnUJJSlWXJvY&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_TnUJJSlWXJvY_read_more=2
         exoneration_degressive = 1.2 * (assiette_exoneration / 0.4) * (1.6 * smic_proratise / salaire_de_base)
         
         sous_plancher = salaire_de_base <= (1.2 * smic_proratise)
-        sous_plafond = salaire_de_base <= (1.6 * smic_proratise)
+        sous_plafond = salaire_de_base < (1.6 * smic_proratise)
         exoneration = where(sous_plancher, assiette_exoneration, sous_plafond * exoneration_degressive)
 
         return eligible * exoneration

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -88,7 +88,8 @@ class exoneration_cotisations_employeur_tode(Variable):
         contribution_solidarite_autonomie = individu('contribution_solidarite_autonomie', period)
         chomage_employeur = individu('chomage_employeur', period)
 
-        assiette_exoneration = (
+        # les cotisations sont des prélèvements, l'exonération leur opposé
+        assiette_exoneration = -1 * (
             cotisations_asa
             + famille
             + accident_du_travail

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -14,6 +14,38 @@ class jei_date_demande(Variable):
     set_input = set_input_dispatch_by_period
 
 
+class exoneration_cotisations_employeur_tode_eligibilite(Variable):
+    value_type = bool
+    entity = Individu
+    label = "Éligibilité à l'exonération de cotisations employeur agricole pour travailleur occasionnel demandeur d'emploi (TO-DE)"
+    reference = "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037947610/"
+    definition_period = MONTH
+    set_input = set_input_divide_by_period
+    documentation = '''
+        Non modélisé (2022): 
+        Employeurs MSA sauf ces employeurs d'après 
+        https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels :
+        Coopératives d'utilisation de matériel agricole (CUMA).
+        Coopératives de transformation, conditionnement et commercialisation.
+        Entreprises paysagistes.
+        Structures exerçant des activités de tourisme à la ferme.
+        Entreprises de service (Crédit agricole, Groupama, caisses de MSA, groupements professionnels agricoles, Chambres d'agriculture…).
+        Artisans ruraux.
+        Entreprises de travail temporaire (ETT) et les entreprises de travail temporaire d'insertion (ETTI).
+        Entreprises de travaux agricoles, ruraux et forestiers (ETARF).
+    '''
+
+    def formula_2019(individu, period):   
+        # employeur relevant de la MSA
+        secteur_agricole = individu('secteur_activite_employeur', period) == TypesSecteurActivite.agricole
+        regime_agricole = individu("regime_securite_sociale", period) == RegimeSecuriteSociale.regime_agricole
+        
+        # salarié travailleur occasionnel agricole
+        travailleur_occasionnel_agricole = individu("travailleur_occasionnel_agricole", period)
+
+        return (secteur_agricole + regime_agricole) * travailleur_occasionnel_agricole
+
+
 class exoneration_cotisations_employeur_tode(Variable):
     value_type = float
     entity = Individu
@@ -43,15 +75,7 @@ class exoneration_cotisations_employeur_tode(Variable):
 
     def formula_2019(individu, period, parameters):
         # l'individu est l'exploitant agricole ? le travailleur occasionnel ?
-        
-        # employeur relevant de la MSA
-        secteur_agricole = individu('secteur_activite_employeur', period) == TypesSecteurActivite.agricole
-        regime_agricole = individu("regime_securite_sociale", period) == RegimeSecuriteSociale.regime_agricole
-        
-        # salarié travailleur occasionnel agricole
-        travailleur_occasionnel_agricole = individu("travailleur_occasionnel_agricole", period)
-
-        eligible = (secteur_agricole + regime_agricole) * travailleur_occasionnel_agricole
+        eligible = individu("exoneration_cotisations_employeur_tode_eligibilite", period)
 
         # cotisations assurances sociales
         mmid_employeur = individu("mmid_employeur", period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -24,6 +24,7 @@ class exoneration_cotisations_employeur_tode_eligibilite(Variable):
         ]
     definition_period = MONTH
     set_input = set_input_divide_by_period
+    end = '2022-12-31'
     documentation = '''
         Non modélisé (2022), tout employeur MSA sauf ces employeurs :
         Coopératives d'utilisation de matériel agricole (CUMA).
@@ -57,6 +58,7 @@ class exoneration_cotisations_employeur_tode(Variable):
         ]
     definition_period = MONTH
     set_input = set_input_divide_by_period
+    end = '2022-12-31'
     documentation = '''
         Exonération de cotisations et contributions employeur sur les bas salaires.
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -73,8 +73,8 @@ class exoneration_cotisations_employeur_tode(Variable):
 
         # cotisations assurances sociales agricoles (ASA) - identiques régime général
         mmid_employeur = individu('mmid_employeur', period)
-        allegement_cotisation_maladie = individu('allegement_cotisation_maladie', period)  # si rémunération <= 2.5 smic
-        cotisations_asa = mmid_employeur + allegement_cotisation_maladie
+        allegement_cotisation_maladie_base = individu('allegement_cotisation_maladie_base', period)  # si rémunération <= 2.5 smic
+        cotisations_asa = mmid_employeur + allegement_cotisation_maladie_base
 
         famille = individu('famille', period)
         accident_du_travail = individu('accident_du_travail', period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -23,7 +23,7 @@ class exoneration_cotisations_employeur_tode_eligibilite(Variable):
         'https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels'
         ]
     definition_period = MONTH
-    set_input = set_input_divide_by_period
+    set_input = set_input_dispatch_by_period
     end = '2022-12-31'
     documentation = '''
         Non modélisé (2022), tout employeur MSA sauf ces employeurs :
@@ -130,7 +130,7 @@ class choix_exoneration_cotisations_employeur_agricole(Variable):
     label = "L'employeur agricole choisit une exonération de cotisations employeur spécifique au secteur agricole"
     reference = 'https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels'
     definition_period = MONTH
-    set_input = set_input_divide_by_period
+    set_input = set_input_dispatch_by_period
     documentation = '''
     Pour un travailleur occasionnel, l'employeur agricole a le choix
     entre la réduction générale de cotisations sur les bas salaires (Fillon)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -24,7 +24,7 @@ class exoneration_cotisations_employeur_tode_eligibilite(Variable):
         ]
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
-    end = '2022-12-31'
+    end = '2025-12-31'
     documentation = '''
         Non modélisé (2022), tout employeur MSA sauf ces employeurs :
         Coopératives d'utilisation de matériel agricole (CUMA).
@@ -58,7 +58,7 @@ class exoneration_cotisations_employeur_tode(Variable):
         ]
     definition_period = MONTH
     set_input = set_input_divide_by_period
-    end = '2022-12-31'
+    end = '2025-12-31'
     documentation = '''
         Exonération de cotisations et contributions employeur sur les bas salaires.
 

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -1526,6 +1526,8 @@ class exonerations_et_allegements(Variable):
             'exoneration_cotisations_employeur_apprenti', period, options = [ADD])
         exoneration_cotisations_employeur_geographiques = individu(
             'exoneration_cotisations_employeur_geographiques', period)
+        exoneration_cotisations_employeur_tode = individu(
+            'exoneration_cotisations_employeur_tode', period)
         exoneration_cotisations_employeur_jei = individu(
             'exoneration_cotisations_employeur_jei', period, options = [ADD])
         exoneration_cotisations_employeur_stagiaire = individu(
@@ -1539,6 +1541,7 @@ class exonerations_et_allegements(Variable):
             allegement_fillon
             + allegement_cotisation_maladie
             + allegement_cotisation_allocations_familiales
+            + exoneration_cotisations_employeur_tode
             + exoneration_cotisations_employeur_geographiques
             + exoneration_cotisations_employeur_jei
             + exoneration_cotisations_employeur_apprenti

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -1595,6 +1595,23 @@ class type_conges(Variable):
     set_input = set_input_dispatch_by_period
 
 
+class TypesTaches(Enum):
+    non_renseigne = "Non renseigné"
+    production_animale_vegetale = "Tâches dans les activités liées au cycle de la production animale et végétale"
+    prolongement_production = "Tâches dans les activités constituant le prolongement direct de l'acte de production"
+    travaux_forestiers = "Tâches dans les activités liées aux travaux forestiers"
+
+
+class taches_salarie_type(Variable):
+    value_type = Enum
+    possible_values = TypesTaches
+    default_value = TypesTaches.non_renseigne
+    entity = Individu
+    label = 'Type des tâches affectées au salarié'
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+
+
 class travailleur_occasionnel_agricole(Variable):
     value_type = bool
     entity = Individu
@@ -1624,5 +1641,11 @@ class travailleur_occasionnel_agricole(Variable):
             + (contrat_duree_determinee_type == TypesContratTravailDureeDeterminee.contrat_insertion)
             + (contrat_duree_determinee_type == TypesContratTravailDureeDeterminee.contrat_initiative_emploi)
             )
-        return secteur_agricole * cdd * cdd_occasionnel_agricole
 
+        taches_salarie_type = individu("taches_salarie_type", period)
+        taches_eligibles = (
+            (taches_salarie_type == TypesTaches.production_animale_vegetale)
+            + (taches_salarie_type == TypesTaches.prolongement_production)
+            + (taches_salarie_type == TypesTaches.travaux_forestiers)
+            )
+        return secteur_agricole * cdd * cdd_occasionnel_agricole * taches_eligibles

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -324,29 +324,31 @@ class contrat_de_travail_type(Variable):
 
 
 class TypesContratTravailDureeDeterminee(Enum):
+    '''
+    Tous contrats : https://travail-emploi.gouv.fr/droit-du-travail/les-contrats-de-travail/
+    CDD, types et durées : https://www.service-public.fr/particuliers/vosdroits/F36
+
+    Contrat vendanges : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006585176/
+    CDD d'insertion : https://www.service-public.fr/particuliers/vosdroits/F14100
+
+    Contrat unique d'insertion (CUI), types : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000019869576
+    PEC en CDD ou CDI : https://travail-emploi.gouv.fr/emploi-et-insertion/parcours-emploi-competences/pec
+
+    Articulation CUI/PEC et secteur : https://www.service-public.fr/particuliers/vosdroits/F21006
+    CUI-CIE = Parcours emploi compétence (PEC) - secteur marchand
+    CUI-CAE = Parcours emploi compétence (PEC) - secteur non marchand
+    '''
     __order__ = 'non_renseigne contrat_general contrat_saisonnier contrat_vendanges contrat_usage contrat_insertion contrat_initiative_emploi contrat_accompagnement_emploi'  # Needed to preserve the enum order in Python 2
-    # Tous contrats : # https://travail-emploi.gouv.fr/droit-du-travail/les-contrats-de-travail/
-    # Conclusion du contrat de travail à durée déterminée : 
-    # https://www.service-public.fr/particuliers/vosdroits/F36
 
     non_renseigne = "Non renseigné"
     contrat_general = "Cas général du contrat de travail à durée déterminée (CDD)"
+    
     contrat_saisonnier = "CDD à caractère saisonnier"
-    
-    # https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006585176/ :
     contrat_vendanges = "CDD à caractère saisonnier pour travaux de vendanges"
-    
-    contrat_usage = "CDD d'usage (CDDU)" # exemple : "CDD d'extra"
-
-    # https://www.service-public.fr/particuliers/vosdroits/F14100
+    contrat_usage = "CDD d'usage (CDDU)"  # exemple : "CDD d'extra"
     contrat_insertion = "CDD d'insertion (CDDI)"
 
-    # https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000019869576
-    # https://www.service-public.fr/particuliers/vosdroits/F21006
-    # https://travail-emploi.gouv.fr/emploi-et-insertion/parcours-emploi-competences/pec (CDD ou CDI)
-    # Parcours emploi compétence (PEC) - secteur marchand
     contrat_initiative_emploi = "Contrat unique d'insertion - Contrat initiative emploi (CUI-CIE)"
-    # Parcours emploi compétence (PEC) - secteur non marchand
     contrat_accompagnement_emploi = "Contrat unique d'insertion - Contrat d'accompagnement dans l'emploi (CUI-CAE)"
 
 

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -325,7 +325,7 @@ class contrat_de_travail_type(Variable):
 
 class TypesContratTravailDureeDeterminee(Enum):
     '''
-    Tous contrats : https://travail-emploi.gouv.fr/droit-du-travail/les-contrats-de-travail/
+    Tous types contrats : https://travail-emploi.gouv.fr/droit-du-travail/les-contrats-de-travail/
     CDD, types et durées : https://www.service-public.fr/particuliers/vosdroits/F36
 
     Contrat vendanges : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006585176/
@@ -340,12 +340,12 @@ class TypesContratTravailDureeDeterminee(Enum):
     '''
     __order__ = 'non_renseigne contrat_general contrat_saisonnier contrat_vendanges contrat_usage contrat_insertion contrat_initiative_emploi contrat_accompagnement_emploi'  # Needed to preserve the enum order in Python 2
 
-    non_renseigne = "Non renseigné"
-    contrat_general = "Cas général du contrat de travail à durée déterminée (CDD)"
-    
-    contrat_saisonnier = "CDD à caractère saisonnier"
-    contrat_vendanges = "CDD à caractère saisonnier pour travaux de vendanges"
-    contrat_usage = "CDD d'usage (CDDU)"  # exemple : "CDD d'extra"
+    non_renseigne = 'Non renseigné'
+    contrat_general = 'Cas général du contrat de travail à durée déterminée (CDD)'
+
+    contrat_saisonnier = 'CDD à caractère saisonnier'
+    contrat_vendanges = 'CDD à caractère saisonnier pour travaux de vendanges'
+    contrat_usage = "CDD d'usage (CDDU)"  # exemple : CDD d'extra
     contrat_insertion = "CDD d'insertion (CDDI)"
 
     contrat_initiative_emploi = "Contrat unique d'insertion - Contrat initiative emploi (CUI-CIE)"
@@ -1598,10 +1598,11 @@ class type_conges(Variable):
 
 
 class TypesTaches(Enum):
-    non_renseigne = "Non renseigné"
-    production_animale_vegetale = "Tâches dans les activités liées au cycle de la production animale et végétale"
+    # https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels (bénéficiaires)
+    non_renseigne = 'Non renseigné'
+    production_animale_vegetale = 'Tâches dans les activités liées au cycle de la production animale et végétale'
     prolongement_production = "Tâches dans les activités constituant le prolongement direct de l'acte de production"
-    travaux_forestiers = "Tâches dans les activités liées aux travaux forestiers"
+    travaux_forestiers = 'Tâches dans les activités liées aux travaux forestiers'
 
 
 class taches_salarie_type(Variable):
@@ -1617,24 +1618,24 @@ class taches_salarie_type(Variable):
 class travailleur_occasionnel_agricole(Variable):
     value_type = bool
     entity = Individu
-    label = "Le salarié est travailleur occasionnel agricole"
+    label = 'Le salarié est travailleur occasionnel agricole'
     definition_period = MONTH
-    reference = "https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels"
+    reference = 'https://www.msa.fr/lfp/employeur/exonerations-travailleurs-occasionnels'
     set_input = set_input_dispatch_by_period
     documentation = '''
     Sont considérés comme "travailleurs occasionnels agricoles", les salariés qui remplissent deux conditions
     se rapportant à la nature de leur contrat de travail et à la nature des tâches affectées.
 
-    Cas non modélisé : CDI conclu avec un demandeur d'emploi (inscrit à Pôle emploi depuis au moins 4 mois ou 1 mois 
+    Cas non modélisé (2022): CDI conclu avec un demandeur d'emploi (inscrit à Pôle emploi depuis au moins 4 mois ou 1 mois
     si cette inscription fait suite à un licenciement) par un groupement d'employeurs composés exclusivement de membres
-    exerçant les activités éligibles (cycle de la production animale et végétale, travaux forestiers, 
+    exerçant les activités éligibles (cycle de la production animale et végétale, travaux forestiers,
     activités constituant le prolongement direct de l'acte de production).
     '''
 
     def formula(individu, period):
         secteur_agricole = individu('secteur_activite_employeur', period) == TypesSecteurActivite.agricole
-        cdd = individu("contrat_de_travail_type", period) == TypesContrat.cdd
-        contrat_duree_determinee_type = individu("contrat_duree_determinee_type", period)
+        cdd = individu('contrat_de_travail_type', period) == TypesContrat.cdd
+        contrat_duree_determinee_type = individu('contrat_duree_determinee_type', period)
 
         cdd_occasionnel_agricole = (
             (contrat_duree_determinee_type == TypesContratTravailDureeDeterminee.contrat_saisonnier)
@@ -1644,7 +1645,7 @@ class travailleur_occasionnel_agricole(Variable):
             + (contrat_duree_determinee_type == TypesContratTravailDureeDeterminee.contrat_initiative_emploi)
             )
 
-        taches_salarie_type = individu("taches_salarie_type", period)
+        taches_salarie_type = individu('taches_salarie_type', period)
         taches_eligibles = (
             (taches_salarie_type == TypesTaches.production_animale_vegetale)
             + (taches_salarie_type == TypesTaches.prolongement_production)

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/index.yaml
@@ -1,0 +1,4 @@
+description: Exonération pour travailleur occasionnel demandeur d'emploi (TO-DE) des cotisations employeur de Sécurité sociale (SS)
+metadata:
+  ux_name: Exonération TO-DE (secteur agricole)
+  description_en: SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/index.yaml
@@ -1,4 +1,4 @@
 description: Exonération pour travailleur occasionnel demandeur d'emploi (TO-DE) des cotisations employeur de Sécurité sociale (SS)
 metadata:
-  ux_name: Exonération TO-DE (secteur agricole)
-  description_en: SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)
+  short_label: Exonération TO-DE (secteur agricole)
+  label_en: SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
@@ -3,11 +3,11 @@ values:
   2019-01-01:
     value: 1.6
 metadata:
-  ux_name: Plafond
+  ux_name: Point d'annulation TO-DE en nombre de SMIC
   description_en: Ceiling of resources in SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)
   unit: /1
   reference:
     2019-01-01:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038026966
       title: Article D741-60 du Code rural et de la pêche maritime
-  last_review: "2022-06-29"
+  last_review: "2022-09-21"

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
@@ -1,0 +1,13 @@
+description: Plafond de ressources en nombre de SMIC pour exonération travailleur occasionnel demandeur d'emploi (TO-DE) du secteur agricole
+values:
+  2019-01-01:
+    value: 1.6
+metadata:
+  ux_name: Plafond
+  description_en: Ceiling of resources in SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)
+  unit: /1
+  reference:
+    2019-01-01:
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038026966
+      title: Article D741-60 du Code rural et de la pêche maritime
+  last_review: "2022-06-29"

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
@@ -8,6 +8,8 @@ metadata:
   unit: /1
   reference:
     2019-01-01:
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038026966
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006585701/2019-01-01/
+      title: Article L741-16 du Code rural et de la pêche maritime
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038026966
       title: Article D741-60 du Code rural et de la pêche maritime
   last_review: "2022-09-21"

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
@@ -3,8 +3,8 @@ values:
   2019-01-01:
     value: 1.6
 metadata:
-  ux_name: Point d'annulation TO-DE en nombre de SMIC
-  description_en: Ceiling of resources in SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)
+  short_label: Point d'annulation TO-DE en nombre de SMIC
+  label_en: Ceiling of resources in SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)
   unit: /1
   reference:
     2019-01-01:
@@ -12,4 +12,4 @@ metadata:
       title: Article L741-16 du Code rural et de la pêche maritime
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038026966
       title: Article D741-60 du Code rural et de la pêche maritime
-  last_review: "2022-09-21"
+  last_value_still_valid_on: "2022-09-21"

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond_exoneration_integrale.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond_exoneration_integrale.yaml
@@ -1,13 +1,13 @@
-description: Seuil de ressources en nombre de SMIC de dégressivité de l'exonération travailleur occasionnel demandeur d'emploi (TO-DE) du secteur agricole
+description: Plafond de ressources en nombre de SMIC d'exonération intégrale TO-DE (travailleur occasionnel demandeur d'emploi) du secteur agricole 
 values:
   2019-01-01:
     value: 1.2
 metadata:
-  ux_name: Seuil
+  ux_name: Plafond d'exonération intégrale TO-DE en nombre de SMIC
   description_en: Threshold of resources in SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)
   unit: /1
   reference:
     2019-01-01:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038026966
       title: Article D741-60 du Code rural et de la pêche maritime
-  last_review: "2022-06-29"
+  last_review: "2022-09-21"

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond_exoneration_integrale.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond_exoneration_integrale.yaml
@@ -8,6 +8,8 @@ metadata:
   unit: /1
   reference:
     2019-01-01:
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038026966
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006585701/2019-01-01/
+      title: Article L741-16 du Code rural et de la pêche maritime
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038026966
       title: Article D741-60 du Code rural et de la pêche maritime
   last_review: "2022-09-21"

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond_exoneration_integrale.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond_exoneration_integrale.yaml
@@ -1,10 +1,10 @@
-description: Plafond de ressources en nombre de SMIC d'exonération intégrale TO-DE (travailleur occasionnel demandeur d'emploi) du secteur agricole 
+description: Plafond de ressources en nombre de SMIC d'exonération intégrale TO-DE (travailleur occasionnel demandeur d'emploi) du secteur agricole
 values:
   2019-01-01:
     value: 1.2
 metadata:
-  ux_name: Plafond d'exonération intégrale TO-DE en nombre de SMIC
-  description_en: Threshold of resources in SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)
+  short_label: Plafond d'exonération intégrale TO-DE en nombre de SMIC
+  label_en: Threshold of resources in SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)
   unit: /1
   reference:
     2019-01-01:
@@ -12,4 +12,4 @@ metadata:
       title: Article L741-16 du Code rural et de la pêche maritime
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038026966
       title: Article D741-60 du Code rural et de la pêche maritime
-  last_review: "2022-09-21"
+  last_value_still_valid_on: "2022-09-21"

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/seuil.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/seuil.yaml
@@ -1,0 +1,13 @@
+description: Seuil de ressources en nombre de SMIC de dégressivité de l'exonération travailleur occasionnel demandeur d'emploi (TO-DE) du secteur agricole
+values:
+  2019-01-01:
+    value: 1.2
+metadata:
+  ux_name: Seuil
+  description_en: Threshold of resources in SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)
+  unit: /1
+  reference:
+    2019-01-01:
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038026966
+      title: Article D741-60 du Code rural et de la pêche maritime
+  last_review: "2022-06-29"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '144.1.0',
+    version = '144.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -56,6 +56,8 @@
     cotisation_sociale_mode_recouvrement: mensuel_strict  # famille
   
   output:
+    assiette_cotisations_sociales: 1603.15 * 1.5
+
     mmid_employeur: -1 * 1603.15 * 1.5 * 0.13  # cotisation avant allègement (vérifier cas Alsace Moselle)
     assiette_allegement: 1603.15 * 1.5
     allegement_cotisation_maladie: (1603.15 * 1.5) * (0.13 - 0.07)  # sous 2.5 SMIC
@@ -70,45 +72,47 @@
     contribution_solidarite_autonomie: -1 * (1603.15 * 1.5) * 0.003
     chomage_employeur: -1 * (1603.15 * 1.5) * 0.0405  # sous 4 PSS
 
-    exoneration_cotisations_employeur_tode_eligibilite: True 
+    exoneration_cotisations_employeur_tode_eligibilite: True
     # -819.05 = -1 * 1603.15 * 1.5 * (0.07 + 0.0525 + 0.009 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
     exoneration_cotisations_employeur_tode: 1.2 * (-819.05 / 0.4) * (1.6 * 1603.15 / (1603.15 * 1.5))
 
 
-- name: rémunération annuelle > 2.5 SMIC (contrainte MMID) mais <= 3.5 SMIC (contrainte AF)
+- name: Exonération nulle de TO-DE pour salarié agricole à rémunération mensuelle brute >= 1.6 SMIC
   period: 2022-04
   relative_error_margin: 0.001
   input:
-    secteur_activite_employeur: agricole  # TO
-    contrat_de_travail_type: cdd
-    contrat_duree_determinee_type: contrat_saisonnier
-    taches_salarie_type: travaux_forestiers
-    salaire_de_base: 1603.15 * 3.5
-    allegement_cotisation_maladie_mode_recouvrement: anticipe  # maladie
-    cotisation_sociale_mode_recouvrement: mensuel_strict  # famille
+    secteur_activite_employeur: agricole
+    effectif_entreprise: 10  # moins de 50 salariés (seuil fnal 2020+)
 
-    categorie_salarie: prive_non_cadre
+    contrat_de_travail_type: cdd
+    contrat_duree_determinee_type: contrat_vendanges
+    categorie_salarie: prive_cadre
+    taches_salarie_type: prolongement_production
     exposition_accident: faible
 
-    effectif_entreprise: 5  # moins de 50 salariés (seuil 2020+)
+    salaire_de_base: 1603.15 * 2.6  # 4168.19
+    hsup: 0
+
+    allegement_cotisation_maladie_mode_recouvrement: anticipe  # maladie
+    cotisation_sociale_mode_recouvrement: mensuel_strict  # famille
+    
   output:
-    mmid_employeur: -1 * 1603.15 * 3.5 * 0.13
-    assiette_allegement: 1603.15 * 3.5
+    assiette_cotisations_sociales: 1603.15 * 2.6
+
+    mmid_employeur: -1 * 1603.15 * 2.6 * 0.13
+    assiette_allegement: 1603.15 * 2.6
     allegement_cotisation_maladie: 0  # pas d'allègement au-delà de 2.5 SMIC
-
-    assiette_cotisations_sociales: 1603.15 * 3.5
-    famille: -1 * 1603.15 * 3.5 * 0.0525  # cotisation avant allègement
-
-    accident_du_travail: -1 * 1603.15 * 3.5 * 0.009  # devrait être à 1.16% 
-    # d'après https://www.msa.fr/lfp/documents/11566/86370053/MSA+-+Taux+des+cotisations+accident+du+travail+%28AT%29+2021/033cfbf5-bc8f-a41a-3e79-3726fcb51911
-    # via https://www.msa.fr/lfp/employeur/taux-cotisations-sur-salaires?p_p_id=com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_BPTM0Ywvg0nX&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_BPTM0Ywvg0nX_read_more=2
-
-    fnal: -1 * (3428 * 0.001) # Pas de contribution au-delà de 1 PSS = 3428 / mois en 2021
+    
+    famille: -1 * 1603.15 * 2.6 * 0.0525  # FIXME: à <= 3.5 SMIC devrait être au prelevements_sociaux.cotisations_securite_sociale_regime_general.famille.taux_reduit
+    accident_du_travail: -1 * 1603.15 * 2.6 * 0.009  # FIXME: taux 2018 à mettre à jour
+    fnal: -1 * (3428 * 0.001) # plafond à 1 PSS = 3428/mois
 
     vieillesse_plafonnee_employeur: -1 * 3428 * 0.0855  # plafond à 1 PSS
-    vieillesse_deplafonnee_employeur: -1 * (1603.15 * 3.5) * 0.019  # sur totalité de la rémunération
-    agirc_arrco_employeur: -1 * 3428 * 0.0472 - ((1603.15 * 3.5) - 3428) * 0.1295
-    contribution_equilibre_general_employeur: -1 * 3428 * 0.0129 - ((1603.15 * 3.5) - 3428) * 0.0162
+    vieillesse_deplafonnee_employeur: -1 * (1603.15 * 2.6) * 0.019  # sur totalité de la rémunération
+    agirc_arrco_employeur: -1 * 3428 * 0.0472 - ((1603.15 * 2.6) - 3428) * 0.1295
+    contribution_equilibre_general_employeur: -1 * 3428 * 0.0129 - ((1603.15 * 2.6) - 3428) * 0.0162
+    contribution_solidarite_autonomie: -1 * (1603.15 * 2.6) * 0.003
+    chomage_employeur: -1 * (1603.15 * 2.6) * 0.0405
 
-    contribution_solidarite_autonomie: -1 * (1603.15 * 3.5) * 0.003
-    chomage_employeur: -1 * (1603.15 * 3.5) * 0.0405
+    exoneration_cotisations_employeur_tode_eligibilite: True
+    exoneration_cotisations_employeur_tode: 0

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -6,7 +6,7 @@
       Eden:
         secteur_activite_employeur: agricole  # TO secteur agricole
         regime_securite_sociale: regime_agricole  # MSA (optionnel si secteur défini)
-        choix_exoneration_cotisations_employeur_agricole: True
+        choix_exoneration_cotisations_employeur_agricole: true
         effectif_entreprise: 5  # moins de 50 salariés (seuil fnal 2020+)
 
         contrat_de_travail_type: cdd
@@ -33,10 +33,10 @@
         chomage_employeur: -1 * (1603.15 * 1.2) * 0.0405  # sous 4 PSS
   output:
     exoneration_cotisations_employeur_tode_eligibilite: true
-    # -625.61 = -1 * 1603.15 * 1.2 * (0.07 + 0.0345 + 0.0116 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
-    exoneration_cotisations_employeur_tode: -625.61
+    # 625.61 = 1603.15 * 1.2 * (0.07 + 0.0345 + 0.0116 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
+    exoneration_cotisations_employeur_tode: 625.61
     allegement_fillon: 0
-    exonerations_et_allegements: -625.61
+    exonerations_et_allegements: 625.61
 
 
 - name: Exonération partielle de TO-DE pour salarié agricole à rémunération mensuelle brute < 1.6 SMIC
@@ -44,7 +44,7 @@
   relative_error_margin: 0.002  # fnal : 0.001 -> 0.002
   input:
     secteur_activite_employeur: agricole
-    choix_exoneration_cotisations_employeur_agricole: True
+    choix_exoneration_cotisations_employeur_agricole: true
     effectif_entreprise: 10  # moins de 50 salariés (seuil fnal 2020+)
 
     contrat_de_travail_type: cdd
@@ -77,10 +77,10 @@
     chomage_employeur: -1 * (1603.15 * 1.5) * 0.0405  # sous 4 PSS
 
     exoneration_cotisations_employeur_tode_eligibilite: true
-    # -819.05 = -1 * 1603.15 * 1.5 * (0.07 + 0.0525 + 0.009 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
+    # 819.05 = 1603.15 * 1.5 * (0.07 + 0.0525 + 0.009 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
     exoneration_cotisations_employeur_tode: 1.2 * (-819.05 / 0.4) * (1.6 * 1603.15 / (1603.15 * 1.5) - 1)
     allegement_fillon: 0
-    exonerations_et_allegements: -819.05
+    exonerations_et_allegements: 819.05
 
 
 - name: Exonération nulle de TO-DE pour salarié agricole à rémunération mensuelle brute >= 1.6 SMIC
@@ -88,7 +88,7 @@
   relative_error_margin: 0.001
   input:
     secteur_activite_employeur: agricole
-    choix_exoneration_cotisations_employeur_agricole: True
+    choix_exoneration_cotisations_employeur_agricole: true
     effectif_entreprise: 10  # moins de 50 salariés (seuil fnal 2020+)
 
     contrat_de_travail_type: cdd

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -1,45 +1,38 @@
-- name: Exonération cotisations employeur agricole pour travailleur occasionnel demandeur d'emploi (TO-DE)
+- name: Exonération totale TO-DE pour salarié agricole à rémunération mensuelle brute <= 1.2 SMIC
   period: 2022-04
   relative_error_margin: 0.002  # fnal : 0.001 -> 0.002
   input:
     individus:
       Eden:
         secteur_activite_employeur: agricole
+        effectif_entreprise: 5  # moins de 50 salariés (seuil fnal 2020+)
+        
         contrat_de_travail_type: cdd
         contrat_duree_determinee_type: contrat_saisonnier
         categorie_salarie: prive_non_cadre
         taches_salarie_type: travaux_forestiers
-        exposition_accident: faible  # :D
+        exposition_accident: faible
 
         salaire_de_base: 1603.15 * 1.2  # 1923.78        
         hsup: 150
 
-        # allegement_cotisation_maladie_mode_recouvrement: anticipe
-        # cotisation_sociale_mode_recouvrement: mensuel_strict
-
         mmid_employeur: -1 * 1603.15 * 1.2 * 0.13
         assiette_allegement: 1603.15 * 1.2
-        allegement_cotisation_maladie: (1603.15 * 1.2) * (0.13 - 0.07)  # pas d'allègement au-delà de 2.5 SMIC
+        allegement_cotisation_maladie: (1603.15 * 1.2) * (0.13 - 0.07)  # sous 2.5 SMIC
 
-        assiette_cotisations_sociales: 1603.15 * 1.2
-        famille: -1 * 1603.15 * 1.2 * 0.0525  # cotisation avant allègement
-
-        accident_du_travail: -1 * 1603.15 * 1.2 * 0.009  # devrait être à 1.16%
-
-        effectif_entreprise: 5  # moins de 50 salariés (seuil fnal 2020+)
-        fnal: -1 * (1603.15 * 1.2) * 0.001 # -1 * (3428 * 0.001) # Pas de contribution au-delà de 1 PSS = 3428 / mois en 2020
-
-
-        vieillesse_plafonnee_employeur: -1 * (1603.15 * 1.2) * 0.0855  # sous plafond à 1 PSS
+        famille: -1 * 1603.15 * 1.2 * 0.0345  # taux réduit sous 3.5 SMIC
+        accident_du_travail: -1 * 1603.15 * 1.2 * 0.0116  # taux 2022
+        fnal: -1 * (1603.15 * 1.2) * 0.001  # sous 1 PSS
+        vieillesse_plafonnee_employeur: -1 * (1603.15 * 1.2) * 0.0855  # sous 1 PSS
         vieillesse_deplafonnee_employeur: -1 * (1603.15 * 1.2) * 0.019  # sur totalité de la rémunération
-        agirc_arrco_employeur: -1 * (1603.15 * 1.2) * 0.0472  # sous plafond à 1 PSS
-        contribution_equilibre_general_employeur: -1 * (1603.15 * 1.2) * 0.0129    # sous plafond à 1 PSS
-
+        agirc_arrco_employeur: -1 * (1603.15 * 1.2) * 0.0472  # sous 1 PSS
+        contribution_equilibre_general_employeur: -1 * (1603.15 * 1.2) * 0.0129  # sous 1 PSS
         contribution_solidarite_autonomie: -1 * (1603.15 * 1.2) * 0.003
-        chomage_employeur: -1 * (1603.15 * 1.2) * 0.0405
+        chomage_employeur: -1 * (1603.15 * 1.2) * 0.0405  # sous 4 PSS
   output: 
-    # -1 * 1603.15 * 1.2 * (0.07 + 0.0525 + 0.009 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
-    exoneration_cotisations_employeur_tode: -655.24
+    exoneration_cotisations_employeur_tode_eligibilite: True
+    # -1 * 1603.15 * 1.2 * (0.07 + 0.0345 + 0.0116 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
+    exoneration_cotisations_employeur_tode: -625.61
 
 
 - name: rémunération annuelle <= 2.5 SMIC (contrainte MMID)
@@ -60,7 +53,7 @@
     allegement_cotisation_maladie: (1603.15 * 2.5) * (0.13 - 0.07)
 
     assiette_cotisations_sociales: 1603.15 * 2.5
-    famille: -1 * 1603.15 * 2.5 * 0.0525  # cotisation avant allègement
+    famille: -1 * 1603.15 * 2.5 * 0.0525  # FIXME: à <= 3.5 SMIC devrait être au prelevements_sociaux.cotisations_securite_sociale_regime_general.famille.taux_reduit
 
 - name: rémunération annuelle > 2.5 SMIC (contrainte MMID) mais <= 3.5 SMIC (contrainte AF)
   period: 2022-04

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -6,6 +6,7 @@
       Eden:
         secteur_activite_employeur: agricole  # TO secteur agricole
         regime_securite_sociale: regime_agricole  # MSA (optionnel si secteur défini)
+        choix_exoneration_cotisations_employeur_agricole: True
         effectif_entreprise: 5  # moins de 50 salariés (seuil fnal 2020+)
 
         contrat_de_travail_type: cdd
@@ -34,6 +35,8 @@
     exoneration_cotisations_employeur_tode_eligibilite: true
     # -625.61 = -1 * 1603.15 * 1.2 * (0.07 + 0.0345 + 0.0116 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
     exoneration_cotisations_employeur_tode: -625.61
+    allegement_fillon: 0
+    exonerations_et_allegements: -625.61
 
 
 - name: Exonération partielle de TO-DE pour salarié agricole à rémunération mensuelle brute < 1.6 SMIC
@@ -41,6 +44,7 @@
   relative_error_margin: 0.002  # fnal : 0.001 -> 0.002
   input:
     secteur_activite_employeur: agricole
+    choix_exoneration_cotisations_employeur_agricole: True
     effectif_entreprise: 10  # moins de 50 salariés (seuil fnal 2020+)
 
     contrat_de_travail_type: cdd
@@ -75,6 +79,8 @@
     exoneration_cotisations_employeur_tode_eligibilite: true
     # -819.05 = -1 * 1603.15 * 1.5 * (0.07 + 0.0525 + 0.009 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
     exoneration_cotisations_employeur_tode: 1.2 * (-819.05 / 0.4) * (1.6 * 1603.15 / (1603.15 * 1.5) - 1)
+    allegement_fillon: 0
+    exonerations_et_allegements: -819.05
 
 
 - name: Exonération nulle de TO-DE pour salarié agricole à rémunération mensuelle brute >= 1.6 SMIC
@@ -82,6 +88,7 @@
   relative_error_margin: 0.001
   input:
     secteur_activite_employeur: agricole
+    choix_exoneration_cotisations_employeur_agricole: True
     effectif_entreprise: 10  # moins de 50 salariés (seuil fnal 2020+)
 
     contrat_de_travail_type: cdd
@@ -116,3 +123,5 @@
 
     exoneration_cotisations_employeur_tode_eligibilite: true
     exoneration_cotisations_employeur_tode: 0
+    allegement_fillon: 0
+    exonerations_et_allegements: 0

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -32,7 +32,7 @@
         chomage_employeur: -1 * (1603.15 * 1.2) * 0.0405  # sous 4 PSS
   output:
     exoneration_cotisations_employeur_tode_eligibilite: true
-    # -1 * 1603.15 * 1.2 * (0.07 + 0.0345 + 0.0116 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
+    # -625.61 = -1 * 1603.15 * 1.2 * (0.07 + 0.0345 + 0.0116 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
     exoneration_cotisations_employeur_tode: -625.61
 
 
@@ -58,7 +58,7 @@
   output:
     assiette_cotisations_sociales: 1603.15 * 1.5
 
-    mmid_employeur: -1 * 1603.15 * 1.5 * 0.13  # cotisation avant allègement (vérifier cas Alsace Moselle)
+    mmid_employeur: -1 * 1603.15 * 1.5 * 0.13  # cotisation avant allègement
     assiette_allegement: 1603.15 * 1.5
     allegement_cotisation_maladie: (1603.15 * 1.5) * (0.13 - 0.07)  # sous 2.5 SMIC
 
@@ -74,7 +74,7 @@
 
     exoneration_cotisations_employeur_tode_eligibilite: true
     # -819.05 = -1 * 1603.15 * 1.5 * (0.07 + 0.0525 + 0.009 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
-    exoneration_cotisations_employeur_tode: 1.2 * (-819.05 / 0.4) * (1.6 * 1603.15 / (1603.15 * 1.5))
+    exoneration_cotisations_employeur_tode: 1.2 * (-819.05 / 0.4) * (1.6 * 1603.15 / (1603.15 * 1.5) - 1)
 
 
 - name: Exonération nulle de TO-DE pour salarié agricole à rémunération mensuelle brute >= 1.6 SMIC

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -1,25 +1,46 @@
 - name: Exonération cotisations employeur agricole pour travailleur occasionnel demandeur d'emploi (TO-DE)
-  period: 2020-01
+  period: 2022-04
+  relative_error_margin: 0.002  # fnal : 0.001 -> 0.002
   input:
-    individus:
-      claude:
-        salaire_de_base: 1539.45 * 1.2  # 1847.34
-        hsup: 150
-        agirc_arrco_employeur: 0
-        
+    salaire_de_base: 1603.15 * 1.2  # 1923.78
+    hsup: 150
 
-        mmid_employeur: -139.86
-        accident_du_travail: -139.86
-        vieillesse_plafonnee_employeur: -170.83
-        vieillesse_deplafonnee_employeur: -37.96
-        # retraite complémentaire ?        
-        famille: -68.93
-        chomage_employeur: -80.92
-        # chômage AGS ?
-        fnal: -2
-        contribution_solidarite_autonomie: -5.99
+    allegement_cotisation_maladie_mode_recouvrement: anticipe
+    cotisation_sociale_mode_recouvrement: mensuel_strict
+    categorie_salarie: prive_non_cadre
+    exposition_accident: faible
+    effectif_entreprise: 5  # moins de 50 salariés (seuil 2020+)
+    # agirc_arrco_employeur: 0
+    # mmid_employeur: -139.86
+    # accident_du_travail: -139.86
+    # vieillesse_plafonnee_employeur: -170.83
+    # vieillesse_deplafonnee_employeur: -37.96
+    # # retraite complémentaire ?        
+    # famille: -68.93
+    # chomage_employeur: -80.92
+    # # chômage AGS ?
+    # fnal: -2
+    # contribution_solidarite_autonomie: -5.99
   output:
-    exoneration_cotisations_employeur_tode: -640.36
+    mmid_employeur: -1 * 1603.15 * 1.2 * 0.13
+    assiette_allegement: 1603.15 * 1.2
+    allegement_cotisation_maladie: (1603.15 * 1.2) * (0.13 - 0.07)  # pas d'allègement au-delà de 2.5 SMIC
+
+    assiette_cotisations_sociales: 1603.15 * 1.2
+    famille: -1 * 1603.15 * 1.2 * 0.0525  # cotisation avant allègement
+    
+    accident_du_travail: -1 * 1603.15 * 1.2 * 0.009  # devrait être à 1.16%
+
+    fnal: -1 * (1603.15 * 1.2) * 0.001 # -1 * (3428 * 0.001) # Pas de contribution au-delà de 1 PSS = 3428 / mois en 2020
+
+    vieillesse_plafonnee_employeur: -1 * (1603.15 * 1.2) * 0.0855  # sous plafond à 1 PSS
+    vieillesse_deplafonnee_employeur: -1 * (1603.15 * 1.2) * 0.019  # sur totalité de la rémunération
+    agirc_arrco_employeur: -1 * (1603.15 * 1.2) * 0.0472  # sous plafond à 1 PSS
+    contribution_equilibre_general_employeur: -1 * (1603.15 * 1.2) * 0.0129    # sous plafond à 1 PSS
+
+    contribution_solidarite_autonomie: -1 * (1603.15 * 1.2) * 0.003
+    chomage_employeur: -1 * (1603.15 * 1.2) * 0.0405
+    exoneration_cotisations_employeur_tode: 0
 
 
 - name: rémunération annuelle <= 2.5 SMIC (contrainte MMID)

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -4,7 +4,8 @@
   input:
     individus:
       Eden:
-        secteur_activite_employeur: agricole
+        secteur_activite_employeur: agricole  # TO secteur agricole
+        regime_securite_sociale: regime_agricole  # MSA (optionnel si secteur défini)
         effectif_entreprise: 5  # moins de 50 salariés (seuil fnal 2020+)
         
         contrat_de_travail_type: cdd
@@ -22,7 +23,7 @@
 
         famille: -1 * 1603.15 * 1.2 * 0.0345  # taux réduit sous 3.5 SMIC
         accident_du_travail: -1 * 1603.15 * 1.2 * 0.0116  # taux 2022
-        fnal: -1 * (1603.15 * 1.2) * 0.001  # sous 1 PSS
+        fnal: -1 * (1603.15 * 1.2) * 0.001  # sous 1 PSS (3428€)
         vieillesse_plafonnee_employeur: -1 * (1603.15 * 1.2) * 0.0855  # sous 1 PSS
         vieillesse_deplafonnee_employeur: -1 * (1603.15 * 1.2) * 0.019  # sur totalité de la rémunération
         agirc_arrco_employeur: -1 * (1603.15 * 1.2) * 0.0472  # sous 1 PSS
@@ -35,32 +36,50 @@
     exoneration_cotisations_employeur_tode: -625.61
 
 
-- name: rémunération annuelle <= 2.5 SMIC (contrainte MMID)
+- name: Exonération partielle de TO-DE pour salarié agricole à rémunération mensuelle brute < 1.6 SMIC
   period: 2022-04
-  relative_error_margin: 0.001
+  relative_error_margin: 0.002  # fnal : 0.001 -> 0.002
   input:
-    secteur_activite_employeur: agricole  # TO
-    regime_securite_sociale: regime_agricole  # MSA (optionnel si secteur défini)
+    secteur_activite_employeur: agricole
+    effectif_entreprise: 10  # moins de 50 salariés (seuil fnal 2020+)
 
     contrat_de_travail_type: cdd
     contrat_duree_determinee_type: contrat_saisonnier
-    taches_salarie_type: travaux_forestiers
-    salaire_de_base: 1603.15 * 2.5
-    allegement_cotisation_maladie_mode_recouvrement: anticipe
-  output:
-    mmid_employeur: -1 * 1603.15 * 2.5 * 0.13  # cotisation avant allègement # vérifier Alsace Moselle
-    assiette_allegement: 1603.15 * 2.5
-    allegement_cotisation_maladie: (1603.15 * 2.5) * (0.13 - 0.07)
+    categorie_salarie: prive_non_cadre
+    taches_salarie_type: prolongement_production
+    exposition_accident: faible
 
-    assiette_cotisations_sociales: 1603.15 * 2.5
-    famille: -1 * 1603.15 * 2.5 * 0.0525  # FIXME: à <= 3.5 SMIC devrait être au prelevements_sociaux.cotisations_securite_sociale_regime_general.famille.taux_reduit
+    salaire_de_base: 1603.15 * 1.5  # 2404.72
+    hsup: 0
+
+    allegement_cotisation_maladie_mode_recouvrement: anticipe  # maladie
+    cotisation_sociale_mode_recouvrement: mensuel_strict  # famille
+  
+  output:
+    mmid_employeur: -1 * 1603.15 * 1.5 * 0.13  # cotisation avant allègement (vérifier cas Alsace Moselle)
+    assiette_allegement: 1603.15 * 1.5
+    allegement_cotisation_maladie: (1603.15 * 1.5) * (0.13 - 0.07)  # sous 2.5 SMIC
+
+    famille: -1 * 1603.15 * 1.5 * 0.0525  # FIXME: à <= 3.5 SMIC devrait être au prelevements_sociaux.cotisations_securite_sociale_regime_general.famille.taux_reduit
+    accident_du_travail: -1 * 1603.15 * 1.5 * 0.009  # FIXME: taux 2018 à mettre à jour
+    fnal: -1 * (1603.15 * 1.5) * 0.001  # sous 1 PSS (3428€)
+    vieillesse_plafonnee_employeur: -1 * (1603.15 * 1.5) * 0.0855  # sous 1 PSS
+    vieillesse_deplafonnee_employeur: -1 * (1603.15 * 1.5) * 0.019  # sur totalité de la rémunération
+    agirc_arrco_employeur: -1 * (1603.15 * 1.5) * 0.0472  # sous 1 PSS
+    contribution_equilibre_general_employeur: -1 * (1603.15 * 1.5) * 0.0129  # sous 1 PSS
+    contribution_solidarite_autonomie: -1 * (1603.15 * 1.5) * 0.003
+    chomage_employeur: -1 * (1603.15 * 1.5) * 0.0405  # sous 4 PSS
+
+    exoneration_cotisations_employeur_tode_eligibilite: True 
+    # -819.05 = -1 * 1603.15 * 1.5 * (0.07 + 0.0525 + 0.009 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
+    exoneration_cotisations_employeur_tode: 1.2 * (-819.05 / 0.4) * (1.6 * 1603.15 / (1603.15 * 1.5))
+
 
 - name: rémunération annuelle > 2.5 SMIC (contrainte MMID) mais <= 3.5 SMIC (contrainte AF)
   period: 2022-04
   relative_error_margin: 0.001
   input:
     secteur_activite_employeur: agricole  # TO
-    regime_securite_sociale: regime_agricole  # MSA (optionnel si secteur défini)
     contrat_de_travail_type: cdd
     contrat_duree_determinee_type: contrat_saisonnier
     taches_salarie_type: travaux_forestiers

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -7,14 +7,14 @@
         secteur_activite_employeur: agricole  # TO secteur agricole
         regime_securite_sociale: regime_agricole  # MSA (optionnel si secteur défini)
         effectif_entreprise: 5  # moins de 50 salariés (seuil fnal 2020+)
-        
+
         contrat_de_travail_type: cdd
         contrat_duree_determinee_type: contrat_saisonnier
         categorie_salarie: prive_non_cadre
         taches_salarie_type: travaux_forestiers
         exposition_accident: faible
 
-        salaire_de_base: 1603.15 * 1.2  # 1923.78        
+        salaire_de_base: 1603.15 * 1.2  # 1923.78
         hsup: 150
 
         mmid_employeur: -1 * 1603.15 * 1.2 * 0.13
@@ -30,8 +30,8 @@
         contribution_equilibre_general_employeur: -1 * (1603.15 * 1.2) * 0.0129  # sous 1 PSS
         contribution_solidarite_autonomie: -1 * (1603.15 * 1.2) * 0.003
         chomage_employeur: -1 * (1603.15 * 1.2) * 0.0405  # sous 4 PSS
-  output: 
-    exoneration_cotisations_employeur_tode_eligibilite: True
+  output:
+    exoneration_cotisations_employeur_tode_eligibilite: true
     # -1 * 1603.15 * 1.2 * (0.07 + 0.0345 + 0.0116 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
     exoneration_cotisations_employeur_tode: -625.61
 
@@ -54,7 +54,7 @@
 
     allegement_cotisation_maladie_mode_recouvrement: anticipe  # maladie
     cotisation_sociale_mode_recouvrement: mensuel_strict  # famille
-  
+
   output:
     assiette_cotisations_sociales: 1603.15 * 1.5
 
@@ -72,7 +72,7 @@
     contribution_solidarite_autonomie: -1 * (1603.15 * 1.5) * 0.003
     chomage_employeur: -1 * (1603.15 * 1.5) * 0.0405  # sous 4 PSS
 
-    exoneration_cotisations_employeur_tode_eligibilite: True
+    exoneration_cotisations_employeur_tode_eligibilite: true
     # -819.05 = -1 * 1603.15 * 1.5 * (0.07 + 0.0525 + 0.009 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
     exoneration_cotisations_employeur_tode: 1.2 * (-819.05 / 0.4) * (1.6 * 1603.15 / (1603.15 * 1.5))
 
@@ -95,14 +95,14 @@
 
     allegement_cotisation_maladie_mode_recouvrement: anticipe  # maladie
     cotisation_sociale_mode_recouvrement: mensuel_strict  # famille
-    
+
   output:
     assiette_cotisations_sociales: 1603.15 * 2.6
 
     mmid_employeur: -1 * 1603.15 * 2.6 * 0.13
     assiette_allegement: 1603.15 * 2.6
     allegement_cotisation_maladie: 0  # pas d'allègement au-delà de 2.5 SMIC
-    
+
     famille: -1 * 1603.15 * 2.6 * 0.0525  # FIXME: à <= 3.5 SMIC devrait être au prelevements_sociaux.cotisations_securite_sociale_regime_general.famille.taux_reduit
     accident_du_travail: -1 * 1603.15 * 2.6 * 0.009  # FIXME: taux 2018 à mettre à jour
     fnal: -1 * (3428 * 0.001) # plafond à 1 PSS = 3428/mois
@@ -114,5 +114,5 @@
     contribution_solidarite_autonomie: -1 * (1603.15 * 2.6) * 0.003
     chomage_employeur: -1 * (1603.15 * 2.6) * 0.0405
 
-    exoneration_cotisations_employeur_tode_eligibilite: True
+    exoneration_cotisations_employeur_tode_eligibilite: true
     exoneration_cotisations_employeur_tode: 0

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -20,3 +20,52 @@
         contribution_solidarite_autonomie: -5.99
   output:
     exoneration_cotisations_employeur_tode: -640.36
+
+
+- name: rémunération annuelle <= 2.5 SMIC (contrainte MMID)
+  period: 2022-04
+  relative_error_margin: 0.001
+  input:
+    salaire_de_base: 1603.15 * 2.5
+    allegement_cotisation_maladie_mode_recouvrement: anticipe
+  output:
+    mmid_employeur: -1 * 1603.15 * 2.5 * 0.13  # cotisation avant allègement # vérifier Alsace Moselle
+    assiette_allegement: 1603.15 * 2.5
+    allegement_cotisation_maladie: (1603.15 * 2.5) * (0.13 - 0.07)
+
+    assiette_cotisations_sociales: 1603.15 * 2.5
+    famille: -1 * 1603.15 * 2.5 * 0.0525  # cotisation avant allègement
+
+- name: rémunération annuelle > 2.5 SMIC (contrainte MMID) mais <= 3.5 SMIC (contrainte AF)
+  period: 2022-04
+  relative_error_margin: 0.001
+  input:
+    salaire_de_base: 1603.15 * 3.5
+    allegement_cotisation_maladie_mode_recouvrement: anticipe  # maladie
+    cotisation_sociale_mode_recouvrement: mensuel_strict  # famille
+
+    categorie_salarie: prive_non_cadre
+    exposition_accident: faible
+
+    effectif_entreprise: 5  # moins de 50 salariés (seuil 2020+)
+  output:
+    mmid_employeur: -1 * 1603.15 * 3.5 * 0.13
+    assiette_allegement: 1603.15 * 3.5
+    allegement_cotisation_maladie: 0  # pas d'allègement au-delà de 2.5 SMIC
+
+    assiette_cotisations_sociales: 1603.15 * 3.5
+    famille: -1 * 1603.15 * 3.5 * 0.0525  # cotisation avant allègement
+
+    accident_du_travail: -1 * 1603.15 * 3.5 * 0.009  # devrait être à 1.16% 
+    # d'après https://www.msa.fr/lfp/documents/11566/86370053/MSA+-+Taux+des+cotisations+accident+du+travail+%28AT%29+2021/033cfbf5-bc8f-a41a-3e79-3726fcb51911
+    # via https://www.msa.fr/lfp/employeur/taux-cotisations-sur-salaires?p_p_id=com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_BPTM0Ywvg0nX&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_BPTM0Ywvg0nX_read_more=2
+
+    fnal: -1 * (3428 * 0.001) # Pas de contribution au-delà de 1 PSS = 3428 / mois en 2021
+
+    vieillesse_plafonnee_employeur: -1 * 3428 * 0.0855  # plafond à 1 PSS
+    vieillesse_deplafonnee_employeur: -1 * (1603.15 * 3.5) * 0.019  # sur totalité de la rémunération
+    agirc_arrco_employeur: -1 * 3428 * 0.0472 - ((1603.15 * 3.5) - 3428) * 0.1295
+    contribution_equilibre_general_employeur: -1 * 3428 * 0.0129 - ((1603.15 * 3.5) - 3428) * 0.0162
+
+    contribution_solidarite_autonomie: -1 * (1603.15 * 3.5) * 0.003
+    chomage_employeur: -1 * (1603.15 * 3.5) * 0.0405

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -1,0 +1,22 @@
+- name: Exonération cotisations employeur agricole pour travailleur occasionnel demandeur d'emploi (TO-DE)
+  period: 2020-01
+  input:
+    individus:
+      claude:
+        salaire_de_base: 1539.45 * 1.2  # 1847.34
+        hsup: 150
+        agirc_arrco_employeur: 0
+        
+
+        mmid_employeur: -139.86
+        accident_du_travail: -139.86
+        vieillesse_plafonnee_employeur: -170.83
+        vieillesse_deplafonnee_employeur: -37.96
+        # retraite complémentaire ?        
+        famille: -68.93
+        chomage_employeur: -80.92
+        # chômage AGS ?
+        fnal: -2
+        contribution_solidarite_autonomie: -5.99
+  output:
+    exoneration_cotisations_employeur_tode: -640.36

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -2,51 +2,56 @@
   period: 2022-04
   relative_error_margin: 0.002  # fnal : 0.001 -> 0.002
   input:
-    salaire_de_base: 1603.15 * 1.2  # 1923.78
-    hsup: 150
+    individus:
+      Eden:
+        secteur_activite_employeur: agricole
+        contrat_de_travail_type: cdd
+        contrat_duree_determinee_type: contrat_saisonnier
+        categorie_salarie: prive_non_cadre
+        taches_salarie_type: travaux_forestiers
+        exposition_accident: faible  # :D
 
-    allegement_cotisation_maladie_mode_recouvrement: anticipe
-    cotisation_sociale_mode_recouvrement: mensuel_strict
-    categorie_salarie: prive_non_cadre
-    exposition_accident: faible
-    effectif_entreprise: 5  # moins de 50 salariés (seuil 2020+)
-    # agirc_arrco_employeur: 0
-    # mmid_employeur: -139.86
-    # accident_du_travail: -139.86
-    # vieillesse_plafonnee_employeur: -170.83
-    # vieillesse_deplafonnee_employeur: -37.96
-    # # retraite complémentaire ?        
-    # famille: -68.93
-    # chomage_employeur: -80.92
-    # # chômage AGS ?
-    # fnal: -2
-    # contribution_solidarite_autonomie: -5.99
-  output:
-    mmid_employeur: -1 * 1603.15 * 1.2 * 0.13
-    assiette_allegement: 1603.15 * 1.2
-    allegement_cotisation_maladie: (1603.15 * 1.2) * (0.13 - 0.07)  # pas d'allègement au-delà de 2.5 SMIC
+        salaire_de_base: 1603.15 * 1.2  # 1923.78        
+        hsup: 150
 
-    assiette_cotisations_sociales: 1603.15 * 1.2
-    famille: -1 * 1603.15 * 1.2 * 0.0525  # cotisation avant allègement
-    
-    accident_du_travail: -1 * 1603.15 * 1.2 * 0.009  # devrait être à 1.16%
+        # allegement_cotisation_maladie_mode_recouvrement: anticipe
+        # cotisation_sociale_mode_recouvrement: mensuel_strict
 
-    fnal: -1 * (1603.15 * 1.2) * 0.001 # -1 * (3428 * 0.001) # Pas de contribution au-delà de 1 PSS = 3428 / mois en 2020
+        mmid_employeur: -1 * 1603.15 * 1.2 * 0.13
+        assiette_allegement: 1603.15 * 1.2
+        allegement_cotisation_maladie: (1603.15 * 1.2) * (0.13 - 0.07)  # pas d'allègement au-delà de 2.5 SMIC
 
-    vieillesse_plafonnee_employeur: -1 * (1603.15 * 1.2) * 0.0855  # sous plafond à 1 PSS
-    vieillesse_deplafonnee_employeur: -1 * (1603.15 * 1.2) * 0.019  # sur totalité de la rémunération
-    agirc_arrco_employeur: -1 * (1603.15 * 1.2) * 0.0472  # sous plafond à 1 PSS
-    contribution_equilibre_general_employeur: -1 * (1603.15 * 1.2) * 0.0129    # sous plafond à 1 PSS
+        assiette_cotisations_sociales: 1603.15 * 1.2
+        famille: -1 * 1603.15 * 1.2 * 0.0525  # cotisation avant allègement
 
-    contribution_solidarite_autonomie: -1 * (1603.15 * 1.2) * 0.003
-    chomage_employeur: -1 * (1603.15 * 1.2) * 0.0405
-    exoneration_cotisations_employeur_tode: 0
+        accident_du_travail: -1 * 1603.15 * 1.2 * 0.009  # devrait être à 1.16%
+
+        effectif_entreprise: 5  # moins de 50 salariés (seuil fnal 2020+)
+        fnal: -1 * (1603.15 * 1.2) * 0.001 # -1 * (3428 * 0.001) # Pas de contribution au-delà de 1 PSS = 3428 / mois en 2020
+
+
+        vieillesse_plafonnee_employeur: -1 * (1603.15 * 1.2) * 0.0855  # sous plafond à 1 PSS
+        vieillesse_deplafonnee_employeur: -1 * (1603.15 * 1.2) * 0.019  # sur totalité de la rémunération
+        agirc_arrco_employeur: -1 * (1603.15 * 1.2) * 0.0472  # sous plafond à 1 PSS
+        contribution_equilibre_general_employeur: -1 * (1603.15 * 1.2) * 0.0129    # sous plafond à 1 PSS
+
+        contribution_solidarite_autonomie: -1 * (1603.15 * 1.2) * 0.003
+        chomage_employeur: -1 * (1603.15 * 1.2) * 0.0405
+  output: 
+    # -1 * 1603.15 * 1.2 * (0.07 + 0.0525 + 0.009 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
+    exoneration_cotisations_employeur_tode: -655.24
 
 
 - name: rémunération annuelle <= 2.5 SMIC (contrainte MMID)
   period: 2022-04
   relative_error_margin: 0.001
   input:
+    secteur_activite_employeur: agricole  # TO
+    regime_securite_sociale: regime_agricole  # MSA (optionnel si secteur défini)
+
+    contrat_de_travail_type: cdd
+    contrat_duree_determinee_type: contrat_saisonnier
+    taches_salarie_type: travaux_forestiers
     salaire_de_base: 1603.15 * 2.5
     allegement_cotisation_maladie_mode_recouvrement: anticipe
   output:
@@ -61,6 +66,11 @@
   period: 2022-04
   relative_error_margin: 0.001
   input:
+    secteur_activite_employeur: agricole  # TO
+    regime_securite_sociale: regime_agricole  # MSA (optionnel si secteur défini)
+    contrat_de_travail_type: cdd
+    contrat_duree_determinee_type: contrat_saisonnier
+    taches_salarie_type: travaux_forestiers
     salaire_de_base: 1603.15 * 3.5
     allegement_cotisation_maladie_mode_recouvrement: anticipe  # maladie
     cotisation_sociale_mode_recouvrement: mensuel_strict  # famille

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -79,7 +79,7 @@
 
     exoneration_cotisations_employeur_tode_eligibilite: true
     # 819.05 = 1603.15 * 1.5 * (0.07 + 0.0525 + 0.009 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
-    exoneration_cotisations_employeur_tode: 1.2 * (-819.05 / 0.4) * (1.6 * 1603.15 / (1603.15 * 1.5) - 1)
+    exoneration_cotisations_employeur_tode: 1.2 * (819.05 / 0.4) * (1.6 * 1603.15 / (1603.15 * 1.5) - 1)
     allegement_fillon: 0
     allegement_cotisation_allocations_familiales: 0
     exonerations_et_allegements: 819.05

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -82,7 +82,7 @@
     exoneration_cotisations_employeur_tode: 1.2 * (819.05 / 0.4) * (1.6 * 1603.15 / (1603.15 * 1.5) - 1)
     allegement_fillon: 0
     allegement_cotisation_allocations_familiales: 0
-    exonerations_et_allegements: 819.05
+    exonerations_et_allegements: 163.81
 
 
 - name: Exonération nulle de TO-DE pour salarié agricole à rémunération mensuelle brute >= 1.6 SMIC

--- a/tests/formulas/exoneration_cotisations_employeur_tode.yaml
+++ b/tests/formulas/exoneration_cotisations_employeur_tode.yaml
@@ -20,7 +20,7 @@
 
         mmid_employeur: -1 * 1603.15 * 1.2 * 0.13
         assiette_allegement: 1603.15 * 1.2
-        allegement_cotisation_maladie: (1603.15 * 1.2) * (0.13 - 0.07)  # sous 2.5 SMIC
+        allegement_cotisation_maladie_base: (1603.15 * 1.2) * (0.13 - 0.07)  # sous 2.5 SMIC
 
         famille: -1 * 1603.15 * 1.2 * 0.0345  # taux réduit sous 3.5 SMIC
         accident_du_travail: -1 * 1603.15 * 1.2 * 0.0116  # taux 2022
@@ -36,6 +36,7 @@
     # 625.61 = 1603.15 * 1.2 * (0.07 + 0.0345 + 0.0116 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
     exoneration_cotisations_employeur_tode: 625.61
     allegement_fillon: 0
+    allegement_cotisation_allocations_familiales: 0
     exonerations_et_allegements: 625.61
 
 
@@ -64,7 +65,7 @@
 
     mmid_employeur: -1 * 1603.15 * 1.5 * 0.13  # cotisation avant allègement
     assiette_allegement: 1603.15 * 1.5
-    allegement_cotisation_maladie: (1603.15 * 1.5) * (0.13 - 0.07)  # sous 2.5 SMIC
+    allegement_cotisation_maladie_base: (1603.15 * 1.5) * (0.13 - 0.07)  # sous 2.5 SMIC
 
     famille: -1 * 1603.15 * 1.5 * 0.0525  # FIXME: à <= 3.5 SMIC devrait être au prelevements_sociaux.cotisations_securite_sociale_regime_general.famille.taux_reduit
     accident_du_travail: -1 * 1603.15 * 1.5 * 0.009  # FIXME: taux 2018 à mettre à jour
@@ -80,6 +81,7 @@
     # 819.05 = 1603.15 * 1.5 * (0.07 + 0.0525 + 0.009 + 0.001 + 0.0855 + 0.019 + 0.0472 + 0.0129 + 0.003 + 0.0405)
     exoneration_cotisations_employeur_tode: 1.2 * (-819.05 / 0.4) * (1.6 * 1603.15 / (1603.15 * 1.5) - 1)
     allegement_fillon: 0
+    allegement_cotisation_allocations_familiales: 0
     exonerations_et_allegements: 819.05
 
 
@@ -108,7 +110,7 @@
 
     mmid_employeur: -1 * 1603.15 * 2.6 * 0.13
     assiette_allegement: 1603.15 * 2.6
-    allegement_cotisation_maladie: 0  # pas d'allègement au-delà de 2.5 SMIC
+    allegement_cotisation_maladie_base: 0  # pas d'allègement au-delà de 2.5 SMIC
 
     famille: -1 * 1603.15 * 2.6 * 0.0525  # FIXME: à <= 3.5 SMIC devrait être au prelevements_sociaux.cotisations_securite_sociale_regime_general.famille.taux_reduit
     accident_du_travail: -1 * 1603.15 * 2.6 * 0.009  # FIXME: taux 2018 à mettre à jour
@@ -124,4 +126,5 @@
     exoneration_cotisations_employeur_tode_eligibilite: true
     exoneration_cotisations_employeur_tode: 0
     allegement_fillon: 0
+    allegement_cotisation_allocations_familiales: 0
     exonerations_et_allegements: 0

--- a/tests/formulas/maladie_mmid_employeur.yaml
+++ b/tests/formulas/maladie_mmid_employeur.yaml
@@ -6,7 +6,7 @@
   output:
     mmid_employeur: -.1289 * 2300
 
-- name: Cotisation maladie MMID employeur pour rémunération 1xSMIC < 2.5xSMIC
+- name: Cotisation maladie MMID employeur pour rémunération 1xSMIC <= 2.5xSMIC
   period: 2021-02
   relative_error_margin: 0.001
   input:


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées :
  - `model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py`
  - `model/revenus/activite/salarie.py`
  - `parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode`
* Détails :
  - Ajoute à partir de 2019 l'exonération pour travailleur occasionnel demandeur d'emploi (TO-DE) du secteur agricole `exoneration_cotisations_employeur_tode` et la référence dans `exonerations_et_allegements`
  - Ajoute des caractéristiques du salarié : `contrat_duree_determinee_type`, `taches_salarie_type` et `travailleur_occasionnel_agricole`
  - Adapte `allegement_cotisation_allocations_familiales` et ajoute `allegement_cotisation_allocations_familiales_base` pour le non cumul avec `allegement_fillon`

- - - -

Informations complémentaires : 

L'exonération TO-DE s'étend jusqu'au 31 décembre 2025 depuis la promulgation de la LFSS pour 2023 (précédemment, la TO-DE s'achevait au 31 décembre 2022).

Dans `openfisca-france`, [les barèmes de cotisations sont pré-processés](https://github.com/openfisca/openfisca-france/blob/0f045f986de109327a93258d72806b3af2966a0c/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/preprocessing.py). 
Ainsi, si pour vérifier la cotisation employeur exonérée pour le travailleur agricole, on cherche un barème de cotisation employeur, son nom YAML ne sera pas identique à son nom en mémoire qui sera passé par l'étape de pré-processing au chargement du TaxBenefitSystem.

Ensuite, l'application du barème de cotisation employeur se fait par un appel à une fonction auxiliaire partagées par toutes les cotisations, [apply_bareme](https://github.com/openfisca/openfisca-france/blob/0f045f986de109327a93258d72806b3af2966a0c/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/base.py#L291). Cette fonction dépend du mode de recouvrement des cotisations choisi (d'où la présence de cette information dans les tests YAML de cette PR). Puis elle fait appel à [compte_cotisation](https://github.com/openfisca/openfisca-france/blob/0f045f986de109327a93258d72806b3af2966a0c/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/base.py#L329) qui contient également l'assiette de ressources prises en considération pour la calcul des cotisations.

Néanmoins, si le calcul des cotisations est utile au test de l'exonération TO-DE, cette dernière s'applique d'un point de vue calcul après le calcul des cotisations. On ne fait pas donc pas directement mention du mode de recouvrement dans la TO-DE.

- - - -

Ces changements :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
