### PR TITLE
Revalorise les paramètres de la réduction Fillon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 117.0.3 [#1884]([https://github.com/openfisca/openfisca-france/pull/1884)
+
+
+* Changement mineur.
+* Périodes concernées : à partir du 01/01/2022
+* Zones impactées :
+        parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/*
+* Détails :
+       - Revalorise les paramètres de la réduction Fillon (entreprises_de_20_salaries_et_plus, entreprises_de_moins_de_20_salaries et plafond)
+
 ### 117.0.2 [#1846](https://github.com/openfisca/openfisca-france/pull/1846)
 
 * Évolution du système socio-fiscal

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/entreprises_de_20_salaries_et_plus.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/entreprises_de_20_salaries_et_plus.yaml
@@ -18,6 +18,8 @@ values:
     value: 0.3245
   2021-01-01:
     value: 0.3246
+  2022-01-01:
+    value: 0.3235
 metadata:
   ux_name: 20 et plus salariés
   description_en: General SSC reductions, so called Fillon reductions (2003-2016)
@@ -75,6 +77,11 @@ metadata:
     2021-01-01:
       href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042869486/2020-12-30/
       title: Article D241-7 du Code de la Sécurité Sociale
+    2022-01-01:
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044793095
+      title: Décret 2021-1936 du 30/12/2021, art. 2
+    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044944431/2022-01-01/
+      title: Article D241-7 du Code de la Sécurité Sociale
   official_journal_date:
     2003-07-01: 2003-01-18; 2003-06-12
     2004-07-01: 2003-01-18; 2003-06-12
@@ -88,6 +95,7 @@ metadata:
     2018-01-01: "2017-12-31"
     2019-01-01: 2018-12-30; 2018-12-23
     2020-01-01: "2020-01-03"
+    2022-01-01: "2021-12-30"
   notes:
     2003-07-01:
     - title: Loi dite Fillon

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/entreprises_de_20_salaries_et_plus.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/entreprises_de_20_salaries_et_plus.yaml
@@ -78,10 +78,10 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042869486/2020-12-30/
       title: Article D241-7 du Code de la Sécurité Sociale
     2022-01-01:
-    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044793095
-      title: Décret 2021-1936 du 30/12/2021, art. 2
     - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044944431/2022-01-01/
       title: Article D241-7 du Code de la Sécurité Sociale
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044793095
+      title: Décret 2021-1936 du 30/12/2021, art. 2
   official_journal_date:
     2003-07-01: 2003-01-18; 2003-06-12
     2004-07-01: 2003-01-18; 2003-06-12

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/entreprises_de_moins_de_20_salaries.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/entreprises_de_moins_de_20_salaries.yaml
@@ -20,6 +20,8 @@ values:
     value: 0.3205
   2021-01-01:
     value: 0.3206
+  2022-01-01:
+    value: 0.3246 
 metadata:
   ux_name: Moins de 20 salariés
   description_en: General SSC reductions, so called Fillon reductions (2003-2016)
@@ -77,6 +79,11 @@ metadata:
       title: Décret n° 2020-1719 du 28 décembre 2020, art. 2
     - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042869486/2020-12-30/
       title: Article D241-7 du Code de la Sécurité Sociale
+    2022-01-01:
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044793095
+      title: Décret 2021-1936 du 30/12/2021, art. 2
+    - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000044944431/2022-01-01/
+      title: Article D241-7 du Code de la Sécurité Sociale
   official_journal_date:
     2003-07-01: 2003-01-18; 2003-06-12
     2004-07-01: 2003-01-18; 2003-06-12
@@ -90,6 +97,7 @@ metadata:
     2018-01-01: "2017-12-31"
     2019-01-01: 2018-12-30; 2018-12-23
     2020-01-01: "2020-01-03"
+    2022-01-01: "2021-12-30"
   notes:
     2003-07-01:
     - title: Loi dite Fillon

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/entreprises_de_moins_de_20_salaries.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/entreprises_de_moins_de_20_salaries.yaml
@@ -80,10 +80,10 @@ metadata:
     - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000042869486/2020-12-30/
       title: Article D241-7 du Code de la Sécurité Sociale
     2022-01-01:
-    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044793095
-      title: Décret 2021-1936 du 30/12/2021, art. 2
     - href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000044944431/2022-01-01/
       title: Article D241-7 du Code de la Sécurité Sociale
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044793095
+      title: Décret 2021-1936 du 30/12/2021, art. 2
   official_journal_date:
     2003-07-01: 2003-01-18; 2003-06-12
     2004-07-01: 2003-01-18; 2003-06-12

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/plafond.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/plafond.yaml
@@ -24,7 +24,7 @@ metadata:
   official_journal_date:
     2004-07-01: 2003-01-18; 2003-06-12
     2005-01-01: "2004-12-31"
-  last_review: "2021-11-19"
+  last_review: "2022-09-12"
 documentation: |-
   Notes :
   Le salaire de référence pour le calcul de l'allègement avant le 01/07/2005 pour les entreprises ayant signé un accord de RTT avant le 30/06/2003 est la GMR 2.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '117.0.2',
+    version = '117.0.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/2022
* Zones impactées : 
  - `parameters/prelevements_sociaux/reductions_cotisations_sociales/fillon/ensemble_des_entreprises/*`
* Détails :
  - Revalorise les paramètres de la réduction Fillon (`entreprises_de_20_salaries_et_plus`, `entreprises_de_moins_de_20_salaries` et `plafond`)

- - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.
- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).
