### PR TITLE
corrige valeur plafond loyer alloc logement personnes seules zone 2

### DIFF
--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_2/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_2/personnes_seules.yaml
@@ -39,7 +39,7 @@ values:
   2021-10-01:
     value: 259.78
   2022-07-01:
-    value: 252
+    value: 268.87
 metadata:
   ux_name: Personnes seules
   description_en: Parameters for the rental sector (after the 2001 reform)


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2022
* Zones impactées : `openfisca_france\parameters\prestations_sociales\aides_logement\allocations_logement\al_loc2\par_zone\zone_3\personnes_seules.yaml`.
* Détails :
  - Correction valeur de paramètres

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
