### PR TITLE
Ajoute la revalorisation du smic horaire brut au 01/08/2022

### DIFF
--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic_h_b.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic_h_b.yaml
@@ -74,3 +74,6 @@ values:
     value: 10.57
   2022-05-01:
     value: 10.85
+  2022-08-01:
+    value: 11.07
+    reference: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046113517


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/08/2022.
* Zones impactées : `parameters/marche_travail/salaire_minimum/smic_h_b`.
* Détails :
  - Revalorisation du SMIC au 1er aout 2022.

- - - -

Ces changements :
- Corrigent ou améliorent un calcul déjà existant.
