### PR TITLE
Label reference prime noel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# 146.0.5 [#2075](https://github.com/openfisca/openfisca-france/pull/2075)
+
+* Périodes concernées : toutes
+* Zones impactées : 
+* `prestations_sociales/solidarite_insertion/autre_solidarite/aefa`.
+* `prestations_sociales/prestations_familiales/prestations_generales/af/crds`
+* Détails : clarifie les labels des paramètres de la prime de Noël
+
+
 # 146.0.4 [#2076](https://github.com/openfisca/openfisca-france/pull/2076)
 
 * Périodes concernées : toutes

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -42,17 +42,18 @@ class aefa(Variable):
         af_nbenf = famille('af_nbenf', janvier)
         nb_parents = famille('nb_parents', janvier)
         if hasattr(af, 'age3'):
-            nbPAC = nb_enf(famille, janvier, af.af_cm.age1, af.af_cm.age3)
+            nombre_enfants = nb_enf(famille, janvier, af.af_cm.age1, af.af_cm.age3)
         else:
-            nbPAC = af_nbenf
+            nombre_enfants = af_nbenf
 
         aefa = parameters(period).prestations_sociales.solidarite_insertion.autre_solidarite.aefa
 
-        # TODO check nombre de PAC pour une famille
+        nombre_de_personnes_supplementaires_eligibles = (nb_parents >= 2) + nombre_enfants
         majoration = 1 + (condition_majoration * (
-            (nb_parents == 2) * aefa.taux_majoration.tx_2p
-            + nbPAC * aefa.taux_majoration.tx_supp * (nb_parents <= 2)
-            + nbPAC * aefa.taux_majoration.tx_3pac * max_(nbPAC - 2, 0)
+            (nombre_de_personnes_supplementaires_eligibles >= 1) * aefa.taux_majoration.tx_2p
+            + min_(nombre_enfants, 2) * aefa.taux_majoration.tx_supp * (nb_parents == 2)
+            + aefa.taux_majoration.tx_supp * (nb_parents == 1) * (nombre_enfants >= 2)
+            + aefa.taux_majoration.tx_3pac * max_(nombre_enfants - 2, 0)
             ))
 
         montant_aefa = aefa.montant_prime * majoration

--- a/openfisca_france/model/prestations/minima_sociaux/aefa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aefa.py
@@ -21,7 +21,10 @@ class aefa(Variable):
     value_type = float
     entity = Famille
     label = "Aide exceptionelle de fin d'année (prime de Noël)"
-    reference = 'https://www.service-public.fr/particuliers/vosdroits/F1325'
+    reference = [
+        'Décret n° 2022-1568 du 14 décembre 2022',
+        'https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046738342'
+        ]
     definition_period = YEAR
 
     def formula_2002_01_01(famille, period, parameters):

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/index.yaml
@@ -1,4 +1,4 @@
-description: Conditions générales et montants des Allocations Familiales (AF)
+description: Conditions générales et montants des allocations familiales (AF)
 metadata:
   short_label: Conditions générales
   label_en: "Family allowances (AF): General conditions and amount"

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/nb_enfants_min_pour_allocation.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/nb_enfants_min_pour_allocation.yaml
@@ -1,3 +1,4 @@
+description: Nombre minimal d'enfants ouvrant droit aux prestations familiales
 values:
   1932-06-14:
     value: 0
@@ -10,10 +11,10 @@ metadata:
   ipp_csv_id: af_nenf_agemin
   reference:
     1946-09-01:
-    - href: https://www.legifrance.gouv.fr/loda/id/LEGISCTA000006106589
-    - title: Décret 46-2880 du 10/12/1946
-    - href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029963006/
     - title: Article L521-1 du code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029963006/
+    - title: Décret 46-2880 du 10/12/1946
+      href: https://www.legifrance.gouv.fr/loda/id/LEGISCTA000006106589
 documentation: |-
   Notes :
   L'allocation familiale est créée en 1932 par la loi Landry du 11/03/1932, art. 1 et 2 (modif titres III et V du code du travail). Parution au JO 12/03/1932

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/crds.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/crds.yaml
@@ -7,6 +7,6 @@ metadata:
   unit: /1
   reference:
     1996-01-01:
-      title: Ordonnance n° 96-50 du 24 janvier 1996
+    - title: Ordonnance n° 96-50 du 24 janvier 1996, art. 19
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000041466982
 documentation: https://www.economie.gouv.fr/particuliers/contribution-sociale-generalisee-csg

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/index.yaml
@@ -1,6 +1,6 @@
-description: Aide exceptionnelle de fin d'année (AEFA)
+description: Aide exceptionnelle de fin d'année (AEFA) dite "prime de Noël"
 metadata:
-  short_label: AEFA
+  short_label: Prime de Noël
   label_en: "Exceptional end-of-year benefit (AEFA): amount"
   order:
   - montant_prime

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/montant_prime.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/montant_prime.yaml
@@ -1,9 +1,9 @@
-description: Montant pour une personne seule de l'Aide exceptionnelle de fin d'année (AEFA)
+description: Montant de base l'aide pour une personne seule - Aide exceptionnelle de fin d'année (AEFA)
 values:
   2003-12-30:
     value: 152.45
 metadata:
-  short_label: Montant seul
+  short_label: Montant de base pour une personne seule
   last_value_still_valid_on: "2021-09-28"
   label_en: "Exceptional end-of-year benefit (AEFA): amount"
   unit: currency

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/index.yaml
@@ -1,8 +1,8 @@
-description: Taux de majoration selon la taille du foyer de l'Aide exceptionnelle de fin d'année (AEFA)
+description: Majoration du montant de la prime selon la taille du foyer de l'aide exceptionnelle de fin d'année (AEFA)
 metadata:
-  short_label: Taux de majoration
+  short_label: Majoration du montant selon la taille du foyer
   label_en: "Exceptional end-of-year benefit (AEFA): amount"
   order:
   - tx_2p
-  - tx_3pac
   - tx_supp
+  - tx_3pac

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_2p.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_2p.yaml
@@ -1,9 +1,9 @@
-description: Taux de majoration pour 2 personnes de l'Aide exceptionnelle de fin d'année (AEFA)
+description: Taux de majoration pour un foyer composé de deux personnes en couple - Aide exceptionnelle de fin d'année (AEFA)
 values:
   2003-12-30:
     value: 0.5
 metadata:
-  short_label: Foyer de 2 personnes
+  short_label: Majoration pour un couple
   last_value_still_valid_on: "2021-10-04"
   label_en: "Exceptional end-of-year benefit (AEFA): amount"
   unit: /1

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_3pac.yaml
@@ -1,9 +1,9 @@
-description: Taux au delà de la troisième personne à charge incluse de l'Aide exceptionnelle de fin d'année (AEFA)
+description: Taux de majoration du montant de l'aide au delà de la troisième personne à charge ou enfant inclus - Aide exceptionnelle de fin d'année (AEFA)
 values:
   2003-12-30:
     value: 0.4
 metadata:
-  short_label: Au-delà 3e personne à charge incluse
+  short_label: Majoration à partir de la troisième personne à charge
   last_value_still_valid_on: "2021-09-28"
   label_en: "Exceptional end-of-year benefit (AEFA): amount"
   unit: /1

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_supp.yaml
@@ -1,9 +1,9 @@
-description: Taux par personne supplémentaire (si conjoint) de l'Aide exceptionnelle de fin d'année (AEFA)
+description: Taux de majoration par personne à charge ou enfant supplémentaire jusqu'à la deuxième personne incluse - Aide exceptionnelle de fin d'année (AEFA)
 values:
   2003-12-30:
     value: 0.3
 metadata:
-  short_label: Par personne supp.
+  short_label: Majoration par personne à charge jusqu'à la deuxième incluse
   last_value_still_valid_on: "2021-09-28"
   label_en: "Exceptional end-of-year benefit (AEFA): amount"
   unit: /1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '146.0.4',
+    version = '146.0.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/aefa.yaml
+++ b/tests/formulas/aefa.yaml
@@ -1,0 +1,115 @@
+- name: Prime de noël - AEFA
+  description: Montant personne seule
+  period: 2022
+  absolute_error_margin: 1
+  input:
+    nb_parents: 1
+  output:
+    aefa: 152.45
+
+- name: Prime de noël - AEFA
+  description: Montant un parent avec un enfant
+  period: 2022
+  absolute_error_margin: 1
+  input:
+    famille:
+      parents: [parent1]
+      enfants: [enfant1]
+    individus:
+      parent1: {}
+      enfant1:
+        age: 8
+  output:
+    aefa: 228.67 # 152.45 * (1 + .5)
+
+- name: Prime de noël - AEFA
+  description: Montant un parent avec deux enfants
+  period: 2022
+  absolute_error_margin: 1
+  input:
+    famille:
+      parents: [parent1]
+      enfants: [enfant1, enfant2]
+    individus:
+      parent1: {}
+      enfant1:
+        age: 8
+      enfant2:
+        age: 9
+  output:
+    aefa: 274.41 # 152.45 * (1 + .5 + .3)
+
+
+- name: Prime de noël - AEFA
+  description: Montant un parent avec trois enfants
+  period: 2022
+  absolute_error_margin: 1
+  input:
+    famille:
+      parents: [parent1]
+      enfants: [enfant1, enfant2, enfant3]
+    individus:
+      parent1: {}
+      enfant1:
+        age: 8
+      enfant2:
+        age: 9
+      enfant3:
+        age: 10
+  output:
+    aefa: 335.39  # 152.45 * (1 + .5 + .3 + .4)
+
+
+- name: Prime de noël - AEFA
+  description: Montant couple
+  period: 2022
+  absolute_error_margin: 1
+  input:
+    famille:
+      parents: [parent1, parent2]
+    individus:
+      parent1: {}
+      parent2: {}
+  output:
+    aefa: 152.45 * (1 + .5)
+
+
+- name: Prime de noël - AEFA
+  description: Montant couple avec deux enfants
+  period: 2022
+  absolute_error_margin: 1
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2]
+    individus:
+      parent1: {}
+      parent2: {}
+      enfant1:
+        age: 8
+      enfant2:
+        age: 9
+  output:
+    aefa: 320.14  # 152.45 * (1 + .5 + 2 * .3)
+
+
+- name: Prime de noël - AEFA
+  description: Montant couple avec trois enfants
+  period: 2022
+  absolute_error_margin: 1
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2, enfant3]
+      asile_demandeur: true
+    individus:
+      parent1: {}
+      parent2: {}
+      enfant1:
+        age: 8
+      enfant2:
+        age: 9
+      enfant3:
+        age: 10
+  output:
+    aefa: 381.12  # 152.45 * (1 + .5 + 2 * .3 + .4)


### PR DESCRIPTION
* Périodes concernées : toutes
* Zones impactées : 
* `prestations_sociales/solidarite_insertion/autre_solidarite/aefa`.
* `prestations_sociales/prestations_familiales/prestations_generales/af/crds`
* Détails : clarifie les labels des paramètres de la prime de Noël

- - - -

Ces changements modifient l'API publique d'OpenFisca France 