### PR TITLE
Ajoute la revalorisation du taux du livret d'épargne populaire au 01/08/2022

### DIFF
--- a/openfisca_france/parameters/epargne/livret_epargne_populaire.yaml
+++ b/openfisca_france/parameters/epargne/livret_epargne_populaire.yaml
@@ -3,6 +3,10 @@ majoration_base_livret_a:
   values:
     2008-07-28:
       value: 0.005
+    2022-02-01:
+      value: 0.017
+    2022-08-01:
+      value: 0.041
 coefficient_multiplicateur:
   reference: Article L221-15 du code monétaire et financier - https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006072026&idArticle=LEGIARTI000006651936&dateTexte=&categorieLien=cid
   values:


### PR DESCRIPTION
…08/2022

* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/08/2022.
* Zones impactées : `parameters/epargne/livret_epargne_populaire.yaml`.
* Détails :
  - Revalorisation du taux du livret d'épargne populaire au 1er août 2022.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.
