### PR TITLE
Ajout valeur manquante dans la série pour 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog 
 
+### 134.1.0 [#1963](https://github.com/openfisca/openfisca-france/pull/1963)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : 2019.
+* Zones impactées 
+  -`openfisca_france\parameters\impot_revenu\calcul_impot_revenu\plaf_qf\reduction_ss_condition_revenus\plafond_rfr_couple.yaml`
+  - `openfisca_france\parameters\impot_revenu\calcul_impot_revenu\plaf_qf\reduction_ss_condition_revenus\plafond_rfr_celib.yaml`
+  - `openfisca_france\parameters\impot_revenu\calcul_impot_revenu\plaf_qf\reduction_ss_condition_revenus\majoration_plafond_par_demi_parts_supp.yaml`
+* Détails :
+  - Rajoute la valeurs des plafonds de la réduction sous condition de ressources de l'impôt sur le revenu, pour les revenus 2019.
+
 ### 134.0.2 [#1964](https://github.com/openfisca/openfisca-france/pull/1964)
 
 * Amélioration technique.

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/reduction_ss_condition_revenus/majoration_plafond_par_demi_parts_supp.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/reduction_ss_condition_revenus/majoration_plafond_par_demi_parts_supp.yaml
@@ -8,6 +8,8 @@ values:
     value: 3737
   2018-01-01:
     value: 3797
+  2019-01-01:
+    value: 3836
   2020-01-01:
     value: null
 metadata:
@@ -32,6 +34,14 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000038559363&categorieLien=id
     - title: Code Général des impôts, art. 197, I. 4. b
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044978323/2019-12-02/
+    2019-01-01:
+      title: Loi 2019-1479 du 28/12/2019 (LF pour 2020)
+      href: https://www.legifrance.gouv.fr/eli/loi/2019/12/28/CPAX1925229L/jo/texte
+    2020-01-01:
+    - title: Loi 2020-1721, art. 2 du 29/12/2020 (LF pour 2021)
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000042753593
+    - title: Décret 2020-897, art 1. du 22/07/2020
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000042143210
   official_journal_date:
     2016-01-01: "2016-12-30"
     2017-01-01: "2017-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/reduction_ss_condition_revenus/plafond_rfr_celib.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/reduction_ss_condition_revenus/plafond_rfr_celib.yaml
@@ -8,6 +8,8 @@ values:
     value: 18685
   2018-01-01:
     value: 18985
+  2019-01-01:
+    value: 19176
   2020-01-01:
     value: null
 metadata:
@@ -32,6 +34,14 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000038559363&categorieLien=id
     - title: Code Général des impôts, art. 197, I. 4. b. 3º
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044978323/2019-12-02/
+    2019-01-01:
+      title: Loi 2019-1479 du 28/12/2019 (LF pour 2020)
+      href: https://www.legifrance.gouv.fr/eli/loi/2019/12/28/CPAX1925229L/jo/texte
+    2020-01-01:
+    - title: Loi 2020-1721, art. 2 du 29/12/2020 (LF pour 2021)
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000042753593
+    - title: Décret 2020-897, art 1. du 22/07/2020
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000042143210
   official_journal_date:
     2016-01-01: "2016-12-30"
     2017-01-01: "2017-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/reduction_ss_condition_revenus/plafond_rfr_couple.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/reduction_ss_condition_revenus/plafond_rfr_couple.yaml
@@ -8,6 +8,8 @@ values:
     value: 20705
   2018-01-01:
     value: 21037
+  2019-01-01:
+    value: 21249
   2020-01-01:
     value: null
 metadata:
@@ -32,6 +34,14 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000038559363&categorieLien=id
     - title: Code Général des impôts, art. 197, I. 4. b. 3º
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044978323/2019-12-02/
+    2019-01-01:
+      title: Loi 2019-1479 du 28/12/2019 (LF pour 2020)
+      href: https://www.legifrance.gouv.fr/eli/loi/2019/12/28/CPAX1925229L/jo/texte
+    2020-01-01:
+    - title: Loi 2020-1721, art. 2 du 29/12/2020 (LF pour 2021)
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000042753593
+    - title: Décret 2020-897, art 1. du 22/07/2020
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000042143210
   official_journal_date:
     2016-01-01: "2016-12-30"
     2017-01-01: "2017-12-31"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '134.0.2',
+    version = '134.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : 2019.
* Zones impactées 
  -`openfisca_france\parameters\impot_revenu\calcul_impot_revenu\plaf_qf\reduction_ss_condition_revenus\plafond_rfr_couple.yaml`
  - `openfisca_france\parameters\impot_revenu\calcul_impot_revenu\plaf_qf\reduction_ss_condition_revenus\plafond_rfr_celib.yaml`
  - `openfisca_france\parameters\impot_revenu\calcul_impot_revenu\plaf_qf\reduction_ss_condition_revenus\majoration_plafond_par_demi_parts_supp.yaml`
* Détails :
  - Rajoute la valeurs des plafonds de la réduction sous condition de ressources de l'impôt sur le revenu, pour les revenus 2019.

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.
