### PR TITLE
Maj des critères d'obtention de la bourse sur critères sociaux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# 138.0.1 [#1976](https://github.com/openfisca/openfisca-france/pull/1976)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/model/prestations/enseignement_superieur/bourse_criteres_sociaux`.
+* Détails :
+  - Les individus en année d'étude de doctorat ne peuvent plus recevoir de bourse sur critère sociaux
+  - Le doctorat ne fait pas partie des diplômes concernés pour l'obention de la bourse sur critères sociaiux, cf. (source)[https://www.enseignementsup-recherche.gouv.fr/fr/bo/22/Hebdo13/ESRS2209377C.htm?cbo=1&cid_bo=160009].
+
 # 138.0.0 [#1989](https://github.com/openfisca/openfisca-france/pull/1989)
 
 * Évolution du système socio-fiscal. Changement mineur.

--- a/openfisca_france/model/prestations/enseignement_superieur/bourse_criteres_sociaux.py
+++ b/openfisca_france/model/prestations/enseignement_superieur/bourse_criteres_sociaux.py
@@ -2,6 +2,8 @@ from openfisca_core.model_api import not_, select, where, Variable, MONTH, set_i
 from openfisca_france.model.base import Famille, Individu, TypesStatutMarital
 from openfisca_france.model.prestations.education import TypesScolarite, StatutsEtablissementScolaire
 from openfisca_france.model.prestations.education import TypesClasse
+
+
 class bourse_criteres_sociaux(Variable):
     value_type = float
     entity = Individu
@@ -20,9 +22,9 @@ class bourse_criteres_sociaux(Variable):
         en_doctorat_2 = individu('annee_etude', period) == TypesClasse.doctorat_2
         en_doctorat_3 = individu('annee_etude', period) == TypesClasse.doctorat_3
         en_doctorat = en_doctorat_1 + en_doctorat_2 + en_doctorat_3
-        annee_etude = individu('annee_etude', period)
         # If the student is a phD, the amount of the bourse is 0
         return montants.calc(echelon) * (1 - en_doctorat)
+
 
 class bourse_criteres_sociaux_eligibilite_etude(Variable):
     value_type = bool

--- a/openfisca_france/model/prestations/enseignement_superieur/bourse_criteres_sociaux.py
+++ b/openfisca_france/model/prestations/enseignement_superieur/bourse_criteres_sociaux.py
@@ -18,12 +18,13 @@ class bourse_criteres_sociaux(Variable):
     def formula(individu, period, parameters):
         montants = parameters(period).prestations_sociales.aides_jeunes.bourses.bourses_enseignement_superieur.criteres_sociaux.montants
         echelon = individu('bourse_criteres_sociaux_echelon', period)
-        en_doctorat_1 = individu('annee_etude', period) == TypesClasse.doctorat_1
-        en_doctorat_2 = individu('annee_etude', period) == TypesClasse.doctorat_2
-        en_doctorat_3 = individu('annee_etude', period) == TypesClasse.doctorat_3
-        en_doctorat = en_doctorat_1 + en_doctorat_2 + en_doctorat_3
-        # If the student is a phD, the amount of the bourse is 0
-        return montants.calc(echelon) * (1 - en_doctorat)
+        annee_etude = individu('annee_etude', period)
+        en_doctorat_1 = annee_etude == TypesClasse.doctorat_1
+        en_doctorat_2 = annee_etude == TypesClasse.doctorat_2
+        en_doctorat_3 = annee_etude == TypesClasse.doctorat_3
+        doctorant = en_doctorat_1 + en_doctorat_2 + en_doctorat_3
+        # Si l'étudiant est en doctorat, il ne perçoit pas la bourse sur critères sociaux
+        return montants.calc(echelon) * (1 - doctorant)
 
 
 class bourse_criteres_sociaux_eligibilite_etude(Variable):

--- a/openfisca_france/model/prestations/enseignement_superieur/bourse_criteres_sociaux.py
+++ b/openfisca_france/model/prestations/enseignement_superieur/bourse_criteres_sociaux.py
@@ -1,8 +1,7 @@
 from openfisca_core.model_api import not_, select, where, Variable, MONTH, set_input_divide_by_period, set_input_dispatch_by_period
 from openfisca_france.model.base import Famille, Individu, TypesStatutMarital
 from openfisca_france.model.prestations.education import TypesScolarite, StatutsEtablissementScolaire
-
-
+from openfisca_france.model.prestations.education import TypesClasse
 class bourse_criteres_sociaux(Variable):
     value_type = float
     entity = Individu
@@ -17,9 +16,13 @@ class bourse_criteres_sociaux(Variable):
     def formula(individu, period, parameters):
         montants = parameters(period).prestations_sociales.aides_jeunes.bourses.bourses_enseignement_superieur.criteres_sociaux.montants
         echelon = individu('bourse_criteres_sociaux_echelon', period)
-
-        return montants.calc(echelon)
-
+        en_doctorat_1 = individu('annee_etude', period) == TypesClasse.doctorat_1
+        en_doctorat_2 = individu('annee_etude', period) == TypesClasse.doctorat_2
+        en_doctorat_3 = individu('annee_etude', period) == TypesClasse.doctorat_3
+        en_doctorat = en_doctorat_1 + en_doctorat_2 + en_doctorat_3
+        annee_etude = individu('annee_etude', period)
+        # If the student is a phD, the amount of the bourse is 0
+        return montants.calc(echelon) * (1 - en_doctorat)
 
 class bourse_criteres_sociaux_eligibilite_etude(Variable):
     value_type = bool

--- a/openfisca_france/model/prestations/enseignement_superieur/bourse_criteres_sociaux.py
+++ b/openfisca_france/model/prestations/enseignement_superieur/bourse_criteres_sociaux.py
@@ -24,7 +24,7 @@ class bourse_criteres_sociaux(Variable):
         en_doctorat_3 = annee_etude == TypesClasse.doctorat_3
         doctorant = en_doctorat_1 + en_doctorat_2 + en_doctorat_3
         # Si l'étudiant est en doctorat, il ne perçoit pas la bourse sur critères sociaux
-        return montants.calc(echelon) * (1 - doctorant)
+        return montants.calc(echelon) * not_(doctorant)
 
 
 class bourse_criteres_sociaux_eligibilite_etude(Variable):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '138.0.0',
+    version = '138.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/bourses_superieur/bourse_criteres_sociaux.yaml
+++ b/tests/formulas/bourses_superieur/bourse_criteres_sociaux.yaml
@@ -89,6 +89,7 @@
 
 - period: 2021-03
   input:
-    bourse_criteres_sociaux_echelon: [-1, 0, 8]
+    bourse_criteres_sociaux_echelon: [-1, 0, 8, 8, 5, 0]
+    annee_etude: [licence_1, licence_2, master_2, doctorat_1, doctorat_2, doctorat_3]
   output:
-    bourse_criteres_sociaux: [0, 103.2, 567.9]
+    bourse_criteres_sociaux: [0, 103.2, 567.9, 0, 0, 0]


### PR DESCRIPTION
* Évolution du système socio-fiscal
* Périodes concernées : toutes
* Zones impactées : `openfisca_france/model/prestations/enseignement_superieur/bourse_criteres_sociaux`.
* Détails :
  - Les individus en année d'étude de doctorat ne peuvent plus recevoir de bourse sur critère sociaux
  - Le doctorat ne fait pas partie des diplômes concernés pour l'obention de la bourse sur critères sociaiux, cf. (source)[https://www.enseignementsup-recherche.gouv.fr/fr/bo/22/Hebdo13/ESRS2209377C.htm?cbo=1&cid_bo=160009].
 
- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
