### PR TITLE
Retire un residu de gestion de conflit du CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Zones impactées : `parameters/taxation_capital/epargne/livret_a/taux.yaml`.
 * Détails :
   - Mise à jour du taux du livret A au date du 1 février 2022 et au 1 août 2022
+
 ### 138.1.3 [#1981](https://github.com/openfisca/openfisca-france/pull/1981)
 
 * Changement mineur.
@@ -90,11 +91,7 @@
 * Détails :
   - Dans `taxation_capital/impot_solidarite_fortune_isf_1989_2017`, renomme `droits_soc` en `droits_sociaux`
 
-<<<<<<< HEAD
 ## 137.1.1 [#1983](https://github.com/openfisca/openfisca-france/pull/1983)
-=======
-### 137.1.1 [#1983](https://github.com/openfisca/openfisca-france/pull/1983)
->>>>>>> 97e788c94 (met à jour le numéro de version et le changelog)
 
 * Amélioration technique.
 * Périodes concernées : toutes.


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `CHANGELOG.md`.
* Détails :
  - Retire un résidu de gestion de conflit du CHANGELOG.

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
