### PR TITLE
Revalorisation des montants de l'aide à la mobilité

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## 123.2.0 [#1939](https://github.com/openfisca/openfisca-france/pull/1939)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/12/2022.
+* Zones impactées :
+  - `parameters/prestations_sociales/prestations_familiales/aide_mobilite.yaml`
+
+* Détails :
+  - Revalorisation des montants de l'Aide à la mobilité.
+  - https://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2022-56-du-23-novembre-2022-bope-n-2022-79.html?type=dossiers/2022/bope-n-2022-79-du-30-novembre-2022
 ## 123.1.0 [#1938](https://github.com/openfisca/openfisca-france/pull/1938)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/prestations_sociales/aide_mobilite.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aide_mobilite.yaml
@@ -1,7 +1,9 @@
 description: Les différents paramètres pour le calcul de l'aide à la mobilité de pôle emploi.
 metadata:
   reference:
-    href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+    2021-06-09:
+      title: Délibération n°2021-42 du 8 juin 2021
+      href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
 delai_max:
   description: Délai (en jours) de demande maximum, de date à date, après l'action de reclassement pour être éligible à d’aide à la mobilité de Pôle Emploi.
   values:
@@ -9,12 +11,16 @@ delai_max:
       value: 7
   metadata:
     reference:
-      href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+      2021-06-09:
+        title: Délibération n°2021-42 du 8 juin 2021
+        href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
 distance_minimum:
   description: Distances (en kilomètres) minimales requises pour être éligible à l'aide mobilité de Pôle Emploi en fonction du lieu de résidence.
   metadata:
     reference:
-      href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+      2021-06-09:
+        title: Délibération n°2021-42 du 8 juin 2021
+        href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
   hors_metropole:
     description: Distance (en kilomètres) minimale requises pour être éligible à l'aide mobilité de Pôle Emploi en dehors de la métropole.
     values:
@@ -22,7 +28,9 @@ distance_minimum:
         value: 20
     metadata:
       reference:
-        href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+        2021-06-09:
+          title: Délibération n°2021-42 du 8 juin 2021
+          href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
   metropole:
     description: Distance (en kilomètres) minimale requises pour être éligible à l'aide mobilité de Pôle Emploi en métropole.
     values:
@@ -30,7 +38,9 @@ distance_minimum:
         value: 60
     metadata:
       reference:
-        href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+        2021-06-09:
+          title: Délibération n°2021-42 du 8 juin 2021
+          href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
 duree_de_contrat_minimum:
   description: La durée (en mois) minimale de contrat pour être éligible à l'aide mobilité de Pôle Emploi.
   values:
@@ -38,7 +48,9 @@ duree_de_contrat_minimum:
       value: 3
   metadata:
     reference:
-      href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+      2021-06-09:
+        title: Délibération n° 2021-42 du 8 juin 2021
+        href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
 duree_de_formation_minimum:
   description: La durée (en heures) minimale de formation pour être éligible à l'aide mobilité de Pôle Emploi.
   values:
@@ -46,6 +58,7 @@ duree_de_formation_minimum:
       value: 40
   metadata:
     reference:
+      title: Délibération n°2021-42 du 8 juin 2021
       href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
 duree_trajet_minimum:
   description: Temps (en minutes) du trajet aller‑retour entre le lieu de travail et le lieu de résidence pour être éligible à l'aide mobilité de Pôle Emploi.
@@ -54,6 +67,7 @@ duree_trajet_minimum:
       value: 120
   metadata:
     reference:
+      title: Délibération n°2021-42 du 8 juin 2021
       href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
 montants:
   deplacement:
@@ -61,38 +75,72 @@ montants:
     values:
       2021-06-09:
         value: 0.2
+      2022-12-01:
+        value: 0.23
     metadata:
       reference:
-        href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+        2021-06-09:
+          title: Délibération n°2021-42 du 8 juin 2021
+          href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+        2022-12-01:
+          title: Délibération n°2022-56 du 23 novembre 2022
+          href: https://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2022-56-du-23-novembre-2022-bope-n-2022-79.html?type=dossiers/2022/bope-n-2022-79-du-30-novembre-2022
   derogatoire:
     description: Montant annuel maximum de l'aide mobilité de Pôle Emploi dans le cadre d'une dérogation.
     values:
       2021-06-09:
         value: 1500
+      2022-12-01:
+        value: 1560
     metadata:
       reference:
-        href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+        2021-06-09:
+          title: Délibération n°2021-42 du 8 juin 2021
+          href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+        2022-12-01:
+          title: Délibération n°2022-56 du 23 novembre 2022
+          href: https://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2022-56-du-23-novembre-2022-bope-n-2022-79.html?type=dossiers/2022/bope-n-2022-79-du-30-novembre-2022
   hebergement:
     description: Montant de prise en charge des frais d'hébergement par nuitée pour l'aide mobilité de Pôle Emploi.
     values:
       2021-06-09:
         value: 30
+      2022-12-01:
+        value: 31.20
     metadata:
       reference:
-        href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+        2021-06-09:
+          title: Délibération n°2021-42 du 8 juin 2021
+          href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+        2022-12-01:
+          title: Délibération n°2022-56 du 23 novembre 2022
+          href: https://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2022-56-du-23-novembre-2022-bope-n-2022-79.html?type=dossiers/2022/bope-n-2022-79-du-30-novembre-2022
   maximum:
     description: Montant annuel maximum de l'aide mobilité de Pôle Emploi.
     values:
       2021-06-09:
         value: 5000
+      2022-12-01:
+        value: 5200
     metadata:
       reference:
-        href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+        2021-06-09:
+          title: Délibération n°2021-42 du 8 juin 2021
+          href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+        2022-12-01:
+          title: Délibération n°2022-56 du 23 novembre 2022
+          href: https://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2022-56-du-23-novembre-2022-bope-n-2022-79.html?type=dossiers/2022/bope-n-2022-79-du-30-novembre-2022
   repas:
     description: Montant de prise en charge des frais de repas par jour pour l'aide mobilité de Pôle Emploi.
     values:
       2021-06-09:
         value: 6
+      2022-12-01:
+        value: 6.25
     metadata:
-      reference:
+      2021-06-09:
+        title: Délibération n°2021-42 du 8 juin 2021
         href: http://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2021-42-du-8-juin-2021-bope-n2021-43.html?type=dossiers/2021/bope-n-2021-043-du-11-juin-2021#
+      2022-12-01:
+        title: Délibération n°2022-56 du 23 novembre 2022
+        href: https://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2022-56-du-23-novembre-2022-bope-n-2022-79.html?type=dossiers/2022/bope-n-2022-79-du-30-novembre-2022

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '123.1.0',
+    version = '123.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/12/2022.
* Zones impactées : `parameters/prestations_sociales/aide_mobilite.yaml`.
* Détails :
  - Revalorisation des montants (+ ~4%) de l'Aide à la mobilité suite à la [délibération n° 2022-56 du 23 novembre 2022 du conseil d'administration de Pôle emploi](https://www.bo-pole-emploi.org/bulletinsofficiels/deliberation-n-2022-56-du-23-novembre-2022-bope-n-2022-79.html?type=dossiers/2022/bope-n-2022-79-du-30-novembre-2022)

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.