### PR TITLE
Met en propre la réforme de l'abattement minimum pour les chomeurs de longue durée

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### 117.0.5 [#1895]([https://github.com/openfisca/openfisca-france/pull/1895)
+
+* Changement mineur.
+* Périodes concernées : à partir du 01/01/2018.
+* Zones impactées :
+  - `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`
+  - `openfisca_france/model/prestations/aides_logement.py`
+  - `openfisca_france/model/revenus/remplacement/chomage.py`
+  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min2.yaml`
+  - `openfisca_france/parameters/indemnite_inflation.yaml`
+* Détails :
+  - Améliore la prise en compte d'une réforme.
+  - Ne devrait pas changer de calcul.
+  - Met un end date à une variable (une case concrètement) qui n'existe plus.
+  - Corrige des formules à partir de 2018.
+  - Petit bug fix dans un autre fichier (met des guillemets).
+
 ### 117.0.4 [#1891]([https://github.com/openfisca/openfisca-france/pull/1891)
 
 * Changement mineur.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -427,6 +427,19 @@ class revenu_assimile_salaire_apres_abattements(Variable):
             * max_(0, revenu_assimile_salaire - abatfor)
             )
 
+    def formula_2018_01_01(individu, period, parameters):
+        revenu_assimile_salaire = individu('revenu_assimile_salaire', period)
+        frais_reels = individu('frais_reels', period)
+        abatpro = parameters(period).impot_revenu.calcul_revenus_imposables.tspr.abatpro
+
+        abatfor = round_(min_(max_(abatpro.taux * revenu_assimile_salaire, abatpro.min), abatpro.max))
+        return (
+            (frais_reels > abatfor)
+            * (revenu_assimile_salaire - frais_reels)
+            + (frais_reels <= abatfor)
+            * max_(0, revenu_assimile_salaire - abatfor)
+            )
+
 
 class revenu_assimile_pension(Variable):
     value_type = float

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -611,10 +611,9 @@ class aide_logement_base_ressources_individu(Variable):
 
         revenus = revenus * (1 - aide_logement_condition_neutralisation)
 
-        hsup = individu('hsup', period.last_year, options = [ADD])
         glo = individu('glo', period.last_year)
 
-        return revenus + revenu_assimile_pension + hsup + glo
+        return revenus + revenu_assimile_pension + glo
 
     def formula_2018_01_01(individu, period, parameters):
 
@@ -654,10 +653,9 @@ class aide_logement_base_ressources_individu(Variable):
 
         revenus = revenus * (1 - aide_logement_condition_neutralisation)
 
-        hsup = individu('hsup', period.n_2, options = [ADD])
         glo = individu('glo', period.n_2)
 
-        return revenus + revenu_assimile_pension_apres_abattements + hsup + glo
+        return revenus + revenu_assimile_pension_apres_abattements + glo
 
     def formula(individu, period, parameters):
 

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -575,12 +575,10 @@ class aide_logement_base_ressources_individu(Variable):
 
         revenu_assimile_salaire = salaire_imposable + chomage_imposable + f1tt + f3vj
 
-        chomeur_longue_duree = individu('chomeur_longue_duree', period, options = [DIVIDE])
         frais_reels = individu('frais_reels', period_frais)
 
         abatpro = parameters(period.last_year).impot_revenu.calcul_revenus_imposables.tspr.abatpro
-        abattement_minimum = where(chomeur_longue_duree, abatpro.min2, abatpro.min)
-        abattement_forfaitaire = round_(min_(max_(abatpro.taux * revenu_assimile_salaire, abattement_minimum), abatpro.max))
+        abattement_forfaitaire = round_(min_(max_(abatpro.taux * revenu_assimile_salaire, abatpro.min), abatpro.max))
 
         abattement_frais_pro = where(frais_reels > abattement_forfaitaire, frais_reels, abattement_forfaitaire)
 

--- a/openfisca_france/model/revenus/remplacement/chomage.py
+++ b/openfisca_france/model/revenus/remplacement/chomage.py
@@ -15,6 +15,7 @@ class chomeur_longue_duree(Variable):
     entity = Individu
     label = "Demandeur d'emploi inscrit depuis plus d'un an"
     definition_period = YEAR
+    end = '2017-12-31'
     # Pour toutes les variables de ce type, les pac3 ne sont plus proposés après 2007
 
 

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min2.yaml
@@ -44,7 +44,7 @@ values:
       title: I. 6° a) de l'article 30 de la LOI n° 2018-1317 du 28 décembre 2018 de finances pour 2019 (1)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000037882381
 metadata:
-  last_review: '2022-09-26'
+  last_review: "2022-09-26"
   unit: currency
   reference:
     title: Barèmes IPP - https://www.ipp.eu/wp-content/uploads/2017/07/baremes-ipp-impot-revenu-income-tax.xlsx

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min2.yaml
@@ -39,10 +39,12 @@ values:
   2017-01-01:
     value: 947
   2018-01-01:
-    value: 437
-  2019-01-01:
-    value: 441
+    value: NULL
+    reference:
+      title: I. 6° a) de l'article 30 de la LOI n° 2018-1317 du 28 décembre 2018 de finances pour 2019 (1)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000037882381
 metadata:
+  last_review: '2022-09-26'
   unit: currency
   reference:
     title: Barèmes IPP - https://www.ipp.eu/wp-content/uploads/2017/07/baremes-ipp-impot-revenu-income-tax.xlsx

--- a/openfisca_france/parameters/indemnite_inflation.yaml
+++ b/openfisca_france/parameters/indemnite_inflation.yaml
@@ -5,7 +5,7 @@ values:
   2022-01-01:
     value: null
 metadata:
-  last_review: 2022-08-03
+  last_review: '2022-08-03'
   unit: currency
   reference:
     2021-01-01:

--- a/openfisca_france/parameters/indemnite_inflation.yaml
+++ b/openfisca_france/parameters/indemnite_inflation.yaml
@@ -5,7 +5,7 @@ values:
   2022-01-01:
     value: null
 metadata:
-  last_review: '2022-08-03'
+  last_review: "2022-08-03"
   unit: currency
   reference:
     2021-01-01:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '117.0.4',
+    version = '117.0.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/2018.
* Zones impactées : 
  - `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`
  - `openfisca_france/model/prestations/aides_logement.py`
  - `openfisca_france/model/revenus/remplacement/chomage.py`
  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min2.yaml`
  - `openfisca_france/parameters/indemnite_inflation.yaml`
* Détails :
  - Améliore la prise en compte d'une réforme.
  - Ne devrait pas changer de calcul.
  - Met un end date à une variable (une case concrètement) qui n'existe plus.
  - Corrige des formules à partir de 2018.
  - Petit bug fix dans un autre fichier (met des guillemets).

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.
