### PR TITLE
Correction de la date d'entrée en vigueur de la déduction d'impôt pour pensions alimentaires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 132.1.0 [#1956](https://github.com/openfisca/openfisca-france/pull/1956)
+
+* Amélioration technique.
+* Périodes concernées : 2002-2006
+* Zones impactées :
+    - `model/prelevements_obligatoires/impot_revenu/charges_deductibles.py`.
+    -`parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/taux_jgt_2006`
+* Détails :
+  - Correction suite issue: https://github.com/openfisca/openfisca-france/issues/1954
+  - Correction de la date d'entrée en vigueur de la déduction d'impôt pour pensions alimentaires
+
 # 132.0.0 [#1955](https://github.com/openfisca/openfisca-france/pull/1955)
 
 * Évolution du système socio-fiscal. | Amélioration technique.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/charges_deductibles.py
@@ -548,7 +548,7 @@ class pensions_alimentaires_deduites(Variable):
     reference = 'http://frederic.anne.free.fr/Cours/ITV.htm'
     definition_period = YEAR
 
-    def formula(foyer_fiscal, period, parameters):
+    def formula_2006_01_01(foyer_fiscal, period, parameters):
         f6gi = foyer_fiscal('f6gi', period)
         f6gj = foyer_fiscal('f6gj', period)
         f6gp = foyer_fiscal('f6gp', period)

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/taux_jgt_2006.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/taux_jgt_2006.yaml
@@ -2,26 +2,20 @@ description: Coefficient de majoration (si ouverture du droit) si décision de j
 values:
   1973-01-01:
     value: null
-  2002-01-01:
+  2006-01-01:
     value: 0.25
 metadata:
   ux_name: Majoration
   unit: /1
   reference:
-    2002-01-01:
-    - title: Loi 2001-1275 du 28/12/2001 (LF pour 2002)
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000592233
-    - title: BOI 5 B-3-02 n°18 du 25/01/2002
     2006-01-01:
-      - title: Loi 2005-1719 du 30/12/2005 (LF pour 2006)
-        href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000634802
-      - title: BOI 5 B-6-06 n°8 du 18/01/2006
+      - title: Code général des impôts, art. 158, 7.
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006307989/2007-01-01/
   official_journal_date:
-    2002-01-01: "2002-12-31"
     2006-01-01: "2006-12-27"
 documentation: |
   Pensions alimentaires : 
   plafond : 2° du II de art. 156 du CGI, et art. 196 B du CGI;
   coefficient majoration pour les pensions suite à une décision de justice avant le 01/01/2006 : art. 158 du CGI
-  http://bofip.impots.gouv.fr/bofip/4930-PGP
+  https://bofip.impots.gouv.fr/bofip/4930-PGP.html/identifiant%3DBOI-IR-BASE-20-30-20-20-20120912#Reevaluation_des_pensions_a_13
   https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000037985596&cidTexte=LEGITEXT0000

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '132.0.0',
+    version = '132.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Correction suite issue: https://github.com/openfisca/openfisca-france/issues/1954

* Amélioration technique.
* Périodes concernées : 2002-2006
* Zones impactées :
    - `model/prelevements_obligatoires/impot_revenu/charges_deductibles.py`.
    -`parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/taux_jgt_2006`
* Détails :
  - Correction de la date d'entrée en vigueur de la déduction d'impôt pour pensions alimentaires

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.