### PR TITLE
Msa fiab abattement aah fev 2023

### DIFF
--- a/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/abattement_cessation_activite.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/abattement_cessation_activite.yaml
@@ -1,0 +1,12 @@
+description: Taux d'abattement des revenus d'activité du bénéficiaire en cas de cessation d'activité pour bénéficier de l'Allocation aux adultes handicapés (AAH)
+values:
+  2011-01-01:
+    value: 0.3
+metadata:
+  ux_name: Taux d'abbatement (cessation d'activité)
+  description_en: Adult disability allowance (AAH)
+  ipp_csv_id: abbatement_cessation_activite
+  unit: /1
+  reference:
+    2011-05-20:
+      title: Circulaire n°2011-011 du 20/05/2011

--- a/tests/formulas/aah/aah.yaml
+++ b/tests/formulas/aah/aah.yaml
@@ -4,12 +4,17 @@
   absolute_error_margin: 1
   input:
     taux_incapacite: 0.9
-    age: 22  # eligible aah
+    age: 22 # eligible aah
     aah_base_ressources: 500 / 12
     en_couple: 0
     af_nbenf: 0
+    activite:
+      2018-05: 0
+      2018-04: 0
+      2018-03: 0
+      2018-02: 0
   output:
-    aah: 9100 / 12  # (9605,40 - 500)  / 12
+    aah: 9100 / 12 # (9605,40 - 500)  / 12
 
 - name: AAH niveau Individu - Eligible, en concubinage, sans enfants, ressources supérieures au plafond
   description: Montant AAH au niveau de l individu
@@ -17,19 +22,29 @@
   absolute_error_margin: 1
   input:
     taux_incapacite: 0.9
-    age: 33  # eligible aah
+    age: 33 # eligible aah
     aah_base_ressources: 15000 / 12
     en_couple: 1
     af_nbenf: 0
+    activite:
+      2018-05: 0
+      2018-04: 0
+      2018-03: 0
+      2018-02: 0
   output:
-    aah: 2846.88 / 12  # (743.62 * 24 (17846.88) - 12000)  / 12
+    aah: 2846.88 / 12 # (743.62 * 24 (17846.88) - 12000)  / 12
 
 - name: AAH Eligibilité personne seule sans revenus
   period: 2015-11
   absolute_error_margin: 1
   input:
     taux_incapacite: 0.9
-    age: 33  # eligible aah
+    age: 33 # eligible aah
+    activite:
+      2018-05: 4
+      2018-04: 4
+      2018-03: 4
+      2018-02: 4
   output:
     aah_base: 807.65
 
@@ -44,14 +59,26 @@
       parent1:
         age: 40
         taux_incapacite: 0.9
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
+
       parent2:
         age: 40
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
+
   output:
     af_nbenf: 0
     en_couple: 1
     aah_base:
-    - 807.65
-    - 0
+      - 807.65
+      - 0
 
 - name: AAH Eligibilité couple sans ressource avec enfant
   description: Montant AAH pour un couple avec enfant sans revenus
@@ -65,19 +92,33 @@
       parent1:
         age: 40
         taux_incapacite: 0.9
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
       parent2:
         age: 40
         taux_incapacite: 0.9
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
       enfant1:
         age: 12
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
   output:
     en_couple: 1
     af_nbenf: 1
     aah_base:
-    - 807.65
-    - 807.65
-    - 0
-
+      - 807.65
+      - 807.65
+      - 0
 
 - name: AAH Eligibilité couple sans ressource avec enfant
   description: Montant AAH pour un couple avec enfant sans revenus
@@ -91,17 +132,32 @@
       parent1:
         age: 40
         taux_incapacite: 0.9
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
       parent2:
         age: 40
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
       enfant1:
         age: 12
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
   output:
     en_couple: 1
     af_nbenf: 1
     aah_base:
-    - 807.65
-    - 0
-    - 0
+      - 807.65
+      - 0
+      - 0
 
 - name: AAH salarié célibataire (K.P.), moins de 30% du SMIC
   period: 2015-11
@@ -113,6 +169,11 @@
       2015-10: 400
       2015-09: 400
       2015-08: 400
+    activite:
+      2018-05: 0
+      2018-04: 0
+      2018-03: 0
+      2018-02: 0
   output:
     aah_base_ressources:
       2015-11: 80
@@ -124,6 +185,11 @@
   absolute_error_margin: 1
   input:
     taux_incapacite: 0.9
+    activite:
+      2018-05: 0
+      2018-04: 0
+      2018-03: 0
+      2018-02: 0
     salaire_imposable:
       2015-11: 1471
       2015-10: 1471
@@ -131,7 +197,7 @@
       2015-08: 1471
   output:
     aah_base_ressources:
-      2015-11: (0.3 * 1457) * 0.2 + (1471 - 0.3 * 1457) * 0.6 # = 8494, Abat. de 80% sur les 30% du SMIC + abat. de 40% sur le reste
+      2015-11: (0.3 * 1457) * 0.2 + (1471 - 0.3 * 1457) * 0.6 # = 8494, Abat. de 80% sur les 30% du SMIC + abat. de 00% sur le reste
     aah_base:
       2015-11: 99.89
 
@@ -142,6 +208,11 @@
     taux_incapacite: 0.9
     salaire_imposable:
       2013: 770
+    activite:
+      2018-05: 4
+      2018-04: 4
+      2018-03: 4
+      2018-02: 4
   output:
     aah_base_ressources:
       2015-11: 154 / 12
@@ -158,10 +229,20 @@
       parent1:
         age: 40
         taux_incapacite: 0.9
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
       parent2:
         age: 40
         salaire_imposable:
           2013: 1128.70 * 12
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
   output:
     aah_base_ressources:
       2015-11:
@@ -178,6 +259,11 @@
       parent1:
         age: 40
         taux_incapacite: 0.9
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2015-11: 1471
           2015-10: 1471
@@ -185,6 +271,11 @@
           2015-08: 1471
       parent2:
         age: 40
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2015-11: 1000
           2015-10: 1000
@@ -214,6 +305,11 @@
     age: 50
     taux_incapacite: 0.55
     aah_restriction_substantielle_durable_acces_emploi: false
+    activite:
+      2018-05: 0
+      2018-04: 0
+      2018-03: 0
+      2018-02: 0
     salaire_imposable:
       2018-05: 2400
       2018-04: 1500
@@ -235,6 +331,11 @@
     age: 50
     taux_incapacite: 0.55
     aah_restriction_substantielle_durable_acces_emploi: true
+    activite:
+      2018-05: 0
+      2018-04: 0
+      2018-03: 0
+      2018-02: 0
     salaire_imposable:
       2018-05: 2400
       2018-04: 1500
@@ -256,13 +357,17 @@
     age: 50
     taux_incapacite: 0.55
     aah_restriction_substantielle_durable_acces_emploi: true
+    activite:
+      2018-05: 0
+      2018-04: 0
+      2018-03: 0
+      2018-02: 0
     salaire_imposable:
       2018-05: 2400
       2018-04: 1500
       2018-03: 1500
   output:
     aah: 398.81
-
 
 - name: "Revalorisation 01-04-2018, Cas Passant 2 : AAH personne de 42 ans avec un taux d'incapacité entre 50% et 79% et un revenu de 12500€ ainsi qu'1 enfant à charge"
   period: 2018-05
@@ -276,6 +381,11 @@
         age: 42
         taux_incapacite: 0.55
         aah_restriction_substantielle_durable_acces_emploi: true
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 2250
           2018-04: 2250
@@ -285,8 +395,14 @@
           2017-12: 2000
       enfant1:
         age: 15
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
   output:
     aah: [158.31, 0]
+
 - name: "Revalorisation 01-04-2018, Cas Passant 3 : AAH personne de 38 ans avec un taux d'incapacité supérieur à 80% et un revenu de 2500€ avec 1 personne de 36 ans avec un revenu de 19000€"
   period: 2018-05
   absolute_error_margin: 1
@@ -297,6 +413,11 @@
       parent1:
         age: 38
         taux_incapacite: 0.81
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 500
           2018-04: 500
@@ -305,6 +426,11 @@
           2018-01: 500
       parent2:
         age: 36
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 4000
           2018-04: 3000
@@ -325,6 +451,11 @@
       parent1:
         age: 38
         taux_incapacite: 0.55
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 2000
           2018-04: 2000
@@ -334,6 +465,11 @@
           2017-12: 2000
       parent2:
         age: 36
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 2000
           2018-04: 2000
@@ -343,6 +479,11 @@
           2017-12: 3000
       enfant1:
         age: 7
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
   output:
     aah: [0, 0, 0]
 - name: "Revalorisation 01-04-2018, Cas Passant 5 : AAH personne de 38 ans avec un taux d'incapacité entre 50% et 79% et un revenu de 12000€ avec 1 personne de 36 ans avec un revenu de 20000€ ainsi que deux enfants de 7 et 5 ans"
@@ -356,6 +497,11 @@
       parent1:
         age: 38
         taux_incapacite: 0.55
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 2000
           2018-04: 2000
@@ -365,6 +511,11 @@
           2017-12: 2000
       parent2:
         age: 36
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 4000
           2018-04: 4000
@@ -374,8 +525,18 @@
           2017-12: 3000
       enfant1:
         age: 7
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
       enfant2:
         age: 5
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
   output:
     aah: [0, 0, 0, 0]
 - name: "Revalorisation 01-04-2018, Cas Non Passant 1 : Non eligible AAH : personne seule de 50 ans avec un taux d'incapacité entre 50% et 79% et un revenu de 12000€"
@@ -384,6 +545,11 @@
   input:
     age: 50
     taux_incapacite: 0.55
+    activite:
+      2018-05: 0
+      2018-04: 0
+      2018-03: 0
+      2018-02: 0
     salaire_imposable:
       2018-05: 2000
       2018-04: 2000
@@ -400,6 +566,11 @@
   input:
     age: 50
     taux_incapacite: 0.55
+    activite:
+      2018-05: 0
+      2018-04: 0
+      2018-03: 0
+      2018-02: 0
     salaire_imposable:
       2018-05: 1000
       2018-04: 1300
@@ -423,6 +594,11 @@
       parent1:
         age: 42
         taux_incapacite: 0.55
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 4000
           2018-04: 4000
@@ -432,6 +608,11 @@
           2017-12: 3000
       enfant1:
         age: 15
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
   output:
     aah: 0
 
@@ -445,6 +626,11 @@
       parent1:
         age: 38
         taux_incapacite: 0.81
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 500
           2018-04: 500
@@ -452,6 +638,11 @@
           2018-02: 500
       parent2:
         age: 36
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 5000
           2018-04: 4000
@@ -473,6 +664,11 @@
       parent1:
         age: 38
         taux_incapacite: 0.55
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 3000
           2018-04: 3000
@@ -482,6 +678,11 @@
           2017-12: 2000
       parent2:
         age: 36
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 5000
           2018-04: 4000
@@ -491,6 +692,11 @@
           2017-12: 4000
       enfant1:
         age: 7
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
   output:
     aah: 0
 
@@ -505,6 +711,11 @@
       parent1:
         age: 38
         taux_incapacite: 0.55
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 4000
           2018-04: 4000
@@ -514,6 +725,11 @@
           2017-12: 3000
       parent2:
         age: 36
+        activite:
+          2018-05: 0
+          2018-04: 0
+          2018-03: 0
+          2018-02: 0
         salaire_imposable:
           2018-05: 5000
           2018-04: 5000
@@ -523,8 +739,18 @@
           2017-12: 5000
       enfant1:
         age: 7
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
       enfant2:
         age: 5
+        activite:
+          2018-05: 4
+          2018-04: 4
+          2018-03: 4
+          2018-02: 4
   output:
     aah: 0
 
@@ -538,6 +764,11 @@
       parent1:
         age: 40
         taux_incapacite: 0.9
+        activite:
+          2022-05: 0
+          2022-04: 0
+          2022-03: 0
+          2022-02: 0
         salaire_imposable:
           2022-05: 1471
           2022-04: 1471
@@ -546,6 +777,11 @@
           2022-01: 1471
       parent2:
         age: 40
+        activite:
+          2022-05: 0
+          2022-04: 0
+          2022-03: 0
+          2022-02: 0
         salaire_imposable:
           2022-05: 1000
           2022-04: 1000
@@ -573,6 +809,11 @@
       parent1:
         age: 40
         taux_incapacite: 0.9
+        activite:
+          2022-05: 0
+          2022-04: 0
+          2022-03: 0
+          2022-02: 0
         salaire_imposable:
           2022-05: 1471
           2022-04: 1471
@@ -581,6 +822,11 @@
           2022-01: 1471
       parent2:
         age: 40
+        activite:
+          2022-05: 0
+          2022-04: 0
+          2022-03: 0
+          2022-02: 0
         salaire_imposable:
           2022-05: 1000
           2022-04: 1000
@@ -589,6 +835,11 @@
           2022-01: 1000
       enfant1:
         age: 12
+        activite:
+          2022-05: 4
+          2022-04: 4
+          2022-03: 4
+          2022-02: 4
   output:
     aah_base_ressources_activite_eval_trimestrielle:
       2022-05: [17652, 12000, 0]

--- a/tests/formulas/aah/aah_cessation_activite.yaml
+++ b/tests/formulas/aah/aah_cessation_activite.yaml
@@ -1,0 +1,61 @@
+- name: AAH niveau Individu - Eligible car cessation d'activité, célibataire, sans enfants
+  description: Montant AAH au niveau de l individu
+  period: 2023-03
+  absolute_error_margin: 1
+  input:
+    taux_incapacite: 0.8
+    age: 50  # eligible aah
+    salaire_imposable: 
+      2023-03: 2000 
+      2023-02: 2000 
+      2023-01: 2000
+      2022-12: 2000
+      2022-11: 2000
+      2022-10: 2000
+      2022-9: 2000
+      2022-8: 2000
+      2022-7: 2000
+      2022-6: 2000
+      2022-5: 2000
+      2022-4: 2000
+      2022-3: 2000
+    en_couple: 0
+    af_nbenf: 0
+    activite: 
+      2023-03: 1
+      2023-02: 0 
+      2023-01: 0 
+      2022-12: 0 
+  output:
+    aah: 260 
+
+- name: AAH niveau Individu - Eligible, célibataire, sans enfants
+  description: Montant AAH au niveau de l individu
+  period: 2023-03
+  absolute_error_margin: 1
+  input:
+    taux_incapacite: 0.8
+    age: 50  # eligible aah
+    salaire_imposable: 
+      2023-03: 1502 
+      2023-02: 1502 
+      2023-01: 1502
+      2022-12: 1502
+      2022-11: 1502
+      2022-10: 1502
+      2022-9: 1502
+      2022-8: 1502
+      2022-7: 1502
+      2022-6: 1502
+      2022-5: 1502
+      2022-4: 1502
+      2022-3: 1502
+    en_couple: 0
+    af_nbenf: 0
+    activite: 
+      2023-03: 0
+      2023-02: 0 
+      2023-01: 0 
+      2022-12: 0 
+  output:
+    aah: 260

--- a/tests/formulas/aah/aah_couple.yaml
+++ b/tests/formulas/aah/aah_couple.yaml
@@ -10,23 +10,33 @@
     individus:
       parent1:
         aah_eligible: true
+        activite:
+          2018-11: 0
+          2018-10: 0
+          2018-09: 0
+          2018-08: 0
         aah_base_ressources: 16790.72 / 12
       parent2:
         aah_eligible: false
+        activite:
+          2018-11: 4
+          2018-10: 4
+          2018-09: 4
+          2018-08: 4
     foyers_fiscaux:
       foyer_fiscal_0:
         declarants:
-        - parent1
+          - parent1
       foyer_fiscal_1:
         declarants:
-        - parent2
+          - parent2
     menages:
       menage_0:
         personne_de_reference:
-        - parent1
+          - parent1
       menage_1:
         personne_de_reference:
-        - parent2
+          - parent2
   output:
     individus:
       parent1:
@@ -46,23 +56,33 @@
     individus:
       parent1:
         aah_eligible: true
+        activite:
+          2018-11: 0
+          2018-10: 0
+          2018-09: 0
+          2018-08: 0
         aah_base_ressources: 8777.70 / 12
       parent2:
         aah_eligible: false
+        activite:
+          2018-11: 4
+          2018-10: 4
+          2018-09: 4
+          2018-08: 4
     foyers_fiscaux:
       foyer_fiscal_0:
         declarants:
-        - parent1
+          - parent1
       foyer_fiscal_1:
         declarants:
-        - parent2
+          - parent2
     menages:
       menage_0:
         personne_de_reference:
-        - parent1
+          - parent1
       menage_1:
         personne_de_reference:
-        - parent2
+          - parent2
   output:
     individus:
       parent1:
@@ -82,23 +102,33 @@
     individus:
       parent1:
         aah_eligible: false
+        activite:
+          2018-11: 4
+          2018-10: 4
+          2018-09: 4
+          2018-08: 4
       parent2:
         aah_eligible: true
+        activite:
+          2018-11: 0
+          2018-10: 0
+          2018-09: 0
+          2018-08: 0
         aah_base_ressources: 12585.68 / 12
     foyers_fiscaux:
       foyer_fiscal_0:
         declarants:
-        - parent1
+          - parent1
       foyer_fiscal_1:
         declarants:
-        - parent2
+          - parent2
     menages:
       menage_0:
         personne_de_reference:
-        - parent1
+          - parent1
       menage_1:
         personne_de_reference:
-        - parent2
+          - parent2
   output:
     individus:
       parent1:
@@ -116,20 +146,30 @@
       parent1:
         salaire_imposable:
           2019: 12000
-      parent2: {}
+        activite:
+          2021-06: 4
+          2021-05: 4
+          2021-04: 4
+          2021-03: 4
+      parent2:
+        activite:
+          2021-06: 4
+          2021-05: 4
+          2021-04: 4
+          2021-03: 4
     foyers_fiscaux:
       foyer_fiscal_0:
         declarants:
-        - parent1
+          - parent1
       foyer_fiscal_1:
         declarants:
-        - parent2
+          - parent2
     menages:
       menage_0:
         personne_de_reference:
-        - parent1
+          - parent1
       menage_1:
         personne_de_reference:
-        - parent2
+          - parent2
   output:
     aah_base_ressources: [413.42, 720]

--- a/tests/formulas/aah/aah_eligible.yaml
+++ b/tests/formulas/aah/aah_eligible.yaml
@@ -4,6 +4,11 @@
   input:
     handicap: true
     taux_incapacite: 0.9
+    activite:
+      2015-01: 4
+      2014-12: 4
+      2014-11: 4
+      2014-10: 4
     age: 50
   output:
     aah_eligible: true
@@ -14,6 +19,11 @@
   input:
     age: 28
     handicap: true
+    activite:
+      2013-12: 4
+      2013-11: 4
+      2013-10: 4
+      2013-09: 4
     taux_incapacite: 0.9
   output:
     aah_eligible: true
@@ -25,10 +35,14 @@
     age: 19
     handicap: true
     taux_incapacite: 0.9
+    activite:
+      2012-06: 4
+      2012-05: 4
+      2012-04: 4
+      2012-03: 4
     autonomie_financiere: false
   output:
     aah_eligible: false
-
 
 - name: Eligibilité AAH -Handicap, âge inférieur à l'âge limite AEEH, autonomie financière vàv des prestations familiales
   description: Eligible à AAH
@@ -37,10 +51,14 @@
     age: 18
     handicap: true
     taux_incapacite: 0.9
+    activite:
+      2013-07: 4
+      2013-06: 4
+      2013-05: 4
+      2013-04: 4
     autonomie_financiere: true
   output:
     aah_eligible: true
-
 
 - name: "Ineligibilité à l'AAH: taux d'incapacité inférieur à 50%"
   description: Eligible à AAH
@@ -48,19 +66,29 @@
   input:
     age: 50
     handicap: true
+    activite:
+      2013-07: 4
+      2013-06: 4
+      2013-05: 4
+      2013-04: 4
     taux_incapacite: 0.4
   output:
     aah_eligible: false
 
 - name: "Ineligibilité à l'AAH: taux d'incapacité inférieur à 50% et
     une estriction substantielle et durable pour l'accès à l'emploi
-      reconnue par la commission des droits et
-      de l'autonomie des personnes handicapées"
+    reconnue par la commission des droits et
+    de l'autonomie des personnes handicapées"
   description: Eligible à AAH
   period: 2013-07
   input:
     age: 50
     handicap: true
+    activite:
+      2013-07: 4
+      2013-06: 4
+      2013-05: 4
+      2013-04: 4
     taux_incapacite: 0.4
     aah_restriction_substantielle_durable_acces_emploi: true
   output:
@@ -68,14 +96,19 @@
 
 - name: "Ineligibilité à l'AAH: taux d'incapacité supérieur à 50% et
     une estriction substantielle et durable pour l'accès à l'emploi
-      reconnue par la commission des droits et
-      de l'autonomie des personnes handicapées"
+    reconnue par la commission des droits et
+    de l'autonomie des personnes handicapées"
   description: Eligible à AAH
   period: 2013-07
   input:
     age: 50
     handicap: true
     taux_incapacite: 0.6
+    activite:
+      2013-07: 4
+      2013-06: 4
+      2013-05: 4
+      2013-04: 4
     aah_restriction_substantielle_durable_acces_emploi: true
   output:
     aah_eligible: true
@@ -86,6 +119,11 @@
   input:
     age: 50
     handicap: true
+    activite:
+      2013-07: 4
+      2013-06: 4
+      2013-05: 4
+      2013-04: 4
     taux_incapacite: 0.6
   output:
     aah_eligible: false

--- a/tests/formulas/aah/aah_famille.yaml
+++ b/tests/formulas/aah/aah_famille.yaml
@@ -11,13 +11,18 @@
       parent1:
         taux_incapacite: 0.9
         age: 50
+        activite:
+          2015-01: 0
+          2014-12: 0
+          2014-11: 0
+          2014-10: 0
         aah_base_ressources: 9700 / 12
     foyer_fiscal:
       declarants:
-      - parent1
+        - parent1
     menage:
       personne_de_reference:
-      - parent1
+        - parent1
   output:
     aah_base: 0
 
@@ -33,16 +38,21 @@
     individus:
       parent1:
         taux_incapacite: 0.9
+        activite:
+          2015-01: 4
+          2014-12: 4
+          2014-11: 4
+          2014-10: 4
         age: 27
         aah_base_ressources: 0
     foyer_fiscal:
       declarants:
-      - parent1
+        - parent1
     menage:
       personne_de_reference:
-      - parent1
+        - parent1
   output:
-    aah_base: 800.45  # l'aah taux plein
+    aah_base: 800.45 # l'aah taux plein
 
 - name: AAH niveau Famille - concubinage, sans enfants, un éligible (chef), ressources inférieures au plafond
   description: Montant AAH au niveau de la famille
@@ -56,23 +66,33 @@
     individus:
       parent1:
         aah_eligible: true
+        activite:
+          2013-03: 0
+          2013-02: 0
+          2013-01: 0
+          2012-12: 0
         aah_base_ressources: 15000 / 12
       parent2:
         aah_eligible: false
+        activite:
+          2013-03: 4
+          2013-02: 4
+          2013-01: 4
+          2012-12: 4
     foyers_fiscaux:
       foyer_fiscal_0:
         declarants:
-        - parent1
+          - parent1
       foyer_fiscal_1:
         declarants:
-        - parent2
+          - parent2
     menages:
       menage_0:
         personne_de_reference:
-        - parent1
+          - parent1
       menage_1:
         personne_de_reference:
-        - parent2
+          - parent2
   output:
     individus:
       parent1:
@@ -92,30 +112,40 @@
     individus:
       parent1:
         aah_eligible: true
+        activite:
+          2013-03: 0
+          2013-02: 0
+          2013-01: 0
+          2012-12: 0
         aah_base_ressources: 15000 / 12
       parent2:
         aah_eligible: true
+        activite:
+          2013-03: 0
+          2013-02: 0
+          2013-01: 0
+          2012-12: 0
         aah_base_ressources: 15000 / 12
     foyers_fiscaux:
       foyer_fiscal_0:
         declarants:
-        - parent1
+          - parent1
       foyer_fiscal_1:
         declarants:
-        - parent2
+          - parent2
     menages:
       menage_0:
         personne_de_reference:
-        - parent1
+          - parent1
       menage_1:
         personne_de_reference:
-        - parent2
+          - parent2
   output:
     individus:
       parent1:
         aah_base: 3638.16 / 12
       parent2:
-        aah_base: 3638.16 / 12  # (18638,16 - 15000) / 12   # il faut que ce soit ça, ou le double ??
+        aah_base: 3638.16 / 12 # (18638,16 - 15000) / 12   # il faut que ce soit ça, ou le double ??
 
 - name: AAH niveau Famille - concubinage, avec enfants, un seul éligible, ressources inférieures au plafond
   description: Montant AAH au niveau de la famille
@@ -129,23 +159,33 @@
     individus:
       parent1:
         aah_eligible: false
+        activite:
+          2013-10: 4
+          2013-09: 4
+          2013-08: 4
+          2013-07: 4
       parent2:
         aah_eligible: true
+        activite:
+          2013-10: 0
+          2013-09: 0
+          2013-08: 0
+          2013-07: 0
         aah_base_ressources: 20000 / 12
     foyers_fiscaux:
       foyer_fiscal_0:
         declarants:
-        - parent1
+          - parent1
       foyer_fiscal_1:
         declarants:
-        - parent2
+          - parent2
     menages:
       menage_0:
         personne_de_reference:
-        - parent1
+          - parent1
       menage_1:
         personne_de_reference:
-        - parent2
+          - parent2
   output:
     individus:
       parent1:
@@ -166,38 +206,58 @@
     individus:
       parent1:
         aah_eligible: false
+        activite:
+          2014-01: 4
+          2013-12: 4
+          2013-11: 4
+          2013-10: 4
       parent2:
         aah_eligible: false
+        activite:
+          2014-01: 4
+          2013-12: 4
+          2013-11: 4
+          2013-10: 4
       enfant1:
         aah_eligible: true
+        activite:
+          2014-01: 0
+          2013-12: 0
+          2013-11: 0
+          2013-10: 0
         aah_base_ressources: 25000 / 12
       enfant2:
         aah_eligible: false
+        activite:
+          2014-01: 4
+          2013-12: 4
+          2013-11: 4
+          2013-10: 4
     foyers_fiscaux:
       foyer_fiscal_0:
         declarants:
-        - parent1
+          - parent1
       foyer_fiscal_1:
         declarants:
-        - parent2
+          - parent2
       foyer_fiscal_2:
         declarants:
-        - enfant1
+          - enfant1
       foyer_fiscal_3:
         declarants:
-        - enfant2
+          - enfant2
     menages:
       menage_0:
         personne_de_reference:
-        - parent1
+          - parent1
       menage_1:
         personne_de_reference:
-        - parent2
+          - parent2
       menage_2:
         personne_de_reference:
-        - enfant1
+          - enfant1
       menage_3:
         personne_de_reference:
-        - enfant2
+          - enfant2
   output:
     aah_base: [0, 0, 287, 0] # xxxxx.xx (conucub + 2enf à charge, grille montants pre-Sept.2014) - 25000 / 12  = 3446.48 / 12


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées à partir du 01/01/2022.
* Zones impactées : `openfisca_france\model\prestations\minima_sociaux\aah.py`.
* Détails :
  - Ajout de l'abattement appliqué aux individus qui viennent de cesser une activité.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [ ] Documentez votre contribution avec des références législatives.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
