### PR TITLE
Corrige l'identation d'une référence.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 116.13.2 [#1862](https://github.com/openfisca/openfisca-france/pull/1862)
+
+* Changement mineur.
+* Périodes concernées : sans objet
+* Zones impactées : aucune variable impactée.
+* Détails :
+  - Corrige l'identation d'une référence d'un paramètre YAML.
+  - Correction d'une typo dans le changelog.
+
 ### 116.13.1 [#1845](https://github.com/openfisca/openfisca-france/pull/1845)
 
 * Changement mineur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-### 116.13.1 [#1845](https://github.com/openfisca/openfisca-france/pull/1845
+### 116.13.1 [#1845](https://github.com/openfisca/openfisca-france/pull/1845)
+
 * Changement mineur.
 * Périodes concernés : à partir du 1/1/2016
 * Zonesimpactées : parameters/prestations_sociales/aides_logement/action_logement

--- a/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/nonbat/seuil.yaml
+++ b/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/nonbat/seuil.yaml
@@ -6,6 +6,6 @@ metadata:
   unit: currency
   reference:
     2018-01-01:
-    href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036385037
-    title: Article 976 III. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036385037
+      title: Article 976 III. du Code général des impôts
   last_review: "2022-05-12"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '116.13.1',
+    version = '116.13.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : sans objet
* Zones impactées : aucune variable impactée.
* Détails :
  - Corrige l'identation d'une référence d'un paramètre YAML.
