### PR TITLE
Règle de deconjugalisation du plafond de ressources pour l'aah

### DIFF
--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -501,9 +501,7 @@ class aah_plafond_ressources(Variable):
         montant_max = law.prestations_etat_de_sante.invalidite.aah.montant
 
         return montant_max * (
-            + 1
-            + law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_par_enfant_supplementaire
-            * af_nbenf
+            1 + (law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_par_enfant_supplementaire * af_nbenf)
             )
         
     def formula(individu, period, parameters):
@@ -514,11 +512,9 @@ class aah_plafond_ressources(Variable):
         montant_max = law.prestations_etat_de_sante.invalidite.aah.montant
 
         return montant_max * (
-            + 1
-            + en_couple
-            * law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_plafond_couple
-            + law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_par_enfant_supplementaire
-            * af_nbenf
+            1
+            + (en_couple * law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_plafond_couple)
+            + (law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_par_enfant_supplementaire * af_nbenf)
             )
 
 

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -496,25 +496,27 @@ class aah_plafond_ressources(Variable):
 
     def formula_2023_09_01(individu, period, parameters):
         law = parameters(period).prestations_sociales
+        aah_law = law.prestations_etat_de_sante.invalidite.aah
 
         af_nbenf = individu.famille('af_nbenf', period)
-        montant_max = law.prestations_etat_de_sante.invalidite.aah.montant
+        montant_max = aah_law.montant
 
         return montant_max * (
-            1 + (law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_par_enfant_supplementaire * af_nbenf)
+            1 + (aah_law.majoration_plafond.majoration_par_enfant_supplementaire * af_nbenf)
             )
         
     def formula(individu, period, parameters):
         law = parameters(period).prestations_sociales
-
+        aah_law = law.prestations_etat_de_sante.invalidite.aah
+        
         en_couple = individu.famille('en_couple', period)
         af_nbenf = individu.famille('af_nbenf', period)
-        montant_max = law.prestations_etat_de_sante.invalidite.aah.montant
+        montant_max = aah_law.montant
 
         return montant_max * (
             1
-            + (en_couple * law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_plafond_couple)
-            + (law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_par_enfant_supplementaire * af_nbenf)
+            + (en_couple * aah_law.majoration_plafond.majoration_plafond_couple)
+            + (aah_law.majoration_plafond.majoration_par_enfant_supplementaire * af_nbenf)
             )
 
 

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -494,6 +494,18 @@ class aah_plafond_ressources(Variable):
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
+    def formula_2023_09_01(individu, period, parameters):
+        law = parameters(period).prestations_sociales
+
+        af_nbenf = individu.famille('af_nbenf', period)
+        montant_max = law.prestations_etat_de_sante.invalidite.aah.montant
+
+        return montant_max * (
+            + 1
+            + law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_par_enfant_supplementaire
+            * af_nbenf
+            )
+        
     def formula(individu, period, parameters):
         law = parameters(period).prestations_sociales
 
@@ -586,7 +598,7 @@ class aah(Variable):
         return where(aah_reduction, aah_base * aah_parameters.pourcentage_aah.prison_hospitalisation, aah_base)
 
     def formula_2023_09_01(individu, period, parameters):
-        aah_base = max_(individu('aah_base', period), individu('aah_base_conjugalise', period))
+        aah_base = max_(individu('aah_base', period), individu('aah_base_conjugalisee', period))
         aah_parameters = parameters(period).prestations_sociales.prestations_etat_de_sante.invalidite.aah
         m_2 = datetime64(period.offset(-60, 'day').start)
 

--- a/openfisca_france/reforms/aah_deconjugalisee.py
+++ b/openfisca_france/reforms/aah_deconjugalisee.py
@@ -169,7 +169,7 @@ class aah_deconjugalisee(Reform):
 
             aah_eligible = individu('aah_eligible', period)
             aah_base_ressources = individu('aah_base_ressources_deconjugalisee', period)
-            plaf_ress_aah = individu('aah_plafond_ressources', period)
+            plaf_ress_aah = individu('aah_plafond_ressources_deconjugalisee', period)
             # Le montant de l'AAH est plafonné au montant de base.
             montant_max = law.prestations_etat_de_sante.invalidite.aah.montant
             montant_aah = min_(montant_max, max_(0, plaf_ress_aah - aah_base_ressources))
@@ -180,6 +180,27 @@ class aah_deconjugalisee(Reform):
         
         def formula(individu, period, parameters):
             return
+
+class aah_plafond_ressources(Variable):
+    value_type = float
+    label = 'Montant plafond des ressources déconjugalisées pour bénéficier de l\'Allocation adulte handicapé (hors complément)'
+    entity = Individu
+    reference = [
+        'Article D821-2 du Code de la sécurité sociale',
+        'https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=4B54EC7065520E4812F84677B918A48E.tplgfr28s_2?idArticle=LEGIARTI000019077584&cidTexte=LEGITEXT000006073189&dateTexte=20081218'
+        ]
+    definition_period = MONTH
+    set_input = set_input_divide_by_period
+
+    def formula(individu, period, parameters):
+        law = parameters(period).prestations_sociales
+
+        af_nbenf = individu.famille('af_nbenf', period)
+        montant_max = law.prestations_etat_de_sante.invalidite.aah.montant
+
+        return montant_max * (
+            1 + (law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_par_enfant_supplementaire * af_nbenf)
+            )
 
     class aah(Variable):
         calculate_output = calculate_output_add

--- a/openfisca_france/reforms/aah_deconjugalisee.py
+++ b/openfisca_france/reforms/aah_deconjugalisee.py
@@ -181,26 +181,26 @@ class aah_deconjugalisee(Reform):
         def formula(individu, period, parameters):
             return
 
-class aah_plafond_ressources(Variable):
-    value_type = float
-    label = 'Montant plafond des ressources déconjugalisées pour bénéficier de l\'Allocation adulte handicapé (hors complément)'
-    entity = Individu
-    reference = [
-        'Article D821-2 du Code de la sécurité sociale',
-        'https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=4B54EC7065520E4812F84677B918A48E.tplgfr28s_2?idArticle=LEGIARTI000019077584&cidTexte=LEGITEXT000006073189&dateTexte=20081218'
-        ]
-    definition_period = MONTH
-    set_input = set_input_divide_by_period
+    class aah_plafond_ressources_deconjugalisee(Variable):
+        value_type = float
+        label = 'Montant plafond des ressources déconjugalisées pour bénéficier de l\'Allocation adulte handicapé (hors complément)'
+        entity = Individu
+        reference = [
+            'Article D821-2 du Code de la sécurité sociale',
+            'https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=4B54EC7065520E4812F84677B918A48E.tplgfr28s_2?idArticle=LEGIARTI000019077584&cidTexte=LEGITEXT000006073189&dateTexte=20081218'
+            ]
+        definition_period = MONTH
+        set_input = set_input_divide_by_period
 
-    def formula(individu, period, parameters):
-        law = parameters(period).prestations_sociales
+        def formula(individu, period, parameters):
+            law = parameters(period).prestations_sociales
 
-        af_nbenf = individu.famille('af_nbenf', period)
-        montant_max = law.prestations_etat_de_sante.invalidite.aah.montant
+            af_nbenf = individu.famille('af_nbenf', period)
+            montant_max = law.prestations_etat_de_sante.invalidite.aah.montant
 
-        return montant_max * (
-            1 + (law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_par_enfant_supplementaire * af_nbenf)
-            )
+            return montant_max * (
+                1 + (law.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_par_enfant_supplementaire * af_nbenf)
+                )
 
     class aah(Variable):
         calculate_output = calculate_output_add
@@ -251,5 +251,5 @@ class aah_plafond_ressources(Variable):
     def apply(self):
         for variable in [self.aah_base_ressources, self.aah_base, self.aah]:
             self.update_variable(variable)
-        for variable in [self.aah_base_ressources_deconjugalisee, self.aah_base_deconjugalisee, self.aah_deconjugalisee]:
+        for variable in [self.aah_base_ressources_deconjugalisee, self.aah_base_deconjugalisee, self.aah_plafond_ressources_deconjugalisee, self.aah_deconjugalisee]:
             self.add_variable(variable)

--- a/tests/formulas/aah/aah_couple.yaml
+++ b/tests/formulas/aah/aah_couple.yaml
@@ -133,3 +133,65 @@
         - parent2
   output:
     aah_base_ressources: [413.42, 720]
+
+- name: Couple de personnes en situation de handicap, déconjugalisation
+  period: 2023-11
+  absolute_error_margin: 1
+  input:
+    famille:
+      parents: [parent1, parent2]
+    individus:
+      parent1:
+        activite: actif
+        salaire_imposable:
+          2023: 12000
+        aah_eligible: true
+      parent2:
+        activite: actif
+        salaire_imposable:
+          2023: 13000
+        aah_eligible: true
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+        - parent2
+    menages:
+      menage_0:
+        personne_de_reference: parent1
+        conjoint: parent2
+  output:
+    aah_plafond_ressources: [956.65, 956.65]
+    aah_base_ressources: [394.88, 444.88]
+    aah: [561.77, 511.77]  # 956.65 maximum en attendant l'actualisation du montant min((956.65 * 1.81 - 998.53), 965.65)
+
+- name: Couple de personnes en situation de handicap, juste avant déconjugalisation
+  period: 2023-08
+  absolute_error_margin: 1
+  input:
+    famille:
+      parents: [parent1, parent2]
+    individus:
+      parent1:
+        activite: actif
+        salaire_imposable:
+          2023: 12000
+        aah_eligible: true
+      parent2:
+        activite: actif
+        salaire_imposable:
+          2023: 13000
+        aah_eligible: true
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+        - parent2
+    menages:
+      menage_0:
+        personne_de_reference: parent1
+        conjoint: parent2
+  output:
+    aah_plafond_ressources: [1731.54, 1731.54]
+    aah_base_ressources: [953.21, 928.21]
+    aah: [778.32, 803.32]  # 956.65 maximum en attendant l'actualisation du montant min((956.65 * 1.81 - 998.53), 965.65)


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/09/2023.
* Zones impactées : `tests\formulas\aah\aah_couple.yaml`, `openfisca_france\model\prestations\minima_sociaux\aah.py`.
* Détails :
  - Déconjugalisation des plafonds des ressources pour l'AAH

- - - -

Ces changements:

- Corrigent ou améliorent un calcul déjà existant.
