### PR TITLE
Met à jour les paramètres de la taxe d'habitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### 116.14.0 [#1867](https://github.com/openfisca/openfisca-france/pull/1867)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : 2022.
+* Zones impactées :
+    - `openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev.yaml`
+    - `openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev_degressif.yaml`
+    - `openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/taux_sup_plaf.yaml`
+    - `openfisca_france/parameters/taxation_indirecte/taxe_habitation/exon_plaf_rfr.yaml`
+* Détails :
+    - Met à jour les taux de la taxe d'habitation pour 2022.
+
+
 ### 116.13.2 [#1862](https://github.com/openfisca/openfisca-france/pull/1862)
 
 * Changement mineur.

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev.yaml
@@ -36,6 +36,7 @@ deux_premieres_demi_parts_supp:
     2022-01-01:
       value: 8340
   metadata:
+    last_review: "2022-08-01"
     unit: currency
     reference:
       2022-01-01:
@@ -55,6 +56,7 @@ premiere_part:
     2022-01-01:
       value: 28150
   metadata:
+    last_review: "2022-08-01"
     unit: currency
     reference:
       2022-01-01:

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev.yaml
@@ -13,6 +13,8 @@ autres_demi_parts_supp:
       value: 6157
     2021-01-01:
       value: 6169
+    2022-01-01:
+      value: 6255
   metadata:
     unit: currency
 deux_premieres_demi_parts_supp:
@@ -26,6 +28,8 @@ deux_premieres_demi_parts_supp:
       value: 8210
     2021-01-01:
       value: 8225
+    2022-01-01:
+      value: 8340
   metadata:
     unit: currency
 premiere_part:
@@ -39,5 +43,7 @@ premiere_part:
       value: 27706
     2021-01-01:
       value: 27761
+    2022-01-01:
+      value: 28150
   metadata:
     unit: currency

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev.yaml
@@ -17,6 +17,10 @@ autres_demi_parts_supp:
       value: 6255
   metadata:
     unit: currency
+    reference:
+      2022-01-01:
+        href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045757184
+        title: "Décret n° 2022-782 du 4 mai 2022, article"
 deux_premieres_demi_parts_supp:
   description: Plafond de revenu fiscal de référence pour le dégrèvement d'office à taux plein - deux premières demi-parts supplémentaires
   values:
@@ -32,6 +36,10 @@ deux_premieres_demi_parts_supp:
       value: 8340
   metadata:
     unit: currency
+    reference:
+      2022-01-01:
+        href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045757184
+        title: "Décret n° 2022-782 du 4 mai 2022, article"
 premiere_part:
   description: Plafonds de revenu fiscal de référence pour le dégrèvement d'office à taux plein - 1ère part
   values:
@@ -47,3 +55,7 @@ premiere_part:
       value: 28150
   metadata:
     unit: currency
+    reference:
+      2022-01-01:
+        href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045757184
+        title: "Décret n° 2022-782 du 4 mai 2022, article"

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev.yaml
@@ -16,6 +16,7 @@ autres_demi_parts_supp:
     2022-01-01:
       value: 6255
   metadata:
+    last_review: "2022-08-01"
     unit: currency
     reference:
       2022-01-01:

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev_degressif.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev_degressif.yaml
@@ -17,6 +17,11 @@ autres_demi_parts_supp:
       value: 6255
   metadata:
     unit: currency
+    reference:
+      2022-01-01:
+        href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045757184
+        title: "Décret n° 2022-782 du 4 mai 2022, article"
+
 deux_premieres_demi_parts_supp:
   description: Plafond de revenu fiscal de référence pour le dégrèvement d'office dégressif - deux premières demi-parts supplémentaires
   values:
@@ -32,6 +37,10 @@ deux_premieres_demi_parts_supp:
       value: 8861
   metadata:
     unit: currency
+    reference:
+      2022-01-01:
+        href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045757184
+        title: "Décret n° 2022-782 du 4 mai 2022, article"
 premiere_part:
   description: Plafond de revenu fiscal de référence pour le dégrèvement d'office dégressif - 1ère part
   values:
@@ -47,3 +56,7 @@ premiere_part:
       value: 29192
   metadata:
     unit: currency
+    reference:
+      2022-01-01:
+        href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045757184
+        title: "Décret n° 2022-782 du 4 mai 2022, article"

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev_degressif.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev_degressif.yaml
@@ -16,6 +16,7 @@ autres_demi_parts_supp:
     2022-01-01:
       value: 6255
   metadata:
+    last_review: "2022-08-01"
     unit: currency
     reference:
       2022-01-01:
@@ -36,6 +37,7 @@ deux_premieres_demi_parts_supp:
     2022-01-01:
       value: 8861
   metadata:
+    last_review: "2022-08-01"
     unit: currency
     reference:
       2022-01-01:
@@ -55,6 +57,7 @@ premiere_part:
     2022-01-01:
       value: 29192
   metadata:
+    last_review: "2022-08-01"
     unit: currency
     reference:
       2022-01-01:

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev_degressif.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev_degressif.yaml
@@ -13,6 +13,8 @@ autres_demi_parts_supp:
       value: 6157
     2021-01-01:
       value: 6169
+    2022-01-01:
+      value: 6255
   metadata:
     unit: currency
 deux_premieres_demi_parts_supp:
@@ -26,6 +28,8 @@ deux_premieres_demi_parts_supp:
       value: 8723
     2021-01-01:
       value: 8739
+    2022-01-01:
+      value: 8861
   metadata:
     unit: currency
 premiere_part:
@@ -39,5 +43,7 @@ premiere_part:
       value: 28732
     2021-01-01:
       value: 28789
+    2022-01-01:
+      value: 29192
   metadata:
     unit: currency

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/taux_sup_plaf.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/taux_sup_plaf.yaml
@@ -7,6 +7,7 @@ values:
   2022-01-01:
     value: 0.65
 metadata:
+  last_review: "2022-08-01"
   unit: /1
   reference:
     2017-01-01: 

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/taux_sup_plaf.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/taux_sup_plaf.yaml
@@ -10,6 +10,7 @@ metadata:
   unit: /1
   reference:
     2017-01-01: 
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041465111/
       title: art. 1414 C du CGI
     2022-01-01:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045757184

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/taux_sup_plaf.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/taux_sup_plaf.yaml
@@ -4,6 +4,8 @@ values:
     value: 0
   2021-01-01:
     value: 0.3
+  2022-01-01:
+    value: 0.65
 metadata:
   unit: /1
   reference:

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/taux_sup_plaf.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/taux_sup_plaf.yaml
@@ -9,4 +9,8 @@ values:
 metadata:
   unit: /1
   reference:
-    title: art. 1414 C du CGI
+    2017-01-01: 
+      title: art. 1414 C du CGI
+    2022-01-01:
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045757184
+      title: "Décret n° 2022-782 du 4 mai 2022, article"

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/exon_plaf_rfr.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/exon_plaf_rfr.yaml
@@ -18,6 +18,7 @@ demi_part_supp:
     2022-01-01:
       value: 3011
   metadata:
+    last_review: "2022-08-01"
     unit: currency
     reference:
       2022-01-01:
@@ -39,6 +40,7 @@ premiere_part:
     2022-01-01:
       value: 11276
   metadata:
+    last_review: "2022-08-01"
     unit: currency
     reference:
       2022-01-01:

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/exon_plaf_rfr.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/exon_plaf_rfr.yaml
@@ -19,6 +19,10 @@ demi_part_supp:
       value: 3011
   metadata:
     unit: currency
+    reference:
+      2022-01-01:
+        href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045757184
+        title: "Décret n° 2022-782 du 4 mai 2022, article"
 premiere_part:
   description: Plafond de revenu fiscal de référence pour l'exonération de la taxe d'habitation - 1ère part
   values:
@@ -36,3 +40,7 @@ premiere_part:
       value: 11276
   metadata:
     unit: currency
+    reference:
+      2022-01-01:
+        href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045757184
+        title: "Décret n° 2022-782 du 4 mai 2022, article"

--- a/openfisca_france/parameters/taxation_indirecte/taxe_habitation/exon_plaf_rfr.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxe_habitation/exon_plaf_rfr.yaml
@@ -15,6 +15,8 @@ demi_part_supp:
       value: 2963
     2021-01-01:
       value: 2969
+    2022-01-01:
+      value: 3011
   metadata:
     unit: currency
 premiere_part:
@@ -30,5 +32,7 @@ premiere_part:
       value: 11098
     2021-01-01:
       value: 11120
+    2022-01-01:
+      value: 11276
   metadata:
     unit: currency

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '116.13.2',
+    version = '116.14.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : 2022.
* Zones impactées : 
  - `openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev.yaml`
  - `openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/plaf_rfr_degrev_degressif.yaml`
  - `openfisca_france/parameters/taxation_indirecte/taxe_habitation/degrevement_d_office/taux_sup_plaf.yaml`
  - `openfisca_france/parameters/taxation_indirecte/taxe_habitation/exon_plaf_rfr.yaml`
* Détails :
  - Met à jour les taux de la taxe d'habitation pour 2022.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.