### PR TITLE
Mise a jour criteres bourse criteres sociaux pour les années 2021-2022 et 2022-2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### 143.0.2 [#2027](https://github.com/openfisca/openfisca-france/pull/2027)
+
+* Évolution du système socio-fiscal..
+* Périodes concernées : à partir du 27/07/2021
+* Zones impactées :
+  - `openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/
+  montants.yaml`
+  - `openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_*.yaml`
+* Détails :
+  - Revalorisation du 18 juillet 2022 fixant les plafonds et montants de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour les années universitaire 2021-2022 et 2022-2023
+
+- - - -
+
+Ces changements:
+
+- Corrigent ou améliorent un calcul déjà existant.
+
 ### 143.0.1 [#2034](https://github.com/openfisca/openfisca-france/pull/2034)
 
 * Amélioration technique.
@@ -12,15 +29,15 @@
 # 143.0.0 [#2001](https://github.com/openfisca/openfisca-france/pull/2001)
 
 * Amélioration technique
-* Périodes concernées : toutes. 
+* Périodes concernées : toutes.
 * Zones impactées : `openfisca_france/parameters`.
 * Détails :
   - Prise en compte d'une partie du formatage validé par la communauté dans cette RFC: https://github.com/openfisca/openfisca-france/issues/1672
   - Changements principaux:
       - `description_en` devient `label_en`
-      - `ux_name` devient `short_label` 
+      - `ux_name` devient `short_label`
       - `last_review` devient `last_value_still_valid_on`
-  
+
 - Les formatages qui viendront dans une prochaine PR
   - Changements principaux:
       - `description` devient `label`
@@ -30,7 +47,7 @@
 
 * Changement mineur.
 * Périodes concernées : toutes. | jusqu'au JJ/MM/AAAA. | à partir du JJ/MM/AAAA.
-* Zones impactées : 
+* Zones impactées :
      * `parameters/prelevements_sociaux/contributions_sociales/crds`.
      *  `prelevements_sociaux/contributions_sociales/csg`
      *  `prestations_sociales/prestations_familiales/education_presence_parentale/aeeh`
@@ -38,7 +55,7 @@
      *  `prestations_sociales/prestations_familiales/prestations_generales/af`
      *  `prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/complement_familial`
 
-* Détails 
+* Détails
     - Modifie les labels pour les rendre plus explicites
     - Rectifie des erreurs de labels
     - Ajoute des références, notamment les articles codifiés.

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/montants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/montants.yaml
@@ -10,6 +10,8 @@ brackets:
       value: 103.2
     2021-07-27:
       value: 104.2
+    2022-07-18:
+      value: 108.4
 - threshold:
     2020-07-22:
       value: 1
@@ -20,6 +22,8 @@ brackets:
       value: 170.7
     2021-07-27:
       value: 172.4
+    2022-07-18:
+      value: 179.3
 - threshold:
     2020-07-22:
       value: 2
@@ -30,6 +34,8 @@ brackets:
       value: 257.1
     2021-07-27:
       value: 259.7
+    2022-07-18:
+      value: 270.1
 - threshold:
     2020-07-22:
       value: 3
@@ -40,6 +46,8 @@ brackets:
       value: 329.2
     2021-07-27:
       value: 332.5
+    2022-07-18:
+      value: 345.8
 - threshold:
     2020-07-22:
       value: 4
@@ -50,6 +58,8 @@ brackets:
       value: 401.5
     2021-07-27:
       value: 405.5
+    2022-07-18:
+      value: 421.7
 - threshold:
     2020-07-22:
       value: 5
@@ -60,6 +70,8 @@ brackets:
       value: 461
     2021-07-27:
       value: 465.6
+    2022-07-18:
+      value: 484.2
 - threshold:
     2020-07-22:
       value: 6
@@ -70,6 +82,8 @@ brackets:
       value: 488.9
     2021-07-27:
       value: 493.8
+    2022-07-18:
+      value: 513.6
 - threshold:
     2020-07-22:
       value: 7
@@ -80,6 +94,8 @@ brackets:
       value: 567.9
     2021-07-27:
       value: 573.6
+    2022-07-18:
+      value: 596.5
 metadata:
   short_label: Montants
   reference:
@@ -91,4 +107,7 @@ metadata:
     2021-07-27:
     - title: Arrêté du 27 juillet 2021 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868543
+    2022-07-18:
+    - title: Arrêté du 18 juillet 2022 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096018
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/montants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/montants.yaml
@@ -8,6 +8,8 @@ brackets:
       value: 100.8
     2020-07-22:
       value: 103.2
+    2021-07-27:
+      value: 104.2
 - threshold:
     2020-07-22:
       value: 1
@@ -16,6 +18,8 @@ brackets:
       value: 166.7
     2020-07-22:
       value: 170.7
+    2021-07-27:
+      value: 172.4
 - threshold:
     2020-07-22:
       value: 2
@@ -24,6 +28,8 @@ brackets:
       value: 251
     2020-07-22:
       value: 257.1
+    2021-07-27:
+      value: 259.7
 - threshold:
     2020-07-22:
       value: 3
@@ -32,6 +38,8 @@ brackets:
       value: 321.5
     2020-07-22:
       value: 329.2
+    2021-07-27:
+      value: 332.5
 - threshold:
     2020-07-22:
       value: 4
@@ -40,6 +48,8 @@ brackets:
       value: 392
     2020-07-22:
       value: 401.5
+    2021-07-27:
+      value: 405.5
 - threshold:
     2020-07-22:
       value: 5
@@ -48,6 +58,8 @@ brackets:
       value: 450
     2020-07-22:
       value: 461
+    2021-07-27:
+      value: 465.6
 - threshold:
     2020-07-22:
       value: 6
@@ -56,6 +68,8 @@ brackets:
       value: 477.3
     2020-07-22:
       value: 488.9
+    2021-07-27:
+      value: 493.8
 - threshold:
     2020-07-22:
       value: 7
@@ -64,6 +78,8 @@ brackets:
       value: 554.5
     2020-07-22:
       value: 567.9
+    2021-07-27:
+      value: 573.6
 metadata:
   short_label: Montants
   reference:
@@ -72,4 +88,7 @@ metadata:
     2020-07-22:
     - title: Arrêté du 22 juillet 2020 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
     - href: https://www.legifrance.gouv.fr/eli/arrete/2020/7/22/ESRS2015874A/jo/texte
+    2021-07-27:
+    - title: Arrêté du 27 juillet 2021 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868543
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
@@ -183,8 +183,8 @@ brackets:
 metadata:
   reference:
     2020-07-22:
-    - title: Arrêté du 22 juillet 2020 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
-    - href: https://www.legifrance.gouv.fr/eli/arrete/2020/7/22/ESRS2015874A/jo/texte
+    - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
   reference:
     2021-07-16:
     - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
@@ -3,114 +3,190 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
+    2021-07-16:
+      value: 0
   amount:
     2020-07-22:
+      value: 33100
+    2021-07-16:
       value: 33100
 - threshold:
     2020-07-22:
       value: 1
+    2021-07-16:
+      value: 1
   amount:
     2020-07-22:
+      value: 36760
+    2021-07-16:
       value: 36760
 - threshold:
     2020-07-22:
       value: 2
+    2021-07-16:
+      value: 2
   amount:
     2020-07-22:
+      value: 40450
+    2021-07-16:
       value: 40450
 - threshold:
     2020-07-22:
       value: 3
+    2021-07-16:
+      value: 3
   amount:
     2020-07-22:
+      value: 44120
+    2021-07-16:
       value: 44120
 - threshold:
     2020-07-22:
       value: 4
+    2021-07-16:
+      value: 4
   amount:
     2020-07-22:
+      value: 47800
+    2021-07-16:
       value: 47800
 - threshold:
     2020-07-22:
       value: 5
+    2021-07-16:
+      value: 5
   amount:
     2020-07-22:
+      value: 51480
+    2021-07-16:
       value: 51480
 - threshold:
     2020-07-22:
       value: 6
+    2021-07-16:
+      value: 6
   amount:
     2020-07-22:
+      value: 55150
+    2021-07-16:
       value: 55150
 - threshold:
     2020-07-22:
       value: 7
+    2021-07-16:
+      value: 7
   amount:
     2020-07-22:
+      value: 58830
+    2021-07-16:
       value: 58830
 - threshold:
     2020-07-22:
       value: 8
+    2021-07-16:
+      value: 8
   amount:
     2020-07-22:
+      value: 62510
+    2021-07-16:
       value: 62510
 - threshold:
     2020-07-22:
       value: 9
+    2021-07-16:
+      value: 9
   amount:
     2020-07-22:
+      value: 66180
+    2021-07-16:
       value: 66180
 - threshold:
     2020-07-22:
       value: 10
+    2021-07-16:
+      value: 10
   amount:
     2020-07-22:
+      value: 69860
+    2021-07-16:
       value: 69860
 - threshold:
     2020-07-22:
       value: 11
+    2021-07-16:
+      value: 11
   amount:
     2020-07-22:
+      value: 73540
+    2021-07-16:
       value: 73540
 - threshold:
     2020-07-22:
       value: 12
+    2021-07-16:
+      value: 12
   amount:
     2020-07-22:
+      value: 77210
+    2021-07-16:
       value: 77210
 - threshold:
     2020-07-22:
       value: 13
+    2021-07-16:
+      value: 13
   amount:
     2020-07-22:
+      value: 80890
+    2021-07-16:
       value: 80890
 - threshold:
     2020-07-22:
       value: 14
+    2021-07-16:
+      value: 14
   amount:
     2020-07-22:
+      value: 84560
+    2021-07-16:
       value: 84560
 - threshold:
     2020-07-22:
       value: 15
+    2021-07-16:
+      value: 15
   amount:
     2020-07-22:
+      value: 88250
+    2021-07-16:
       value: 88250
 - threshold:
     2020-07-22:
       value: 16
+    2021-07-16:
+      value: 16
   amount:
     2020-07-22:
+      value: 91920
+    2021-07-16:
       value: 91920
 - threshold:
     2020-07-22:
       value: 17
+    2021-07-16:
+      value: 17
   amount:
     2020-07-22:
+      value: 95610
+    2021-07-16:
       value: 95610
 metadata:
   reference:
     2020-07-22:
     - title: Arrêté du 22 juillet 2020 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
     - href: https://www.legifrance.gouv.fr/eli/arrete/2020/7/22/ESRS2015874A/jo/texte
+  reference:
+    2021-07-16:
+    - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
@@ -262,6 +262,6 @@ metadata:
     - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
     2022-07-18:
-    - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-202
+    - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
@@ -257,7 +257,6 @@ metadata:
     2020-07-22:
     - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
-  reference:
     2021-07-16:
     - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
@@ -5,180 +5,252 @@ brackets:
       value: 0
     2021-07-16:
       value: 0
+    2022-07-18:
+      value: 0
   amount:
     2020-07-22:
       value: 33100
     2021-07-16:
+      value: 33100
+    2022-07-18:
       value: 33100
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
+    2022-07-18:
+      value: 1
   amount:
     2020-07-22:
       value: 36760
     2021-07-16:
+      value: 36760
+    2022-07-18:
       value: 36760
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
+      value: 2
+    2022-07-18:
       value: 2
   amount:
     2020-07-22:
       value: 40450
     2021-07-16:
+      value: 40450
+    2022-07-18:
       value: 40450
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
+      value: 3
+    2022-07-18:
       value: 3
   amount:
     2020-07-22:
       value: 44120
     2021-07-16:
+      value: 44120
+    2022-07-18:
       value: 44120
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
+      value: 4
+    2022-07-18:
       value: 4
   amount:
     2020-07-22:
       value: 47800
     2021-07-16:
+      value: 47800
+    2022-07-18:
       value: 47800
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
+      value: 5
+    2022-07-18:
       value: 5
   amount:
     2020-07-22:
       value: 51480
     2021-07-16:
+      value: 51480
+    2022-07-18:
       value: 51480
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
+      value: 6
+    2022-07-18:
       value: 6
   amount:
     2020-07-22:
       value: 55150
     2021-07-16:
+      value: 55150
+    2022-07-18:
       value: 55150
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
+      value: 7
+    2022-07-18:
       value: 7
   amount:
     2020-07-22:
       value: 58830
     2021-07-16:
+      value: 58830
+    2022-07-18:
       value: 58830
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
+      value: 8
+    2022-07-18:
       value: 8
   amount:
     2020-07-22:
       value: 62510
     2021-07-16:
+      value: 62510
+    2022-07-18:
       value: 62510
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
+      value: 9
+    2022-07-18:
       value: 9
   amount:
     2020-07-22:
       value: 66180
     2021-07-16:
+      value: 66180
+    2022-07-18:
       value: 66180
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
+      value: 10
+    2022-07-18:
       value: 10
   amount:
     2020-07-22:
       value: 69860
     2021-07-16:
+      value: 69860
+    2022-07-18:
       value: 69860
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
+      value: 11
+    2022-07-18:
       value: 11
   amount:
     2020-07-22:
       value: 73540
     2021-07-16:
+      value: 73540
+    2022-07-18:
       value: 73540
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
+      value: 12
+    2022-07-18:
       value: 12
   amount:
     2020-07-22:
       value: 77210
     2021-07-16:
+      value: 77210
+    2022-07-18:
       value: 77210
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
+      value: 13
+    2022-07-18:
       value: 13
   amount:
     2020-07-22:
       value: 80890
     2021-07-16:
+      value: 80890
+    2022-07-18:
       value: 80890
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
+      value: 14
+    2022-07-18:
       value: 14
   amount:
     2020-07-22:
       value: 84560
     2021-07-16:
+      value: 84560
+    2022-07-18:
       value: 84560
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
+      value: 15
+    2022-07-18:
       value: 15
   amount:
     2020-07-22:
       value: 88250
     2021-07-16:
+      value: 88250
+    2022-07-18:
       value: 88250
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
+      value: 16
+    2022-07-18:
       value: 16
   amount:
     2020-07-22:
       value: 91920
     2021-07-16:
+      value: 91920
+    2022-07-18:
       value: 91920
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
+      value: 17
+    2022-07-18:
       value: 17
   amount:
     2020-07-22:
       value: 95610
     2021-07-16:
+      value: 95610
+    2022-07-18:
       value: 95610
 metadata:
   reference:
@@ -189,4 +261,7 @@ metadata:
     2021-07-16:
     - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
+    2022-07-18:
+    - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-202
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
@@ -183,8 +183,8 @@ brackets:
 metadata:
   reference:
     2020-07-22:
-    - title: Arrêté du 22 juillet 2020 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
-    - href: https://www.legifrance.gouv.fr/eli/arrete/2020/7/22/ESRS2015874A/jo/texte
+    - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
     2021-07-16:
     - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
@@ -3,114 +3,189 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
+    2021-07-16:
+      value: 0
   amount:
     2020-07-22:
+      value: 22500
+    2021-07-16:
       value: 22500
 - threshold:
     2020-07-22:
       value: 1
+    2021-07-16:
+      value: 1
   amount:
     2020-07-22:
+      value: 25000
+    2021-07-16:
       value: 25000
 - threshold:
     2020-07-22:
       value: 2
+    2021-07-16:
+      value: 2
   amount:
     2020-07-22:
+      value: 27500
+    2021-07-16:
       value: 27500
 - threshold:
     2020-07-22:
       value: 3
+    2021-07-16:
+      value: 3
   amount:
     2020-07-22:
+      value: 30000
+    2021-07-16:
       value: 30000
 - threshold:
     2020-07-22:
       value: 4
+    2021-07-16:
+      value: 4
   amount:
     2020-07-22:
+      value: 32500
+    2021-07-16:
       value: 32500
 - threshold:
     2020-07-22:
       value: 5
+    2021-07-16:
+      value: 5
   amount:
     2020-07-22:
+      value: 35010
+    2021-07-16:
       value: 35010
 - threshold:
     2020-07-22:
       value: 6
+    2021-07-16:
+      value: 6
   amount:
     2020-07-22:
+      value: 37510
+    2021-07-16:
       value: 37510
 - threshold:
     2020-07-22:
       value: 7
+    2021-07-16:
+      value: 7
   amount:
     2020-07-22:
+      value: 40010
+    2021-07-16:
       value: 40010
 - threshold:
     2020-07-22:
       value: 8
+    2021-07-16:
+      value: 8
   amount:
     2020-07-22:
+      value: 42510
+    2021-07-16:
       value: 42510
 - threshold:
     2020-07-22:
       value: 9
+    2021-07-16:
+      value: 9
   amount:
     2020-07-22:
+      value: 45000
+    2021-07-16:
       value: 45000
 - threshold:
     2020-07-22:
       value: 10
+    2021-07-16:
+      value: 10
   amount:
     2020-07-22:
+      value: 47510
+    2021-07-16:
       value: 47510
 - threshold:
     2020-07-22:
       value: 11
+    2021-07-16:
+      value: 11
   amount:
     2020-07-22:
+      value: 50010
+    2021-07-16:
       value: 50010
 - threshold:
     2020-07-22:
       value: 12
+    2021-07-16:
+      value: 12
   amount:
     2020-07-22:
+      value: 52500
+    2021-07-16:
       value: 52500
 - threshold:
     2020-07-22:
       value: 13
+    2021-07-16:
+      value: 13
   amount:
     2020-07-22:
+      value: 55000
+    2021-07-16:
       value: 55000
 - threshold:
     2020-07-22:
       value: 14
+    2021-07-16:
+      value: 14
   amount:
     2020-07-22:
+      value: 57520
+    2021-07-16:
       value: 57520
 - threshold:
     2020-07-22:
       value: 15
+    2021-07-16:
+      value: 15
   amount:
     2020-07-22:
+      value: 60010
+    2021-07-16:
       value: 60010
 - threshold:
     2020-07-22:
       value: 16
+    2021-07-16:
+      value: 16
   amount:
     2020-07-22:
+      value: 62510
+    2021-07-16:
       value: 62510
 - threshold:
     2020-07-22:
       value: 17
+    2021-07-16:
+      value: 17
   amount:
     2020-07-22:
+      value: 65010
+    2021-07-16:
       value: 65010
 metadata:
   reference:
     2020-07-22:
     - title: Arrêté du 22 juillet 2020 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
     - href: https://www.legifrance.gouv.fr/eli/arrete/2020/7/22/ESRS2015874A/jo/texte
+    2021-07-16:
+    - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
@@ -5,180 +5,252 @@ brackets:
       value: 0
     2021-07-16:
       value: 0
+    2022-07-18:
+      value: 0
   amount:
     2020-07-22:
       value: 22500
     2021-07-16:
+      value: 22500
+    2022-07-18:
       value: 22500
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
+    2022-07-18:
+      value: 1
   amount:
     2020-07-22:
       value: 25000
     2021-07-16:
+      value: 25000
+    2022-07-18:
       value: 25000
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
+      value: 2
+    2022-07-18:
       value: 2
   amount:
     2020-07-22:
       value: 27500
     2021-07-16:
+      value: 27500
+    2022-07-18:
       value: 27500
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
+      value: 3
+    2022-07-18:
       value: 3
   amount:
     2020-07-22:
       value: 30000
     2021-07-16:
+      value: 30000
+    2022-07-18:
       value: 30000
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
+      value: 4
+    2022-07-18:
       value: 4
   amount:
     2020-07-22:
       value: 32500
     2021-07-16:
+      value: 32500
+    2022-07-18:
       value: 32500
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
+      value: 5
+    2022-07-18:
       value: 5
   amount:
     2020-07-22:
       value: 35010
     2021-07-16:
+      value: 35010
+    2022-07-18:
       value: 35010
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
+      value: 6
+    2022-07-18:
       value: 6
   amount:
     2020-07-22:
       value: 37510
     2021-07-16:
+      value: 37510
+    2022-07-18:
       value: 37510
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
+      value: 7
+    2022-07-18:
       value: 7
   amount:
     2020-07-22:
       value: 40010
     2021-07-16:
+      value: 40010
+    2022-07-18:
       value: 40010
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
+      value: 8
+    2022-07-18:
       value: 8
   amount:
     2020-07-22:
       value: 42510
     2021-07-16:
+      value: 42510
+    2022-07-18:
       value: 42510
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
+      value: 9
+    2022-07-18:
       value: 9
   amount:
     2020-07-22:
       value: 45000
     2021-07-16:
+      value: 45000
+    2022-07-18:
       value: 45000
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
+      value: 10
+    2022-07-18:
       value: 10
   amount:
     2020-07-22:
       value: 47510
     2021-07-16:
+      value: 47510
+    2022-07-18:
       value: 47510
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
+      value: 11
+    2022-07-18:
       value: 11
   amount:
     2020-07-22:
       value: 50010
     2021-07-16:
+      value: 50010
+    2022-07-18:
       value: 50010
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
+      value: 12
+    2022-07-18:
       value: 12
   amount:
     2020-07-22:
       value: 52500
     2021-07-16:
+      value: 52500
+    2022-07-18:
       value: 52500
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
+      value: 13
+    2022-07-18:
       value: 13
   amount:
     2020-07-22:
       value: 55000
     2021-07-16:
+      value: 55000
+    2022-07-18:
       value: 55000
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
+      value: 14
+    2022-07-18:
       value: 14
   amount:
     2020-07-22:
       value: 57520
     2021-07-16:
+      value: 57520
+    2022-07-18:
       value: 57520
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
+      value: 15
+    2022-07-18:
       value: 15
   amount:
     2020-07-22:
       value: 60010
     2021-07-16:
+      value: 60010
+    2022-07-18:
       value: 60010
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
+      value: 16
+    2022-07-18:
       value: 16
   amount:
     2020-07-22:
       value: 62510
     2021-07-16:
+      value: 62510
+    2022-07-18:
       value: 62510
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
+      value: 17
+    2022-07-18:
       value: 17
   amount:
     2020-07-22:
       value: 65010
     2021-07-16:
+      value: 65010
+    2022-07-18:
       value: 65010
 metadata:
   reference:
@@ -188,4 +260,7 @@ metadata:
     2021-07-16:
     - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
+    2022-07-18:
+    - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
@@ -111,6 +111,6 @@ brackets:
 metadata:
   reference:
     2020-07-22:
-    - title: Arrêté du 22 juillet 2020 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
-    - href: https://www.legifrance.gouv.fr/eli/arrete/2020/7/22/ESRS2015874A/jo/texte
+    - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
@@ -5,180 +5,252 @@ brackets:
       value: 0
     2021-07-16:
       value: 0
+    2022-07-18:
+      value: 0
   amount:
     2020-07-22:
       value: 18190
     2021-07-16:
+      value: 18190
+    2022-07-18:
       value: 18190
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
+    2022-07-18:
+      value: 1
   amount:
     2020-07-22:
       value: 20210
     2021-07-16:
+      value: 20210
+    2022-07-18:
       value: 20210
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
+      value: 2
+    2022-07-18:
       value: 2
   amount:
     2020-07-22:
       value: 22230
     2021-07-16:
+      value: 22230
+    2022-07-18:
       value: 22230
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
+      value: 3
+    2022-07-18:
       value: 3
   amount:
     2020-07-22:
       value: 24250
     2021-07-16:
+      value: 24250
+    2022-07-18:
       value: 24250
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
+      value: 4
+    2022-07-18:
       value: 4
   amount:
     2020-07-22:
       value: 26270
     2021-07-16:
+      value: 26270
+    2022-07-18:
       value: 26270
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
+      value: 5
+    2022-07-18:
       value: 5
   amount:
     2020-07-22:
       value: 28300
     2021-07-16:
+      value: 28300
+    2022-07-18:
       value: 28300
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
+      value: 6
+    2022-07-18:
       value: 6
   amount:
     2020-07-22:
       value: 30320
     2021-07-16:
+      value: 30320
+    2022-07-18:
       value: 30320
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
+      value: 7
+    2022-07-18:
       value: 7
   amount:
     2020-07-22:
       value: 32340
     2021-07-16:
+      value: 32340
+    2022-07-18:
       value: 32340
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
+      value: 8
+    2022-07-18:
       value: 8
   amount:
     2020-07-22:
       value: 34360
     2021-07-16:
+      value: 34360
+    2022-07-18:
       value: 34360
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
+      value: 9
+    2022-07-18:
       value: 9
   amount:
     2020-07-22:
       value: 36380
     2021-07-16:
+      value: 36380
+    2022-07-18:
       value: 36380
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
+      value: 10
+    2022-07-18:
       value: 10
   amount:
     2020-07-22:
       value: 38400
     2021-07-16:
+      value: 38400
+    2022-07-18:
       value: 38400
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
+      value: 11
+    2022-07-18:
       value: 11
   amount:
     2020-07-22:
       value: 40410
     2021-07-16:
+      value: 40410
+    2022-07-18:
       value: 40410
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
+      value: 12
+    2022-07-18:
       value: 12
   amount:
     2020-07-22:
       value: 42430
     2021-07-16:
+      value: 42430
+    2022-07-18:
       value: 42430
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
+      value: 13
+    2022-07-18:
       value: 13
   amount:
     2020-07-22:
       value: 44450
     2021-07-16:
+      value: 44450
+    2022-07-18:
       value: 44450
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
+      value: 14
+    2022-07-18:
       value: 14
   amount:
     2020-07-22:
       value: 46480
     2021-07-16:
+      value: 46480
+    2022-07-18:
       value: 46480
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
+      value: 15
+    2022-07-18:
       value: 15
   amount:
     2020-07-22:
       value: 48500
     2021-07-16:
+      value: 48500
+    2022-07-18:
       value: 48500
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
+      value: 16
+    2022-07-18:
       value: 16
   amount:
     2020-07-22:
       value: 50520
     2021-07-16:
+      value: 50520
+    2022-07-18:
       value: 50520
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
+      value: 17
+    2022-07-18:
       value: 17
   amount:
     2020-07-22:
       value: 52540
     2021-07-16:
+      value: 52540
+    2022-07-18:
       value: 52540
 metadata:
   reference:
@@ -188,4 +260,7 @@ metadata:
     2021-07-16:
     - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
+    2022-07-18:
+    - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
@@ -3,114 +3,189 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
+    2021-07-16:
+      value: 0
   amount:
     2020-07-22:
+      value: 18190
+    2021-07-16:
       value: 18190
 - threshold:
     2020-07-22:
       value: 1
+    2021-07-16:
+      value: 1
   amount:
     2020-07-22:
+      value: 20210
+    2021-07-16:
       value: 20210
 - threshold:
     2020-07-22:
       value: 2
+    2021-07-16:
+      value: 2
   amount:
     2020-07-22:
+      value: 22230
+    2021-07-16:
       value: 22230
 - threshold:
     2020-07-22:
       value: 3
+    2021-07-16:
+      value: 3
   amount:
     2020-07-22:
+      value: 24250
+    2021-07-16:
       value: 24250
 - threshold:
     2020-07-22:
       value: 4
+    2021-07-16:
+      value: 4
   amount:
     2020-07-22:
+      value: 26270
+    2021-07-16:
       value: 26270
 - threshold:
     2020-07-22:
       value: 5
+    2021-07-16:
+      value: 5
   amount:
     2020-07-22:
+      value: 28300
+    2021-07-16:
       value: 28300
 - threshold:
     2020-07-22:
       value: 6
+    2021-07-16:
+      value: 6
   amount:
     2020-07-22:
+      value: 30320
+    2021-07-16:
       value: 30320
 - threshold:
     2020-07-22:
       value: 7
+    2021-07-16:
+      value: 7
   amount:
     2020-07-22:
+      value: 32340
+    2021-07-16:
       value: 32340
 - threshold:
     2020-07-22:
       value: 8
+    2021-07-16:
+      value: 8
   amount:
     2020-07-22:
+      value: 34360
+    2021-07-16:
       value: 34360
 - threshold:
     2020-07-22:
       value: 9
+    2021-07-16:
+      value: 9
   amount:
     2020-07-22:
+      value: 36380
+    2021-07-16:
       value: 36380
 - threshold:
     2020-07-22:
       value: 10
+    2021-07-16:
+      value: 10
   amount:
     2020-07-22:
+      value: 38400
+    2021-07-16:
       value: 38400
 - threshold:
     2020-07-22:
       value: 11
+    2021-07-16:
+      value: 11
   amount:
     2020-07-22:
+      value: 40410
+    2021-07-16:
       value: 40410
 - threshold:
     2020-07-22:
       value: 12
+    2021-07-16:
+      value: 12
   amount:
     2020-07-22:
+      value: 42430
+    2021-07-16:
       value: 42430
 - threshold:
     2020-07-22:
       value: 13
+    2021-07-16:
+      value: 13
   amount:
     2020-07-22:
+      value: 44450
+    2021-07-16:
       value: 44450
 - threshold:
     2020-07-22:
       value: 14
+    2021-07-16:
+      value: 14
   amount:
     2020-07-22:
+      value: 46480
+    2021-07-16:
       value: 46480
 - threshold:
     2020-07-22:
       value: 15
+    2021-07-16:
+      value: 15
   amount:
     2020-07-22:
+      value: 48500
+    2021-07-16:
       value: 48500
 - threshold:
     2020-07-22:
       value: 16
+    2021-07-16:
+      value: 16
   amount:
     2020-07-22:
+      value: 50520
+    2021-07-16:
       value: 50520
 - threshold:
     2020-07-22:
       value: 17
+    2021-07-16:
+      value: 17
   amount:
     2020-07-22:
+      value: 52540
+    2021-07-16:
       value: 52540
 metadata:
   reference:
     2020-07-22:
     - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
+    2021-07-16:
+    - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
@@ -111,6 +111,6 @@ brackets:
 metadata:
   reference:
     2020-07-22:
-    - title: Arrêté du 22 juillet 2020 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
-    - href: https://www.legifrance.gouv.fr/eli/arrete/2020/7/22/ESRS2015874A/jo/texte
+    - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
@@ -5,180 +5,252 @@ brackets:
       value: 0
     2021-07-16:
       value: 0
+    2022-07-18:
+      value: 0
   amount:
     2020-07-22:
       value: 16070
     2021-07-16:
+      value: 16070
+    2022-07-18:
       value: 16070
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
+    2022-07-18:
+      value: 1
   amount:
     2020-07-22:
       value: 17850
     2021-07-16:
+      value: 17850
+    2022-07-18:
       value: 17850
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
+      value: 2
+    2022-07-18:
       value: 2
   amount:
     2020-07-22:
       value: 19640
     2021-07-16:
+      value: 19640
+    2022-07-18:
       value: 19640
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
+      value: 3
+    2022-07-18:
       value: 3
   amount:
     2020-07-22:
       value: 21430
     2021-07-16:
+      value: 21430
+    2022-07-18:
       value: 21430
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
+      value: 4
+    2022-07-18:
       value: 4
   amount:
     2020-07-22:
       value: 23210
     2021-07-16:
+      value: 23210
+    2022-07-18:
       value: 23210
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
+      value: 5
+    2022-07-18:
       value: 5
   amount:
     2020-07-22:
       value: 25000
     2021-07-16:
+      value: 25000
+    2022-07-18:
       value: 25000
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
+      value: 6
+    2022-07-18:
       value: 6
   amount:
     2020-07-22:
       value: 26770
     2021-07-16:
+      value: 26770
+    2022-07-18:
       value: 26770
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
+      value: 7
+    2022-07-18:
       value: 7
   amount:
     2020-07-22:
       value: 28560
     2021-07-16:
+      value: 28560
+    2022-07-18:
       value: 28560
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
+      value: 8
+    2022-07-18:
       value: 8
   amount:
     2020-07-22:
       value: 30350
     2021-07-16:
+      value: 30350
+    2022-07-18:
       value: 30350
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
+      value: 9
+    2022-07-18:
       value: 9
   amount:
     2020-07-22:
       value: 32130
     2021-07-16:
+      value: 32130
+    2022-07-18:
       value: 32130
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
+      value: 10
+    2022-07-18:
       value: 10
   amount:
     2020-07-22:
       value: 33920
     2021-07-16:
+      value: 33920
+    2022-07-18:
       value: 33920
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
+      value: 11
+    2022-07-18:
       value: 11
   amount:
     2020-07-22:
       value: 35710
     2021-07-16:
+      value: 35710
+    2022-07-18:
       value: 35710
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
+      value: 12
+    2022-07-18:
       value: 12
   amount:
     2020-07-22:
       value: 37490
     2021-07-16:
+      value: 37490
+    2022-07-18:
       value: 37490
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
+      value: 13
+    2022-07-18:
       value: 13
   amount:
     2020-07-22:
       value: 39280
     2021-07-16:
+      value: 39280
+    2022-07-18:
       value: 39280
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
+      value: 14
+    2022-07-18:
       value: 14
   amount:
     2020-07-22:
       value: 41050
     2021-07-16:
+      value: 41050
+    2022-07-18:
       value: 41050
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
+      value: 15
+    2022-07-18:
       value: 15
   amount:
     2020-07-22:
       value: 42840
     2021-07-16:
+      value: 42840
+    2022-07-18:
       value: 42840
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
+      value: 16
+    2022-07-18:
       value: 16
   amount:
     2020-07-22:
       value: 44630
     2021-07-16:
+      value: 44630
+    2022-07-18:
       value: 44630
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
+      value: 17
+    2022-07-18:
       value: 17
   amount:
     2020-07-22:
       value: 46410
     2021-07-16:
+      value: 46410
+    2022-07-18:
       value: 46410
 metadata:
   reference:
@@ -188,4 +260,7 @@ metadata:
     2021-07-16:
     - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
+    2022-07-18:
+    - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
@@ -3,114 +3,189 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
+    2021-07-16:
+      value: 0
   amount:
     2020-07-22:
+      value: 16070
+    2021-07-16:
       value: 16070
 - threshold:
     2020-07-22:
       value: 1
+    2021-07-16:
+      value: 1
   amount:
     2020-07-22:
+      value: 17850
+    2021-07-16:
       value: 17850
 - threshold:
     2020-07-22:
       value: 2
+    2021-07-16:
+      value: 2
   amount:
     2020-07-22:
+      value: 19640
+    2021-07-16:
       value: 19640
 - threshold:
     2020-07-22:
       value: 3
+    2021-07-16:
+      value: 3
   amount:
     2020-07-22:
+      value: 21430
+    2021-07-16:
       value: 21430
 - threshold:
     2020-07-22:
       value: 4
+    2021-07-16:
+      value: 4
   amount:
     2020-07-22:
+      value: 23210
+    2021-07-16:
       value: 23210
 - threshold:
     2020-07-22:
       value: 5
+    2021-07-16:
+      value: 5
   amount:
     2020-07-22:
+      value: 25000
+    2021-07-16:
       value: 25000
 - threshold:
     2020-07-22:
       value: 6
+    2021-07-16:
+      value: 6
   amount:
     2020-07-22:
+      value: 26770
+    2021-07-16:
       value: 26770
 - threshold:
     2020-07-22:
       value: 7
+    2021-07-16:
+      value: 7
   amount:
     2020-07-22:
+      value: 28560
+    2021-07-16:
       value: 28560
 - threshold:
     2020-07-22:
       value: 8
+    2021-07-16:
+      value: 8
   amount:
     2020-07-22:
+      value: 30350
+    2021-07-16:
       value: 30350
 - threshold:
     2020-07-22:
       value: 9
+    2021-07-16:
+      value: 9
   amount:
     2020-07-22:
+      value: 32130
+    2021-07-16:
       value: 32130
 - threshold:
     2020-07-22:
       value: 10
+    2021-07-16:
+      value: 10
   amount:
     2020-07-22:
+      value: 33920
+    2021-07-16:
       value: 33920
 - threshold:
     2020-07-22:
       value: 11
+    2021-07-16:
+      value: 11
   amount:
     2020-07-22:
+      value: 35710
+    2021-07-16:
       value: 35710
 - threshold:
     2020-07-22:
       value: 12
+    2021-07-16:
+      value: 12
   amount:
     2020-07-22:
+      value: 37490
+    2021-07-16:
       value: 37490
 - threshold:
     2020-07-22:
       value: 13
+    2021-07-16:
+      value: 13
   amount:
     2020-07-22:
+      value: 39280
+    2021-07-16:
       value: 39280
 - threshold:
     2020-07-22:
       value: 14
+    2021-07-16:
+      value: 14
   amount:
     2020-07-22:
+      value: 41050
+    2021-07-16:
       value: 41050
 - threshold:
     2020-07-22:
       value: 15
+    2021-07-16:
+      value: 15
   amount:
     2020-07-22:
+      value: 42840
+    2021-07-16:
       value: 42840
 - threshold:
     2020-07-22:
       value: 16
+    2021-07-16:
+      value: 16
   amount:
     2020-07-22:
+      value: 44630
+    2021-07-16:
       value: 44630
 - threshold:
     2020-07-22:
       value: 17
+    2021-07-16:
+      value: 17
   amount:
     2020-07-22:
+      value: 46410
+    2021-07-16:
       value: 46410
 metadata:
   reference:
     2020-07-22:
     - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
+    2021-07-16:
+    - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
@@ -5,180 +5,252 @@ brackets:
       value: 0
     2021-07-16:
       value: 0
+    2022-07-18:
+      value: 0
   amount:
     2020-07-22:
       value: 13990
     2021-07-16:
+      value: 13990
+    2022-07-18:
       value: 13990
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
+    2022-07-18:
+      value: 1
   amount:
     2020-07-22:
       value: 15540
     2021-07-16:
+      value: 15540
+    2022-07-18:
       value: 15540
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
+      value: 2
+    2022-07-18:
       value: 2
   amount:
     2020-07-22:
       value: 17100
     2021-07-16:
+      value: 17100
+    2022-07-18:
       value: 17100
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
+      value: 3
+    2022-07-18:
       value: 3
   amount:
     2020-07-22:
       value: 18640
     2021-07-16:
+      value: 18640
+    2022-07-18:
       value: 18640
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
+      value: 4
+    2022-07-18:
       value: 4
   amount:
     2020-07-22:
       value: 20200
     2021-07-16:
+      value: 20200
+    2022-07-18:
       value: 20200
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
+      value: 5
+    2022-07-18:
       value: 5
   amount:
     2020-07-22:
       value: 21760
     2021-07-16:
+      value: 21760
+    2022-07-18:
       value: 21760
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
+      value: 6
+    2022-07-18:
       value: 6
   amount:
     2020-07-22:
       value: 23310
     2021-07-16:
+      value: 23310
+    2022-07-18:
       value: 23310
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
+      value: 7
+    2022-07-18:
       value: 7
   amount:
     2020-07-22:
       value: 24860
     2021-07-16:
+      value: 24860
+    2022-07-18:
       value: 24860
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
+      value: 8
+    2022-07-18:
       value: 8
   amount:
     2020-07-22:
       value: 26420
     2021-07-16:
+      value: 26420
+    2022-07-18:
       value: 26420
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
+      value: 9
+    2022-07-18:
       value: 9
   amount:
     2020-07-22:
       value: 27970
     2021-07-16:
+      value: 27970
+    2022-07-18:
       value: 27970
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
+      value: 10
+    2022-07-18:
       value: 10
   amount:
     2020-07-22:
       value: 29520
     2021-07-16:
+      value: 29520
+    2022-07-18:
       value: 29520
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
+      value: 11
+    2022-07-18:
       value: 11
   amount:
     2020-07-22:
       value: 31090
     2021-07-16:
+      value: 31090
+    2022-07-18:
       value: 31090
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
+      value: 12
+    2022-07-18:
       value: 12
   amount:
     2020-07-22:
       value: 32630
     2021-07-16:
+      value: 32630
+    2022-07-18:
       value: 32630
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
+      value: 13
+    2022-07-18:
       value: 13
   amount:
     2020-07-22:
       value: 34180
     2021-07-16:
+      value: 34180
+    2022-07-18:
       value: 34180
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
+      value: 14
+    2022-07-18:
       value: 14
   amount:
     2020-07-22:
       value: 35750
     2021-07-16:
+      value: 35750
+    2022-07-18:
       value: 35750
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
+      value: 15
+    2022-07-18:
       value: 15
   amount:
     2020-07-22:
       value: 37300
     2021-07-16:
+      value: 37300
+    2022-07-18:
       value: 37300
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
+      value: 16
+    2022-07-18:
       value: 16
   amount:
     2020-07-22:
       value: 38840
     2021-07-16:
+      value: 38840
+    2022-07-18:
       value: 38840
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
+      value: 17
+    2022-07-18:
       value: 17
   amount:
     2020-07-22:
       value: 40400
     2021-07-16:
+      value: 40400
+    2022-07-18:
       value: 40400
 metadata:
   reference:
@@ -188,4 +260,7 @@ metadata:
     2021-07-16:
     - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
+    2022-07-18:
+    - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
@@ -111,6 +111,6 @@ brackets:
 metadata:
   reference:
     2020-07-22:
-    - title: Arrêté du 22 juillet 2020 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
-    - href: https://www.legifrance.gouv.fr/eli/arrete/2020/7/22/ESRS2015874A/jo/texte
+    - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
@@ -3,114 +3,189 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
+    2021-07-16:
+      value: 0
   amount:
     2020-07-22:
+      value: 13990
+    2021-07-16:
       value: 13990
 - threshold:
     2020-07-22:
       value: 1
+    2021-07-16:
+      value: 1
   amount:
     2020-07-22:
+      value: 15540
+    2021-07-16:
       value: 15540
 - threshold:
     2020-07-22:
       value: 2
+    2021-07-16:
+      value: 2
   amount:
     2020-07-22:
+      value: 17100
+    2021-07-16:
       value: 17100
 - threshold:
     2020-07-22:
       value: 3
+    2021-07-16:
+      value: 3
   amount:
     2020-07-22:
+      value: 18640
+    2021-07-16:
       value: 18640
 - threshold:
     2020-07-22:
       value: 4
+    2021-07-16:
+      value: 4
   amount:
     2020-07-22:
+      value: 20200
+    2021-07-16:
       value: 20200
 - threshold:
     2020-07-22:
       value: 5
+    2021-07-16:
+      value: 5
   amount:
     2020-07-22:
+      value: 21760
+    2021-07-16:
       value: 21760
 - threshold:
     2020-07-22:
       value: 6
+    2021-07-16:
+      value: 6
   amount:
     2020-07-22:
+      value: 23310
+    2021-07-16:
       value: 23310
 - threshold:
     2020-07-22:
       value: 7
+    2021-07-16:
+      value: 7
   amount:
     2020-07-22:
+      value: 24860
+    2021-07-16:
       value: 24860
 - threshold:
     2020-07-22:
       value: 8
+    2021-07-16:
+      value: 8
   amount:
     2020-07-22:
+      value: 26420
+    2021-07-16:
       value: 26420
 - threshold:
     2020-07-22:
       value: 9
+    2021-07-16:
+      value: 9
   amount:
     2020-07-22:
+      value: 27970
+    2021-07-16:
       value: 27970
 - threshold:
     2020-07-22:
       value: 10
+    2021-07-16:
+      value: 10
   amount:
     2020-07-22:
+      value: 29520
+    2021-07-16:
       value: 29520
 - threshold:
     2020-07-22:
       value: 11
+    2021-07-16:
+      value: 11
   amount:
     2020-07-22:
+      value: 31090
+    2021-07-16:
       value: 31090
 - threshold:
     2020-07-22:
       value: 12
+    2021-07-16:
+      value: 12
   amount:
     2020-07-22:
+      value: 32630
+    2021-07-16:
       value: 32630
 - threshold:
     2020-07-22:
       value: 13
+    2021-07-16:
+      value: 13
   amount:
     2020-07-22:
+      value: 34180
+    2021-07-16:
       value: 34180
 - threshold:
     2020-07-22:
       value: 14
+    2021-07-16:
+      value: 14
   amount:
     2020-07-22:
+      value: 35750
+    2021-07-16:
       value: 35750
 - threshold:
     2020-07-22:
       value: 15
+    2021-07-16:
+      value: 15
   amount:
     2020-07-22:
+      value: 37300
+    2021-07-16:
       value: 37300
 - threshold:
     2020-07-22:
       value: 16
+    2021-07-16:
+      value: 16
   amount:
     2020-07-22:
+      value: 38840
+    2021-07-16:
       value: 38840
 - threshold:
     2020-07-22:
       value: 17
+    2021-07-16:
+      value: 17
   amount:
     2020-07-22:
+      value: 40400
+    2021-07-16:
       value: 40400
 metadata:
   reference:
     2020-07-22:
     - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
+    2021-07-16:
+    - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
@@ -5,180 +5,252 @@ brackets:
       value: 0
     2021-07-16:
       value: 0
+    2022-07-18:
+      value: 0
   amount:
     2020-07-22:
       value: 11950
     2021-07-16:
+      value: 11950
+    2022-07-18:
       value: 11950
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
+    2022-07-18:
+      value: 1
   amount:
     2020-07-22:
       value: 13280
     2021-07-16:
+      value: 13280
+    2022-07-18:
       value: 13280
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
+      value: 2
+    2022-07-18:
       value: 2
   amount:
     2020-07-22:
       value: 14600
     2021-07-16:
+      value: 14600
+    2022-07-18:
       value: 14600
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
+      value: 3
+    2022-07-18:
       value: 3
   amount:
     2020-07-22:
       value: 15920
     2021-07-16:
+      value: 15920
+    2022-07-18:
       value: 15920
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
+      value: 4
+    2022-07-18:
       value: 4
   amount:
     2020-07-22:
       value: 17250
     2021-07-16:
+      value: 17250
+    2022-07-18:
       value: 17250
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
+      value: 5
+    2022-07-18:
       value: 5
   amount:
     2020-07-22:
       value: 18580
     2021-07-16:
+      value: 18580
+    2022-07-18:
       value: 18580
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
+      value: 6
+    2022-07-18:
       value: 6
   amount:
     2020-07-22:
       value: 19910
     2021-07-16:
+      value: 19910
+    2022-07-18:
       value: 19910
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
+      value: 7
+    2022-07-18:
       value: 7
   amount:
     2020-07-22:
       value: 21240
     2021-07-16:
+      value: 21240
+    2022-07-18:
       value: 21240
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
+      value: 8
+    2022-07-18:
       value: 8
   amount:
     2020-07-22:
       value: 22560
     2021-07-16:
+      value: 22560
+    2022-07-18:
       value: 22560
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
+      value: 9
+    2022-07-18:
       value: 9
   amount:
     2020-07-22:
       value: 23890
     2021-07-16:
+      value: 23890
+    2022-07-18:
       value: 23890
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
+      value: 10
+    2022-07-18:
       value: 10
   amount:
     2020-07-22:
       value: 25220
     2021-07-16:
+      value: 25220
+    2022-07-18:
       value: 25220
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
+      value: 11
+    2022-07-18:
       value: 11
   amount:
     2020-07-22:
       value: 26540
     2021-07-16:
+      value: 26540
+    2022-07-18:
       value: 26540
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
+      value: 12
+    2022-07-18:
       value: 12
   amount:
     2020-07-22:
       value: 27870
     2021-07-16:
+      value: 27870
+    2022-07-18:
       value: 27870
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
+      value: 13
+    2022-07-18:
       value: 13
   amount:
     2020-07-22:
       value: 29200
     2021-07-16:
+      value: 29200
+    2022-07-18:
       value: 29200
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
+      value: 14
+    2022-07-18:
       value: 14
   amount:
     2020-07-22:
       value: 30530
     2021-07-16:
+      value: 30530
+    2022-07-18:
       value: 30530
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
+      value: 15
+    2022-07-18:
       value: 15
   amount:
     2020-07-22:
       value: 31860
     2021-07-16:
+      value: 31860
+    2022-07-18:
       value: 31860
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
+      value: 16
+    2022-07-18:
       value: 16
   amount:
     2020-07-22:
       value: 33190
     2021-07-16:
+      value: 33190
+    2022-07-18:
       value: 33190
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
+      value: 17
+    2022-07-18:
       value: 17
   amount:
     2020-07-22:
       value: 34510
     2021-07-16:
+      value: 34510
+    2022-07-18:
       value: 34510
 metadata:
   reference:
@@ -188,4 +260,7 @@ metadata:
     2021-07-16:
     - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
+    2022-07-18:
+    - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
@@ -3,114 +3,189 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
+    2021-07-16:
+      value: 0
   amount:
     2020-07-22:
+      value: 11950
+    2021-07-16:
       value: 11950
 - threshold:
     2020-07-22:
       value: 1
+    2021-07-16:
+      value: 1
   amount:
     2020-07-22:
+      value: 13280
+    2021-07-16:
       value: 13280
 - threshold:
     2020-07-22:
       value: 2
+    2021-07-16:
+      value: 2
   amount:
     2020-07-22:
+      value: 14600
+    2021-07-16:
       value: 14600
 - threshold:
     2020-07-22:
       value: 3
+    2021-07-16:
+      value: 3
   amount:
     2020-07-22:
+      value: 15920
+    2021-07-16:
       value: 15920
 - threshold:
     2020-07-22:
       value: 4
+    2021-07-16:
+      value: 4
   amount:
     2020-07-22:
+      value: 17250
+    2021-07-16:
       value: 17250
 - threshold:
     2020-07-22:
       value: 5
+    2021-07-16:
+      value: 5
   amount:
     2020-07-22:
+      value: 18580
+    2021-07-16:
       value: 18580
 - threshold:
     2020-07-22:
       value: 6
+    2021-07-16:
+      value: 6
   amount:
     2020-07-22:
+      value: 19910
+    2021-07-16:
       value: 19910
 - threshold:
     2020-07-22:
       value: 7
+    2021-07-16:
+      value: 7
   amount:
     2020-07-22:
+      value: 21240
+    2021-07-16:
       value: 21240
 - threshold:
     2020-07-22:
       value: 8
+    2021-07-16:
+      value: 8
   amount:
     2020-07-22:
+      value: 22560
+    2021-07-16:
       value: 22560
 - threshold:
     2020-07-22:
       value: 9
+    2021-07-16:
+      value: 9
   amount:
     2020-07-22:
+      value: 23890
+    2021-07-16:
       value: 23890
 - threshold:
     2020-07-22:
       value: 10
+    2021-07-16:
+      value: 10
   amount:
     2020-07-22:
+      value: 25220
+    2021-07-16:
       value: 25220
 - threshold:
     2020-07-22:
       value: 11
+    2021-07-16:
+      value: 11
   amount:
     2020-07-22:
+      value: 26540
+    2021-07-16:
       value: 26540
 - threshold:
     2020-07-22:
       value: 12
+    2021-07-16:
+      value: 12
   amount:
     2020-07-22:
+      value: 27870
+    2021-07-16:
       value: 27870
 - threshold:
     2020-07-22:
       value: 13
+    2021-07-16:
+      value: 13
   amount:
     2020-07-22:
+      value: 29200
+    2021-07-16:
       value: 29200
 - threshold:
     2020-07-22:
       value: 14
+    2021-07-16:
+      value: 14
   amount:
     2020-07-22:
+      value: 30530
+    2021-07-16:
       value: 30530
 - threshold:
     2020-07-22:
       value: 15
+    2021-07-16:
+      value: 15
   amount:
     2020-07-22:
+      value: 31860
+    2021-07-16:
       value: 31860
 - threshold:
     2020-07-22:
       value: 16
+    2021-07-16:
+      value: 16
   amount:
     2020-07-22:
+      value: 33190
+    2021-07-16:
       value: 33190
 - threshold:
     2020-07-22:
       value: 17
+    2021-07-16:
+      value: 17
   amount:
     2020-07-22:
+      value: 34510
+    2021-07-16:
       value: 34510
 metadata:
   reference:
     2020-07-22:
     - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
+    2021-07-16:
+    - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
@@ -111,6 +111,6 @@ brackets:
 metadata:
   reference:
     2020-07-22:
-    - title: Arrêté du 22 juillet 2020 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
-    - href: https://www.legifrance.gouv.fr/eli/arrete/2020/7/22/ESRS2015874A/jo/texte
+    - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
@@ -5,180 +5,252 @@ brackets:
       value: 0
     2021-07-16:
       value: 0
+    2022-07-18:
+      value: 0
   amount:
     2020-07-22:
       value: 7540
     2021-07-16:
+      value: 7540
+    2022-07-18:
       value: 7540
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
+    2022-07-18:
+      value: 1
   amount:
     2020-07-22:
       value: 8370
     2021-07-16:
+      value: 8370
+    2022-07-18:
       value: 8370
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
+      value: 2
+    2022-07-18:
       value: 2
   amount:
     2020-07-22:
       value: 9220
     2021-07-16:
+      value: 9220
+    2022-07-18:
       value: 9220
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
+      value: 3
+    2022-07-18:
       value: 3
   amount:
     2020-07-22:
       value: 10050
     2021-07-16:
+      value: 10050
+    2022-07-18:
       value: 10050
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
+      value: 4
+    2022-07-18:
       value: 4
   amount:
     2020-07-22:
       value: 10880
     2021-07-16:
+      value: 10880
+    2022-07-18:
       value: 10880
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
+      value: 5
+    2022-07-18:
       value: 5
   amount:
     2020-07-22:
       value: 11730
     2021-07-16:
+      value: 11730
+    2022-07-18:
       value: 11730
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
+      value: 6
+    2022-07-18:
       value: 6
   amount:
     2020-07-22:
       value: 12570
     2021-07-16:
+      value: 12570
+    2022-07-18:
       value: 12570
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
+      value: 7
+    2022-07-18:
       value: 7
   amount:
     2020-07-22:
       value: 13410
     2021-07-16:
+      value: 13410
+    2022-07-18:
       value: 13410
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
+      value: 8
+    2022-07-18:
       value: 8
   amount:
     2020-07-22:
       value: 14240
     2021-07-16:
+      value: 14240
+    2022-07-18:
       value: 14240
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
+      value: 9
+    2022-07-18:
       value: 9
   amount:
     2020-07-22:
       value: 15080
     2021-07-16:
+      value: 15080
+    2022-07-18:
       value: 15080
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
+      value: 10
+    2022-07-18:
       value: 10
   amount:
     2020-07-22:
       value: 15910
     2021-07-16:
+      value: 15910
+    2022-07-18:
       value: 15910
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
+      value: 11
+    2022-07-18:
       value: 11
   amount:
     2020-07-22:
       value: 16750
     2021-07-16:
+      value: 16750
+    2022-07-18:
       value: 16750
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
+      value: 12
+    2022-07-18:
       value: 12
   amount:
     2020-07-22:
       value: 17590
     2021-07-16:
+      value: 17590
+    2022-07-18:
       value: 17590
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
+      value: 13
+    2022-07-18:
       value: 13
   amount:
     2020-07-22:
       value: 18420
     2021-07-16:
+      value: 18420
+    2022-07-18:
       value: 18420
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
+      value: 14
+    2022-07-18:
       value: 14
   amount:
     2020-07-22:
       value: 19270
     2021-07-16:
+      value: 19270
+    2022-07-18:
       value: 19270
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
+      value: 15
+    2022-07-18:
       value: 15
   amount:
     2020-07-22:
       value: 20110
     2021-07-16:
+      value: 20110
+    2022-07-18:
       value: 20110
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
+      value: 16
+    2022-07-18:
       value: 16
   amount:
     2020-07-22:
       value: 20940
     2021-07-16:
+      value: 20940
+    2022-07-18:
       value: 20940
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
+      value: 17
+    2022-07-18:
       value: 17
   amount:
     2020-07-22:
       value: 21780
     2021-07-16:
+      value: 21780
+    2022-07-18:
       value: 21780
 metadata:
   reference:
@@ -188,4 +260,7 @@ metadata:
     2021-07-16:
     - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
+    2022-07-18:
+    - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
@@ -3,114 +3,189 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
+    2021-07-16:
+      value: 0
   amount:
     2020-07-22:
+      value: 7540
+    2021-07-16:
       value: 7540
 - threshold:
     2020-07-22:
       value: 1
+    2021-07-16:
+      value: 1
   amount:
     2020-07-22:
+      value: 8370
+    2021-07-16:
       value: 8370
 - threshold:
     2020-07-22:
       value: 2
+    2021-07-16:
+      value: 2
   amount:
     2020-07-22:
+      value: 9220
+    2021-07-16:
       value: 9220
 - threshold:
     2020-07-22:
       value: 3
+    2021-07-16:
+      value: 3
   amount:
     2020-07-22:
+      value: 10050
+    2021-07-16:
       value: 10050
 - threshold:
     2020-07-22:
       value: 4
+    2021-07-16:
+      value: 4
   amount:
     2020-07-22:
+      value: 10880
+    2021-07-16:
       value: 10880
 - threshold:
     2020-07-22:
       value: 5
+    2021-07-16:
+      value: 5
   amount:
     2020-07-22:
+      value: 11730
+    2021-07-16:
       value: 11730
 - threshold:
     2020-07-22:
       value: 6
+    2021-07-16:
+      value: 6
   amount:
     2020-07-22:
+      value: 12570
+    2021-07-16:
       value: 12570
 - threshold:
     2020-07-22:
       value: 7
+    2021-07-16:
+      value: 7
   amount:
     2020-07-22:
+      value: 13410
+    2021-07-16:
       value: 13410
 - threshold:
     2020-07-22:
       value: 8
+    2021-07-16:
+      value: 8
   amount:
     2020-07-22:
+      value: 14240
+    2021-07-16:
       value: 14240
 - threshold:
     2020-07-22:
       value: 9
+    2021-07-16:
+      value: 9
   amount:
     2020-07-22:
+      value: 15080
+    2021-07-16:
       value: 15080
 - threshold:
     2020-07-22:
       value: 10
+    2021-07-16:
+      value: 10
   amount:
     2020-07-22:
+      value: 15910
+    2021-07-16:
       value: 15910
 - threshold:
     2020-07-22:
       value: 11
+    2021-07-16:
+      value: 11
   amount:
     2020-07-22:
+      value: 16750
+    2021-07-16:
       value: 16750
 - threshold:
     2020-07-22:
       value: 12
+    2021-07-16:
+      value: 12
   amount:
     2020-07-22:
+      value: 17590
+    2021-07-16:
       value: 17590
 - threshold:
     2020-07-22:
       value: 13
+    2021-07-16:
+      value: 13
   amount:
     2020-07-22:
+      value: 18420
+    2021-07-16:
       value: 18420
 - threshold:
     2020-07-22:
       value: 14
+    2021-07-16:
+      value: 14
   amount:
     2020-07-22:
+      value: 19270
+    2021-07-16:
       value: 19270
 - threshold:
     2020-07-22:
       value: 15
+    2021-07-16:
+      value: 15
   amount:
     2020-07-22:
+      value: 20110
+    2021-07-16:
       value: 20110
 - threshold:
     2020-07-22:
       value: 16
+    2021-07-16:
+      value: 16
   amount:
     2020-07-22:
+      value: 20940
+    2021-07-16:
       value: 20940
 - threshold:
     2020-07-22:
       value: 17
+    2021-07-16:
+      value: 17
   amount:
     2020-07-22:
+      value: 21780
+    2021-07-16:
       value: 21780
 metadata:
   reference:
     2020-07-22:
     - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
+    2021-07-16:
+    - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
@@ -111,6 +111,6 @@ brackets:
 metadata:
   reference:
     2020-07-22:
-    - title: Arrêté du 22 juillet 2020 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
-    - href: https://www.legifrance.gouv.fr/eli/arrete/2020/7/22/ESRS2015874A/jo/texte
+    - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
@@ -111,6 +111,6 @@ brackets:
 metadata:
   reference:
     2020-07-22:
-    - title: Arrêté du 22 juillet 2020 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
-    - href: https://www.legifrance.gouv.fr/eli/arrete/2020/7/22/ESRS2015874A/jo/texte
+    - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
@@ -5,180 +5,252 @@ brackets:
       value: 0
     2021-07-16:
       value: 0
+    2022-07-18:
+      value: 0
   amount:
     2020-07-22:
       value: 250
     2021-07-16:
+      value: 250
+    2022-07-18:
       value: 250
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
+    2022-07-18:
+      value: 1
   amount:
     2020-07-22:
       value: 500
     2021-07-16:
+      value: 500
+    2022-07-18:
       value: 500
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
+      value: 2
+    2022-07-18:
       value: 2
   amount:
     2020-07-22:
       value: 750
     2021-07-16:
+      value: 750
+    2022-07-18:
       value: 750
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
+      value: 3
+    2022-07-18:
       value: 3
   amount:
     2020-07-22:
       value: 1000
     2021-07-16:
+      value: 1000
+    2022-07-18:
       value: 1000
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
+      value: 4
+    2022-07-18:
       value: 4
   amount:
     2020-07-22:
       value: 1250
     2021-07-16:
+      value: 1250
+    2022-07-18:
       value: 1250
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
+      value: 5
+    2022-07-18:
       value: 5
   amount:
     2020-07-22:
       value: 1500
     2021-07-16:
+      value: 1500
+    2022-07-18:
       value: 1500
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
+      value: 6
+    2022-07-18:
       value: 6
   amount:
     2020-07-22:
       value: 1750
     2021-07-16:
+      value: 1750
+    2022-07-18:
       value: 1750
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
+      value: 7
+    2022-07-18:
       value: 7
   amount:
     2020-07-22:
       value: 2000
     2021-07-16:
+      value: 2000
+    2022-07-18:
       value: 2000
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
+      value: 8
+    2022-07-18:
       value: 8
   amount:
     2020-07-22:
       value: 2250
     2021-07-16:
+      value: 2250
+    2022-07-18:
       value: 2250
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
+      value: 9
+    2022-07-18:
       value: 9
   amount:
     2020-07-22:
       value: 2500
     2021-07-16:
+      value: 2500
+    2022-07-18:
       value: 2500
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
+      value: 10
+    2022-07-18:
       value: 10
   amount:
     2020-07-22:
       value: 2750
     2021-07-16:
+      value: 2750
+    2022-07-18:
       value: 2750
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
+      value: 11
+    2022-07-18:
       value: 11
   amount:
     2020-07-22:
       value: 3000
     2021-07-16:
+      value: 3000
+    2022-07-18:
       value: 3000
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
+      value: 12
+    2022-07-18:
       value: 12
   amount:
     2020-07-22:
       value: 3250
     2021-07-16:
+      value: 3250
+    2022-07-18:
       value: 3250
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
+      value: 13
+    2022-07-18:
       value: 13
   amount:
     2020-07-22:
       value: 3500
     2021-07-16:
+      value: 3500
+    2022-07-18:
       value: 3500
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
+      value: 14
+    2022-07-18:
       value: 14
   amount:
     2020-07-22:
       value: 3750
     2021-07-16:
+      value: 3750
+    2022-07-18:
       value: 3750
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
+      value: 15
+    2022-07-18:
       value: 15
   amount:
     2020-07-22:
       value: 4000
     2021-07-16:
+      value: 4000
+    2022-07-18:
       value: 4000
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
+      value: 16
+    2022-07-18:
       value: 16
   amount:
     2020-07-22:
       value: 4250
     2021-07-16:
+      value: 4250
+    2022-07-18:
       value: 4250
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
+      value: 17
+    2022-07-18:
       value: 17
   amount:
     2020-07-22:
       value: 4500
     2021-07-16:
+      value: 4500
+    2022-07-18:
       value: 4500
 metadata:
   reference:
@@ -188,4 +260,7 @@ metadata:
     2021-07-16:
     - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
+    2022-07-18:
+    - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
@@ -3,114 +3,189 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
+    2021-07-16:
+      value: 0
   amount:
     2020-07-22:
+      value: 250
+    2021-07-16:
       value: 250
 - threshold:
     2020-07-22:
       value: 1
+    2021-07-16:
+      value: 1
   amount:
     2020-07-22:
+      value: 500
+    2021-07-16:
       value: 500
 - threshold:
     2020-07-22:
       value: 2
+    2021-07-16:
+      value: 2
   amount:
     2020-07-22:
+      value: 750
+    2021-07-16:
       value: 750
 - threshold:
     2020-07-22:
       value: 3
+    2021-07-16:
+      value: 3
   amount:
     2020-07-22:
+      value: 1000
+    2021-07-16:
       value: 1000
 - threshold:
     2020-07-22:
       value: 4
+    2021-07-16:
+      value: 4
   amount:
     2020-07-22:
+      value: 1250
+    2021-07-16:
       value: 1250
 - threshold:
     2020-07-22:
       value: 5
+    2021-07-16:
+      value: 5
   amount:
     2020-07-22:
+      value: 1500
+    2021-07-16:
       value: 1500
 - threshold:
     2020-07-22:
       value: 6
+    2021-07-16:
+      value: 6
   amount:
     2020-07-22:
+      value: 1750
+    2021-07-16:
       value: 1750
 - threshold:
     2020-07-22:
       value: 7
+    2021-07-16:
+      value: 7
   amount:
     2020-07-22:
+      value: 2000
+    2021-07-16:
       value: 2000
 - threshold:
     2020-07-22:
       value: 8
+    2021-07-16:
+      value: 8
   amount:
     2020-07-22:
+      value: 2250
+    2021-07-16:
       value: 2250
 - threshold:
     2020-07-22:
       value: 9
+    2021-07-16:
+      value: 9
   amount:
     2020-07-22:
+      value: 2500
+    2021-07-16:
       value: 2500
 - threshold:
     2020-07-22:
       value: 10
+    2021-07-16:
+      value: 10
   amount:
     2020-07-22:
+      value: 2750
+    2021-07-16:
       value: 2750
 - threshold:
     2020-07-22:
       value: 11
+    2021-07-16:
+      value: 11
   amount:
     2020-07-22:
+      value: 3000
+    2021-07-16:
       value: 3000
 - threshold:
     2020-07-22:
       value: 12
+    2021-07-16:
+      value: 12
   amount:
     2020-07-22:
+      value: 3250
+    2021-07-16:
       value: 3250
 - threshold:
     2020-07-22:
       value: 13
+    2021-07-16:
+      value: 13
   amount:
     2020-07-22:
+      value: 3500
+    2021-07-16:
       value: 3500
 - threshold:
     2020-07-22:
       value: 14
+    2021-07-16:
+      value: 14
   amount:
     2020-07-22:
+      value: 3750
+    2021-07-16:
       value: 3750
 - threshold:
     2020-07-22:
       value: 15
+    2021-07-16:
+      value: 15
   amount:
     2020-07-22:
+      value: 4000
+    2021-07-16:
       value: 4000
 - threshold:
     2020-07-22:
       value: 16
+    2021-07-16:
+      value: 16
   amount:
     2020-07-22:
+      value: 4250
+    2021-07-16:
       value: 4250
 - threshold:
     2020-07-22:
       value: 17
+    2021-07-16:
+      value: 17
   amount:
     2020-07-22:
+      value: 4500
+    2021-07-16:
       value: 4500
 metadata:
   reference:
     2020-07-22:
     - title: Arrêté du 22 juillet 2020 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2020-2021
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042170756
+    2021-07-16:
+    - title: Arrêté du 16 juillet 2021 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur, de la recherche et de l'innovation pour l'année universitaire 2021-2022
+    - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043868508
   type: single_amount

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '143.0.1',
+    version = '143.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal..
* Périodes concernées : à partir du 27/07/2021
* Zones impactées : 
  - `openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux
/montants.yaml`.
  - `openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_*.yaml
* Détails :
  - Revalorisation du 18 juillet 2022 fixant les plafonds et montants de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour les années universitaire 2021-2022 et 2022-2023

- - - -

Ces changements:

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
