### PR TITLE
Supprime des order superflus dans le preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-# 142.0.1 [#2020](https://github.com/openfisca/openfisca-france/pull/2020)
+### 142.0.2 [#2023](https://github.com/openfisca/openfisca-france/pull/2023)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `parameters/cotsoc`.
+* Détails :
+  - Suppression des valeurs superflues dans les `order` des cotsocs après passage dans le preprocessing.
+
+### 142.0.1 [#2020](https://github.com/openfisca/openfisca-france/pull/2020)
 
 * Changement mineur.
 * Périodes concernées : toutes.

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/preprocessing.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/preprocessing.py
@@ -97,6 +97,11 @@ def build_pat(node_json):  # Ici node_json c'est le dossier 'parameters'
     if autres.fin_syndic.metadata is not None and autres.fin_syndic.metadata.get('order') is not None:
         commun.metadata['order'] += autres.fin_syndic.metadata['order']
 
+    # Enlève de commun.metadata['order'] les paramètres qui ne font pas partie de commun.
+    for id in commun.metadata['order'].copy():
+        if all(child.id != id for child in commun.children):
+            commun.metadata['order'].remove(id)
+
     # Réindexation NonCadre
     # Initialisation
     noncadre = ParameterNode('noncadre', data=dict(
@@ -188,6 +193,8 @@ def build_pat(node_json):  # Ici node_json c'est le dossier 'parameters'
                 'formprof_moins_de_10_salaries', 'formprof_moins_de_11_salaries', 'formprof_20_salaries_et_plus', 'formprof_11_salaries_et_plus', 'formprof_entre_10_et_19_salaries',
                 'vieillesse_deplafonnee', 'vieillesse_plafonnee']:
         del commun.children[var]
+        if var in commun.metadata['order']:
+            commun.metadata['order'].remove(var)
 
     for var in ['apprentissage_taxe', 'apprentissage_contribution_additionnelle', 'apprentissage_taxe_alsace_moselle',
                 'formprof_moins_de_10_salaries', 'formprof_moins_de_11_salaries', 'formprof_20_salaries_et_plus', 'formprof_11_salaries_et_plus', 'formprof_entre_10_et_19_salaries',

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/preprocessing.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/preprocessing.py
@@ -99,7 +99,7 @@ def build_pat(node_json):  # Ici node_json c'est le dossier 'parameters'
 
     # Enlève de commun.metadata['order'] les paramètres qui ne font pas partie de commun.
     for id in commun.metadata['order'].copy():
-        if all(child.id != id for child in commun.children):
+        if all(child_id != id for child_id in commun.children.keys()):
             commun.metadata['order'].remove(id)
 
     # Réindexation NonCadre

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '142.0.1',
+    version = '142.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `parameters/cotsoc`.
* Détails :
  - Suppression des valeurs superflues dans les `order` des cotsocs après passage dans le preprocessing.