### PR TITLE
Revalorisation taux LEP au 01/02/2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 140.0.2 []()
+### 140.0.2 [2014](https://github.com/openfisca/openfisca-france/pull/2014)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/02/2023.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 140.0.2 []()
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/02/2023.
+* Détails :
+  - Prends en compte le taux d'inflation dans celui du Livret d'Épargne Populaire
 # 140.0.1 [#2013](https://github.com/openfisca/openfisca-france/pull/2013)
 
 * Changement mineur.

--- a/openfisca_france/parameters/taxation_capital/epargne/taux_inflation.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/taux_inflation.yaml
@@ -4,6 +4,8 @@ values:
     value: 0
   2022-08-01:
     value: 0.046
+  2023-02-01:
+    value: 0.061
 metadata:
   reference:
     0001-01-01:
@@ -12,3 +14,6 @@ metadata:
     2022-08-01:
     - title: Avis relatif aux taux d'intérêt des produits d'épargne réglementée
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046082158
+    2023-02-01:
+    - title: Arrêté du 27 janvier 2023 relatif aux taux d'intérêt des produits d'épargne réglementée
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047069197

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '140.0.1',
+    version = '140.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/02/2023.
* Zones impactées : `parameters/taxation_capital/epargne/taux_inflation.yaml`
* Détails :
  - Revalorisation du taux du livret d'épargne populaire au 1er février 2023.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.
