### PR TITLE
Ajoute un taux d'inflation par défaut à zéro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 138.1.3 [#1981](https://github.com/openfisca/openfisca-france/pull/1981)
+
+* Changement mineur.
+* Périodes concernées : jusqu'au 08/2022.
+* Zones impactées : `parameters/taxation_capital/epargne/taux_inflation.yaml`.
+* Détails :
+  - Ajoute un taux d'inflation par défaut à zéro pour permettre les calculs avant août 2022
+
 ### 138.1.2 [#1864](https://github.com/openfisca/openfisca-france/pull/1864)
 
 * Changement mineur.

--- a/openfisca_france/parameters/taxation_capital/epargne/taux_inflation.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/taux_inflation.yaml
@@ -1,5 +1,7 @@
 description: Taux d'inflation
 values:
+  0001-01-01:
+    value: 0
   2022-08-01:
     value: 0.046
 metadata:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '138.1.2',
+    version = '138.1.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Avec #1881 j'ai cassé le calcul de l'éligibilité au livret d'épargne populaire avant la disponibilité du taux d'inflation dans les paramètres c'est à dire août 2022.


* Changement mineur.
* Périodes concernées : jusqu'au 08/2022.
* Zones impactées : `parameters/taxation_capital/epargne/taux_inflation.yaml`.
* Détails :
  - Ajoute un taux d'inflation par défaut à zéro pour permettre les calculs avant août 2022

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -