### PR TITLE
Revalorisation montants bourse criteres sociaux 2023-2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# 145.1.0 [#2068](https://github.com/openfisca/openfisca-france/pull/2068)
+
+* Évolution du système socio-fiscal : Changement mineur.
+* Périodes concernées : à partir du 15/03/2023 (En attente de publication legifrance)
+* Zones impactées :
+- `openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/*`.
+- `openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/montants.yaml`.
+* Détails :
+  - Revalorisation des plafonds et montants de la Bourse aux Critères Sociaux pour tous les échelons pour la periode 2023-2024.
+  - Les données nous viennent d'une correspondance avec le CNOUS, les dates et le sources seront éditées dès publication sur Legifrance.
+
 # 145.0.0 [#2039](https://github.com/openfisca/openfisca-france/pull/2039)
 
 * Amélioration technique.

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/montants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/montants.yaml
@@ -12,6 +12,8 @@ brackets:
       value: 104.2
     2022-07-18:
       value: 108.4
+    2023-09-01:
+      value: 145.4
 - threshold:
     2020-07-22:
       value: 1
@@ -24,6 +26,8 @@ brackets:
       value: 172.4
     2022-07-18:
       value: 179.3
+    2023-09-01:
+      value: 216.3
 - threshold:
     2020-07-22:
       value: 2
@@ -36,6 +40,8 @@ brackets:
       value: 259.7
     2022-07-18:
       value: 270.1
+    2023-09-01:
+      value: 307.1
 - threshold:
     2020-07-22:
       value: 3
@@ -48,6 +54,8 @@ brackets:
       value: 332.5
     2022-07-18:
       value: 345.8
+    2023-09-01:
+      value: 382.8
 - threshold:
     2020-07-22:
       value: 4
@@ -60,6 +68,8 @@ brackets:
       value: 405.5
     2022-07-18:
       value: 421.7
+    2023-09-01:
+      value: 458.7
 - threshold:
     2020-07-22:
       value: 5
@@ -72,6 +82,8 @@ brackets:
       value: 465.6
     2022-07-18:
       value: 484.2
+    2023-09-01:
+      value: 521.2
 - threshold:
     2020-07-22:
       value: 6
@@ -84,6 +96,8 @@ brackets:
       value: 493.8
     2022-07-18:
       value: 513.6
+    2023-09-01:
+      value: 550.6
 - threshold:
     2020-07-22:
       value: 7
@@ -96,6 +110,8 @@ brackets:
       value: 573.6
     2022-07-18:
       value: 596.5
+    2023-09-01:
+      value: 633.5
 metadata:
   short_label: Montants
   reference:
@@ -110,4 +126,6 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096018
+    2023-09-01:
+    - title : À renseigner dès que la publication officielle est disponible.
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/montants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/montants.yaml
@@ -12,7 +12,7 @@ brackets:
       value: 104.2
     2022-07-18:
       value: 108.4
-    2023-09-01:
+    2023-03-15:
       value: 145.4
 - threshold:
     2020-07-22:
@@ -26,7 +26,7 @@ brackets:
       value: 172.4
     2022-07-18:
       value: 179.3
-    2023-09-01:
+    2023-03-15:
       value: 216.3
 - threshold:
     2020-07-22:
@@ -40,7 +40,7 @@ brackets:
       value: 259.7
     2022-07-18:
       value: 270.1
-    2023-09-01:
+    2023-03-15:
       value: 307.1
 - threshold:
     2020-07-22:
@@ -54,7 +54,7 @@ brackets:
       value: 332.5
     2022-07-18:
       value: 345.8
-    2023-09-01:
+    2023-03-15:
       value: 382.8
 - threshold:
     2020-07-22:
@@ -68,7 +68,7 @@ brackets:
       value: 405.5
     2022-07-18:
       value: 421.7
-    2023-09-01:
+    2023-03-15:
       value: 458.7
 - threshold:
     2020-07-22:
@@ -82,7 +82,7 @@ brackets:
       value: 465.6
     2022-07-18:
       value: 484.2
-    2023-09-01:
+    2023-03-15:
       value: 521.2
 - threshold:
     2020-07-22:
@@ -96,7 +96,7 @@ brackets:
       value: 493.8
     2022-07-18:
       value: 513.6
-    2023-09-01:
+    2023-03-15:
       value: 550.6
 - threshold:
     2020-07-22:
@@ -110,7 +110,7 @@ brackets:
       value: 573.6
     2022-07-18:
       value: 596.5
-    2023-09-01:
+    2023-03-15:
       value: 633.5
 metadata:
   short_label: Montants
@@ -126,6 +126,6 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 relatif aux taux des bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096018
-    2023-09-01:
+    2023-03-15:
     - title : À renseigner dès que la publication officielle est disponible.
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
@@ -7,6 +7,8 @@ brackets:
       value: 0
     2022-07-18:
       value: 0
+    2023-04-01:
+      value: 0
   amount:
     2020-07-22:
       value: 33100
@@ -14,12 +16,16 @@ brackets:
       value: 33100
     2022-07-18:
       value: 33100
+    2023-04-01:
+      value: 35086
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
     2022-07-18:
+      value: 1
+    2023-04-01:
       value: 1
   amount:
     2020-07-22:
@@ -28,12 +34,16 @@ brackets:
       value: 36760
     2022-07-18:
       value: 36760
+    2023-04-01:
+      value: 38966
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
       value: 2
     2022-07-18:
+      value: 2
+    2023-04-01:
       value: 2
   amount:
     2020-07-22:
@@ -42,12 +52,16 @@ brackets:
       value: 40450
     2022-07-18:
       value: 40450
+    2023-04-01:
+      value: 42877
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
       value: 3
     2022-07-18:
+      value: 3
+    2023-04-01:
       value: 3
   amount:
     2020-07-22:
@@ -56,12 +70,16 @@ brackets:
       value: 44120
     2022-07-18:
       value: 44120
+    2023-04-01:
+      value: 46767
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
       value: 4
     2022-07-18:
+      value: 4
+    2023-04-01:
       value: 4
   amount:
     2020-07-22:
@@ -70,12 +88,16 @@ brackets:
       value: 47800
     2022-07-18:
       value: 47800
+    2023-04-01:
+      value: 50668
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
       value: 5
     2022-07-18:
+      value: 5
+    2023-04-01:
       value: 5
   amount:
     2020-07-22:
@@ -84,12 +106,16 @@ brackets:
       value: 51480
     2022-07-18:
       value: 51480
+    2023-04-01:
+      value: 54569
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
       value: 6
     2022-07-18:
+      value: 6
+    2023-04-01:
       value: 6
   amount:
     2020-07-22:
@@ -98,12 +124,16 @@ brackets:
       value: 55150
     2022-07-18:
       value: 55150
+    2023-04-01:
+      value: 58459
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
       value: 7
     2022-07-18:
+      value: 7
+    2023-04-01:
       value: 7
   amount:
     2020-07-22:
@@ -112,12 +142,16 @@ brackets:
       value: 58830
     2022-07-18:
       value: 58830
+    2023-04-01:
+      value: 62360
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
       value: 8
     2022-07-18:
+      value: 8
+    2023-04-01:
       value: 8
   amount:
     2020-07-22:
@@ -126,12 +160,16 @@ brackets:
       value: 62510
     2022-07-18:
       value: 62510
+    2023-04-01:
+      value: 66261
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
       value: 9
     2022-07-18:
+      value: 9
+    2023-04-01:
       value: 9
   amount:
     2020-07-22:
@@ -140,12 +178,16 @@ brackets:
       value: 66180
     2022-07-18:
       value: 66180
+    2023-04-01:
+      value: 70151
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
       value: 10
     2022-07-18:
+      value: 10
+    2023-04-01:
       value: 10
   amount:
     2020-07-22:
@@ -154,12 +196,16 @@ brackets:
       value: 69860
     2022-07-18:
       value: 69860
+    2023-04-01:
+      value: 74052
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
       value: 11
     2022-07-18:
+      value: 11
+    2023-04-01:
       value: 11
   amount:
     2020-07-22:
@@ -168,12 +214,16 @@ brackets:
       value: 73540
     2022-07-18:
       value: 73540
+    2023-04-01:
+      value: 77952
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
       value: 12
     2022-07-18:
+      value: 12
+    2023-04-01:
       value: 12
   amount:
     2020-07-22:
@@ -182,12 +232,16 @@ brackets:
       value: 77210
     2022-07-18:
       value: 77210
+    2023-04-01:
+      value: 81843
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
       value: 13
     2022-07-18:
+      value: 13
+    2023-04-01:
       value: 13
   amount:
     2020-07-22:
@@ -196,12 +250,16 @@ brackets:
       value: 80890
     2022-07-18:
       value: 80890
+    2023-04-01:
+      value: 85743
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
       value: 14
     2022-07-18:
+      value: 14
+    2023-04-01:
       value: 14
   amount:
     2020-07-22:
@@ -210,12 +268,16 @@ brackets:
       value: 84560
     2022-07-18:
       value: 84560
+    2023-04-01:
+      value: 89634
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
       value: 15
     2022-07-18:
+      value: 15
+    2023-04-01:
       value: 15
   amount:
     2020-07-22:
@@ -224,12 +286,16 @@ brackets:
       value: 88250
     2022-07-18:
       value: 88250
+    2023-04-01:
+      value: 93545
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
       value: 16
     2022-07-18:
+      value: 16
+    2023-04-01:
       value: 16
   amount:
     2020-07-22:
@@ -238,12 +304,16 @@ brackets:
       value: 91920
     2022-07-18:
       value: 91920
+    2023-04-01:
+      value: 97435
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
       value: 17
     2022-07-18:
+      value: 17
+    2023-04-01:
       value: 17
   amount:
     2020-07-22:
@@ -252,6 +322,8 @@ brackets:
       value: 95610
     2022-07-18:
       value: 95610
+    2023-04-01:
+      value: 101347
 metadata:
   reference:
     2020-07-22:
@@ -263,4 +335,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
+    2023-04-01:
+    - title: Aucun document officiel encore, à mettre à jour lors de la publication!
+    - href: A mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
@@ -10,7 +10,7 @@ brackets:
       value: 33100
     2022-07-18:
       value: 33100
-    2023-09-01:
+    2023-03-15:
       value: 35086
 - threshold:
     2020-07-22:
@@ -22,7 +22,7 @@ brackets:
       value: 36760
     2022-07-18:
       value: 36760
-    2023-09-01:
+    2023-03-15:
       value: 38966
 - threshold:
     2020-07-22:
@@ -34,7 +34,7 @@ brackets:
       value: 40450
     2022-07-18:
       value: 40450
-    2023-09-01:
+    2023-03-15:
       value: 42877
 - threshold:
     2020-07-22:
@@ -46,7 +46,7 @@ brackets:
       value: 44120
     2022-07-18:
       value: 44120
-    2023-09-01:
+    2023-03-15:
       value: 46767
 - threshold:
     2020-07-22:
@@ -58,7 +58,7 @@ brackets:
       value: 47800
     2022-07-18:
       value: 47800
-    2023-09-01:
+    2023-03-15:
       value: 50668
 - threshold:
     2020-07-22:
@@ -70,7 +70,7 @@ brackets:
       value: 51480
     2022-07-18:
       value: 51480
-    2023-09-01:
+    2023-03-15:
       value: 54569
 - threshold:
     2020-07-22:
@@ -82,7 +82,7 @@ brackets:
       value: 55150
     2022-07-18:
       value: 55150
-    2023-09-01:
+    2023-03-15:
       value: 58459
 - threshold:
     2020-07-22:
@@ -94,7 +94,7 @@ brackets:
       value: 58830
     2022-07-18:
       value: 58830
-    2023-09-01:
+    2023-03-15:
       value: 62360
 - threshold:
     2020-07-22:
@@ -106,7 +106,7 @@ brackets:
       value: 62510
     2022-07-18:
       value: 62510
-    2023-09-01:
+    2023-03-15:
       value: 66261
 - threshold:
     2020-07-22:
@@ -118,7 +118,7 @@ brackets:
       value: 66180
     2022-07-18:
       value: 66180
-    2023-09-01:
+    2023-03-15:
       value: 70151
 - threshold:
     2020-07-22:
@@ -130,7 +130,7 @@ brackets:
       value: 69860
     2022-07-18:
       value: 69860
-    2023-09-01:
+    2023-03-15:
       value: 74052
 - threshold:
     2020-07-22:
@@ -142,7 +142,7 @@ brackets:
       value: 73540
     2022-07-18:
       value: 73540
-    2023-09-01:
+    2023-03-15:
       value: 77952
 - threshold:
     2020-07-22:
@@ -154,7 +154,7 @@ brackets:
       value: 77210
     2022-07-18:
       value: 77210
-    2023-09-01:
+    2023-03-15:
       value: 81843
 - threshold:
     2020-07-22:
@@ -166,7 +166,7 @@ brackets:
       value: 80890
     2022-07-18:
       value: 80890
-    2023-09-01:
+    2023-03-15:
       value: 85743
 - threshold:
     2020-07-22:
@@ -178,7 +178,7 @@ brackets:
       value: 84560
     2022-07-18:
       value: 84560
-    2023-09-01:
+    2023-03-15:
       value: 89634
 - threshold:
     2020-07-22:
@@ -190,7 +190,7 @@ brackets:
       value: 88250
     2022-07-18:
       value: 88250
-    2023-09-01:
+    2023-03-15:
       value: 93545
 - threshold:
     2020-07-22:
@@ -202,7 +202,7 @@ brackets:
       value: 91920
     2022-07-18:
       value: 91920
-    2023-09-01:
+    2023-03-15:
       value: 97435
 - threshold:
     2020-07-22:
@@ -214,7 +214,7 @@ brackets:
       value: 95610
     2022-07-18:
       value: 95610
-    2023-09-01:
+    2023-03-15:
       value: 101347
 metadata:
   reference:
@@ -227,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-09-01:
+    2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: A mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_0bis.yaml
@@ -3,12 +3,6 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
-    2021-07-16:
-      value: 0
-    2022-07-18:
-      value: 0
-    2023-04-01:
-      value: 0
   amount:
     2020-07-22:
       value: 33100
@@ -16,17 +10,11 @@ brackets:
       value: 33100
     2022-07-18:
       value: 33100
-    2023-04-01:
+    2023-09-01:
       value: 35086
 - threshold:
     2020-07-22:
       value: 1
-    2021-07-16:
-      value: 1
-    2022-07-18:
-      value: 1
-    2023-04-01:
-      value: 1
   amount:
     2020-07-22:
       value: 36760
@@ -34,17 +22,11 @@ brackets:
       value: 36760
     2022-07-18:
       value: 36760
-    2023-04-01:
+    2023-09-01:
       value: 38966
 - threshold:
     2020-07-22:
       value: 2
-    2021-07-16:
-      value: 2
-    2022-07-18:
-      value: 2
-    2023-04-01:
-      value: 2
   amount:
     2020-07-22:
       value: 40450
@@ -52,17 +34,11 @@ brackets:
       value: 40450
     2022-07-18:
       value: 40450
-    2023-04-01:
+    2023-09-01:
       value: 42877
 - threshold:
     2020-07-22:
       value: 3
-    2021-07-16:
-      value: 3
-    2022-07-18:
-      value: 3
-    2023-04-01:
-      value: 3
   amount:
     2020-07-22:
       value: 44120
@@ -70,17 +46,11 @@ brackets:
       value: 44120
     2022-07-18:
       value: 44120
-    2023-04-01:
+    2023-09-01:
       value: 46767
 - threshold:
     2020-07-22:
       value: 4
-    2021-07-16:
-      value: 4
-    2022-07-18:
-      value: 4
-    2023-04-01:
-      value: 4
   amount:
     2020-07-22:
       value: 47800
@@ -88,17 +58,11 @@ brackets:
       value: 47800
     2022-07-18:
       value: 47800
-    2023-04-01:
+    2023-09-01:
       value: 50668
 - threshold:
     2020-07-22:
       value: 5
-    2021-07-16:
-      value: 5
-    2022-07-18:
-      value: 5
-    2023-04-01:
-      value: 5
   amount:
     2020-07-22:
       value: 51480
@@ -106,17 +70,11 @@ brackets:
       value: 51480
     2022-07-18:
       value: 51480
-    2023-04-01:
+    2023-09-01:
       value: 54569
 - threshold:
     2020-07-22:
       value: 6
-    2021-07-16:
-      value: 6
-    2022-07-18:
-      value: 6
-    2023-04-01:
-      value: 6
   amount:
     2020-07-22:
       value: 55150
@@ -124,17 +82,11 @@ brackets:
       value: 55150
     2022-07-18:
       value: 55150
-    2023-04-01:
+    2023-09-01:
       value: 58459
 - threshold:
     2020-07-22:
       value: 7
-    2021-07-16:
-      value: 7
-    2022-07-18:
-      value: 7
-    2023-04-01:
-      value: 7
   amount:
     2020-07-22:
       value: 58830
@@ -142,17 +94,11 @@ brackets:
       value: 58830
     2022-07-18:
       value: 58830
-    2023-04-01:
+    2023-09-01:
       value: 62360
 - threshold:
     2020-07-22:
       value: 8
-    2021-07-16:
-      value: 8
-    2022-07-18:
-      value: 8
-    2023-04-01:
-      value: 8
   amount:
     2020-07-22:
       value: 62510
@@ -160,17 +106,11 @@ brackets:
       value: 62510
     2022-07-18:
       value: 62510
-    2023-04-01:
+    2023-09-01:
       value: 66261
 - threshold:
     2020-07-22:
       value: 9
-    2021-07-16:
-      value: 9
-    2022-07-18:
-      value: 9
-    2023-04-01:
-      value: 9
   amount:
     2020-07-22:
       value: 66180
@@ -178,17 +118,11 @@ brackets:
       value: 66180
     2022-07-18:
       value: 66180
-    2023-04-01:
+    2023-09-01:
       value: 70151
 - threshold:
     2020-07-22:
       value: 10
-    2021-07-16:
-      value: 10
-    2022-07-18:
-      value: 10
-    2023-04-01:
-      value: 10
   amount:
     2020-07-22:
       value: 69860
@@ -196,17 +130,11 @@ brackets:
       value: 69860
     2022-07-18:
       value: 69860
-    2023-04-01:
+    2023-09-01:
       value: 74052
 - threshold:
     2020-07-22:
       value: 11
-    2021-07-16:
-      value: 11
-    2022-07-18:
-      value: 11
-    2023-04-01:
-      value: 11
   amount:
     2020-07-22:
       value: 73540
@@ -214,17 +142,11 @@ brackets:
       value: 73540
     2022-07-18:
       value: 73540
-    2023-04-01:
+    2023-09-01:
       value: 77952
 - threshold:
     2020-07-22:
       value: 12
-    2021-07-16:
-      value: 12
-    2022-07-18:
-      value: 12
-    2023-04-01:
-      value: 12
   amount:
     2020-07-22:
       value: 77210
@@ -232,17 +154,11 @@ brackets:
       value: 77210
     2022-07-18:
       value: 77210
-    2023-04-01:
+    2023-09-01:
       value: 81843
 - threshold:
     2020-07-22:
       value: 13
-    2021-07-16:
-      value: 13
-    2022-07-18:
-      value: 13
-    2023-04-01:
-      value: 13
   amount:
     2020-07-22:
       value: 80890
@@ -250,17 +166,11 @@ brackets:
       value: 80890
     2022-07-18:
       value: 80890
-    2023-04-01:
+    2023-09-01:
       value: 85743
 - threshold:
     2020-07-22:
       value: 14
-    2021-07-16:
-      value: 14
-    2022-07-18:
-      value: 14
-    2023-04-01:
-      value: 14
   amount:
     2020-07-22:
       value: 84560
@@ -268,17 +178,11 @@ brackets:
       value: 84560
     2022-07-18:
       value: 84560
-    2023-04-01:
+    2023-09-01:
       value: 89634
 - threshold:
     2020-07-22:
       value: 15
-    2021-07-16:
-      value: 15
-    2022-07-18:
-      value: 15
-    2023-04-01:
-      value: 15
   amount:
     2020-07-22:
       value: 88250
@@ -286,17 +190,11 @@ brackets:
       value: 88250
     2022-07-18:
       value: 88250
-    2023-04-01:
+    2023-09-01:
       value: 93545
 - threshold:
     2020-07-22:
       value: 16
-    2021-07-16:
-      value: 16
-    2022-07-18:
-      value: 16
-    2023-04-01:
-      value: 16
   amount:
     2020-07-22:
       value: 91920
@@ -304,17 +202,11 @@ brackets:
       value: 91920
     2022-07-18:
       value: 91920
-    2023-04-01:
+    2023-09-01:
       value: 97435
 - threshold:
     2020-07-22:
       value: 17
-    2021-07-16:
-      value: 17
-    2022-07-18:
-      value: 17
-    2023-04-01:
-      value: 17
   amount:
     2020-07-22:
       value: 95610
@@ -322,7 +214,7 @@ brackets:
       value: 95610
     2022-07-18:
       value: 95610
-    2023-04-01:
+    2023-09-01:
       value: 101347
 metadata:
   reference:
@@ -335,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-04-01:
+    2023-09-01:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: A mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
@@ -7,6 +7,8 @@ brackets:
       value: 0
     2022-07-18:
       value: 0
+    2023-04-01:
+      value: 0
   amount:
     2020-07-22:
       value: 22500
@@ -14,12 +16,16 @@ brackets:
       value: 22500
     2022-07-18:
       value: 22500
+    2023-04-01:
+      value: 23850
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
     2022-07-18:
+      value: 1
+    2023-04-01:
       value: 1
   amount:
     2020-07-22:
@@ -28,12 +34,16 @@ brackets:
       value: 25000
     2022-07-18:
       value: 25000
+    2023-04-01:
+      value: 26500
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
       value: 2
     2022-07-18:
+      value: 2
+    2023-04-01:
       value: 2
   amount:
     2020-07-22:
@@ -42,12 +52,16 @@ brackets:
       value: 27500
     2022-07-18:
       value: 27500
+    2023-04-01:
+      value: 29150
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
       value: 3
     2022-07-18:
+      value: 3
+    2023-04-01:
       value: 3
   amount:
     2020-07-22:
@@ -56,12 +70,16 @@ brackets:
       value: 30000
     2022-07-18:
       value: 30000
+    2023-04-01:
+      value: 31800
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
       value: 4
     2022-07-18:
+      value: 4
+    2023-04-01:
       value: 4
   amount:
     2020-07-22:
@@ -70,12 +88,16 @@ brackets:
       value: 32500
     2022-07-18:
       value: 32500
+    2023-04-01:
+      value: 34450
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
       value: 5
     2022-07-18:
+      value: 5
+    2023-04-01:
       value: 5
   amount:
     2020-07-22:
@@ -84,12 +106,16 @@ brackets:
       value: 35010
     2022-07-18:
       value: 35010
+    2023-04-01:
+      value: 37111
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
       value: 6
     2022-07-18:
+      value: 6
+    2023-04-01:
       value: 6
   amount:
     2020-07-22:
@@ -98,12 +124,16 @@ brackets:
       value: 37510
     2022-07-18:
       value: 37510
+    2023-04-01:
+      value: 39761
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
       value: 7
     2022-07-18:
+      value: 7
+    2023-04-01:
       value: 7
   amount:
     2020-07-22:
@@ -112,12 +142,16 @@ brackets:
       value: 40010
     2022-07-18:
       value: 40010
+    2023-04-01:
+      value: 42411
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
       value: 8
     2022-07-18:
+      value: 8
+    2023-04-01:
       value: 8
   amount:
     2020-07-22:
@@ -126,12 +160,16 @@ brackets:
       value: 42510
     2022-07-18:
       value: 42510
+    2023-04-01:
+      value: 45061
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
       value: 9
     2022-07-18:
+      value: 9
+    2023-04-01:
       value: 9
   amount:
     2020-07-22:
@@ -140,12 +178,16 @@ brackets:
       value: 45000
     2022-07-18:
       value: 45000
+    2023-04-01:
+      value: 47700
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
       value: 10
     2022-07-18:
+      value: 10
+    2023-04-01:
       value: 10
   amount:
     2020-07-22:
@@ -154,12 +196,16 @@ brackets:
       value: 47510
     2022-07-18:
       value: 47510
+    2023-04-01:
+      value: 50361
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
       value: 11
     2022-07-18:
+      value: 11
+    2023-04-01:
       value: 11
   amount:
     2020-07-22:
@@ -168,12 +214,16 @@ brackets:
       value: 50010
     2022-07-18:
       value: 50010
+    2023-04-01:
+      value: 53011
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
       value: 12
     2022-07-18:
+      value: 12
+    2023-04-01:
       value: 12
   amount:
     2020-07-22:
@@ -182,12 +232,16 @@ brackets:
       value: 52500
     2022-07-18:
       value: 52500
+    2023-04-01:
+      value: 55650
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
       value: 13
     2022-07-18:
+      value: 13
+    2023-04-01:
       value: 13
   amount:
     2020-07-22:
@@ -196,12 +250,16 @@ brackets:
       value: 55000
     2022-07-18:
       value: 55000
+    2023-04-01:
+      value: 58300
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
       value: 14
     2022-07-18:
+      value: 14
+    2023-04-01:
       value: 14
   amount:
     2020-07-22:
@@ -210,12 +268,16 @@ brackets:
       value: 57520
     2022-07-18:
       value: 57520
+    2023-04-01:
+      value: 60971
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
       value: 15
     2022-07-18:
+      value: 15
+    2023-04-01:
       value: 15
   amount:
     2020-07-22:
@@ -224,12 +286,16 @@ brackets:
       value: 60010
     2022-07-18:
       value: 60010
+    2023-04-01:
+      value: 63611
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
       value: 16
     2022-07-18:
+      value: 16
+    2023-04-01:
       value: 16
   amount:
     2020-07-22:
@@ -238,12 +304,16 @@ brackets:
       value: 62510
     2022-07-18:
       value: 62510
+    2023-04-01:
+      value: 66261
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
       value: 17
     2022-07-18:
+      value: 17
+    2023-04-01:
       value: 17
   amount:
     2020-07-22:
@@ -252,6 +322,8 @@ brackets:
       value: 65010
     2022-07-18:
       value: 65010
+    2023-04-01:
+      value: 68911
 metadata:
   reference:
     2020-07-22:
@@ -263,4 +335,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
+    2023-04-01:
+    - title: Aucun document officiel encore, à mettre à jour lors de la publication!
+    - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
@@ -229,5 +229,5 @@ metadata:
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
     2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
-    - href: Á mettre à jour!
+    - href: A mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
@@ -3,12 +3,6 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
-    2021-07-16:
-      value: 0
-    2022-07-18:
-      value: 0
-    2023-04-01:
-      value: 0
   amount:
     2020-07-22:
       value: 22500
@@ -16,17 +10,11 @@ brackets:
       value: 22500
     2022-07-18:
       value: 22500
-    2023-04-01:
+    2023-09-01:
       value: 23850
 - threshold:
     2020-07-22:
       value: 1
-    2021-07-16:
-      value: 1
-    2022-07-18:
-      value: 1
-    2023-04-01:
-      value: 1
   amount:
     2020-07-22:
       value: 25000
@@ -34,17 +22,11 @@ brackets:
       value: 25000
     2022-07-18:
       value: 25000
-    2023-04-01:
+    2023-09-01:
       value: 26500
 - threshold:
     2020-07-22:
       value: 2
-    2021-07-16:
-      value: 2
-    2022-07-18:
-      value: 2
-    2023-04-01:
-      value: 2
   amount:
     2020-07-22:
       value: 27500
@@ -52,17 +34,11 @@ brackets:
       value: 27500
     2022-07-18:
       value: 27500
-    2023-04-01:
+    2023-09-01:
       value: 29150
 - threshold:
     2020-07-22:
       value: 3
-    2021-07-16:
-      value: 3
-    2022-07-18:
-      value: 3
-    2023-04-01:
-      value: 3
   amount:
     2020-07-22:
       value: 30000
@@ -70,17 +46,11 @@ brackets:
       value: 30000
     2022-07-18:
       value: 30000
-    2023-04-01:
+    2023-09-01:
       value: 31800
 - threshold:
     2020-07-22:
       value: 4
-    2021-07-16:
-      value: 4
-    2022-07-18:
-      value: 4
-    2023-04-01:
-      value: 4
   amount:
     2020-07-22:
       value: 32500
@@ -88,17 +58,11 @@ brackets:
       value: 32500
     2022-07-18:
       value: 32500
-    2023-04-01:
+    2023-09-01:
       value: 34450
 - threshold:
     2020-07-22:
       value: 5
-    2021-07-16:
-      value: 5
-    2022-07-18:
-      value: 5
-    2023-04-01:
-      value: 5
   amount:
     2020-07-22:
       value: 35010
@@ -106,17 +70,11 @@ brackets:
       value: 35010
     2022-07-18:
       value: 35010
-    2023-04-01:
+    2023-09-01:
       value: 37111
 - threshold:
     2020-07-22:
       value: 6
-    2021-07-16:
-      value: 6
-    2022-07-18:
-      value: 6
-    2023-04-01:
-      value: 6
   amount:
     2020-07-22:
       value: 37510
@@ -124,17 +82,11 @@ brackets:
       value: 37510
     2022-07-18:
       value: 37510
-    2023-04-01:
+    2023-09-01:
       value: 39761
 - threshold:
     2020-07-22:
       value: 7
-    2021-07-16:
-      value: 7
-    2022-07-18:
-      value: 7
-    2023-04-01:
-      value: 7
   amount:
     2020-07-22:
       value: 40010
@@ -142,17 +94,11 @@ brackets:
       value: 40010
     2022-07-18:
       value: 40010
-    2023-04-01:
+    2023-09-01:
       value: 42411
 - threshold:
     2020-07-22:
       value: 8
-    2021-07-16:
-      value: 8
-    2022-07-18:
-      value: 8
-    2023-04-01:
-      value: 8
   amount:
     2020-07-22:
       value: 42510
@@ -160,17 +106,11 @@ brackets:
       value: 42510
     2022-07-18:
       value: 42510
-    2023-04-01:
+    2023-09-01:
       value: 45061
 - threshold:
     2020-07-22:
       value: 9
-    2021-07-16:
-      value: 9
-    2022-07-18:
-      value: 9
-    2023-04-01:
-      value: 9
   amount:
     2020-07-22:
       value: 45000
@@ -178,17 +118,11 @@ brackets:
       value: 45000
     2022-07-18:
       value: 45000
-    2023-04-01:
+    2023-09-01:
       value: 47700
 - threshold:
     2020-07-22:
       value: 10
-    2021-07-16:
-      value: 10
-    2022-07-18:
-      value: 10
-    2023-04-01:
-      value: 10
   amount:
     2020-07-22:
       value: 47510
@@ -196,17 +130,11 @@ brackets:
       value: 47510
     2022-07-18:
       value: 47510
-    2023-04-01:
+    2023-09-01:
       value: 50361
 - threshold:
     2020-07-22:
       value: 11
-    2021-07-16:
-      value: 11
-    2022-07-18:
-      value: 11
-    2023-04-01:
-      value: 11
   amount:
     2020-07-22:
       value: 50010
@@ -214,17 +142,11 @@ brackets:
       value: 50010
     2022-07-18:
       value: 50010
-    2023-04-01:
+    2023-09-01:
       value: 53011
 - threshold:
     2020-07-22:
       value: 12
-    2021-07-16:
-      value: 12
-    2022-07-18:
-      value: 12
-    2023-04-01:
-      value: 12
   amount:
     2020-07-22:
       value: 52500
@@ -232,17 +154,11 @@ brackets:
       value: 52500
     2022-07-18:
       value: 52500
-    2023-04-01:
+    2023-09-01:
       value: 55650
 - threshold:
     2020-07-22:
       value: 13
-    2021-07-16:
-      value: 13
-    2022-07-18:
-      value: 13
-    2023-04-01:
-      value: 13
   amount:
     2020-07-22:
       value: 55000
@@ -250,17 +166,11 @@ brackets:
       value: 55000
     2022-07-18:
       value: 55000
-    2023-04-01:
+    2023-09-01:
       value: 58300
 - threshold:
     2020-07-22:
       value: 14
-    2021-07-16:
-      value: 14
-    2022-07-18:
-      value: 14
-    2023-04-01:
-      value: 14
   amount:
     2020-07-22:
       value: 57520
@@ -268,17 +178,11 @@ brackets:
       value: 57520
     2022-07-18:
       value: 57520
-    2023-04-01:
+    2023-09-01:
       value: 60971
 - threshold:
     2020-07-22:
       value: 15
-    2021-07-16:
-      value: 15
-    2022-07-18:
-      value: 15
-    2023-04-01:
-      value: 15
   amount:
     2020-07-22:
       value: 60010
@@ -286,17 +190,11 @@ brackets:
       value: 60010
     2022-07-18:
       value: 60010
-    2023-04-01:
+    2023-09-01:
       value: 63611
 - threshold:
     2020-07-22:
       value: 16
-    2021-07-16:
-      value: 16
-    2022-07-18:
-      value: 16
-    2023-04-01:
-      value: 16
   amount:
     2020-07-22:
       value: 62510
@@ -304,17 +202,11 @@ brackets:
       value: 62510
     2022-07-18:
       value: 62510
-    2023-04-01:
+    2023-09-01:
       value: 66261
 - threshold:
     2020-07-22:
       value: 17
-    2021-07-16:
-      value: 17
-    2022-07-18:
-      value: 17
-    2023-04-01:
-      value: 17
   amount:
     2020-07-22:
       value: 65010
@@ -322,7 +214,7 @@ brackets:
       value: 65010
     2022-07-18:
       value: 65010
-    2023-04-01:
+    2023-09-01:
       value: 68911
 metadata:
   reference:
@@ -335,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-04-01:
+    2023-09-01:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_1.yaml
@@ -10,7 +10,7 @@ brackets:
       value: 22500
     2022-07-18:
       value: 22500
-    2023-09-01:
+    2023-03-15:
       value: 23850
 - threshold:
     2020-07-22:
@@ -22,7 +22,7 @@ brackets:
       value: 25000
     2022-07-18:
       value: 25000
-    2023-09-01:
+    2023-03-15:
       value: 26500
 - threshold:
     2020-07-22:
@@ -34,7 +34,7 @@ brackets:
       value: 27500
     2022-07-18:
       value: 27500
-    2023-09-01:
+    2023-03-15:
       value: 29150
 - threshold:
     2020-07-22:
@@ -46,7 +46,7 @@ brackets:
       value: 30000
     2022-07-18:
       value: 30000
-    2023-09-01:
+    2023-03-15:
       value: 31800
 - threshold:
     2020-07-22:
@@ -58,7 +58,7 @@ brackets:
       value: 32500
     2022-07-18:
       value: 32500
-    2023-09-01:
+    2023-03-15:
       value: 34450
 - threshold:
     2020-07-22:
@@ -70,7 +70,7 @@ brackets:
       value: 35010
     2022-07-18:
       value: 35010
-    2023-09-01:
+    2023-03-15:
       value: 37111
 - threshold:
     2020-07-22:
@@ -82,7 +82,7 @@ brackets:
       value: 37510
     2022-07-18:
       value: 37510
-    2023-09-01:
+    2023-03-15:
       value: 39761
 - threshold:
     2020-07-22:
@@ -94,7 +94,7 @@ brackets:
       value: 40010
     2022-07-18:
       value: 40010
-    2023-09-01:
+    2023-03-15:
       value: 42411
 - threshold:
     2020-07-22:
@@ -106,7 +106,7 @@ brackets:
       value: 42510
     2022-07-18:
       value: 42510
-    2023-09-01:
+    2023-03-15:
       value: 45061
 - threshold:
     2020-07-22:
@@ -118,7 +118,7 @@ brackets:
       value: 45000
     2022-07-18:
       value: 45000
-    2023-09-01:
+    2023-03-15:
       value: 47700
 - threshold:
     2020-07-22:
@@ -130,7 +130,7 @@ brackets:
       value: 47510
     2022-07-18:
       value: 47510
-    2023-09-01:
+    2023-03-15:
       value: 50361
 - threshold:
     2020-07-22:
@@ -142,7 +142,7 @@ brackets:
       value: 50010
     2022-07-18:
       value: 50010
-    2023-09-01:
+    2023-03-15:
       value: 53011
 - threshold:
     2020-07-22:
@@ -154,7 +154,7 @@ brackets:
       value: 52500
     2022-07-18:
       value: 52500
-    2023-09-01:
+    2023-03-15:
       value: 55650
 - threshold:
     2020-07-22:
@@ -166,7 +166,7 @@ brackets:
       value: 55000
     2022-07-18:
       value: 55000
-    2023-09-01:
+    2023-03-15:
       value: 58300
 - threshold:
     2020-07-22:
@@ -178,7 +178,7 @@ brackets:
       value: 57520
     2022-07-18:
       value: 57520
-    2023-09-01:
+    2023-03-15:
       value: 60971
 - threshold:
     2020-07-22:
@@ -190,7 +190,7 @@ brackets:
       value: 60010
     2022-07-18:
       value: 60010
-    2023-09-01:
+    2023-03-15:
       value: 63611
 - threshold:
     2020-07-22:
@@ -202,7 +202,7 @@ brackets:
       value: 62510
     2022-07-18:
       value: 62510
-    2023-09-01:
+    2023-03-15:
       value: 66261
 - threshold:
     2020-07-22:
@@ -214,7 +214,7 @@ brackets:
       value: 65010
     2022-07-18:
       value: 65010
-    2023-09-01:
+    2023-03-15:
       value: 68911
 metadata:
   reference:
@@ -227,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-09-01:
+    2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
@@ -7,6 +7,8 @@ brackets:
       value: 0
     2022-07-18:
       value: 0
+    2023-04-01:
+      value: 0
   amount:
     2020-07-22:
       value: 18190
@@ -14,12 +16,16 @@ brackets:
       value: 18190
     2022-07-18:
       value: 18190
+    2023-04-01:
+      value: 19281
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
     2022-07-18:
+      value: 1
+    2023-04-01:
       value: 1
   amount:
     2020-07-22:
@@ -28,12 +34,16 @@ brackets:
       value: 20210
     2022-07-18:
       value: 20210
+    2023-04-01:
+      value: 21423
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
       value: 2
     2022-07-18:
+      value: 2
+    2023-04-01:
       value: 2
   amount:
     2020-07-22:
@@ -42,12 +52,16 @@ brackets:
       value: 22230
     2022-07-18:
       value: 22230
+    2023-04-01:
+      value: 23564
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
       value: 3
     2022-07-18:
+      value: 3
+    2023-04-01:
       value: 3
   amount:
     2020-07-22:
@@ -56,12 +70,16 @@ brackets:
       value: 24250
     2022-07-18:
       value: 24250
+    2023-04-01:
+      value: 25705
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
       value: 4
     2022-07-18:
+      value: 4
+    2023-04-01:
       value: 4
   amount:
     2020-07-22:
@@ -70,12 +88,16 @@ brackets:
       value: 26270
     2022-07-18:
       value: 26270
+    2023-04-01:
+      value: 27846
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
       value: 5
     2022-07-18:
+      value: 5
+    2023-04-01:
       value: 5
   amount:
     2020-07-22:
@@ -84,12 +106,16 @@ brackets:
       value: 28300
     2022-07-18:
       value: 28300
+    2023-04-01:
+      value: 29998
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
       value: 6
     2022-07-18:
+      value: 6
+    2023-04-01:
       value: 6
   amount:
     2020-07-22:
@@ -98,12 +124,16 @@ brackets:
       value: 30320
     2022-07-18:
       value: 30320
+    2023-04-01:
+      value: 32139
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
       value: 7
     2022-07-18:
+      value: 7
+    2023-04-01:
       value: 7
   amount:
     2020-07-22:
@@ -112,12 +142,16 @@ brackets:
       value: 32340
     2022-07-18:
       value: 32340
+    2023-04-01:
+      value: 34280
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
       value: 8
     2022-07-18:
+      value: 8
+    2023-04-01:
       value: 8
   amount:
     2020-07-22:
@@ -126,12 +160,16 @@ brackets:
       value: 34360
     2022-07-18:
       value: 34360
+    2023-04-01:
+      value: 36422
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
       value: 9
     2022-07-18:
+      value: 9
+    2023-04-01:
       value: 9
   amount:
     2020-07-22:
@@ -140,12 +178,16 @@ brackets:
       value: 36380
     2022-07-18:
       value: 36380
+    2023-04-01:
+      value: 38563
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
       value: 10
     2022-07-18:
+      value: 10
+    2023-04-01:
       value: 10
   amount:
     2020-07-22:
@@ -154,12 +196,16 @@ brackets:
       value: 38400
     2022-07-18:
       value: 38400
+    2023-04-01:
+      value: 40704
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
       value: 11
     2022-07-18:
+      value: 11
+    2023-04-01:
       value: 11
   amount:
     2020-07-22:
@@ -168,12 +214,16 @@ brackets:
       value: 40410
     2022-07-18:
       value: 40410
+    2023-04-01:
+      value: 42835
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
       value: 12
     2022-07-18:
+      value: 12
+    2023-04-01:
       value: 12
   amount:
     2020-07-22:
@@ -182,12 +232,16 @@ brackets:
       value: 42430
     2022-07-18:
       value: 42430
+    2023-04-01:
+      value: 44976
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
       value: 13
     2022-07-18:
+      value: 13
+    2023-04-01:
       value: 13
   amount:
     2020-07-22:
@@ -196,12 +250,16 @@ brackets:
       value: 44450
     2022-07-18:
       value: 44450
+    2023-04-01:
+      value: 47117
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
       value: 14
     2022-07-18:
+      value: 14
+    2023-04-01:
       value: 14
   amount:
     2020-07-22:
@@ -210,12 +268,16 @@ brackets:
       value: 46480
     2022-07-18:
       value: 46480
+    2023-04-01:
+      value: 49269
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
       value: 15
     2022-07-18:
+      value: 15
+    2023-04-01:
       value: 15
   amount:
     2020-07-22:
@@ -224,12 +286,16 @@ brackets:
       value: 48500
     2022-07-18:
       value: 48500
+    2023-04-01:
+      value: 51410
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
       value: 16
     2022-07-18:
+      value: 16
+    2023-04-01:
       value: 16
   amount:
     2020-07-22:
@@ -238,12 +304,16 @@ brackets:
       value: 50520
     2022-07-18:
       value: 50520
+    2023-04-01:
+      value: 53551
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
       value: 17
     2022-07-18:
+      value: 17
+    2023-04-01:
       value: 17
   amount:
     2020-07-22:
@@ -252,6 +322,8 @@ brackets:
       value: 52540
     2022-07-18:
       value: 52540
+    2023-04-01:
+      value: 55692
 metadata:
   reference:
     2020-07-22:
@@ -263,4 +335,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
+    2023-04-01:
+    - title: Aucun document officiel encore, à mettre à jour lors de la publication!
+    - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
@@ -3,12 +3,6 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
-    2021-07-16:
-      value: 0
-    2022-07-18:
-      value: 0
-    2023-04-01:
-      value: 0
   amount:
     2020-07-22:
       value: 18190
@@ -16,17 +10,11 @@ brackets:
       value: 18190
     2022-07-18:
       value: 18190
-    2023-04-01:
+    2023-09-01:
       value: 19281
 - threshold:
     2020-07-22:
       value: 1
-    2021-07-16:
-      value: 1
-    2022-07-18:
-      value: 1
-    2023-04-01:
-      value: 1
   amount:
     2020-07-22:
       value: 20210
@@ -34,17 +22,11 @@ brackets:
       value: 20210
     2022-07-18:
       value: 20210
-    2023-04-01:
+    2023-09-01:
       value: 21423
 - threshold:
     2020-07-22:
       value: 2
-    2021-07-16:
-      value: 2
-    2022-07-18:
-      value: 2
-    2023-04-01:
-      value: 2
   amount:
     2020-07-22:
       value: 22230
@@ -52,17 +34,11 @@ brackets:
       value: 22230
     2022-07-18:
       value: 22230
-    2023-04-01:
+    2023-09-01:
       value: 23564
 - threshold:
     2020-07-22:
       value: 3
-    2021-07-16:
-      value: 3
-    2022-07-18:
-      value: 3
-    2023-04-01:
-      value: 3
   amount:
     2020-07-22:
       value: 24250
@@ -70,17 +46,11 @@ brackets:
       value: 24250
     2022-07-18:
       value: 24250
-    2023-04-01:
+    2023-09-01:
       value: 25705
 - threshold:
     2020-07-22:
       value: 4
-    2021-07-16:
-      value: 4
-    2022-07-18:
-      value: 4
-    2023-04-01:
-      value: 4
   amount:
     2020-07-22:
       value: 26270
@@ -88,17 +58,11 @@ brackets:
       value: 26270
     2022-07-18:
       value: 26270
-    2023-04-01:
+    2023-09-01:
       value: 27846
 - threshold:
     2020-07-22:
       value: 5
-    2021-07-16:
-      value: 5
-    2022-07-18:
-      value: 5
-    2023-04-01:
-      value: 5
   amount:
     2020-07-22:
       value: 28300
@@ -106,17 +70,11 @@ brackets:
       value: 28300
     2022-07-18:
       value: 28300
-    2023-04-01:
+    2023-09-01:
       value: 29998
 - threshold:
     2020-07-22:
       value: 6
-    2021-07-16:
-      value: 6
-    2022-07-18:
-      value: 6
-    2023-04-01:
-      value: 6
   amount:
     2020-07-22:
       value: 30320
@@ -124,17 +82,11 @@ brackets:
       value: 30320
     2022-07-18:
       value: 30320
-    2023-04-01:
+    2023-09-01:
       value: 32139
 - threshold:
     2020-07-22:
       value: 7
-    2021-07-16:
-      value: 7
-    2022-07-18:
-      value: 7
-    2023-04-01:
-      value: 7
   amount:
     2020-07-22:
       value: 32340
@@ -142,17 +94,11 @@ brackets:
       value: 32340
     2022-07-18:
       value: 32340
-    2023-04-01:
+    2023-09-01:
       value: 34280
 - threshold:
     2020-07-22:
       value: 8
-    2021-07-16:
-      value: 8
-    2022-07-18:
-      value: 8
-    2023-04-01:
-      value: 8
   amount:
     2020-07-22:
       value: 34360
@@ -160,17 +106,11 @@ brackets:
       value: 34360
     2022-07-18:
       value: 34360
-    2023-04-01:
+    2023-09-01:
       value: 36422
 - threshold:
     2020-07-22:
       value: 9
-    2021-07-16:
-      value: 9
-    2022-07-18:
-      value: 9
-    2023-04-01:
-      value: 9
   amount:
     2020-07-22:
       value: 36380
@@ -178,17 +118,11 @@ brackets:
       value: 36380
     2022-07-18:
       value: 36380
-    2023-04-01:
+    2023-09-01:
       value: 38563
 - threshold:
     2020-07-22:
       value: 10
-    2021-07-16:
-      value: 10
-    2022-07-18:
-      value: 10
-    2023-04-01:
-      value: 10
   amount:
     2020-07-22:
       value: 38400
@@ -196,17 +130,11 @@ brackets:
       value: 38400
     2022-07-18:
       value: 38400
-    2023-04-01:
+    2023-09-01:
       value: 40704
 - threshold:
     2020-07-22:
       value: 11
-    2021-07-16:
-      value: 11
-    2022-07-18:
-      value: 11
-    2023-04-01:
-      value: 11
   amount:
     2020-07-22:
       value: 40410
@@ -214,17 +142,11 @@ brackets:
       value: 40410
     2022-07-18:
       value: 40410
-    2023-04-01:
+    2023-09-01:
       value: 42835
 - threshold:
     2020-07-22:
       value: 12
-    2021-07-16:
-      value: 12
-    2022-07-18:
-      value: 12
-    2023-04-01:
-      value: 12
   amount:
     2020-07-22:
       value: 42430
@@ -232,17 +154,11 @@ brackets:
       value: 42430
     2022-07-18:
       value: 42430
-    2023-04-01:
+    2023-09-01:
       value: 44976
 - threshold:
     2020-07-22:
       value: 13
-    2021-07-16:
-      value: 13
-    2022-07-18:
-      value: 13
-    2023-04-01:
-      value: 13
   amount:
     2020-07-22:
       value: 44450
@@ -250,17 +166,11 @@ brackets:
       value: 44450
     2022-07-18:
       value: 44450
-    2023-04-01:
+    2023-09-01:
       value: 47117
 - threshold:
     2020-07-22:
       value: 14
-    2021-07-16:
-      value: 14
-    2022-07-18:
-      value: 14
-    2023-04-01:
-      value: 14
   amount:
     2020-07-22:
       value: 46480
@@ -268,17 +178,11 @@ brackets:
       value: 46480
     2022-07-18:
       value: 46480
-    2023-04-01:
+    2023-09-01:
       value: 49269
 - threshold:
     2020-07-22:
       value: 15
-    2021-07-16:
-      value: 15
-    2022-07-18:
-      value: 15
-    2023-04-01:
-      value: 15
   amount:
     2020-07-22:
       value: 48500
@@ -286,17 +190,11 @@ brackets:
       value: 48500
     2022-07-18:
       value: 48500
-    2023-04-01:
+    2023-09-01:
       value: 51410
 - threshold:
     2020-07-22:
       value: 16
-    2021-07-16:
-      value: 16
-    2022-07-18:
-      value: 16
-    2023-04-01:
-      value: 16
   amount:
     2020-07-22:
       value: 50520
@@ -304,17 +202,11 @@ brackets:
       value: 50520
     2022-07-18:
       value: 50520
-    2023-04-01:
+    2023-09-01:
       value: 53551
 - threshold:
     2020-07-22:
       value: 17
-    2021-07-16:
-      value: 17
-    2022-07-18:
-      value: 17
-    2023-04-01:
-      value: 17
   amount:
     2020-07-22:
       value: 52540
@@ -322,7 +214,7 @@ brackets:
       value: 52540
     2022-07-18:
       value: 52540
-    2023-04-01:
+    2023-09-01:
       value: 55692
 metadata:
   reference:
@@ -335,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-04-01:
+    2023-09-01:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
@@ -229,5 +229,5 @@ metadata:
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
     2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
-    - href: Á mettre à jour!
+    - href: A mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_2.yaml
@@ -10,7 +10,7 @@ brackets:
       value: 18190
     2022-07-18:
       value: 18190
-    2023-09-01:
+    2023-03-15:
       value: 19281
 - threshold:
     2020-07-22:
@@ -22,7 +22,7 @@ brackets:
       value: 20210
     2022-07-18:
       value: 20210
-    2023-09-01:
+    2023-03-15:
       value: 21423
 - threshold:
     2020-07-22:
@@ -34,7 +34,7 @@ brackets:
       value: 22230
     2022-07-18:
       value: 22230
-    2023-09-01:
+    2023-03-15:
       value: 23564
 - threshold:
     2020-07-22:
@@ -46,7 +46,7 @@ brackets:
       value: 24250
     2022-07-18:
       value: 24250
-    2023-09-01:
+    2023-03-15:
       value: 25705
 - threshold:
     2020-07-22:
@@ -58,7 +58,7 @@ brackets:
       value: 26270
     2022-07-18:
       value: 26270
-    2023-09-01:
+    2023-03-15:
       value: 27846
 - threshold:
     2020-07-22:
@@ -70,7 +70,7 @@ brackets:
       value: 28300
     2022-07-18:
       value: 28300
-    2023-09-01:
+    2023-03-15:
       value: 29998
 - threshold:
     2020-07-22:
@@ -82,7 +82,7 @@ brackets:
       value: 30320
     2022-07-18:
       value: 30320
-    2023-09-01:
+    2023-03-15:
       value: 32139
 - threshold:
     2020-07-22:
@@ -94,7 +94,7 @@ brackets:
       value: 32340
     2022-07-18:
       value: 32340
-    2023-09-01:
+    2023-03-15:
       value: 34280
 - threshold:
     2020-07-22:
@@ -106,7 +106,7 @@ brackets:
       value: 34360
     2022-07-18:
       value: 34360
-    2023-09-01:
+    2023-03-15:
       value: 36422
 - threshold:
     2020-07-22:
@@ -118,7 +118,7 @@ brackets:
       value: 36380
     2022-07-18:
       value: 36380
-    2023-09-01:
+    2023-03-15:
       value: 38563
 - threshold:
     2020-07-22:
@@ -130,7 +130,7 @@ brackets:
       value: 38400
     2022-07-18:
       value: 38400
-    2023-09-01:
+    2023-03-15:
       value: 40704
 - threshold:
     2020-07-22:
@@ -142,7 +142,7 @@ brackets:
       value: 40410
     2022-07-18:
       value: 40410
-    2023-09-01:
+    2023-03-15:
       value: 42835
 - threshold:
     2020-07-22:
@@ -154,7 +154,7 @@ brackets:
       value: 42430
     2022-07-18:
       value: 42430
-    2023-09-01:
+    2023-03-15:
       value: 44976
 - threshold:
     2020-07-22:
@@ -166,7 +166,7 @@ brackets:
       value: 44450
     2022-07-18:
       value: 44450
-    2023-09-01:
+    2023-03-15:
       value: 47117
 - threshold:
     2020-07-22:
@@ -178,7 +178,7 @@ brackets:
       value: 46480
     2022-07-18:
       value: 46480
-    2023-09-01:
+    2023-03-15:
       value: 49269
 - threshold:
     2020-07-22:
@@ -190,7 +190,7 @@ brackets:
       value: 48500
     2022-07-18:
       value: 48500
-    2023-09-01:
+    2023-03-15:
       value: 51410
 - threshold:
     2020-07-22:
@@ -202,7 +202,7 @@ brackets:
       value: 50520
     2022-07-18:
       value: 50520
-    2023-09-01:
+    2023-03-15:
       value: 53551
 - threshold:
     2020-07-22:
@@ -214,7 +214,7 @@ brackets:
       value: 52540
     2022-07-18:
       value: 52540
-    2023-09-01:
+    2023-03-15:
       value: 55692
 metadata:
   reference:
@@ -227,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-09-01:
+    2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
@@ -7,6 +7,8 @@ brackets:
       value: 0
     2022-07-18:
       value: 0
+    2023-04-01:
+      value: 0
   amount:
     2020-07-22:
       value: 16070
@@ -14,12 +16,16 @@ brackets:
       value: 16070
     2022-07-18:
       value: 16070
+    2023-04-01:
+      value: 17034
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
     2022-07-18:
+      value: 1
+    2023-04-01:
       value: 1
   amount:
     2020-07-22:
@@ -28,12 +34,16 @@ brackets:
       value: 17850
     2022-07-18:
       value: 17850
+    2023-04-01:
+      value: 18921
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
       value: 2
     2022-07-18:
+      value: 2
+    2023-04-01:
       value: 2
   amount:
     2020-07-22:
@@ -42,12 +52,16 @@ brackets:
       value: 19640
     2022-07-18:
       value: 19640
+    2023-04-01:
+      value: 20818
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
       value: 3
     2022-07-18:
+      value: 3
+    2023-04-01:
       value: 3
   amount:
     2020-07-22:
@@ -56,12 +70,16 @@ brackets:
       value: 21430
     2022-07-18:
       value: 21430
+    2023-04-01:
+      value: 22716
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
       value: 4
     2022-07-18:
+      value: 4
+    2023-04-01:
       value: 4
   amount:
     2020-07-22:
@@ -70,12 +88,16 @@ brackets:
       value: 23210
     2022-07-18:
       value: 23210
+    2023-04-01:
+      value: 24603
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
       value: 5
     2022-07-18:
+      value: 5
+    2023-04-01:
       value: 5
   amount:
     2020-07-22:
@@ -84,12 +106,16 @@ brackets:
       value: 25000
     2022-07-18:
       value: 25000
+    2023-04-01:
+      value: 26500
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
       value: 6
     2022-07-18:
+      value: 6
+    2023-04-01:
       value: 6
   amount:
     2020-07-22:
@@ -98,12 +124,16 @@ brackets:
       value: 26770
     2022-07-18:
       value: 26770
+    2023-04-01:
+      value: 28376
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
       value: 7
     2022-07-18:
+      value: 7
+    2023-04-01:
       value: 7
   amount:
     2020-07-22:
@@ -112,12 +142,16 @@ brackets:
       value: 28560
     2022-07-18:
       value: 28560
+    2023-04-01:
+      value: 30274
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
       value: 8
     2022-07-18:
+      value: 8
+    2023-04-01:
       value: 8
   amount:
     2020-07-22:
@@ -126,12 +160,16 @@ brackets:
       value: 30350
     2022-07-18:
       value: 30350
+    2023-04-01:
+      value: 32171
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
       value: 9
     2022-07-18:
+      value: 9
+    2023-04-01:
       value: 9
   amount:
     2020-07-22:
@@ -140,12 +178,16 @@ brackets:
       value: 32130
     2022-07-18:
       value: 32130
+    2023-04-01:
+      value: 34058
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
       value: 10
     2022-07-18:
+      value: 10
+    2023-04-01:
       value: 10
   amount:
     2020-07-22:
@@ -154,12 +196,16 @@ brackets:
       value: 33920
     2022-07-18:
       value: 33920
+    2023-04-01:
+      value: 35955
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
       value: 11
     2022-07-18:
+      value: 11
+    2023-04-01:
       value: 11
   amount:
     2020-07-22:
@@ -168,12 +214,16 @@ brackets:
       value: 35710
     2022-07-18:
       value: 35710
+    2023-04-01:
+      value: 37853
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
       value: 12
     2022-07-18:
+      value: 12
+    2023-04-01:
       value: 12
   amount:
     2020-07-22:
@@ -182,12 +232,16 @@ brackets:
       value: 37490
     2022-07-18:
       value: 37490
+    2023-04-01:
+      value: 39739
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
       value: 13
     2022-07-18:
+      value: 13
+    2023-04-01:
       value: 13
   amount:
     2020-07-22:
@@ -196,12 +250,16 @@ brackets:
       value: 39280
     2022-07-18:
       value: 39280
+    2023-04-01:
+      value: 41637
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
       value: 14
     2022-07-18:
+      value: 14
+    2023-04-01:
       value: 14
   amount:
     2020-07-22:
@@ -210,12 +268,16 @@ brackets:
       value: 41050
     2022-07-18:
       value: 41050
+    2023-04-01:
+      value: 43513
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
       value: 15
     2022-07-18:
+      value: 15
+    2023-04-01:
       value: 15
   amount:
     2020-07-22:
@@ -224,12 +286,16 @@ brackets:
       value: 42840
     2022-07-18:
       value: 42840
+    2023-04-01:
+      value: 45410
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
       value: 16
     2022-07-18:
+      value: 16
+    2023-04-01:
       value: 16
   amount:
     2020-07-22:
@@ -238,12 +304,16 @@ brackets:
       value: 44630
     2022-07-18:
       value: 44630
+    2023-04-01:
+      value: 47308
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
       value: 17
     2022-07-18:
+      value: 17
+    2023-04-01:
       value: 17
   amount:
     2020-07-22:
@@ -252,6 +322,8 @@ brackets:
       value: 46410
     2022-07-18:
       value: 46410
+    2023-04-01:
+      value: 49195
 metadata:
   reference:
     2020-07-22:
@@ -263,4 +335,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
+    2023-04-01:
+    - title: Aucun document officiel encore, à mettre à jour lors de la publication!
+    - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
@@ -3,12 +3,6 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
-    2021-07-16:
-      value: 0
-    2022-07-18:
-      value: 0
-    2023-04-01:
-      value: 0
   amount:
     2020-07-22:
       value: 16070
@@ -16,17 +10,11 @@ brackets:
       value: 16070
     2022-07-18:
       value: 16070
-    2023-04-01:
+    2023-09-01:
       value: 17034
 - threshold:
     2020-07-22:
       value: 1
-    2021-07-16:
-      value: 1
-    2022-07-18:
-      value: 1
-    2023-04-01:
-      value: 1
   amount:
     2020-07-22:
       value: 17850
@@ -34,17 +22,11 @@ brackets:
       value: 17850
     2022-07-18:
       value: 17850
-    2023-04-01:
+    2023-09-01:
       value: 18921
 - threshold:
     2020-07-22:
       value: 2
-    2021-07-16:
-      value: 2
-    2022-07-18:
-      value: 2
-    2023-04-01:
-      value: 2
   amount:
     2020-07-22:
       value: 19640
@@ -52,17 +34,11 @@ brackets:
       value: 19640
     2022-07-18:
       value: 19640
-    2023-04-01:
+    2023-09-01:
       value: 20818
 - threshold:
     2020-07-22:
       value: 3
-    2021-07-16:
-      value: 3
-    2022-07-18:
-      value: 3
-    2023-04-01:
-      value: 3
   amount:
     2020-07-22:
       value: 21430
@@ -70,17 +46,11 @@ brackets:
       value: 21430
     2022-07-18:
       value: 21430
-    2023-04-01:
+    2023-09-01:
       value: 22716
 - threshold:
     2020-07-22:
       value: 4
-    2021-07-16:
-      value: 4
-    2022-07-18:
-      value: 4
-    2023-04-01:
-      value: 4
   amount:
     2020-07-22:
       value: 23210
@@ -88,17 +58,11 @@ brackets:
       value: 23210
     2022-07-18:
       value: 23210
-    2023-04-01:
+    2023-09-01:
       value: 24603
 - threshold:
     2020-07-22:
       value: 5
-    2021-07-16:
-      value: 5
-    2022-07-18:
-      value: 5
-    2023-04-01:
-      value: 5
   amount:
     2020-07-22:
       value: 25000
@@ -106,17 +70,11 @@ brackets:
       value: 25000
     2022-07-18:
       value: 25000
-    2023-04-01:
+    2023-09-01:
       value: 26500
 - threshold:
     2020-07-22:
       value: 6
-    2021-07-16:
-      value: 6
-    2022-07-18:
-      value: 6
-    2023-04-01:
-      value: 6
   amount:
     2020-07-22:
       value: 26770
@@ -124,17 +82,11 @@ brackets:
       value: 26770
     2022-07-18:
       value: 26770
-    2023-04-01:
+    2023-09-01:
       value: 28376
 - threshold:
     2020-07-22:
       value: 7
-    2021-07-16:
-      value: 7
-    2022-07-18:
-      value: 7
-    2023-04-01:
-      value: 7
   amount:
     2020-07-22:
       value: 28560
@@ -142,17 +94,11 @@ brackets:
       value: 28560
     2022-07-18:
       value: 28560
-    2023-04-01:
+    2023-09-01:
       value: 30274
 - threshold:
     2020-07-22:
       value: 8
-    2021-07-16:
-      value: 8
-    2022-07-18:
-      value: 8
-    2023-04-01:
-      value: 8
   amount:
     2020-07-22:
       value: 30350
@@ -160,17 +106,11 @@ brackets:
       value: 30350
     2022-07-18:
       value: 30350
-    2023-04-01:
+    2023-09-01:
       value: 32171
 - threshold:
     2020-07-22:
       value: 9
-    2021-07-16:
-      value: 9
-    2022-07-18:
-      value: 9
-    2023-04-01:
-      value: 9
   amount:
     2020-07-22:
       value: 32130
@@ -178,17 +118,11 @@ brackets:
       value: 32130
     2022-07-18:
       value: 32130
-    2023-04-01:
+    2023-09-01:
       value: 34058
 - threshold:
     2020-07-22:
       value: 10
-    2021-07-16:
-      value: 10
-    2022-07-18:
-      value: 10
-    2023-04-01:
-      value: 10
   amount:
     2020-07-22:
       value: 33920
@@ -196,17 +130,11 @@ brackets:
       value: 33920
     2022-07-18:
       value: 33920
-    2023-04-01:
+    2023-09-01:
       value: 35955
 - threshold:
     2020-07-22:
       value: 11
-    2021-07-16:
-      value: 11
-    2022-07-18:
-      value: 11
-    2023-04-01:
-      value: 11
   amount:
     2020-07-22:
       value: 35710
@@ -214,17 +142,11 @@ brackets:
       value: 35710
     2022-07-18:
       value: 35710
-    2023-04-01:
+    2023-09-01:
       value: 37853
 - threshold:
     2020-07-22:
       value: 12
-    2021-07-16:
-      value: 12
-    2022-07-18:
-      value: 12
-    2023-04-01:
-      value: 12
   amount:
     2020-07-22:
       value: 37490
@@ -232,17 +154,11 @@ brackets:
       value: 37490
     2022-07-18:
       value: 37490
-    2023-04-01:
+    2023-09-01:
       value: 39739
 - threshold:
     2020-07-22:
       value: 13
-    2021-07-16:
-      value: 13
-    2022-07-18:
-      value: 13
-    2023-04-01:
-      value: 13
   amount:
     2020-07-22:
       value: 39280
@@ -250,17 +166,11 @@ brackets:
       value: 39280
     2022-07-18:
       value: 39280
-    2023-04-01:
+    2023-09-01:
       value: 41637
 - threshold:
     2020-07-22:
       value: 14
-    2021-07-16:
-      value: 14
-    2022-07-18:
-      value: 14
-    2023-04-01:
-      value: 14
   amount:
     2020-07-22:
       value: 41050
@@ -268,17 +178,11 @@ brackets:
       value: 41050
     2022-07-18:
       value: 41050
-    2023-04-01:
+    2023-09-01:
       value: 43513
 - threshold:
     2020-07-22:
       value: 15
-    2021-07-16:
-      value: 15
-    2022-07-18:
-      value: 15
-    2023-04-01:
-      value: 15
   amount:
     2020-07-22:
       value: 42840
@@ -286,17 +190,11 @@ brackets:
       value: 42840
     2022-07-18:
       value: 42840
-    2023-04-01:
+    2023-09-01:
       value: 45410
 - threshold:
     2020-07-22:
       value: 16
-    2021-07-16:
-      value: 16
-    2022-07-18:
-      value: 16
-    2023-04-01:
-      value: 16
   amount:
     2020-07-22:
       value: 44630
@@ -304,17 +202,11 @@ brackets:
       value: 44630
     2022-07-18:
       value: 44630
-    2023-04-01:
+    2023-09-01:
       value: 47308
 - threshold:
     2020-07-22:
       value: 17
-    2021-07-16:
-      value: 17
-    2022-07-18:
-      value: 17
-    2023-04-01:
-      value: 17
   amount:
     2020-07-22:
       value: 46410
@@ -322,7 +214,7 @@ brackets:
       value: 46410
     2022-07-18:
       value: 46410
-    2023-04-01:
+    2023-09-01:
       value: 49195
 metadata:
   reference:
@@ -335,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-04-01:
+    2023-09-01:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
@@ -10,7 +10,7 @@ brackets:
       value: 16070
     2022-07-18:
       value: 16070
-    2023-09-01:
+    2023-03-15:
       value: 17034
 - threshold:
     2020-07-22:
@@ -22,7 +22,7 @@ brackets:
       value: 17850
     2022-07-18:
       value: 17850
-    2023-09-01:
+    2023-03-15:
       value: 18921
 - threshold:
     2020-07-22:
@@ -34,7 +34,7 @@ brackets:
       value: 19640
     2022-07-18:
       value: 19640
-    2023-09-01:
+    2023-03-15:
       value: 20818
 - threshold:
     2020-07-22:
@@ -46,7 +46,7 @@ brackets:
       value: 21430
     2022-07-18:
       value: 21430
-    2023-09-01:
+    2023-03-15:
       value: 22716
 - threshold:
     2020-07-22:
@@ -58,7 +58,7 @@ brackets:
       value: 23210
     2022-07-18:
       value: 23210
-    2023-09-01:
+    2023-03-15:
       value: 24603
 - threshold:
     2020-07-22:
@@ -70,7 +70,7 @@ brackets:
       value: 25000
     2022-07-18:
       value: 25000
-    2023-09-01:
+    2023-03-15:
       value: 26500
 - threshold:
     2020-07-22:
@@ -82,7 +82,7 @@ brackets:
       value: 26770
     2022-07-18:
       value: 26770
-    2023-09-01:
+    2023-03-15:
       value: 28376
 - threshold:
     2020-07-22:
@@ -94,7 +94,7 @@ brackets:
       value: 28560
     2022-07-18:
       value: 28560
-    2023-09-01:
+    2023-03-15:
       value: 30274
 - threshold:
     2020-07-22:
@@ -106,7 +106,7 @@ brackets:
       value: 30350
     2022-07-18:
       value: 30350
-    2023-09-01:
+    2023-03-15:
       value: 32171
 - threshold:
     2020-07-22:
@@ -118,7 +118,7 @@ brackets:
       value: 32130
     2022-07-18:
       value: 32130
-    2023-09-01:
+    2023-03-15:
       value: 34058
 - threshold:
     2020-07-22:
@@ -130,7 +130,7 @@ brackets:
       value: 33920
     2022-07-18:
       value: 33920
-    2023-09-01:
+    2023-03-15:
       value: 35955
 - threshold:
     2020-07-22:
@@ -142,7 +142,7 @@ brackets:
       value: 35710
     2022-07-18:
       value: 35710
-    2023-09-01:
+    2023-03-15:
       value: 37853
 - threshold:
     2020-07-22:
@@ -154,7 +154,7 @@ brackets:
       value: 37490
     2022-07-18:
       value: 37490
-    2023-09-01:
+    2023-03-15:
       value: 39739
 - threshold:
     2020-07-22:
@@ -166,7 +166,7 @@ brackets:
       value: 39280
     2022-07-18:
       value: 39280
-    2023-09-01:
+    2023-03-15:
       value: 41637
 - threshold:
     2020-07-22:
@@ -178,7 +178,7 @@ brackets:
       value: 41050
     2022-07-18:
       value: 41050
-    2023-09-01:
+    2023-03-15:
       value: 43513
 - threshold:
     2020-07-22:
@@ -190,7 +190,7 @@ brackets:
       value: 42840
     2022-07-18:
       value: 42840
-    2023-09-01:
+    2023-03-15:
       value: 45410
 - threshold:
     2020-07-22:
@@ -202,7 +202,7 @@ brackets:
       value: 44630
     2022-07-18:
       value: 44630
-    2023-09-01:
+    2023-03-15:
       value: 47308
 - threshold:
     2020-07-22:
@@ -214,7 +214,7 @@ brackets:
       value: 46410
     2022-07-18:
       value: 46410
-    2023-09-01:
+    2023-03-15:
       value: 49195
 metadata:
   reference:
@@ -227,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-09-01:
+    2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
@@ -229,5 +229,5 @@ metadata:
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
     2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
-    - href: Á mettre à jour!
+    - href: A mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
@@ -3,12 +3,6 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
-    2021-07-16:
-      value: 0
-    2022-07-18:
-      value: 0
-    2023-04-01:
-      value: 0
   amount:
     2020-07-22:
       value: 13990
@@ -16,17 +10,11 @@ brackets:
       value: 13990
     2022-07-18:
       value: 13990
-    2023-04-01:
+    2023-09-01:
       value: 14829
 - threshold:
     2020-07-22:
       value: 1
-    2021-07-16:
-      value: 1
-    2022-07-18:
-      value: 1
-    2023-04-01:
-      value: 1
   amount:
     2020-07-22:
       value: 15540
@@ -34,17 +22,11 @@ brackets:
       value: 15540
     2022-07-18:
       value: 15540
-    2023-04-01:
+    2023-09-01:
       value: 16472
 - threshold:
     2020-07-22:
       value: 2
-    2021-07-16:
-      value: 2
-    2022-07-18:
-      value: 2
-    2023-04-01:
-      value: 2
   amount:
     2020-07-22:
       value: 17100
@@ -52,17 +34,11 @@ brackets:
       value: 17100
     2022-07-18:
       value: 17100
-    2023-04-01:
+    2023-09-01:
       value: 18126
 - threshold:
     2020-07-22:
       value: 3
-    2021-07-16:
-      value: 3
-    2022-07-18:
-      value: 3
-    2023-04-01:
-      value: 3
   amount:
     2020-07-22:
       value: 18640
@@ -70,17 +46,11 @@ brackets:
       value: 18640
     2022-07-18:
       value: 18640
-    2023-04-01:
+    2023-09-01:
       value: 19758
 - threshold:
     2020-07-22:
       value: 4
-    2021-07-16:
-      value: 4
-    2022-07-18:
-      value: 4
-    2023-04-01:
-      value: 4
   amount:
     2020-07-22:
       value: 20200
@@ -88,17 +58,11 @@ brackets:
       value: 20200
     2022-07-18:
       value: 20200
-    2023-04-01:
+    2023-09-01:
       value: 21412
 - threshold:
     2020-07-22:
       value: 5
-    2021-07-16:
-      value: 5
-    2022-07-18:
-      value: 5
-    2023-04-01:
-      value: 5
   amount:
     2020-07-22:
       value: 21760
@@ -106,17 +70,11 @@ brackets:
       value: 21760
     2022-07-18:
       value: 21760
-    2023-04-01:
+    2023-09-01:
       value: 23066
 - threshold:
     2020-07-22:
       value: 6
-    2021-07-16:
-      value: 6
-    2022-07-18:
-      value: 6
-    2023-04-01:
-      value: 6
   amount:
     2020-07-22:
       value: 23310
@@ -124,17 +82,11 @@ brackets:
       value: 23310
     2022-07-18:
       value: 23310
-    2023-04-01:
+    2023-09-01:
       value: 24709
 - threshold:
     2020-07-22:
       value: 7
-    2021-07-16:
-      value: 7
-    2022-07-18:
-      value: 7
-    2023-04-01:
-      value: 7
   amount:
     2020-07-22:
       value: 24860
@@ -142,17 +94,11 @@ brackets:
       value: 24860
     2022-07-18:
       value: 24860
-    2023-04-01:
+    2023-09-01:
       value: 26352
 - threshold:
     2020-07-22:
       value: 8
-    2021-07-16:
-      value: 8
-    2022-07-18:
-      value: 8
-    2023-04-01:
-      value: 8
   amount:
     2020-07-22:
       value: 26420
@@ -160,17 +106,11 @@ brackets:
       value: 26420
     2022-07-18:
       value: 26420
-    2023-04-01:
+    2023-09-01:
       value: 28005
 - threshold:
     2020-07-22:
       value: 9
-    2021-07-16:
-      value: 9
-    2022-07-18:
-      value: 9
-    2023-04-01:
-      value: 9
   amount:
     2020-07-22:
       value: 27970
@@ -178,17 +118,11 @@ brackets:
       value: 27970
     2022-07-18:
       value: 27970
-    2023-04-01:
+    2023-09-01:
       value: 29648
 - threshold:
     2020-07-22:
       value: 10
-    2021-07-16:
-      value: 10
-    2022-07-18:
-      value: 10
-    2023-04-01:
-      value: 10
   amount:
     2020-07-22:
       value: 29520
@@ -196,17 +130,11 @@ brackets:
       value: 29520
     2022-07-18:
       value: 29520
-    2023-04-01:
+    2023-09-01:
       value: 31291
 - threshold:
     2020-07-22:
       value: 11
-    2021-07-16:
-      value: 11
-    2022-07-18:
-      value: 11
-    2023-04-01:
-      value: 11
   amount:
     2020-07-22:
       value: 31090
@@ -214,17 +142,11 @@ brackets:
       value: 31090
     2022-07-18:
       value: 31090
-    2023-04-01:
+    2023-09-01:
       value: 32955
 - threshold:
     2020-07-22:
       value: 12
-    2021-07-16:
-      value: 12
-    2022-07-18:
-      value: 12
-    2023-04-01:
-      value: 12
   amount:
     2020-07-22:
       value: 32630
@@ -232,17 +154,11 @@ brackets:
       value: 32630
     2022-07-18:
       value: 32630
-    2023-04-01:
+    2023-09-01:
       value: 34588
 - threshold:
     2020-07-22:
       value: 13
-    2021-07-16:
-      value: 13
-    2022-07-18:
-      value: 13
-    2023-04-01:
-      value: 13
   amount:
     2020-07-22:
       value: 34180
@@ -250,17 +166,11 @@ brackets:
       value: 34180
     2022-07-18:
       value: 34180
-    2023-04-01:
+    2023-09-01:
       value: 36231
 - threshold:
     2020-07-22:
       value: 14
-    2021-07-16:
-      value: 14
-    2022-07-18:
-      value: 14
-    2023-04-01:
-      value: 14
   amount:
     2020-07-22:
       value: 35750
@@ -268,17 +178,11 @@ brackets:
       value: 35750
     2022-07-18:
       value: 35750
-    2023-04-01:
+    2023-09-01:
       value: 37895
 - threshold:
     2020-07-22:
       value: 15
-    2021-07-16:
-      value: 15
-    2022-07-18:
-      value: 15
-    2023-04-01:
-      value: 15
   amount:
     2020-07-22:
       value: 37300
@@ -286,17 +190,11 @@ brackets:
       value: 37300
     2022-07-18:
       value: 37300
-    2023-04-01:
+    2023-09-01:
       value: 39538
 - threshold:
     2020-07-22:
       value: 16
-    2021-07-16:
-      value: 16
-    2022-07-18:
-      value: 16
-    2023-04-01:
-      value: 16
   amount:
     2020-07-22:
       value: 38840
@@ -304,17 +202,11 @@ brackets:
       value: 38840
     2022-07-18:
       value: 38840
-    2023-04-01:
+    2023-09-01:
       value: 41170
 - threshold:
     2020-07-22:
       value: 17
-    2021-07-16:
-      value: 17
-    2022-07-18:
-      value: 17
-    2023-04-01:
-      value: 17
   amount:
     2020-07-22:
       value: 40400
@@ -322,7 +214,7 @@ brackets:
       value: 40400
     2022-07-18:
       value: 40400
-    2023-04-01:
+    2023-09-01:
       value: 42824
 metadata:
   reference:
@@ -335,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-04-01:
+    2023-09-01:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
@@ -229,5 +229,5 @@ metadata:
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
     2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
-    - href: Á mettre à jour!
+    - href: A mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
@@ -10,7 +10,7 @@ brackets:
       value: 13990
     2022-07-18:
       value: 13990
-    2023-09-01:
+    2023-03-15:
       value: 14829
 - threshold:
     2020-07-22:
@@ -22,7 +22,7 @@ brackets:
       value: 15540
     2022-07-18:
       value: 15540
-    2023-09-01:
+    2023-03-15:
       value: 16472
 - threshold:
     2020-07-22:
@@ -34,7 +34,7 @@ brackets:
       value: 17100
     2022-07-18:
       value: 17100
-    2023-09-01:
+    2023-03-15:
       value: 18126
 - threshold:
     2020-07-22:
@@ -46,7 +46,7 @@ brackets:
       value: 18640
     2022-07-18:
       value: 18640
-    2023-09-01:
+    2023-03-15:
       value: 19758
 - threshold:
     2020-07-22:
@@ -58,7 +58,7 @@ brackets:
       value: 20200
     2022-07-18:
       value: 20200
-    2023-09-01:
+    2023-03-15:
       value: 21412
 - threshold:
     2020-07-22:
@@ -70,7 +70,7 @@ brackets:
       value: 21760
     2022-07-18:
       value: 21760
-    2023-09-01:
+    2023-03-15:
       value: 23066
 - threshold:
     2020-07-22:
@@ -82,7 +82,7 @@ brackets:
       value: 23310
     2022-07-18:
       value: 23310
-    2023-09-01:
+    2023-03-15:
       value: 24709
 - threshold:
     2020-07-22:
@@ -94,7 +94,7 @@ brackets:
       value: 24860
     2022-07-18:
       value: 24860
-    2023-09-01:
+    2023-03-15:
       value: 26352
 - threshold:
     2020-07-22:
@@ -106,7 +106,7 @@ brackets:
       value: 26420
     2022-07-18:
       value: 26420
-    2023-09-01:
+    2023-03-15:
       value: 28005
 - threshold:
     2020-07-22:
@@ -118,7 +118,7 @@ brackets:
       value: 27970
     2022-07-18:
       value: 27970
-    2023-09-01:
+    2023-03-15:
       value: 29648
 - threshold:
     2020-07-22:
@@ -130,7 +130,7 @@ brackets:
       value: 29520
     2022-07-18:
       value: 29520
-    2023-09-01:
+    2023-03-15:
       value: 31291
 - threshold:
     2020-07-22:
@@ -142,7 +142,7 @@ brackets:
       value: 31090
     2022-07-18:
       value: 31090
-    2023-09-01:
+    2023-03-15:
       value: 32955
 - threshold:
     2020-07-22:
@@ -154,7 +154,7 @@ brackets:
       value: 32630
     2022-07-18:
       value: 32630
-    2023-09-01:
+    2023-03-15:
       value: 34588
 - threshold:
     2020-07-22:
@@ -166,7 +166,7 @@ brackets:
       value: 34180
     2022-07-18:
       value: 34180
-    2023-09-01:
+    2023-03-15:
       value: 36231
 - threshold:
     2020-07-22:
@@ -178,7 +178,7 @@ brackets:
       value: 35750
     2022-07-18:
       value: 35750
-    2023-09-01:
+    2023-03-15:
       value: 37895
 - threshold:
     2020-07-22:
@@ -190,7 +190,7 @@ brackets:
       value: 37300
     2022-07-18:
       value: 37300
-    2023-09-01:
+    2023-03-15:
       value: 39538
 - threshold:
     2020-07-22:
@@ -202,7 +202,7 @@ brackets:
       value: 38840
     2022-07-18:
       value: 38840
-    2023-09-01:
+    2023-03-15:
       value: 41170
 - threshold:
     2020-07-22:
@@ -214,7 +214,7 @@ brackets:
       value: 40400
     2022-07-18:
       value: 40400
-    2023-09-01:
+    2023-03-15:
       value: 42824
 metadata:
   reference:
@@ -227,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-09-01:
+    2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
@@ -7,6 +7,8 @@ brackets:
       value: 0
     2022-07-18:
       value: 0
+    2023-04-01:
+      value: 0
   amount:
     2020-07-22:
       value: 13990
@@ -14,12 +16,16 @@ brackets:
       value: 13990
     2022-07-18:
       value: 13990
+    2023-04-01:
+      value: 14829
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
     2022-07-18:
+      value: 1
+    2023-04-01:
       value: 1
   amount:
     2020-07-22:
@@ -28,12 +34,16 @@ brackets:
       value: 15540
     2022-07-18:
       value: 15540
+    2023-04-01:
+      value: 16472
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
       value: 2
     2022-07-18:
+      value: 2
+    2023-04-01:
       value: 2
   amount:
     2020-07-22:
@@ -42,12 +52,16 @@ brackets:
       value: 17100
     2022-07-18:
       value: 17100
+    2023-04-01:
+      value: 18126
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
       value: 3
     2022-07-18:
+      value: 3
+    2023-04-01:
       value: 3
   amount:
     2020-07-22:
@@ -56,12 +70,16 @@ brackets:
       value: 18640
     2022-07-18:
       value: 18640
+    2023-04-01:
+      value: 19758
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
       value: 4
     2022-07-18:
+      value: 4
+    2023-04-01:
       value: 4
   amount:
     2020-07-22:
@@ -70,12 +88,16 @@ brackets:
       value: 20200
     2022-07-18:
       value: 20200
+    2023-04-01:
+      value: 21412
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
       value: 5
     2022-07-18:
+      value: 5
+    2023-04-01:
       value: 5
   amount:
     2020-07-22:
@@ -84,12 +106,16 @@ brackets:
       value: 21760
     2022-07-18:
       value: 21760
+    2023-04-01:
+      value: 23066
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
       value: 6
     2022-07-18:
+      value: 6
+    2023-04-01:
       value: 6
   amount:
     2020-07-22:
@@ -98,12 +124,16 @@ brackets:
       value: 23310
     2022-07-18:
       value: 23310
+    2023-04-01:
+      value: 24709
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
       value: 7
     2022-07-18:
+      value: 7
+    2023-04-01:
       value: 7
   amount:
     2020-07-22:
@@ -112,12 +142,16 @@ brackets:
       value: 24860
     2022-07-18:
       value: 24860
+    2023-04-01:
+      value: 26352
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
       value: 8
     2022-07-18:
+      value: 8
+    2023-04-01:
       value: 8
   amount:
     2020-07-22:
@@ -126,12 +160,16 @@ brackets:
       value: 26420
     2022-07-18:
       value: 26420
+    2023-04-01:
+      value: 28005
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
       value: 9
     2022-07-18:
+      value: 9
+    2023-04-01:
       value: 9
   amount:
     2020-07-22:
@@ -140,12 +178,16 @@ brackets:
       value: 27970
     2022-07-18:
       value: 27970
+    2023-04-01:
+      value: 29648
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
       value: 10
     2022-07-18:
+      value: 10
+    2023-04-01:
       value: 10
   amount:
     2020-07-22:
@@ -154,12 +196,16 @@ brackets:
       value: 29520
     2022-07-18:
       value: 29520
+    2023-04-01:
+      value: 31291
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
       value: 11
     2022-07-18:
+      value: 11
+    2023-04-01:
       value: 11
   amount:
     2020-07-22:
@@ -168,12 +214,16 @@ brackets:
       value: 31090
     2022-07-18:
       value: 31090
+    2023-04-01:
+      value: 32955
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
       value: 12
     2022-07-18:
+      value: 12
+    2023-04-01:
       value: 12
   amount:
     2020-07-22:
@@ -182,12 +232,16 @@ brackets:
       value: 32630
     2022-07-18:
       value: 32630
+    2023-04-01:
+      value: 34588
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
       value: 13
     2022-07-18:
+      value: 13
+    2023-04-01:
       value: 13
   amount:
     2020-07-22:
@@ -196,12 +250,16 @@ brackets:
       value: 34180
     2022-07-18:
       value: 34180
+    2023-04-01:
+      value: 36231
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
       value: 14
     2022-07-18:
+      value: 14
+    2023-04-01:
       value: 14
   amount:
     2020-07-22:
@@ -210,12 +268,16 @@ brackets:
       value: 35750
     2022-07-18:
       value: 35750
+    2023-04-01:
+      value: 37895
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
       value: 15
     2022-07-18:
+      value: 15
+    2023-04-01:
       value: 15
   amount:
     2020-07-22:
@@ -224,12 +286,16 @@ brackets:
       value: 37300
     2022-07-18:
       value: 37300
+    2023-04-01:
+      value: 39538
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
       value: 16
     2022-07-18:
+      value: 16
+    2023-04-01:
       value: 16
   amount:
     2020-07-22:
@@ -238,12 +304,16 @@ brackets:
       value: 38840
     2022-07-18:
       value: 38840
+    2023-04-01:
+      value: 41170
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
       value: 17
     2022-07-18:
+      value: 17
+    2023-04-01:
       value: 17
   amount:
     2020-07-22:
@@ -252,6 +322,8 @@ brackets:
       value: 40400
     2022-07-18:
       value: 40400
+    2023-04-01:
+      value: 42824
 metadata:
   reference:
     2020-07-22:
@@ -263,4 +335,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
+    2023-04-01:
+    - title: Aucun document officiel encore, à mettre à jour lors de la publication!
+    - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
@@ -3,12 +3,6 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
-    2021-07-16:
-      value: 0
-    2022-07-18:
-      value: 0
-    2023-04-01:
-      value: 0
   amount:
     2020-07-22:
       value: 11950
@@ -16,17 +10,11 @@ brackets:
       value: 11950
     2022-07-18:
       value: 11950
-    2023-04-01:
+    2023-09-01:
       value: 12667
 - threshold:
     2020-07-22:
       value: 1
-    2021-07-16:
-      value: 1
-    2022-07-18:
-      value: 1
-    2023-04-01:
-      value: 1
   amount:
     2020-07-22:
       value: 13280
@@ -34,17 +22,11 @@ brackets:
       value: 13280
     2022-07-18:
       value: 13280
-    2023-04-01:
+    2023-09-01:
       value: 14077
 - threshold:
     2020-07-22:
       value: 2
-    2021-07-16:
-      value: 2
-    2022-07-18:
-      value: 2
-    2023-04-01:
-      value: 2
   amount:
     2020-07-22:
       value: 14600
@@ -52,17 +34,11 @@ brackets:
       value: 14600
     2022-07-18:
       value: 14600
-    2023-04-01:
+    2023-09-01:
       value: 15476
 - threshold:
     2020-07-22:
       value: 3
-    2021-07-16:
-      value: 3
-    2022-07-18:
-      value: 3
-    2023-04-01:
-      value: 3
   amount:
     2020-07-22:
       value: 15920
@@ -70,17 +46,11 @@ brackets:
       value: 15920
     2022-07-18:
       value: 15920
-    2023-04-01:
+    2023-09-01:
       value: 16875
 - threshold:
     2020-07-22:
       value: 4
-    2021-07-16:
-      value: 4
-    2022-07-18:
-      value: 4
-    2023-04-01:
-      value: 4
   amount:
     2020-07-22:
       value: 17250
@@ -88,17 +58,11 @@ brackets:
       value: 17250
     2022-07-18:
       value: 17250
-    2023-04-01:
+    2023-09-01:
       value: 18285
 - threshold:
     2020-07-22:
       value: 5
-    2021-07-16:
-      value: 5
-    2022-07-18:
-      value: 5
-    2023-04-01:
-      value: 5
   amount:
     2020-07-22:
       value: 18580
@@ -106,17 +70,11 @@ brackets:
       value: 18580
     2022-07-18:
       value: 18580
-    2023-04-01:
+    2023-09-01:
       value: 19695
 - threshold:
     2020-07-22:
       value: 6
-    2021-07-16:
-      value: 6
-    2022-07-18:
-      value: 6
-    2023-04-01:
-      value: 6
   amount:
     2020-07-22:
       value: 19910
@@ -124,17 +82,11 @@ brackets:
       value: 19910
     2022-07-18:
       value: 19910
-    2023-04-01:
+    2023-09-01:
       value: 21105
 - threshold:
     2020-07-22:
       value: 7
-    2021-07-16:
-      value: 7
-    2022-07-18:
-      value: 7
-    2023-04-01:
-      value: 7
   amount:
     2020-07-22:
       value: 21240
@@ -142,17 +94,11 @@ brackets:
       value: 21240
     2022-07-18:
       value: 21240
-    2023-04-01:
+    2023-09-01:
       value: 22514
 - threshold:
     2020-07-22:
       value: 8
-    2021-07-16:
-      value: 8
-    2022-07-18:
-      value: 8
-    2023-04-01:
-      value: 8
   amount:
     2020-07-22:
       value: 22560
@@ -160,17 +106,11 @@ brackets:
       value: 22560
     2022-07-18:
       value: 22560
-    2023-04-01:
+    2023-09-01:
       value: 23914
 - threshold:
     2020-07-22:
       value: 9
-    2021-07-16:
-      value: 9
-    2022-07-18:
-      value: 9
-    2023-04-01:
-      value: 9
   amount:
     2020-07-22:
       value: 23890
@@ -178,17 +118,11 @@ brackets:
       value: 23890
     2022-07-18:
       value: 23890
-    2023-04-01:
+    2023-09-01:
       value: 25323
 - threshold:
     2020-07-22:
       value: 10
-    2021-07-16:
-      value: 10
-    2022-07-18:
-      value: 10
-    2023-04-01:
-      value: 10
   amount:
     2020-07-22:
       value: 25220
@@ -196,17 +130,11 @@ brackets:
       value: 25220
     2022-07-18:
       value: 25220
-    2023-04-01:
+    2023-09-01:
       value: 26733
 - threshold:
     2020-07-22:
       value: 11
-    2021-07-16:
-      value: 11
-    2022-07-18:
-      value: 11
-    2023-04-01:
-      value: 11
   amount:
     2020-07-22:
       value: 26540
@@ -214,17 +142,11 @@ brackets:
       value: 26540
     2022-07-18:
       value: 26540
-    2023-04-01:
+    2023-09-01:
       value: 28132
 - threshold:
     2020-07-22:
       value: 12
-    2021-07-16:
-      value: 12
-    2022-07-18:
-      value: 12
-    2023-04-01:
-      value: 12
   amount:
     2020-07-22:
       value: 27870
@@ -232,17 +154,11 @@ brackets:
       value: 27870
     2022-07-18:
       value: 27870
-    2023-04-01:
+    2023-09-01:
       value: 29542
 - threshold:
     2020-07-22:
       value: 13
-    2021-07-16:
-      value: 13
-    2022-07-18:
-      value: 13
-    2023-04-01:
-      value: 13
   amount:
     2020-07-22:
       value: 29200
@@ -250,17 +166,11 @@ brackets:
       value: 29200
     2022-07-18:
       value: 29200
-    2023-04-01:
+    2023-09-01:
       value: 30952
 - threshold:
     2020-07-22:
       value: 14
-    2021-07-16:
-      value: 14
-    2022-07-18:
-      value: 14
-    2023-04-01:
-      value: 14
   amount:
     2020-07-22:
       value: 30530
@@ -268,17 +178,11 @@ brackets:
       value: 30530
     2022-07-18:
       value: 30530
-    2023-04-01:
+    2023-09-01:
       value: 32362
 - threshold:
     2020-07-22:
       value: 15
-    2021-07-16:
-      value: 15
-    2022-07-18:
-      value: 15
-    2023-04-01:
-      value: 15
   amount:
     2020-07-22:
       value: 31860
@@ -286,17 +190,11 @@ brackets:
       value: 31860
     2022-07-18:
       value: 31860
-    2023-04-01:
+    2023-09-01:
       value: 33772
 - threshold:
     2020-07-22:
       value: 16
-    2021-07-16:
-      value: 16
-    2022-07-18:
-      value: 16
-    2023-04-01:
-      value: 16
   amount:
     2020-07-22:
       value: 33190
@@ -304,17 +202,11 @@ brackets:
       value: 33190
     2022-07-18:
       value: 33190
-    2023-04-01:
+    2023-09-01:
       value: 35181
 - threshold:
     2020-07-22:
       value: 17
-    2021-07-16:
-      value: 17
-    2022-07-18:
-      value: 17
-    2023-04-01:
-      value: 17
   amount:
     2020-07-22:
       value: 34510
@@ -322,7 +214,7 @@ brackets:
       value: 34510
     2022-07-18:
       value: 34510
-    2023-04-01:
+    2023-09-01:
       value: 36581
 metadata:
   reference:
@@ -335,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-04-01:
+    2023-09-01:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
@@ -229,5 +229,5 @@ metadata:
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
     2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
-    - href: Á mettre à jour!
+    - href: A mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
@@ -10,7 +10,7 @@ brackets:
       value: 11950
     2022-07-18:
       value: 11950
-    2023-09-01:
+    2023-03-15:
       value: 12667
 - threshold:
     2020-07-22:
@@ -22,7 +22,7 @@ brackets:
       value: 13280
     2022-07-18:
       value: 13280
-    2023-09-01:
+    2023-03-15:
       value: 14077
 - threshold:
     2020-07-22:
@@ -34,7 +34,7 @@ brackets:
       value: 14600
     2022-07-18:
       value: 14600
-    2023-09-01:
+    2023-03-15:
       value: 15476
 - threshold:
     2020-07-22:
@@ -46,7 +46,7 @@ brackets:
       value: 15920
     2022-07-18:
       value: 15920
-    2023-09-01:
+    2023-03-15:
       value: 16875
 - threshold:
     2020-07-22:
@@ -58,7 +58,7 @@ brackets:
       value: 17250
     2022-07-18:
       value: 17250
-    2023-09-01:
+    2023-03-15:
       value: 18285
 - threshold:
     2020-07-22:
@@ -70,7 +70,7 @@ brackets:
       value: 18580
     2022-07-18:
       value: 18580
-    2023-09-01:
+    2023-03-15:
       value: 19695
 - threshold:
     2020-07-22:
@@ -82,7 +82,7 @@ brackets:
       value: 19910
     2022-07-18:
       value: 19910
-    2023-09-01:
+    2023-03-15:
       value: 21105
 - threshold:
     2020-07-22:
@@ -94,7 +94,7 @@ brackets:
       value: 21240
     2022-07-18:
       value: 21240
-    2023-09-01:
+    2023-03-15:
       value: 22514
 - threshold:
     2020-07-22:
@@ -106,7 +106,7 @@ brackets:
       value: 22560
     2022-07-18:
       value: 22560
-    2023-09-01:
+    2023-03-15:
       value: 23914
 - threshold:
     2020-07-22:
@@ -118,7 +118,7 @@ brackets:
       value: 23890
     2022-07-18:
       value: 23890
-    2023-09-01:
+    2023-03-15:
       value: 25323
 - threshold:
     2020-07-22:
@@ -130,7 +130,7 @@ brackets:
       value: 25220
     2022-07-18:
       value: 25220
-    2023-09-01:
+    2023-03-15:
       value: 26733
 - threshold:
     2020-07-22:
@@ -142,7 +142,7 @@ brackets:
       value: 26540
     2022-07-18:
       value: 26540
-    2023-09-01:
+    2023-03-15:
       value: 28132
 - threshold:
     2020-07-22:
@@ -154,7 +154,7 @@ brackets:
       value: 27870
     2022-07-18:
       value: 27870
-    2023-09-01:
+    2023-03-15:
       value: 29542
 - threshold:
     2020-07-22:
@@ -166,7 +166,7 @@ brackets:
       value: 29200
     2022-07-18:
       value: 29200
-    2023-09-01:
+    2023-03-15:
       value: 30952
 - threshold:
     2020-07-22:
@@ -178,7 +178,7 @@ brackets:
       value: 30530
     2022-07-18:
       value: 30530
-    2023-09-01:
+    2023-03-15:
       value: 32362
 - threshold:
     2020-07-22:
@@ -190,7 +190,7 @@ brackets:
       value: 31860
     2022-07-18:
       value: 31860
-    2023-09-01:
+    2023-03-15:
       value: 33772
 - threshold:
     2020-07-22:
@@ -202,7 +202,7 @@ brackets:
       value: 33190
     2022-07-18:
       value: 33190
-    2023-09-01:
+    2023-03-15:
       value: 35181
 - threshold:
     2020-07-22:
@@ -214,7 +214,7 @@ brackets:
       value: 34510
     2022-07-18:
       value: 34510
-    2023-09-01:
+    2023-03-15:
       value: 36581
 metadata:
   reference:
@@ -227,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-09-01:
+    2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_5.yaml
@@ -7,6 +7,8 @@ brackets:
       value: 0
     2022-07-18:
       value: 0
+    2023-04-01:
+      value: 0
   amount:
     2020-07-22:
       value: 11950
@@ -14,12 +16,16 @@ brackets:
       value: 11950
     2022-07-18:
       value: 11950
+    2023-04-01:
+      value: 12667
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
     2022-07-18:
+      value: 1
+    2023-04-01:
       value: 1
   amount:
     2020-07-22:
@@ -28,12 +34,16 @@ brackets:
       value: 13280
     2022-07-18:
       value: 13280
+    2023-04-01:
+      value: 14077
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
       value: 2
     2022-07-18:
+      value: 2
+    2023-04-01:
       value: 2
   amount:
     2020-07-22:
@@ -42,12 +52,16 @@ brackets:
       value: 14600
     2022-07-18:
       value: 14600
+    2023-04-01:
+      value: 15476
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
       value: 3
     2022-07-18:
+      value: 3
+    2023-04-01:
       value: 3
   amount:
     2020-07-22:
@@ -56,12 +70,16 @@ brackets:
       value: 15920
     2022-07-18:
       value: 15920
+    2023-04-01:
+      value: 16875
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
       value: 4
     2022-07-18:
+      value: 4
+    2023-04-01:
       value: 4
   amount:
     2020-07-22:
@@ -70,12 +88,16 @@ brackets:
       value: 17250
     2022-07-18:
       value: 17250
+    2023-04-01:
+      value: 18285
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
       value: 5
     2022-07-18:
+      value: 5
+    2023-04-01:
       value: 5
   amount:
     2020-07-22:
@@ -84,12 +106,16 @@ brackets:
       value: 18580
     2022-07-18:
       value: 18580
+    2023-04-01:
+      value: 19695
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
       value: 6
     2022-07-18:
+      value: 6
+    2023-04-01:
       value: 6
   amount:
     2020-07-22:
@@ -98,12 +124,16 @@ brackets:
       value: 19910
     2022-07-18:
       value: 19910
+    2023-04-01:
+      value: 21105
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
       value: 7
     2022-07-18:
+      value: 7
+    2023-04-01:
       value: 7
   amount:
     2020-07-22:
@@ -112,12 +142,16 @@ brackets:
       value: 21240
     2022-07-18:
       value: 21240
+    2023-04-01:
+      value: 22514
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
       value: 8
     2022-07-18:
+      value: 8
+    2023-04-01:
       value: 8
   amount:
     2020-07-22:
@@ -126,12 +160,16 @@ brackets:
       value: 22560
     2022-07-18:
       value: 22560
+    2023-04-01:
+      value: 23914
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
       value: 9
     2022-07-18:
+      value: 9
+    2023-04-01:
       value: 9
   amount:
     2020-07-22:
@@ -140,12 +178,16 @@ brackets:
       value: 23890
     2022-07-18:
       value: 23890
+    2023-04-01:
+      value: 25323
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
       value: 10
     2022-07-18:
+      value: 10
+    2023-04-01:
       value: 10
   amount:
     2020-07-22:
@@ -154,12 +196,16 @@ brackets:
       value: 25220
     2022-07-18:
       value: 25220
+    2023-04-01:
+      value: 26733
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
       value: 11
     2022-07-18:
+      value: 11
+    2023-04-01:
       value: 11
   amount:
     2020-07-22:
@@ -168,12 +214,16 @@ brackets:
       value: 26540
     2022-07-18:
       value: 26540
+    2023-04-01:
+      value: 28132
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
       value: 12
     2022-07-18:
+      value: 12
+    2023-04-01:
       value: 12
   amount:
     2020-07-22:
@@ -182,12 +232,16 @@ brackets:
       value: 27870
     2022-07-18:
       value: 27870
+    2023-04-01:
+      value: 29542
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
       value: 13
     2022-07-18:
+      value: 13
+    2023-04-01:
       value: 13
   amount:
     2020-07-22:
@@ -196,12 +250,16 @@ brackets:
       value: 29200
     2022-07-18:
       value: 29200
+    2023-04-01:
+      value: 30952
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
       value: 14
     2022-07-18:
+      value: 14
+    2023-04-01:
       value: 14
   amount:
     2020-07-22:
@@ -210,12 +268,16 @@ brackets:
       value: 30530
     2022-07-18:
       value: 30530
+    2023-04-01:
+      value: 32362
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
       value: 15
     2022-07-18:
+      value: 15
+    2023-04-01:
       value: 15
   amount:
     2020-07-22:
@@ -224,12 +286,16 @@ brackets:
       value: 31860
     2022-07-18:
       value: 31860
+    2023-04-01:
+      value: 33772
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
       value: 16
     2022-07-18:
+      value: 16
+    2023-04-01:
       value: 16
   amount:
     2020-07-22:
@@ -238,12 +304,16 @@ brackets:
       value: 33190
     2022-07-18:
       value: 33190
+    2023-04-01:
+      value: 35181
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
       value: 17
     2022-07-18:
+      value: 17
+    2023-04-01:
       value: 17
   amount:
     2020-07-22:
@@ -252,6 +322,8 @@ brackets:
       value: 34510
     2022-07-18:
       value: 34510
+    2023-04-01:
+      value: 36581
 metadata:
   reference:
     2020-07-22:
@@ -263,4 +335,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
+    2023-04-01:
+    - title: Aucun document officiel encore, à mettre à jour lors de la publication!
+    - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
@@ -10,7 +10,7 @@ brackets:
       value: 7540
     2022-07-18:
       value: 7540
-    2023-09-01:
+    2023-03-15:
       value: 7992
 - threshold:
     2020-07-22:
@@ -22,7 +22,7 @@ brackets:
       value: 8370
     2022-07-18:
       value: 8370
-    2023-09-01:
+    2023-03-15:
       value: 8872
 - threshold:
     2020-07-22:
@@ -34,7 +34,7 @@ brackets:
       value: 9220
     2022-07-18:
       value: 9220
-    2023-09-01:
+    2023-03-15:
       value: 9773
 - threshold:
     2020-07-22:
@@ -46,7 +46,7 @@ brackets:
       value: 10050
     2022-07-18:
       value: 10050
-    2023-09-01:
+    2023-03-15:
       value: 10653
 - threshold:
     2020-07-22:
@@ -58,7 +58,7 @@ brackets:
       value: 10880
     2022-07-18:
       value: 10880
-    2023-09-01:
+    2023-03-15:
       value: 11533
 - threshold:
     2020-07-22:
@@ -70,7 +70,7 @@ brackets:
       value: 11730
     2022-07-18:
       value: 11730
-    2023-09-01:
+    2023-03-15:
       value: 12434
 - threshold:
     2020-07-22:
@@ -82,7 +82,7 @@ brackets:
       value: 12570
     2022-07-18:
       value: 12570
-    2023-09-01:
+    2023-03-15:
       value: 13324
 - threshold:
     2020-07-22:
@@ -94,7 +94,7 @@ brackets:
       value: 13410
     2022-07-18:
       value: 13410
-    2023-09-01:
+    2023-03-15:
       value: 14215
 - threshold:
     2020-07-22:
@@ -106,7 +106,7 @@ brackets:
       value: 14240
     2022-07-18:
       value: 14240
-    2023-09-01:
+    2023-03-15:
       value: 15094
 - threshold:
     2020-07-22:
@@ -118,7 +118,7 @@ brackets:
       value: 15080
     2022-07-18:
       value: 15080
-    2023-09-01:
+    2023-03-15:
       value: 15985
 - threshold:
     2020-07-22:
@@ -130,7 +130,7 @@ brackets:
       value: 15910
     2022-07-18:
       value: 15910
-    2023-09-01:
+    2023-03-15:
       value: 16865
 - threshold:
     2020-07-22:
@@ -142,7 +142,7 @@ brackets:
       value: 16750
     2022-07-18:
       value: 16750
-    2023-09-01:
+    2023-03-15:
       value: 17755
 - threshold:
     2020-07-22:
@@ -154,7 +154,7 @@ brackets:
       value: 17590
     2022-07-18:
       value: 17590
-    2023-09-01:
+    2023-03-15:
       value: 18645
 - threshold:
     2020-07-22:
@@ -166,7 +166,7 @@ brackets:
       value: 18420
     2022-07-18:
       value: 18420
-    2023-09-01:
+    2023-03-15:
       value: 19525
 - threshold:
     2020-07-22:
@@ -178,7 +178,7 @@ brackets:
       value: 19270
     2022-07-18:
       value: 19270
-    2023-09-01:
+    2023-03-15:
       value: 20426
 - threshold:
     2020-07-22:
@@ -190,7 +190,7 @@ brackets:
       value: 20110
     2022-07-18:
       value: 20110
-    2023-09-01:
+    2023-03-15:
       value: 21317
 - threshold:
     2020-07-22:
@@ -202,7 +202,7 @@ brackets:
       value: 20940
     2022-07-18:
       value: 20940
-    2023-09-01:
+    2023-03-15:
       value: 22196
 - threshold:
     2020-07-22:
@@ -214,7 +214,7 @@ brackets:
       value: 21780
     2022-07-18:
       value: 21780
-    2023-09-01:
+    2023-03-15:
       value: 23087
 metadata:
   reference:
@@ -227,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-09-01:
+    2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
@@ -229,5 +229,5 @@ metadata:
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
     2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
-    - href: Á mettre à jour!
+    - href: A mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
@@ -3,12 +3,6 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
-    2021-07-16:
-      value: 0
-    2022-07-18:
-      value: 0
-    2023-04-01:
-      value: 0
   amount:
     2020-07-22:
       value: 7540
@@ -16,17 +10,11 @@ brackets:
       value: 7540
     2022-07-18:
       value: 7540
-    2023-04-01:
+    2023-09-01:
       value: 7992
 - threshold:
     2020-07-22:
       value: 1
-    2021-07-16:
-      value: 1
-    2022-07-18:
-      value: 1
-    2023-04-01:
-      value: 1
   amount:
     2020-07-22:
       value: 8370
@@ -34,17 +22,11 @@ brackets:
       value: 8370
     2022-07-18:
       value: 8370
-    2023-04-01:
+    2023-09-01:
       value: 8872
 - threshold:
     2020-07-22:
       value: 2
-    2021-07-16:
-      value: 2
-    2022-07-18:
-      value: 2
-    2023-04-01:
-      value: 2
   amount:
     2020-07-22:
       value: 9220
@@ -52,17 +34,11 @@ brackets:
       value: 9220
     2022-07-18:
       value: 9220
-    2023-04-01:
+    2023-09-01:
       value: 9773
 - threshold:
     2020-07-22:
       value: 3
-    2021-07-16:
-      value: 3
-    2022-07-18:
-      value: 3
-    2023-04-01:
-      value: 3
   amount:
     2020-07-22:
       value: 10050
@@ -70,17 +46,11 @@ brackets:
       value: 10050
     2022-07-18:
       value: 10050
-    2023-04-01:
+    2023-09-01:
       value: 10653
 - threshold:
     2020-07-22:
       value: 4
-    2021-07-16:
-      value: 4
-    2022-07-18:
-      value: 4
-    2023-04-01:
-      value: 4
   amount:
     2020-07-22:
       value: 10880
@@ -88,17 +58,11 @@ brackets:
       value: 10880
     2022-07-18:
       value: 10880
-    2023-04-01:
+    2023-09-01:
       value: 11533
 - threshold:
     2020-07-22:
       value: 5
-    2021-07-16:
-      value: 5
-    2022-07-18:
-      value: 5
-    2023-04-01:
-      value: 5
   amount:
     2020-07-22:
       value: 11730
@@ -106,17 +70,11 @@ brackets:
       value: 11730
     2022-07-18:
       value: 11730
-    2023-04-01:
+    2023-09-01:
       value: 12434
 - threshold:
     2020-07-22:
       value: 6
-    2021-07-16:
-      value: 6
-    2022-07-18:
-      value: 6
-    2023-04-01:
-      value: 6
   amount:
     2020-07-22:
       value: 12570
@@ -124,17 +82,11 @@ brackets:
       value: 12570
     2022-07-18:
       value: 12570
-    2023-04-01:
+    2023-09-01:
       value: 13324
 - threshold:
     2020-07-22:
       value: 7
-    2021-07-16:
-      value: 7
-    2022-07-18:
-      value: 7
-    2023-04-01:
-      value: 7
   amount:
     2020-07-22:
       value: 13410
@@ -142,17 +94,11 @@ brackets:
       value: 13410
     2022-07-18:
       value: 13410
-    2023-04-01:
+    2023-09-01:
       value: 14215
 - threshold:
     2020-07-22:
       value: 8
-    2021-07-16:
-      value: 8
-    2022-07-18:
-      value: 8
-    2023-04-01:
-      value: 8
   amount:
     2020-07-22:
       value: 14240
@@ -160,17 +106,11 @@ brackets:
       value: 14240
     2022-07-18:
       value: 14240
-    2023-04-01:
+    2023-09-01:
       value: 15094
 - threshold:
     2020-07-22:
       value: 9
-    2021-07-16:
-      value: 9
-    2022-07-18:
-      value: 9
-    2023-04-01:
-      value: 9
   amount:
     2020-07-22:
       value: 15080
@@ -178,17 +118,11 @@ brackets:
       value: 15080
     2022-07-18:
       value: 15080
-    2023-04-01:
+    2023-09-01:
       value: 15985
 - threshold:
     2020-07-22:
       value: 10
-    2021-07-16:
-      value: 10
-    2022-07-18:
-      value: 10
-    2023-04-01:
-      value: 10
   amount:
     2020-07-22:
       value: 15910
@@ -196,17 +130,11 @@ brackets:
       value: 15910
     2022-07-18:
       value: 15910
-    2023-04-01:
+    2023-09-01:
       value: 16865
 - threshold:
     2020-07-22:
       value: 11
-    2021-07-16:
-      value: 11
-    2022-07-18:
-      value: 11
-    2023-04-01:
-      value: 11
   amount:
     2020-07-22:
       value: 16750
@@ -214,17 +142,11 @@ brackets:
       value: 16750
     2022-07-18:
       value: 16750
-    2023-04-01:
+    2023-09-01:
       value: 17755
 - threshold:
     2020-07-22:
       value: 12
-    2021-07-16:
-      value: 12
-    2022-07-18:
-      value: 12
-    2023-04-01:
-      value: 12
   amount:
     2020-07-22:
       value: 17590
@@ -232,17 +154,11 @@ brackets:
       value: 17590
     2022-07-18:
       value: 17590
-    2023-04-01:
+    2023-09-01:
       value: 18645
 - threshold:
     2020-07-22:
       value: 13
-    2021-07-16:
-      value: 13
-    2022-07-18:
-      value: 13
-    2023-04-01:
-      value: 13
   amount:
     2020-07-22:
       value: 18420
@@ -250,17 +166,11 @@ brackets:
       value: 18420
     2022-07-18:
       value: 18420
-    2023-04-01:
+    2023-09-01:
       value: 19525
 - threshold:
     2020-07-22:
       value: 14
-    2021-07-16:
-      value: 14
-    2022-07-18:
-      value: 14
-    2023-04-01:
-      value: 14
   amount:
     2020-07-22:
       value: 19270
@@ -268,17 +178,11 @@ brackets:
       value: 19270
     2022-07-18:
       value: 19270
-    2023-04-01:
+    2023-09-01:
       value: 20426
 - threshold:
     2020-07-22:
       value: 15
-    2021-07-16:
-      value: 15
-    2022-07-18:
-      value: 15
-    2023-04-01:
-      value: 15
   amount:
     2020-07-22:
       value: 20110
@@ -286,17 +190,11 @@ brackets:
       value: 20110
     2022-07-18:
       value: 20110
-    2023-04-01:
+    2023-09-01:
       value: 21317
 - threshold:
     2020-07-22:
       value: 16
-    2021-07-16:
-      value: 16
-    2022-07-18:
-      value: 16
-    2023-04-01:
-      value: 16
   amount:
     2020-07-22:
       value: 20940
@@ -304,17 +202,11 @@ brackets:
       value: 20940
     2022-07-18:
       value: 20940
-    2023-04-01:
+    2023-09-01:
       value: 22196
 - threshold:
     2020-07-22:
       value: 17
-    2021-07-16:
-      value: 17
-    2022-07-18:
-      value: 17
-    2023-04-01:
-      value: 17
   amount:
     2020-07-22:
       value: 21780
@@ -322,7 +214,7 @@ brackets:
       value: 21780
     2022-07-18:
       value: 21780
-    2023-04-01:
+    2023-09-01:
       value: 23087
 metadata:
   reference:
@@ -335,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-04-01:
+    2023-09-01:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_6.yaml
@@ -7,6 +7,8 @@ brackets:
       value: 0
     2022-07-18:
       value: 0
+    2023-04-01:
+      value: 0
   amount:
     2020-07-22:
       value: 7540
@@ -14,12 +16,16 @@ brackets:
       value: 7540
     2022-07-18:
       value: 7540
+    2023-04-01:
+      value: 7992
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
     2022-07-18:
+      value: 1
+    2023-04-01:
       value: 1
   amount:
     2020-07-22:
@@ -28,12 +34,16 @@ brackets:
       value: 8370
     2022-07-18:
       value: 8370
+    2023-04-01:
+      value: 8872
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
       value: 2
     2022-07-18:
+      value: 2
+    2023-04-01:
       value: 2
   amount:
     2020-07-22:
@@ -42,12 +52,16 @@ brackets:
       value: 9220
     2022-07-18:
       value: 9220
+    2023-04-01:
+      value: 9773
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
       value: 3
     2022-07-18:
+      value: 3
+    2023-04-01:
       value: 3
   amount:
     2020-07-22:
@@ -56,12 +70,16 @@ brackets:
       value: 10050
     2022-07-18:
       value: 10050
+    2023-04-01:
+      value: 10653
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
       value: 4
     2022-07-18:
+      value: 4
+    2023-04-01:
       value: 4
   amount:
     2020-07-22:
@@ -70,12 +88,16 @@ brackets:
       value: 10880
     2022-07-18:
       value: 10880
+    2023-04-01:
+      value: 11533
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
       value: 5
     2022-07-18:
+      value: 5
+    2023-04-01:
       value: 5
   amount:
     2020-07-22:
@@ -84,12 +106,16 @@ brackets:
       value: 11730
     2022-07-18:
       value: 11730
+    2023-04-01:
+      value: 12434
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
       value: 6
     2022-07-18:
+      value: 6
+    2023-04-01:
       value: 6
   amount:
     2020-07-22:
@@ -98,12 +124,16 @@ brackets:
       value: 12570
     2022-07-18:
       value: 12570
+    2023-04-01:
+      value: 13324
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
       value: 7
     2022-07-18:
+      value: 7
+    2023-04-01:
       value: 7
   amount:
     2020-07-22:
@@ -112,12 +142,16 @@ brackets:
       value: 13410
     2022-07-18:
       value: 13410
+    2023-04-01:
+      value: 14215
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
       value: 8
     2022-07-18:
+      value: 8
+    2023-04-01:
       value: 8
   amount:
     2020-07-22:
@@ -126,12 +160,16 @@ brackets:
       value: 14240
     2022-07-18:
       value: 14240
+    2023-04-01:
+      value: 15094
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
       value: 9
     2022-07-18:
+      value: 9
+    2023-04-01:
       value: 9
   amount:
     2020-07-22:
@@ -140,12 +178,16 @@ brackets:
       value: 15080
     2022-07-18:
       value: 15080
+    2023-04-01:
+      value: 15985
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
       value: 10
     2022-07-18:
+      value: 10
+    2023-04-01:
       value: 10
   amount:
     2020-07-22:
@@ -154,12 +196,16 @@ brackets:
       value: 15910
     2022-07-18:
       value: 15910
+    2023-04-01:
+      value: 16865
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
       value: 11
     2022-07-18:
+      value: 11
+    2023-04-01:
       value: 11
   amount:
     2020-07-22:
@@ -168,12 +214,16 @@ brackets:
       value: 16750
     2022-07-18:
       value: 16750
+    2023-04-01:
+      value: 17755
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
       value: 12
     2022-07-18:
+      value: 12
+    2023-04-01:
       value: 12
   amount:
     2020-07-22:
@@ -182,12 +232,16 @@ brackets:
       value: 17590
     2022-07-18:
       value: 17590
+    2023-04-01:
+      value: 18645
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
       value: 13
     2022-07-18:
+      value: 13
+    2023-04-01:
       value: 13
   amount:
     2020-07-22:
@@ -196,12 +250,16 @@ brackets:
       value: 18420
     2022-07-18:
       value: 18420
+    2023-04-01:
+      value: 19525
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
       value: 14
     2022-07-18:
+      value: 14
+    2023-04-01:
       value: 14
   amount:
     2020-07-22:
@@ -210,12 +268,16 @@ brackets:
       value: 19270
     2022-07-18:
       value: 19270
+    2023-04-01:
+      value: 20426
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
       value: 15
     2022-07-18:
+      value: 15
+    2023-04-01:
       value: 15
   amount:
     2020-07-22:
@@ -224,12 +286,16 @@ brackets:
       value: 20110
     2022-07-18:
       value: 20110
+    2023-04-01:
+      value: 21317
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
       value: 16
     2022-07-18:
+      value: 16
+    2023-04-01:
       value: 16
   amount:
     2020-07-22:
@@ -238,12 +304,16 @@ brackets:
       value: 20940
     2022-07-18:
       value: 20940
+    2023-04-01:
+      value: 22196
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
       value: 17
     2022-07-18:
+      value: 17
+    2023-04-01:
       value: 17
   amount:
     2020-07-22:
@@ -252,6 +322,8 @@ brackets:
       value: 21780
     2022-07-18:
       value: 21780
+    2023-04-01:
+      value: 23087
 metadata:
   reference:
     2020-07-22:
@@ -263,4 +335,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
+    2023-04-01:
+    - title: Aucun document officiel encore, à mettre à jour lors de la publication!
+    - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
@@ -10,7 +10,7 @@ brackets:
       value: 250
     2022-07-18:
       value: 250
-    2023-09-01:
+    2023-03-15:
       value: 265
 - threshold:
     2020-07-22:
@@ -22,7 +22,7 @@ brackets:
       value: 500
     2022-07-18:
       value: 500
-    2023-09-01:
+    2023-03-15:
       value: 530
 - threshold:
     2020-07-22:
@@ -34,7 +34,7 @@ brackets:
       value: 750
     2022-07-18:
       value: 750
-    2023-09-01:
+    2023-03-15:
       value: 795
 - threshold:
     2020-07-22:
@@ -46,7 +46,7 @@ brackets:
       value: 1000
     2022-07-18:
       value: 1000
-    2023-09-01:
+    2023-03-15:
       value: 1060
 - threshold:
     2020-07-22:
@@ -58,7 +58,7 @@ brackets:
       value: 1250
     2022-07-18:
       value: 1250
-    2023-09-01:
+    2023-03-15:
       value: 1325
 - threshold:
     2020-07-22:
@@ -70,7 +70,7 @@ brackets:
       value: 1500
     2022-07-18:
       value: 1500
-    2023-09-01:
+    2023-03-15:
       value: 1590
 - threshold:
     2020-07-22:
@@ -82,7 +82,7 @@ brackets:
       value: 1750
     2022-07-18:
       value: 1750
-    2023-09-01:
+    2023-03-15:
       value: 1855
 - threshold:
     2020-07-22:
@@ -94,7 +94,7 @@ brackets:
       value: 2000
     2022-07-18:
       value: 2000
-    2023-09-01:
+    2023-03-15:
       value: 2120
 - threshold:
     2020-07-22:
@@ -106,7 +106,7 @@ brackets:
       value: 2250
     2022-07-18:
       value: 2250
-    2023-09-01:
+    2023-03-15:
       value: 2385
 - threshold:
     2020-07-22:
@@ -118,7 +118,7 @@ brackets:
       value: 2500
     2022-07-18:
       value: 2500
-    2023-09-01:
+    2023-03-15:
       value: 2650
 - threshold:
     2020-07-22:
@@ -130,7 +130,7 @@ brackets:
       value: 2750
     2022-07-18:
       value: 2750
-    2023-09-01:
+    2023-03-15:
       value: 2915
 - threshold:
     2020-07-22:
@@ -142,7 +142,7 @@ brackets:
       value: 3000
     2022-07-18:
       value: 3000
-    2023-09-01:
+    2023-03-15:
       value: 3180
 - threshold:
     2020-07-22:
@@ -154,7 +154,7 @@ brackets:
       value: 3250
     2022-07-18:
       value: 3250
-    2023-09-01:
+    2023-03-15:
       value: 3445
 - threshold:
     2020-07-22:
@@ -166,7 +166,7 @@ brackets:
       value: 3500
     2022-07-18:
       value: 3500
-    2023-09-01:
+    2023-03-15:
       value: 3710
 - threshold:
     2020-07-22:
@@ -178,7 +178,7 @@ brackets:
       value: 3750
     2022-07-18:
       value: 3750
-    2023-09-01:
+    2023-03-15:
       value: 3975
 - threshold:
     2020-07-22:
@@ -190,7 +190,7 @@ brackets:
       value: 4000
     2022-07-18:
       value: 4000
-    2023-09-01:
+    2023-03-15:
       value: 4240
 - threshold:
     2020-07-22:
@@ -202,7 +202,7 @@ brackets:
       value: 4250
     2022-07-18:
       value: 4250
-    2023-09-01:
+    2023-03-15:
       value: 4505
 - threshold:
     2020-07-22:
@@ -214,7 +214,7 @@ brackets:
       value: 4500
     2022-07-18:
       value: 4500
-    2023-09-01:
+    2023-03-15:
       value: 4770
 metadata:
   reference:
@@ -227,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-09-01:
+    2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
@@ -7,6 +7,8 @@ brackets:
       value: 0
     2022-07-18:
       value: 0
+    2023-04-01:
+      value: 0
   amount:
     2020-07-22:
       value: 250
@@ -14,12 +16,16 @@ brackets:
       value: 250
     2022-07-18:
       value: 250
+    2023-04-01:
+      value: 265
 - threshold:
     2020-07-22:
       value: 1
     2021-07-16:
       value: 1
     2022-07-18:
+      value: 1
+    2023-04-01:
       value: 1
   amount:
     2020-07-22:
@@ -28,12 +34,16 @@ brackets:
       value: 500
     2022-07-18:
       value: 500
+    2023-04-01:
+      value: 530
 - threshold:
     2020-07-22:
       value: 2
     2021-07-16:
       value: 2
     2022-07-18:
+      value: 2
+    2023-04-01:
       value: 2
   amount:
     2020-07-22:
@@ -42,12 +52,16 @@ brackets:
       value: 750
     2022-07-18:
       value: 750
+    2023-04-01:
+      value: 795
 - threshold:
     2020-07-22:
       value: 3
     2021-07-16:
       value: 3
     2022-07-18:
+      value: 3
+    2023-04-01:
       value: 3
   amount:
     2020-07-22:
@@ -56,12 +70,16 @@ brackets:
       value: 1000
     2022-07-18:
       value: 1000
+    2023-04-01:
+      value: 1060
 - threshold:
     2020-07-22:
       value: 4
     2021-07-16:
       value: 4
     2022-07-18:
+      value: 4
+    2023-04-01:
       value: 4
   amount:
     2020-07-22:
@@ -70,12 +88,16 @@ brackets:
       value: 1250
     2022-07-18:
       value: 1250
+    2023-04-01:
+      value: 1325
 - threshold:
     2020-07-22:
       value: 5
     2021-07-16:
       value: 5
     2022-07-18:
+      value: 5
+    2023-04-01:
       value: 5
   amount:
     2020-07-22:
@@ -84,12 +106,16 @@ brackets:
       value: 1500
     2022-07-18:
       value: 1500
+    2023-04-01:
+      value: 1590
 - threshold:
     2020-07-22:
       value: 6
     2021-07-16:
       value: 6
     2022-07-18:
+      value: 6
+    2023-04-01:
       value: 6
   amount:
     2020-07-22:
@@ -98,12 +124,16 @@ brackets:
       value: 1750
     2022-07-18:
       value: 1750
+    2023-04-01:
+      value: 1855
 - threshold:
     2020-07-22:
       value: 7
     2021-07-16:
       value: 7
     2022-07-18:
+      value: 7
+    2023-04-01:
       value: 7
   amount:
     2020-07-22:
@@ -112,12 +142,16 @@ brackets:
       value: 2000
     2022-07-18:
       value: 2000
+    2023-04-01:
+      value: 2120
 - threshold:
     2020-07-22:
       value: 8
     2021-07-16:
       value: 8
     2022-07-18:
+      value: 8
+    2023-04-01:
       value: 8
   amount:
     2020-07-22:
@@ -126,12 +160,16 @@ brackets:
       value: 2250
     2022-07-18:
       value: 2250
+    2023-04-01:
+      value: 2385
 - threshold:
     2020-07-22:
       value: 9
     2021-07-16:
       value: 9
     2022-07-18:
+      value: 9
+    2023-04-01:
       value: 9
   amount:
     2020-07-22:
@@ -140,12 +178,16 @@ brackets:
       value: 2500
     2022-07-18:
       value: 2500
+    2023-04-01:
+      value: 2650
 - threshold:
     2020-07-22:
       value: 10
     2021-07-16:
       value: 10
     2022-07-18:
+      value: 10
+    2023-04-01:
       value: 10
   amount:
     2020-07-22:
@@ -154,12 +196,16 @@ brackets:
       value: 2750
     2022-07-18:
       value: 2750
+    2023-04-01:
+      value: 2915
 - threshold:
     2020-07-22:
       value: 11
     2021-07-16:
       value: 11
     2022-07-18:
+      value: 11
+    2023-04-01:
       value: 11
   amount:
     2020-07-22:
@@ -168,12 +214,16 @@ brackets:
       value: 3000
     2022-07-18:
       value: 3000
+    2023-04-01:
+      value: 3180
 - threshold:
     2020-07-22:
       value: 12
     2021-07-16:
       value: 12
     2022-07-18:
+      value: 12
+    2023-04-01:
       value: 12
   amount:
     2020-07-22:
@@ -182,12 +232,16 @@ brackets:
       value: 3250
     2022-07-18:
       value: 3250
+    2023-04-01:
+      value: 3445
 - threshold:
     2020-07-22:
       value: 13
     2021-07-16:
       value: 13
     2022-07-18:
+      value: 13
+    2023-04-01:
       value: 13
   amount:
     2020-07-22:
@@ -196,12 +250,16 @@ brackets:
       value: 3500
     2022-07-18:
       value: 3500
+    2023-04-01:
+      value: 3710
 - threshold:
     2020-07-22:
       value: 14
     2021-07-16:
       value: 14
     2022-07-18:
+      value: 14
+    2023-04-01:
       value: 14
   amount:
     2020-07-22:
@@ -210,12 +268,16 @@ brackets:
       value: 3750
     2022-07-18:
       value: 3750
+    2023-04-01:
+      value: 3975
 - threshold:
     2020-07-22:
       value: 15
     2021-07-16:
       value: 15
     2022-07-18:
+      value: 15
+    2023-04-01:
       value: 15
   amount:
     2020-07-22:
@@ -224,12 +286,16 @@ brackets:
       value: 4000
     2022-07-18:
       value: 4000
+    2023-04-01:
+      value: 4240
 - threshold:
     2020-07-22:
       value: 16
     2021-07-16:
       value: 16
     2022-07-18:
+      value: 16
+    2023-04-01:
       value: 16
   amount:
     2020-07-22:
@@ -238,12 +304,16 @@ brackets:
       value: 4250
     2022-07-18:
       value: 4250
+    2023-04-01:
+      value: 4505
 - threshold:
     2020-07-22:
       value: 17
     2021-07-16:
       value: 17
     2022-07-18:
+      value: 17
+    2023-04-01:
       value: 17
   amount:
     2020-07-22:
@@ -252,6 +322,8 @@ brackets:
       value: 4500
     2022-07-18:
       value: 4500
+    2023-04-01:
+      value: 4770
 metadata:
   reference:
     2020-07-22:
@@ -263,4 +335,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
+    2023-04-01:
+    - title: Aucun document officiel encore, à mettre à jour lors de la publication!
+    - href: Á mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
@@ -229,5 +229,5 @@ metadata:
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
     2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
-    - href: Á mettre à jour!
+    - href: A mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_7.yaml
@@ -3,12 +3,6 @@ brackets:
 - threshold:
     2020-07-22:
       value: 0
-    2021-07-16:
-      value: 0
-    2022-07-18:
-      value: 0
-    2023-04-01:
-      value: 0
   amount:
     2020-07-22:
       value: 250
@@ -16,17 +10,11 @@ brackets:
       value: 250
     2022-07-18:
       value: 250
-    2023-04-01:
+    2023-09-01:
       value: 265
 - threshold:
     2020-07-22:
       value: 1
-    2021-07-16:
-      value: 1
-    2022-07-18:
-      value: 1
-    2023-04-01:
-      value: 1
   amount:
     2020-07-22:
       value: 500
@@ -34,17 +22,11 @@ brackets:
       value: 500
     2022-07-18:
       value: 500
-    2023-04-01:
+    2023-09-01:
       value: 530
 - threshold:
     2020-07-22:
       value: 2
-    2021-07-16:
-      value: 2
-    2022-07-18:
-      value: 2
-    2023-04-01:
-      value: 2
   amount:
     2020-07-22:
       value: 750
@@ -52,17 +34,11 @@ brackets:
       value: 750
     2022-07-18:
       value: 750
-    2023-04-01:
+    2023-09-01:
       value: 795
 - threshold:
     2020-07-22:
       value: 3
-    2021-07-16:
-      value: 3
-    2022-07-18:
-      value: 3
-    2023-04-01:
-      value: 3
   amount:
     2020-07-22:
       value: 1000
@@ -70,17 +46,11 @@ brackets:
       value: 1000
     2022-07-18:
       value: 1000
-    2023-04-01:
+    2023-09-01:
       value: 1060
 - threshold:
     2020-07-22:
       value: 4
-    2021-07-16:
-      value: 4
-    2022-07-18:
-      value: 4
-    2023-04-01:
-      value: 4
   amount:
     2020-07-22:
       value: 1250
@@ -88,17 +58,11 @@ brackets:
       value: 1250
     2022-07-18:
       value: 1250
-    2023-04-01:
+    2023-09-01:
       value: 1325
 - threshold:
     2020-07-22:
       value: 5
-    2021-07-16:
-      value: 5
-    2022-07-18:
-      value: 5
-    2023-04-01:
-      value: 5
   amount:
     2020-07-22:
       value: 1500
@@ -106,17 +70,11 @@ brackets:
       value: 1500
     2022-07-18:
       value: 1500
-    2023-04-01:
+    2023-09-01:
       value: 1590
 - threshold:
     2020-07-22:
       value: 6
-    2021-07-16:
-      value: 6
-    2022-07-18:
-      value: 6
-    2023-04-01:
-      value: 6
   amount:
     2020-07-22:
       value: 1750
@@ -124,17 +82,11 @@ brackets:
       value: 1750
     2022-07-18:
       value: 1750
-    2023-04-01:
+    2023-09-01:
       value: 1855
 - threshold:
     2020-07-22:
       value: 7
-    2021-07-16:
-      value: 7
-    2022-07-18:
-      value: 7
-    2023-04-01:
-      value: 7
   amount:
     2020-07-22:
       value: 2000
@@ -142,17 +94,11 @@ brackets:
       value: 2000
     2022-07-18:
       value: 2000
-    2023-04-01:
+    2023-09-01:
       value: 2120
 - threshold:
     2020-07-22:
       value: 8
-    2021-07-16:
-      value: 8
-    2022-07-18:
-      value: 8
-    2023-04-01:
-      value: 8
   amount:
     2020-07-22:
       value: 2250
@@ -160,17 +106,11 @@ brackets:
       value: 2250
     2022-07-18:
       value: 2250
-    2023-04-01:
+    2023-09-01:
       value: 2385
 - threshold:
     2020-07-22:
       value: 9
-    2021-07-16:
-      value: 9
-    2022-07-18:
-      value: 9
-    2023-04-01:
-      value: 9
   amount:
     2020-07-22:
       value: 2500
@@ -178,17 +118,11 @@ brackets:
       value: 2500
     2022-07-18:
       value: 2500
-    2023-04-01:
+    2023-09-01:
       value: 2650
 - threshold:
     2020-07-22:
       value: 10
-    2021-07-16:
-      value: 10
-    2022-07-18:
-      value: 10
-    2023-04-01:
-      value: 10
   amount:
     2020-07-22:
       value: 2750
@@ -196,17 +130,11 @@ brackets:
       value: 2750
     2022-07-18:
       value: 2750
-    2023-04-01:
+    2023-09-01:
       value: 2915
 - threshold:
     2020-07-22:
       value: 11
-    2021-07-16:
-      value: 11
-    2022-07-18:
-      value: 11
-    2023-04-01:
-      value: 11
   amount:
     2020-07-22:
       value: 3000
@@ -214,17 +142,11 @@ brackets:
       value: 3000
     2022-07-18:
       value: 3000
-    2023-04-01:
+    2023-09-01:
       value: 3180
 - threshold:
     2020-07-22:
       value: 12
-    2021-07-16:
-      value: 12
-    2022-07-18:
-      value: 12
-    2023-04-01:
-      value: 12
   amount:
     2020-07-22:
       value: 3250
@@ -232,17 +154,11 @@ brackets:
       value: 3250
     2022-07-18:
       value: 3250
-    2023-04-01:
+    2023-09-01:
       value: 3445
 - threshold:
     2020-07-22:
       value: 13
-    2021-07-16:
-      value: 13
-    2022-07-18:
-      value: 13
-    2023-04-01:
-      value: 13
   amount:
     2020-07-22:
       value: 3500
@@ -250,17 +166,11 @@ brackets:
       value: 3500
     2022-07-18:
       value: 3500
-    2023-04-01:
+    2023-09-01:
       value: 3710
 - threshold:
     2020-07-22:
       value: 14
-    2021-07-16:
-      value: 14
-    2022-07-18:
-      value: 14
-    2023-04-01:
-      value: 14
   amount:
     2020-07-22:
       value: 3750
@@ -268,17 +178,11 @@ brackets:
       value: 3750
     2022-07-18:
       value: 3750
-    2023-04-01:
+    2023-09-01:
       value: 3975
 - threshold:
     2020-07-22:
       value: 15
-    2021-07-16:
-      value: 15
-    2022-07-18:
-      value: 15
-    2023-04-01:
-      value: 15
   amount:
     2020-07-22:
       value: 4000
@@ -286,17 +190,11 @@ brackets:
       value: 4000
     2022-07-18:
       value: 4000
-    2023-04-01:
+    2023-09-01:
       value: 4240
 - threshold:
     2020-07-22:
       value: 16
-    2021-07-16:
-      value: 16
-    2022-07-18:
-      value: 16
-    2023-04-01:
-      value: 16
   amount:
     2020-07-22:
       value: 4250
@@ -304,17 +202,11 @@ brackets:
       value: 4250
     2022-07-18:
       value: 4250
-    2023-04-01:
+    2023-09-01:
       value: 4505
 - threshold:
     2020-07-22:
       value: 17
-    2021-07-16:
-      value: 17
-    2022-07-18:
-      value: 17
-    2023-04-01:
-      value: 17
   amount:
     2020-07-22:
       value: 4500
@@ -322,7 +214,7 @@ brackets:
       value: 4500
     2022-07-18:
       value: 4500
-    2023-04-01:
+    2023-09-01:
       value: 4770
 metadata:
   reference:
@@ -335,7 +227,7 @@ metadata:
     2022-07-18:
     - title: Arrêté du 18 juillet 2022 fixant les plafonds de ressources relatifs aux bourses d'enseignement supérieur du ministère de l'enseignement supérieur et de la recherche pour l'année universitaire 2022-2023
     - href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
-    2023-04-01:
+    2023-09-01:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication!
     - href: Á mettre à jour!
   type: single_amount

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '145.0.0',
+    version = '145.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal : Changement mineur.
* Périodes concernées : à partir du 15/03/2023 (En attente de publication legifrance)
* Zones impactées : 
- `openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/*`.
- `openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/montants.yaml`.
* Détails :
  - Revalorisation des plafonds et montants de la Bourse aux Critères Sociaux pour tous les échelons.
  - Les données nous viennent d'une correspondance avec le CNOUS, les dates et le sources seront éditées dès publication sur Legifrance.

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
