### PR TITLE
nettoyage des metadata de paramètres sur le minimum vieillesse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# 128.0.1 [#1937](https://github.com/openfisca/openfisca-france/pull/1937)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/`.
+* Détails :
+  - Nettoyage de certaines métadonnées
+
 # 128.0.0 [#1945](https://github.com/openfisca/openfisca-france/pull/1945)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/as/allocation_supplementaire/as_menage.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/as/allocation_supplementaire/as_menage.yaml
@@ -110,9 +110,6 @@ metadata:
   ipp_csv_id: alloc_sup_men
   unit: currency
   reference:
-    1980-10-01:
-      title: Décret 80-865 du 31/10/1980
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000681571
     1982-07-01:
       title: Décret 82-560 du 29/06/1982
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000336521&categorieLien=id
@@ -265,7 +262,6 @@ metadata:
       title: Circulaire CNAV 2022/3 du 11/01/2023, page 8
       href: https://www.legislation.cnav.fr/Documents/circulaire_cnav_2022_03_11012022.pdf
   official_journal_date:
-    1980-10-01: "1980-11-06"
     1982-07-01: "1982-07-02"
     1983-01-01: "1982-12-30"
     1983-07-01: "1982-12-30"
@@ -309,10 +305,3 @@ metadata:
     2016-04-01:
     - title: L'AVTS est remplacée par l'ASPA en 2007 par le décret 2007-57. Cependant, comme le mentionne l'ordonnance 2004-605, les personnes qui bénéficiaient au moment de l'entrée en vigueur de l'ASPA des anciens dispositifs de mimimum vieillesse continuent à percevoir ces anciennes prestations selon les règles applicables avant cette entrée en vigueur. D'où le fait qu'on garde les barèmes de l'AVTS après 2007.
   last_review: "2021-01-01"
-documentation: |-
-  Notes :
-  Le complément versé entre 1958 et 1962 est à ajouter au montant de l'allocation supplémentaire. Il s'agit de compléments cumulés.
-  A partir de 1963, il y a simple revalorisation. Après 1962, le complément est une majoration exceptionnelle.
-  Sources :
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.
-  CNAV, site web législation - barèmes.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/as/allocation_supplementaire/as_personne_seule.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/as/allocation_supplementaire/as_personne_seule.yaml
@@ -229,9 +229,6 @@ metadata:
       title: Décret 79-1058 du 07/12/1979
     1980-06-01:
       title: Décret 80-499 du 01/07/1980
-    1980-10-01:
-      title: Décret 80-865 du 31/10/1980
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000681571
     1981-01-01:
       title: Décret 80-1158 du 31/12/1980
     1981-07-01:
@@ -419,7 +416,6 @@ metadata:
     1979-07-01: "1979-07-07"
     1979-12-01: "1979-12-08"
     1980-06-01: "1980-07-03"
-    1980-10-01: "1980-11-06"
     1981-01-01: "1981-01-10"
     1981-07-01: "1981-07-01"
     1982-01-01: "1981-12-31"
@@ -470,10 +466,3 @@ metadata:
     2016-04-01:
     - title: L'AVTS est remplacée par l'ASPA en 2007 par le décret 2007-57. Cependant, comme le mentionne l'ordonnance 2004-605, les personnes qui bénéficiaient au moment de l'entrée en vigueur de l'ASPA des anciens dispositifs de mimimum vieillesse continuent à percevoir ces anciennes prestations selon les règles applicables avant cette entrée en vigueur. D'où le fait qu'on garde les barèmes de l'AVTS après 2007.
   last_review: "2021-01-01"
-documentation: |-
-  Notes :
-  Le complément versé entre 1958 et 1962 est à ajouter au montant de l'allocation supplémentaire. Il s'agit de compléments cumulés.
-  A partir de 1963, il y a simple revalorisation. Après 1962, le complément est une majoration exceptionnelle.
-  Sources :
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.
-  CNAV, site web législation - barèmes.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/as/complement_exceptionnel.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/as/complement_exceptionnel.yaml
@@ -8,14 +8,28 @@ values:
     value: 108
   1962-04-01:
     value: 208
+  1963-07-01:
+    value: null
   1974-02-01:
     value: 100
+  1974-07-01:
+    value: null
   1975-09-01:
     value: 700
+  1976-01-01:
+    value: null
   1979-09-01:
     value: 200
+  1979-12-01:
+    value: null
   1980-02-01:
     value: 150
+  1980-06-01:
+    value: null
+  1980-10-01:
+    value: 150
+  1981-01-01:
+    value: null
 metadata:
   ux_name: Complément exceptionnel
   description_en: "Extra allowance (AS): Amount"
@@ -31,29 +45,47 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=LEGITEXT000006073402&categorieLien=id
     1962-04-01:
       title: Décret 62-440 du 14/04/1962
+    1963-07-01:
+      title: Décret 63-921 du 06/09/1963
     1974-02-01:
       title: Décret 74-160 du 26/02/1974
+    1974-07-01:
+      title: Décret 74-612 du 27/06/1974
     1975-09-01:
       title: Décret du 13/09/1975
+    1976-01-01:
+      title: Décret 75-1342 du 31/12/1975
     1979-09-01:
       title: Décret 79-811 du 20/09/1979
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000696977
+    1979-12-01:
+      title: Décret 79-1058 du 07/12/1979
     1980-02-01:
       title: Décret 80-99 du 30/01/1980
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000678078
+    1980-06-01:
+      title: Décret 80-499 du 01/07/1980
     1980-10-01:
       title: Décret 80-865 du 31/10/1980
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000681571
+    1981-01-01:
+      title: Décret 80-1158 du 31/12/1980
   official_journal_date:
     1958-01-01: "1958-09-27"
     1959-01-01: "1958-12-31"
     1961-01-01: "1961-02-18"
     1962-04-01: "1962-04-15"
+    1963-07-01: "1963-09-08"
     1974-02-01: "1974-02-27"
+    1974-07-01: "1974-07-30"
     1975-09-01: "1975-09-14"
+    1976-01-01: "1975-01-03"
     1979-09-01: "1979-09-22"
+    1979-12-01: "1979-12-08"
     1980-02-01: "1980-01-31"
+    1980-06-01: "1980-07-03"
     1980-10-01: "1980-11-06"
+    1981-01-01: "1981-01-10"
   notes:
     1961-01-01:
     - title: Complément de 208 pour les plus de 75 ans.
@@ -62,10 +94,3 @@ metadata:
     1975-09-01:
     - title: Le décret n'a pas de numéro
   last_review: "2021-01-01"
-documentation: |-
-  Notes :
-  Le complément versé entre 1958 et 1962 est à ajouter au montant de l'allocation supplémentaire. Il s'agit de compléments cumulés.
-  A partir de 1963, il y a simple revalorisation. Après 1962, le complément est une majoration exceptionnelle.
-  Sources :
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.
-  CNAV, site web législation - barèmes.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/as/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/as/index.yaml
@@ -6,3 +6,10 @@ metadata:
   - allocation_supplementaire
   - complement_exceptionnel
   - plafond_ressources
+documentation: |-
+  Notes :
+  Le complément versé entre 1958 et 1962 est à ajouter au montant de l'allocation supplémentaire. Il s'agit de compléments cumulés.
+  A partir de 1963, il y a simple revalorisation. Après 1962, le complément est une majoration exceptionnelle.
+  Sources :
+  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.
+  CNAV, site web législation - barèmes.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/as/plafond_ressources/plafond_menage.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/as/plafond_ressources/plafond_menage.yaml
@@ -263,9 +263,6 @@ metadata:
       title: Décret 79-1058 du 07/12/1979
     1980-06-01:
       title: Décret 80-499 du 01/07/1980
-    1980-10-01:
-      title: Décret 80-865 du 31/10/1980
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000681571
     1981-01-01:
       title: Décret 80-1158 du 31/12/1980
     1981-07-01:
@@ -459,7 +456,6 @@ metadata:
     1979-07-01: "1979-07-07"
     1979-12-01: "1979-12-08"
     1980-06-01: "1980-07-03"
-    1980-10-01: "1980-11-06"
     1981-01-01: "1981-01-10"
     1981-07-01: "1981-07-01"
     1982-01-01: "1981-12-31"
@@ -511,10 +507,3 @@ metadata:
     2016-04-01:
     - title: L'AVTS est remplacée par l'ASPA en 2007 par le décret 2007-57. Cependant, comme le mentionne l'ordonnance 2004-605, les personnes qui bénéficiaient au moment de l'entrée en vigueur de l'ASPA des anciens dispositifs de mimimum vieillesse continuent à percevoir ces anciennes prestations selon les règles applicables avant cette entrée en vigueur. D'où le fait qu'on garde les barèmes de l'AVTS après 2007.
   last_review: "2021-01-01"
-documentation: |-
-  Notes :
-  Le complément versé entre 1958 et 1962 est à ajouter au montant de l'allocation supplémentaire. Il s'agit de compléments cumulés.
-  A partir de 1963, il y a simple revalorisation. Après 1962, le complément est une majoration exceptionnelle.
-  Sources :
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.
-  CNAV, site web législation - barèmes.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/as/plafond_ressources/plafond_seul.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/as/plafond_ressources/plafond_seul.yaml
@@ -265,9 +265,6 @@ metadata:
       title: Décret 79-1058 du 07/12/1979
     1980-06-01:
       title: Décret 80-499 du 01/07/1980
-    1980-10-01:
-      title: Décret 80-865 du 31/10/1980
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000681571
     1981-01-01:
       title: Décret 80-1158 du 31/12/1980
     1981-07-01:
@@ -464,7 +461,6 @@ metadata:
     1979-07-01: "1979-07-07"
     1979-12-01: "1979-12-08"
     1980-06-01: "1980-07-03"
-    1980-10-01: "1980-11-06"
     1981-01-01: "1981-01-10"
     1981-07-01: "1981-07-01"
     1982-01-01: "1981-12-31"
@@ -517,10 +513,3 @@ metadata:
     2016-04-01:
     - title: L'AVTS est remplacée par l'ASPA en 2007 par le décret 2007-57. Cependant, comme le mentionne l'ordonnance 2004-605, les personnes qui bénéficiaient au moment de l'entrée en vigueur de l'ASPA des anciens dispositifs de mimimum vieillesse continuent à percevoir ces anciennes prestations selon les règles applicables avant cette entrée en vigueur. D'où le fait qu'on garde les barèmes de l'AVTS après 2007.
   last_review: "2021-01-01"
-documentation: |-
-  Notes :
-  Le complément versé entre 1958 et 1962 est à ajouter au montant de l'allocation supplémentaire. Il s'agit de compléments cumulés.
-  A partir de 1963, il y a simple revalorisation. Après 1962, le complément est une majoration exceptionnelle.
-  Sources :
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.
-  CNAV, site web législation - barèmes.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/index.yaml
@@ -3,5 +3,20 @@ metadata:
   ux_name: ASPA
   description_en: Solidarity income for elderly (ASPA)
   order:
+  - abattement_forfaitaire
   - montant_maximum_annuel
   - plafond_ressources
+  - age_min
+  - duree_min_titre_sejour
+  - maj_3enf
+  - taux_incapacite_aspa_anticipe
+documentation: |-
+  Notes :
+  (1) Ou lorsque un seul des conjoints bénéficie de l'ASPA.
+  (2) Ou lorsqu'un seul conjoint est bénéficiaire de l'ASPA et l'autre de l'allocation supplémentaire d'invalidité.
+  L'ASPA vise à remplacer le minimum vieillesse et une série de dispositifs destinés aux personnes âgées disposant de faibles ressources.
+  L'ASPA est ouverte à toute personne de plus de 65 ans, cette condition d'âge étant abaissée à l'âge minimun de départ en retraite pour les personnes reconnues inaptes au travail (incapcité d'au moins 50%) et les bénéficiaires d'une retraite anticipée pour handicap. Par ailleurs, le demandeur doit satisfaire aux conditions de ressources et de résidence (régulière en métropole ou dans les départements d'outre-mer).
+  https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029619577/#LEGIARTI000020562591
+  Les montants de l'allocation et des plafonds de ressources prévus pour son attribution sont revalorisés au 1er janvier de chaque année
+  (Article L816-2 https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036393188)
+

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/index.yaml
@@ -12,8 +12,8 @@ metadata:
   - taux_incapacite_aspa_anticipe
 documentation: |-
   Notes :
-  (1) Ou lorsque un seul des conjoints bénéficie de l'ASPA.
-  (2) Ou lorsqu'un seul conjoint est bénéficiaire de l'ASPA et l'autre de l'allocation supplémentaire d'invalidité.
+  Le barème "personnes seules" concerne également les couples si un seul des conjoints bénéficie de l'ASPA.
+  Le barème "couples" est appliqué si un seul conjoint est bénéficiaire de l'ASPA et l'autre de l'allocation supplémentaire d'invalidité.
   L'ASPA vise à remplacer le minimum vieillesse et une série de dispositifs destinés aux personnes âgées disposant de faibles ressources.
   L'ASPA est ouverte à toute personne de plus de 65 ans, cette condition d'âge étant abaissée à l'âge minimun de départ en retraite pour les personnes reconnues inaptes au travail (incapcité d'au moins 50%) et les bénéficiaires d'une retraite anticipée pour handicap. Par ailleurs, le demandeur doit satisfaire aux conditions de ressources et de résidence (régulière en métropole ou dans les départements d'outre-mer).
   https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029619577/#LEGIARTI000020562591

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/montant_maximum_annuel/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/montant_maximum_annuel/couples.yaml
@@ -122,11 +122,3 @@ metadata:
     2022-07-01:
     - title: Revalorisation de 1.04 pour protéger le pouvoir d'achat des français
   last_review: "2021-01-01"
-documentation: |-
-  Notes :
-  Pour un couple ou lorsqu'un seul conjoint est bénéficiaire de l'ASPA et l'autre de l'allocation supplémentaire d'invalidité.
-  L'ASPA vise à remplacer le minimum vieillesse et une série de dispositifs destinés aux personnes âgées disposant de faibles ressources.
-  L'ASPA est ouverte à toute personne de plus de 65 ans, cette condition d'âge étant abaissée à l'âge minimun de départ en retraite pour les personnes reconnues inaptes au travail (incapcité d'au moins 50%) et les bénéficiaires d'une retraite anticipée pour handicap. Par ailleurs, le demandeur doit satisfaire aux conditions de ressources et de résidence (régulière en métropole ou dans les départements d'outre-mer).
-  https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029619577/#LEGIARTI000020562591
-  Les montants de l'allocation et des plafonds de ressources prévus pour son attribution sont revalorisés au 1er janvier de chaque année
-  (Article L816-2 https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036393188)

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/montant_maximum_annuel/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/montant_maximum_annuel/personnes_seules.yaml
@@ -122,11 +122,3 @@ metadata:
     2022-07-01:
     - title: Revalorisation de 1.04 pour protéger le pouvoir d'achat des français
   last_review: "2021-01-01"
-documentation: |-
-  Notes :
-  Pour une personne seule ou lorsque un seul des conjoints bénéficie de l'ASPA.
-  L'ASPA vise à remplacer le minimum vieillesse et une série de dispositifs destinés aux personnes âgées disposant de faibles ressources.
-  L'ASPA est ouverte à toute personne de plus de 65 ans, cette condition d'âge étant abaissée à l'âge minimun de départ en retraite pour les personnes reconnues inaptes au travail (incapcité d'au moins 50%) et les bénéficiaires d'une retraite anticipée pour handicap. Par ailleurs, le demandeur doit satisfaire aux conditions de ressources et de résidence (régulière en métropole ou dans les départements d'outre-mer).
-  https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029619577/#LEGIARTI000020562591
-  Les montants de l'allocation et des plafonds de ressources prévus pour son attribution sont revalorisés au 1er janvier de chaque année
-  (Article L816-2 https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036393188)

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/plafond_ressources/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/plafond_ressources/couples.yaml
@@ -122,12 +122,3 @@ metadata:
     2022-07-01:
     - title: Revalorisation de 1.04 pour protéger le pouvoir d'achat des français
   last_review: "2021-01-01"
-documentation: |-
-  Notes :
-  (1) Ou lorsque un seul des conjoints bénéficie de l'ASPA.
-  (2) Ou lorsqu'un seul conjoint est bénéficiaire de l'ASPA et l'autre de l'allocation supplémentaire d'invalidité.
-  L'ASPA vise à remplacer le minimum vieillesse et une série de dispositifs destinés aux personnes âgées disposant de faibles ressources.
-  L'ASPA est ouverte à toute personne de plus de 65 ans, cette condition d'âge étant abaissée à l'âge minimun de départ en retraite pour les personnes reconnues inaptes au travail (incapcité d'au moins 50%) et les bénéficiaires d'une retraite anticipée pour handicap. Par ailleurs, le demandeur doit satisfaire aux conditions de ressources et de résidence (régulière en métropole ou dans les départements d'outre-mer).
-  https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029619577/#LEGIARTI000020562591
-  Les montants de l'allocation et des plafonds de ressources prévus pour son attribution sont revalorisés au 1er janvier de chaque année
-  (Article L816-2 https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036393188)

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/plafond_ressources/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/plafond_ressources/personnes_seules.yaml
@@ -130,12 +130,3 @@ metadata:
     2022-07-01:
     - title: Revalorisation de 1.04 pour protéger le pouvoir d'achat des français
   last_review: "2021-01-01"
-documentation: |-
-  Notes :
-  (1) Ou lorsque un seul des conjoints bénéficie de l'ASPA.
-  (2) Ou lorsqu'un seul conjoint est bénéficiaire de l'ASPA et l'autre de l'allocation supplémentaire d'invalidité.
-  L'ASPA vise à remplacer le minimum vieillesse et une série de dispositifs destinés aux personnes âgées disposant de faibles ressources.
-  L'ASPA est ouverte à toute personne de plus de 65 ans, cette condition d'âge étant abaissée à l'âge minimun de départ en retraite pour les personnes reconnues inaptes au travail (incapcité d'au moins 50%) et les bénéficiaires d'une retraite anticipée pour handicap. Par ailleurs, le demandeur doit satisfaire aux conditions de ressources et de résidence (régulière en métropole ou dans les départements d'outre-mer).
-  https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029619577/#LEGIARTI000020562591
-  Les montants de l'allocation et des plafonds de ressources prévus pour son attribution sont revalorisés au 1er janvier de chaque année
-  (Article L816-2 https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036393188)

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avpf/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avpf/index.yaml
@@ -5,3 +5,8 @@ metadata:
   order:
   - salaire_forfaitaire
   - taux
+documentation: |-
+  Note :
+  Les bénéficiaires de certaines prestations familiales sont affiliés obligatoirement à l'assurance vieillesse des parents au foyer (AVPF) au régime général depuis le :
+  - 01/07/1972 pour les femmes,
+  - 01/07/1979 pour les hommes

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avpf/salaire_forfaitaire/guadeloupe_guyane_martinique.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avpf/salaire_forfaitaire/guadeloupe_guyane_martinique.yaml
@@ -124,8 +124,3 @@ metadata:
     2016-01-01:
     - title: "Le salaire forfaitaire est calculé sur la base du SMIC: SMIC horaire en vigueur au 1er juillet de l’année précédente * 169 (durée hebdomadaire légale du travail (39h) * 52 / 12); cf. article Article R381-3 du CSS"
   last_review: "2021-01-01"
-documentation: |-
-  Note :
-  Les bénéficiaires de certaines prestations familiales sont affiliés obligatoirement à l'assurance vieillesse des parents au foyer (AVPF) au régime général depuis le :
-  - 01/07/1972 pour les femmes,
-  - 01/07/1979 pour les hommes

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avpf/salaire_forfaitaire/metropole.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avpf/salaire_forfaitaire/metropole.yaml
@@ -136,8 +136,3 @@ metadata:
     2016-01-01:
     - title: "Le salaire forfaitaire est calculé sur la base du SMIC: SMIC horaire en vigueur au 1er juillet de l’année précédente * 169 (durée hebdomadaire légale du travail (39h) * 52 / 12); cf. article Article R381-3 du CSS"
   last_review: "2021-01-01"
-documentation: |-
-  Note :
-  Les bénéficiaires de certaines prestations familiales sont affiliés obligatoirement à l'assurance vieillesse des parents au foyer (AVPF) au régime général depuis le :
-  - 01/07/1972 pour les femmes,
-  - 01/07/1979 pour les hommes

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avpf/salaire_forfaitaire/reunion.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avpf/salaire_forfaitaire/reunion.yaml
@@ -124,8 +124,3 @@ metadata:
     2016-01-01:
     - title: "Le salaire forfaitaire est calculé sur la base du SMIC: SMIC horaire en vigueur au 1er juillet de l’année précédente * 169 (durée hebdomadaire légale du travail (39h) * 52 / 12); cf. article Article R381-3 du CSS"
   last_review: "2021-01-01"
-documentation: |-
-  Note :
-  Les bénéficiaires de certaines prestations familiales sont affiliés obligatoirement à l'assurance vieillesse des parents au foyer (AVPF) au régime général depuis le :
-  - 01/07/1972 pour les femmes,
-  - 01/07/1979 pour les hommes

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avpf/taux.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avpf/taux.yaml
@@ -56,8 +56,3 @@ metadata:
     2016-01-01:
     - title: "Le salaire forfaitaire est calculé sur la base du SMIC: SMIC horaire en vigueur au 1er juillet de l’année précédente * 169 (durée hebdomadaire légale du travail (39h) * 52 / 12); cf. article Article R381-3 du CSS"
   last_review: "2021-01-01"
-documentation: |-
-  Note :
-  Les bénéficiaires de certaines prestations familiales sont affiliés obligatoirement à l'assurance vieillesse des parents au foyer (AVPF) au régime général depuis le :
-  - 01/07/1972 pour les femmes,
-  - 01/07/1979 pour les hommes

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts/index.yaml
@@ -6,4 +6,7 @@ metadata:
   - montants_annuels
   - plafonds_de_ressources_personnes_seules
   - plafonds_de_ressources_menages
-documentation: Allocation aux vieux travailleurs salariés, secours viager et allocation aux mères de famille et majoration L. 814-2 du CSS
+documentation: |-
+  Sources:
+  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.
+  Site législation CNAV depuis 1956, Sécurité sociale - son histoire à travers les textes p 242 avant; légifrance pour les références exactes.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts/montants_annuels.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts/montants_annuels.yaml
@@ -489,7 +489,3 @@ metadata:
   notes:
     2012-04-01:
     - title: L'AVTS est remplacée par l'ASPA en 2007 par le décret 2007-57. Cependant, comme le mentionne l'ordonnance 2004-605, les personnes qui bénéficiaient au moment de l'entrée en vigueur de l'ASPA des anciens dispositifs de mimimum vieillesse continuent à percevoir ces anciennes prestations selon les règles applicables avant cette entrée en vigueur. D'où le fait qu'on garde les barèmes de l'AVTS après 2007.; ; Décret 2009-473, art. 1 du 28/04/2009 (modif art. D815-1 et D815-2 du CSS). Ce décret fixe les montants jusqu'à celui en vigueur à partir du 01/04/2012
-documentation: |-
-  Sources:
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.
-  Site législation CNAV depuis 1956, Sécurité sociale - son histoire à travers les textes p 242 avant; légifrance pour les références exactes.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts/plafonds_de_ressources_menages.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts/plafonds_de_ressources_menages.yaml
@@ -526,7 +526,3 @@ metadata:
     - title: L'AVTS est remplacée par l'ASPA en 2007 par le décret 2007-57. Cependant, comme le mentionne l'ordonnance 2004-605, les personnes qui bénéficiaient au moment de l'entrée en vigueur de l'ASPA des anciens dispositifs de mimimum vieillesse continuent à percevoir ces anciennes prestations selon les règles applicables avant cette entrée en vigueur. D'où le fait qu'on garde les barèmes de l'AVTS après 2007.; ; Décret 2009-473, art. 1 du 28/04/2009 (modif art. D815-1 et D815-2 du CSS). Ce décret fixe les montants jusqu'à celui en vigueur à partir du 01/04/2012
     2014-10-01:
     - title: Pas de revalorisation du montant mais revalorisation du plafond
-documentation: |-
-  Sources:
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.
-  Site législation CNAV depuis 1956, Sécurité sociale - son histoire à travers les textes p 242 avant; légifrance pour les références exactes.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts/plafonds_de_ressources_personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts/plafonds_de_ressources_personnes_seules.yaml
@@ -532,7 +532,3 @@ metadata:
     - title: L'AVTS est remplacée par l'ASPA en 2007 par le décret 2007-57. Cependant, comme le mentionne l'ordonnance 2004-605, les personnes qui bénéficiaient au moment de l'entrée en vigueur de l'ASPA des anciens dispositifs de mimimum vieillesse continuent à percevoir ces anciennes prestations selon les règles applicables avant cette entrée en vigueur. D'où le fait qu'on garde les barèmes de l'AVTS après 2007.; ; Décret 2009-473, art. 1 du 28/04/2009 (modif art. D815-1 et D815-2 du CSS). Ce décret fixe les montants jusqu'à celui en vigueur à partir du 01/04/2012
     2014-10-01:
     - title: Pas de revalorisation du montant mais revalorisation du plafond
-documentation: |-
-  Sources:
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.
-  Site législation CNAV depuis 1956, Sécurité sociale - son histoire à travers les textes p 242 avant; légifrance pour les références exactes.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/index.yaml
@@ -7,3 +7,11 @@ metadata:
   - villes_de_moins_de_5000_ha
   - majoration_pour_conjoint
   - region_parisienne
+documentation: |-
+  Condition d'attribution de l'AVTS : Le bénéficiaire doit être âgé de plus de 65 ans (de plus de 60 ans en cas d'invalidité ou de résidence dans un département d'outre-mer). Il doit également avoir été salarié pendant 15 ans après l'âge de 50 ans ou 25 années au cours de son activité, sachant que pour être comptabilisées, les périodes d'activité salariées doivent avoir été exercées en France (ou en Algérie ou à Monaco selon certaines conditions) et avoir procuré au demandeur une rémunération annuelle minimum.
+  Condition d'attribution de l'allocation spéciale : Elle est égale au montant de l'AVTS et vise les personnes de plus de 65 ans qui n'ont droit à aucune prestation vieillesse. Elle peut ainsi être attribuée aux personnes ne relevant d'aucun régime de vieillesse de base (toutes les dépenses qui se rattachent au service de cette allocation sont également prises en charge par le FSV).
+  Condition d'attribution de l'AMF : l'Allocation aux mères de famille est attribuée selon les mêmes montants et plafonds que l'AVTS. Elle est destinée aux femmes de salariés qui ont élevé au moins 5 enfants. (Voir aussi secours viagier, alligné sur ATVS).
+  Condition d'attribution de l'allocation aux vieux travailleurs non salariés (AVTNS): Elle correspond à l'extension de l'AVTS aux personnes relevant des régimes de non salariés des professions artisanales, industrielles et commerciales.
+  Attention : Ces conditions sont celles en vigueur à partir de 1956. Pour les évolutions législatives, notamment pour l'allongement progressif de la durée de travail salarié après 50 ans, se référer à la loi du 14 mars 1941 qui créé l'allocation puis à l'ordonnance 45/170 du 2/02/1945.
+  Sources:
+  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/majoration_pour_conjoint.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/majoration_pour_conjoint.yaml
@@ -85,11 +85,3 @@ metadata:
   notes:
     1960-01-01:
     - title: "Un décret du 14 avril 1962 supprime les différences pour la France. Sources: site législation CNAV depuis 1956, Sécurité sociales - son histoire à travers les textes p 242 avant."
-documentation: |-
-  Condition d'attribution de l'AVTS : Le bénéficiaire doit être âgé de plus de 65 ans (de plus de 60 ans en cas d'invalidité ou de résidence dans un département d'outre-mer). Il doit également avoir été salarié pendant 15 ans après l'âge de 50 ans ou 25 années au cours de son activité, sachant que pour être comptabilisées, les périodes d'activité salariées doivent avoir été exercées en France (ou en Algérie ou à Monaco selon certaines conditions) et avoir procuré au demandeur une rémunération annuelle minimum.
-  Condition d'attribution de l'allocation spéciale : Elle est égale au montant de l'AVTS et vise les personnes de plus de 65 ans qui n'ont droit à aucune prestation vieillesse. Elle peut ainsi être attribuée aux personnes ne relevant d'aucun régime de vieillesse de base (toutes les dépenses qui se rattachent au service de cette allocation sont également prises en charge par le FSV).
-  Condition d'attribution de l'AMF : l'Allocation aux mères de famille est attribuée selon les mêmes montants et plafonds que l'AVTS. Elle est destinée aux femmes de salariés qui ont élevé au moins 5 enfants. (Voir aussi secours viagier, alligné sur ATVS).
-  Condition d'attribution de l'allocation aux vieux travailleurs non salariés (AVTNS): Elle correspond à l'extension de l'AVTS aux personnes relevant des régimes de non salariés des professions artisanales, industrielles et commerciales.
-  Attention : Ces conditions sont celles en vigueur à partir de 1956. Pour les évolutions législatives, notamment pour l'allongement progressif de la durée de travail salarié après 50 ans, se référer à la loi du 14 mars 1941 qui créé l'allocation puis à l'ordonnance 45/170 du 2/02/1945.
-  Sources:
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/region_parisienne.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/region_parisienne.yaml
@@ -36,11 +36,3 @@ metadata:
   notes:
     1960-01-01:
     - title: "Un décret du 14 avril 1962 supprime les différences pour la France. Sources: site législation CNAV depuis 1956, Sécurité sociales - son histoire à travers les textes p 242 avant."
-documentation: |-
-  Condition d'attribution de l'AVTS : Le bénéficiaire doit être âgé de plus de 65 ans (de plus de 60 ans en cas d'invalidité ou de résidence dans un département d'outre-mer). Il doit également avoir été salarié pendant 15 ans après l'âge de 50 ans ou 25 années au cours de son activité, sachant que pour être comptabilisées, les périodes d'activité salariées doivent avoir été exercées en France (ou en Algérie ou à Monaco selon certaines conditions) et avoir procuré au demandeur une rémunération annuelle minimum.
-  Condition d'attribution de l'allocation spéciale : Elle est égale au montant de l'AVTS et vise les personnes de plus de 65 ans qui n'ont droit à aucune prestation vieillesse. Elle peut ainsi être attribuée aux personnes ne relevant d'aucun régime de vieillesse de base (toutes les dépenses qui se rattachent au service de cette allocation sont également prises en charge par le FSV).
-  Condition d'attribution de l'AMF : l'Allocation aux mères de famille est attribuée selon les mêmes montants et plafonds que l'AVTS. Elle est destinée aux femmes de salariés qui ont élevé au moins 5 enfants. (Voir aussi secours viagier, alligné sur ATVS).
-  Condition d'attribution de l'allocation aux vieux travailleurs non salariés (AVTNS): Elle correspond à l'extension de l'AVTS aux personnes relevant des régimes de non salariés des professions artisanales, industrielles et commerciales.
-  Attention : Ces conditions sont celles en vigueur à partir de 1956. Pour les évolutions législatives, notamment pour l'allongement progressif de la durée de travail salarié après 50 ans, se référer à la loi du 14 mars 1941 qui créé l'allocation puis à l'ordonnance 45/170 du 2/02/1945.
-  Sources:
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/villes_de_moins_de_5000_ha/allocation_de_base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/villes_de_moins_de_5000_ha/allocation_de_base.yaml
@@ -90,11 +90,3 @@ metadata:
   notes:
     1960-01-01:
     - title: "Un décret du 14 avril 1962 supprime les différences pour la France. Sources: site législation CNAV depuis 1956, Sécurité sociales - son histoire à travers les textes p 242 avant."
-documentation: |-
-  Condition d'attribution de l'AVTS : Le bénéficiaire doit être âgé de plus de 65 ans (de plus de 60 ans en cas d'invalidité ou de résidence dans un département d'outre-mer). Il doit également avoir été salarié pendant 15 ans après l'âge de 50 ans ou 25 années au cours de son activité, sachant que pour être comptabilisées, les périodes d'activité salariées doivent avoir été exercées en France (ou en Algérie ou à Monaco selon certaines conditions) et avoir procuré au demandeur une rémunération annuelle minimum.
-  Condition d'attribution de l'allocation spéciale : Elle est égale au montant de l'AVTS et vise les personnes de plus de 65 ans qui n'ont droit à aucune prestation vieillesse. Elle peut ainsi être attribuée aux personnes ne relevant d'aucun régime de vieillesse de base (toutes les dépenses qui se rattachent au service de cette allocation sont également prises en charge par le FSV).
-  Condition d'attribution de l'AMF : l'Allocation aux mères de famille est attribuée selon les mêmes montants et plafonds que l'AVTS. Elle est destinée aux femmes de salariés qui ont élevé au moins 5 enfants. (Voir aussi secours viagier, alligné sur ATVS).
-  Condition d'attribution de l'allocation aux vieux travailleurs non salariés (AVTNS): Elle correspond à l'extension de l'AVTS aux personnes relevant des régimes de non salariés des professions artisanales, industrielles et commerciales.
-  Attention : Ces conditions sont celles en vigueur à partir de 1956. Pour les évolutions législatives, notamment pour l'allongement progressif de la durée de travail salarié après 50 ans, se référer à la loi du 14 mars 1941 qui créé l'allocation puis à l'ordonnance 45/170 du 2/02/1945.
-  Sources:
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/villes_de_moins_de_5000_ha/bonification_pour_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/villes_de_moins_de_5000_ha/bonification_pour_enfants.yaml
@@ -80,11 +80,3 @@ metadata:
   notes:
     1960-01-01:
     - title: "Un décret du 14 avril 1962 supprime les différences pour la France. Sources: site législation CNAV depuis 1956, Sécurité sociales - son histoire à travers les textes p 242 avant."
-documentation: |-
-  Condition d'attribution de l'AVTS : Le bénéficiaire doit être âgé de plus de 65 ans (de plus de 60 ans en cas d'invalidité ou de résidence dans un département d'outre-mer). Il doit également avoir été salarié pendant 15 ans après l'âge de 50 ans ou 25 années au cours de son activité, sachant que pour être comptabilisées, les périodes d'activité salariées doivent avoir été exercées en France (ou en Algérie ou à Monaco selon certaines conditions) et avoir procuré au demandeur une rémunération annuelle minimum.
-  Condition d'attribution de l'allocation spéciale : Elle est égale au montant de l'AVTS et vise les personnes de plus de 65 ans qui n'ont droit à aucune prestation vieillesse. Elle peut ainsi être attribuée aux personnes ne relevant d'aucun régime de vieillesse de base (toutes les dépenses qui se rattachent au service de cette allocation sont également prises en charge par le FSV).
-  Condition d'attribution de l'AMF : l'Allocation aux mères de famille est attribuée selon les mêmes montants et plafonds que l'AVTS. Elle est destinée aux femmes de salariés qui ont élevé au moins 5 enfants. (Voir aussi secours viagier, alligné sur ATVS).
-  Condition d'attribution de l'allocation aux vieux travailleurs non salariés (AVTNS): Elle correspond à l'extension de l'AVTS aux personnes relevant des régimes de non salariés des professions artisanales, industrielles et commerciales.
-  Attention : Ces conditions sont celles en vigueur à partir de 1956. Pour les évolutions législatives, notamment pour l'allongement progressif de la durée de travail salarié après 50 ans, se référer à la loi du 14 mars 1941 qui créé l'allocation puis à l'ordonnance 45/170 du 2/02/1945.
-  Sources:
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/villes_de_plus_de_5000_ha/allocation_de_base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/villes_de_plus_de_5000_ha/allocation_de_base.yaml
@@ -90,11 +90,3 @@ metadata:
   notes:
     1960-01-01:
     - title: "Un décret du 14 avril 1962 supprime les différences pour la France. Sources: site législation CNAV depuis 1956, Sécurité sociales - son histoire à travers les textes p 242 avant."
-documentation: |-
-  Condition d'attribution de l'AVTS : Le bénéficiaire doit être âgé de plus de 65 ans (de plus de 60 ans en cas d'invalidité ou de résidence dans un département d'outre-mer). Il doit également avoir été salarié pendant 15 ans après l'âge de 50 ans ou 25 années au cours de son activité, sachant que pour être comptabilisées, les périodes d'activité salariées doivent avoir été exercées en France (ou en Algérie ou à Monaco selon certaines conditions) et avoir procuré au demandeur une rémunération annuelle minimum.
-  Condition d'attribution de l'allocation spéciale : Elle est égale au montant de l'AVTS et vise les personnes de plus de 65 ans qui n'ont droit à aucune prestation vieillesse. Elle peut ainsi être attribuée aux personnes ne relevant d'aucun régime de vieillesse de base (toutes les dépenses qui se rattachent au service de cette allocation sont également prises en charge par le FSV).
-  Condition d'attribution de l'AMF : l'Allocation aux mères de famille est attribuée selon les mêmes montants et plafonds que l'AVTS. Elle est destinée aux femmes de salariés qui ont élevé au moins 5 enfants. (Voir aussi secours viagier, alligné sur ATVS).
-  Condition d'attribution de l'allocation aux vieux travailleurs non salariés (AVTNS): Elle correspond à l'extension de l'AVTS aux personnes relevant des régimes de non salariés des professions artisanales, industrielles et commerciales.
-  Attention : Ces conditions sont celles en vigueur à partir de 1956. Pour les évolutions législatives, notamment pour l'allongement progressif de la durée de travail salarié après 50 ans, se référer à la loi du 14 mars 1941 qui créé l'allocation puis à l'ordonnance 45/170 du 2/02/1945.
-  Sources:
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/villes_de_plus_de_5000_ha/bonification_pour_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/avts_av_1961/villes_de_plus_de_5000_ha/bonification_pour_enfants.yaml
@@ -80,11 +80,3 @@ metadata:
   notes:
     1960-01-01:
     - title: "Un décret du 14 avril 1962 supprime les différences pour la France. Sources: site législation CNAV depuis 1956, Sécurité sociales - son histoire à travers les textes p 242 avant."
-documentation: |-
-  Condition d'attribution de l'AVTS : Le bénéficiaire doit être âgé de plus de 65 ans (de plus de 60 ans en cas d'invalidité ou de résidence dans un département d'outre-mer). Il doit également avoir été salarié pendant 15 ans après l'âge de 50 ans ou 25 années au cours de son activité, sachant que pour être comptabilisées, les périodes d'activité salariées doivent avoir été exercées en France (ou en Algérie ou à Monaco selon certaines conditions) et avoir procuré au demandeur une rémunération annuelle minimum.
-  Condition d'attribution de l'allocation spéciale : Elle est égale au montant de l'AVTS et vise les personnes de plus de 65 ans qui n'ont droit à aucune prestation vieillesse. Elle peut ainsi être attribuée aux personnes ne relevant d'aucun régime de vieillesse de base (toutes les dépenses qui se rattachent au service de cette allocation sont également prises en charge par le FSV).
-  Condition d'attribution de l'AMF : l'Allocation aux mères de famille est attribuée selon les mêmes montants et plafonds que l'AVTS. Elle est destinée aux femmes de salariés qui ont élevé au moins 5 enfants. (Voir aussi secours viagier, alligné sur ATVS).
-  Condition d'attribution de l'allocation aux vieux travailleurs non salariés (AVTNS): Elle correspond à l'extension de l'AVTS aux personnes relevant des régimes de non salariés des professions artisanales, industrielles et commerciales.
-  Attention : Ces conditions sont celles en vigueur à partir de 1956. Pour les évolutions législatives, notamment pour l'allongement progressif de la durée de travail salarié après 50 ans, se référer à la loi du 14 mars 1941 qui créé l'allocation puis à l'ordonnance 45/170 du 2/02/1945.
-  Sources:
-  Bozio, A. (2006), Réformes des retraites : estimations sur données françaises, thèse de doctorat, EHESS, annexe A.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/majconj/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/majconj/index.yaml
@@ -5,3 +5,4 @@ metadata:
   order:
   - montant_majoration_conjoint_charge
   - plafond_conjoint_pour_maj_pac
+documentation: "Conditions d'attribution : La majoration pour conjoint à charge était attribuée au titulaire d'une pension de retraite et aux bénéficiaires de l'AVTS, de l'AMF ou d'une rente garantie. Le conjoint est considéré à charge dès lors que ses revenus personnels sont inférieurs aux montants précisés dans l'onglet suivant. Il doit être âgé de plus de 65 ans (plus de 60 ans en cas d'inaptitude au travail)."

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/majconj/montant_majoration_conjoint_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/majconj/montant_majoration_conjoint_charge.yaml
@@ -180,4 +180,3 @@ metadata:
     2011-01-01:
     - title: La majoration pour conjoint à charge n'est plus attribuée depuis le 1er janvier 2011. Cependant, le paiement de cette prestation est poursuivi pour les bénéficiaires au 31 décembre 2010, tant que le conjoint à charge remplit la condition de ressources.
   last_review: "2021-01-01"
-documentation: "Conditions d'attribution : La majoration pour conjoint à charge était attribuée au titulaire d'une pension de retraite et aux bénéficiaires de l'AVTS, de l'AMF ou d'une rente garantie. Le conjoint est considéré à charge dès lors que ses revenus personnels sont inférieurs aux montants précisés dans l'onglet suivant. Il doit être âgé de plus de 65 ans (plus de 60 ans en cas d'inaptitude au travail)."

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/majconj/plafond_conjoint_pour_maj_pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/majconj/plafond_conjoint_pour_maj_pac.yaml
@@ -478,4 +478,3 @@ metadata:
     2016-04-01:
     - title: La majoration pour conjoint à charge n'est plus attribuée depuis le 01/01/2011. Elle continue à être servie tant que le conjoint à charge remplit les conditions de ressources (Loi 2010-1330 du 09/11/2010, art. 51).
   last_review: "2021-01-01"
-documentation: "Définition des ressources personnelles : Les ressources à retenir sont celles des trois mois précédant la date d'effet de la majoration. Si les ressources des trois mois dépassent le plafond autorisé, les ressources prises en considération sont celles des 12 mois précédant la date d'effet."

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '128.0.0',
+    version = '128.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION

* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/`.
* Détails :
  - Nettoyage de certaines métadonnées

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).
