### PR TITLE
corrige typo cerfa field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 143.0.3 [#2035](https://github.com/openfisca/openfisca-france/pull/2035)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py`.
+* Détails :
+  - Corrige un CERFA field qui a malencontreusement sauté.
+
 ### 143.0.2 [#2027](https://github.com/openfisca/openfisca-france/pull/2027)
 
 * Évolution du système socio-fiscal..
@@ -10,12 +18,6 @@
   - `openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_*.yaml`
 * Détails :
   - Revalorisation du 18 juillet 2022 fixant les plafonds et montants de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour les années universitaire 2021-2022 et 2022-2023
-
-- - - -
-
-Ces changements:
-
-- Corrigent ou améliorent un calcul déjà existant.
 
 ### 143.0.1 [#2034](https://github.com/openfisca/openfisca-france/pull/2034)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -10475,6 +10475,7 @@ class f7ob(Variable):
 
 
 class f7oc(Variable):
+    cerfa_field = '7OC'
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '143.0.2',
+    version = '143.0.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py`.
* Détails :
  - Corrige un CERFA field qui a malencontreusement sauté.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

@benoit-cty @lukas-puschnig @clallemand @NolwennLoisel 
est-ce que ça vous paraît corriger ce qu'il faut corriger d'après [#1996](https://github.com/openfisca/openfisca-france/issues/1996) ?