### PR TITLE
fix encoding in unfold_parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog 
 
+### 134.0.2 [#1964](https://github.com/openfisca/openfisca-france/pull/1964)
+
+* Amélioration technique.
+* Périodes concernées : toutes. 
+* Zones impactées : `/openfisca_france/scripts/parameters/unfold_parameters.py`.
+* Détails :
+  - Ajoute `encoding = 'utf-8'` par défaut dans la fonction `write_parameter`  de `unfold_parameters`
+
 ### 134.0.1 [#1960](https://github.com/openfisca/openfisca-france/pull/1960)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/scripts/parameters/unfold_parameters.py
+++ b/openfisca_france/scripts/parameters/unfold_parameters.py
@@ -154,7 +154,7 @@ def unfold_parameter(
 def write_parameter(ids, parameter, target_dir):
     dir = os.path.join(target_dir, *ids[:-1])
     os.makedirs(dir, exist_ok=True)
-    with open(os.path.join(dir, f'{ids[-1]}.yaml'), 'w') as parameter_file:
+    with open(os.path.join(dir, f'{ids[-1]}.yaml'), 'w', encoding='utf-8') as parameter_file:
         yaml.dump(parameter, parameter_file, allow_unicode=True, Dumper=NoAliasDumper)
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '134.0.1',
+    version = '134.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Amélioration technique.
* Périodes concernées : toutes. 
* Zones impactées : `/openfisca_france/scripts/parameters/unfold_parameters.py`.
* Détails :
  - Ajoute `encoding = 'utf-8'` par défaut dans la fonction `write_parameter`  de `unfold_parameters`

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.