### PR TITLE
Revalorisation de l'ASS au 01/07/2022, rattrapage au 01/04/2022

### DIFF
--- a/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/montant_plein.yaml
+++ b/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/montant_plein.yaml
@@ -74,6 +74,10 @@ values:
     value: 16.89
   2021-04-01:
     value: 16.91
+  2022-04-01:
+    value: 17.21
+  2022-07-01:
+    value: 17.90
 metadata:
   ux_name: Montant journalier (Taux plein)
   description_en: Special UI scheme
@@ -194,6 +198,12 @@ metadata:
     2021-04-01:
       title: Décret n° 2021-523 du 29/04/2021
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043459270
+    2022-04-01:
+      title: Décret n° 2022-493 du 06/04/2022
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045522919
+    2022-07-01:
+      title: Loi n° 2022-1158 du 16/08/2022, Article 9
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046186749
   official_journal_date:
     1984-04-01: 1984-06-05; 1984-11-23
     1984-10-01: "1984-12-27"
@@ -231,6 +241,8 @@ metadata:
     2018-04-01: "2018-06-06"
     2019-04-01: "2019-05-18"
     2020-04-01: "2020-06-04"
+    2022-04-01: "2022-04-06"
+    2022-07-01: "2022-08-16"
   notes:
     1984-04-01:
     - title: "Nouvelle convention: création de l'ASS"

--- a/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/montant_plein_mayotte.yaml
+++ b/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/montant_plein_mayotte.yaml
@@ -38,6 +38,10 @@ values:
     value: 8.23
   2021-04-01:
     value: 8.46
+  2022-04-01:
+    value: 8.61
+  2022-07-01:
+    value: 8.95
 metadata:
   ux_name: Montant plein Mayotte
   description_en: Special UI scheme
@@ -59,4 +63,10 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031781118&cidTexte=LEGITEXT000006072050&dateTexte=20180420&fastPos=1&fastReqId=505933634&oldAction=rechCodeArticle
     2021-04-01:
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000043415805&categorieLien=id
+    2022-04-01:
+      title: Décret n° 2022-494 du 06/04/2022
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045522929
+    2022-07-01:
+      title: Loi n° 2022-1158 du 16/08/2022, Article 9
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046186749
 documentation: Le prestations.minima_sociaux.ass.montant_plein de la métropole est pris par défaut lorsque la valeur spécifique à Mayotte est non répertoriée.


### PR DESCRIPTION
Merci de contribuer à OpenFisca ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)

* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/07/2022.
* Zones impactées :
  ```
  parameters/chomage/allocations_assurance_chomage/ass/montant_plein.yaml
  parameters/chomage/allocations_assurance_chomage/ass/montant_plein_mayotte.yaml
  ```
* Détails :
  - Mise à jour du montant de base de l'ASS (y compris Mayotte) dans le cadre de la loi n° 2022-1158 du 16 août 2022 portant mesures d'urgence pour la protection du pouvoir d'achat.

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.
