### PR TITLE
Renomme  "details" dans les références des paramètres par "note"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 117.1.2 [#1904](https://github.com/openfisca/openfisca-france/pull/1904)
+
+* Changement mineur dans les métadonnées des paramètres
+* Périodes concernées : toutes
+* Zones impactées : `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/`
+* Détails :
+  - Renommage du champ "details" dans les références en "note".
+
 ### 117.1.1 [#1881](https://github.com/openfisca/openfisca-france/pull/1881)
 
 * Évolution du système socio-fiscal.
@@ -11,7 +19,7 @@
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/08/2022.
-* Zones impactées : 
+* Zones impactées :
   - `openfisca_france/parameters/prestations_sociales/aides_logement`
   - `openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah`
   - `openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/asi`
@@ -20,7 +28,7 @@
   - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa`
 
 * Détails :
-  - Mise à jour des prestations sociales suite à la revalorisation exceptionnelle de 4% en  Juillet 2022. 
+  - Mise à jour des prestations sociales suite à la revalorisation exceptionnelle de 4% en  Juillet 2022.
   - https://www.service-public.fr/particuliers/actualites/A15599
 
 ### 117.0.5 [#1895]([https://github.com/openfisca/openfisca-france/pull/1895)

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/max.yaml
@@ -87,13 +87,13 @@ values:
     reference:
       title: Art. 2 de la loi no 2020-1721 du 29 décembre 2020 de finances pour 2021
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042753593
-      details: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
+      note: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
   2021-01-01:
     value: 3912
     reference:
       title: Art. 2 de la loi no 2021-1900 du 30 décembre 2021 de finances pour 2022
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044637653
-      details: Revalorisation de (10 225 / 10 084) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
+      note: Revalorisation de (10 225 / 10 084) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
 metadata:
   unit: currency
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpen/min.yaml
@@ -53,13 +53,13 @@ values:
     reference:
       title: Art. 2 de la loi no 2020-1721 du 29 décembre 2020 de finances pour 2021
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042753593
-      details: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
+      note: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
   2021-01-01:
     value: 400
     reference:
       title: Art. 2 de la loi no 2021-1900 du 30 décembre 2021 de finances pour 2022
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044637653
-      details: Revalorisation de (10 225 / 10 084) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
+      note: Revalorisation de (10 225 / 10 084) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
 metadata:
   unit: currency
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/max.yaml
@@ -89,13 +89,13 @@ values:
     reference:
       title: Art. 2 de la loi no 2020-1721 du 29 décembre 2020 de finances pour 2021
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042753593
-      details: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
+      note: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
   2021-01-01:
     value: 12829
     reference:
       title: Art. 2 de la loi no 2021-1900 du 30 décembre 2021 de finances pour 2022
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044637653
-      details: Revalorisation de (10 225 / 10 084) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
+      note: Revalorisation de (10 225 / 10 084) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
 metadata:
   unit: currency
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/abatpro/min.yaml
@@ -61,13 +61,13 @@ values:
     reference:
       title: Art. 2 de la loi no 2020-1721 du 29 décembre 2020 de finances pour 2021
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042753593
-      details: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
+      note: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
   2021-01-01:
     value: 448
     reference:
       title: Art. 2 de la loi no 2021-1900 du 30 décembre 2021 de finances pour 2022
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044637653
-      details: Revalorisation de (10 225 / 10 084) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
+      note: Revalorisation de (10 225 / 10 084) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
 metadata:
   unit: currency
   reference:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '117.1.1',
+    version = '117.1.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur dans les métadonnées des paramètres
* Périodes concernées : toutes
* Zones impactées : `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/tspr/`
* Détails :
  - Renomme le champ "details" dans les référence en "note".
