### PR TITLE
Typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,23 @@
 # Changelog
 
+### 143.1.2 [#2042](https://github.com/openfisca/openfisca-france/pull/2042)
+
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées : `parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/apl/menage_0_personnes_a_charge.yaml`.
+* Détails :
+  - Correction d'une typo dans les références d'un fichier YAML
+
 ### 143.1.1 [#2030](https://github.com/openfisca/openfisca-france/pull/2029)
 
 * Changement mineur.
-* toutes.
+* Périodes concernées : toutes.
 * Zones impactées : parameters/prestations_sociales/aides_logement.
 * Détails :
    - Clarifie une partie des paramètres des aides personnalisées au logement
    - Ajoute des références (car il y en avait très peu)
 
-### 143.1.0 [#2030](https://github.com/openfisca/openfisca-france/pull/2030)
+## 143.1.0 [#2030](https://github.com/openfisca/openfisca-france/pull/2030)
 
 * Amélioration technique.
 * Périodes concernées : toutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 143.1.2 [#2042](https://github.com/openfisca/openfisca-france/pull/2042)
 
-* Correction d'un crash.
+* Changement mineur.
 * Périodes concernées : toutes.
 * Zones impactées : `parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/apl/menage_0_personnes_a_charge.yaml`.
 * Détails :

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/apl/menage_0_personnes_a_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/apl/menage_0_personnes_a_charge.yaml
@@ -10,4 +10,3 @@ metadata:
     2007-07-01:
     - title: Article D832-25, 2° du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878710/2019-09-01/
-      values:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '143.1.1',
+    version = '143.1.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/apl/menage_0_personnes_a_charge.yaml`.
* Détails :
  - Correction d'une typo dans les références d'un fichier YAML
