### PR TITLE
Introduit la revalorisation CEJ du 1er avril 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 146.0.1 [#2079](https://github.com/openfisca/openfisca-france/pull/2079)
+
+* Actualisation de paramètres.
+* Périodes concernées : à partir du 01/04/2023.
+* Zones impactées : `prestations/jeunes/contrat_engagement_jeune.py`.
+* Détails :
+  - Introduit la revalorisation de l'allocation du CEJ du 1er avril 2023.
+
 # 146.0.0 [#2077](https://github.com/openfisca/openfisca-france/pull/2077)
 
 * Corrections d'erreurs

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/contrat_engagement_jeune/montants/montant_majeurs_1ere_tranche_ir.yml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/contrat_engagement_jeune/montants/montant_majeurs_1ere_tranche_ir.yml
@@ -4,6 +4,8 @@ values:
     value: 300
   2022-07-01:
     value: 312
+  2023-04-01:
+    value: 316.8
 metadata:
   unit: currency
   reference:
@@ -15,6 +17,9 @@ metadata:
     2022-07-01:
     - title: Loi n°2022-1158 du 16 août 2022, art. 9
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046186749
+    2023-04-01:
+    - title: Instruction interministérielle N° DSS/2B/2023/41 du 24 mars 2023
+      href: https://sante.gouv.fr/fichiers/bo/2023/2023.6.sante.pdf#page=119
 documentation: |-
   Notes:
-  Pour la revalorisation de juillet 2022, la référence législative mentionnée fait référence aux dispositifs faisant l'objet d'une revalorisation annuelle en application de l'article L. 161-25 du code de la sécurité sociale. Or, une revalorisation au titre de cet article est bien mentionnée pour la CEJ (cf. IV. de l'art. D5131-19 du Code du travail).
+  Pour les revalorisations de montant, les références législatives mentionnées font référence aux dispositifs faisant l'objet d'une revalorisation annuelle en application de l'article L. 161-25 du code de la sécurité sociale. Or, une revalorisation au titre de cet article est bien mentionnée pour le CEJ (cf. IV. de l'art. D5131-19 du Code du travail).

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/contrat_engagement_jeune/montants/montant_majeurs_non_imposables.yml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/contrat_engagement_jeune/montants/montant_majeurs_non_imposables.yml
@@ -4,6 +4,8 @@ values:
     value: 500
   2022-07-01:
     value: 520
+  2023-04-01:
+    value: 528
 metadata:
   unit: currency
   reference:
@@ -15,6 +17,9 @@ metadata:
     2022-07-01:
     - title: Loi n°2022-1158 du 16 août 2022, art. 9
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046186749
+    2023-04-01:
+    - title: Instruction interministérielle N° DSS/2B/2023/41 du 24 mars 2023
+      href: https://sante.gouv.fr/fichiers/bo/2023/2023.6.sante.pdf#page=119
 documentation: |-
   Notes:
-  Pour la revalorisation de juillet 2022, la référence législative mentionnée fait référence aux dispositifs faisant l'objet d'une revalorisation annuelle en application de l'article L. 161-25 du code de la sécurité sociale. Or, une revalorisation au titre de cet article est bien mentionnée pour la CEJ (cf. IV. de l'art. D5131-19 du Code du travail).
+  Pour les revalorisations de montant, les références législatives mentionnées font référence aux dispositifs faisant l'objet d'une revalorisation annuelle en application de l'article L. 161-25 du code de la sécurité sociale. Or, une revalorisation au titre de cet article est bien mentionnée pour le CEJ (cf. IV. de l'art. D5131-19 du Code du travail).

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/contrat_engagement_jeune/montants/montant_mineurs.yml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/contrat_engagement_jeune/montants/montant_mineurs.yml
@@ -4,6 +4,8 @@ values:
     value: 200
   2022-07-01:
     value: 208
+  2023-04-01:
+    value: 211.2
 metadata:
   unit: currency
   reference:
@@ -15,6 +17,9 @@ metadata:
     2022-07-01:
     - title: Loi n°2022-1158 du 16 août 2022, art. 9
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046186749
+    2023-04-01:
+    - title: Instruction interministérielle N° DSS/2B/2023/41 du 24 mars 2023
+      href: https://sante.gouv.fr/fichiers/bo/2023/2023.6.sante.pdf#page=119
 documentation: |-
   Notes:
-  Pour la revalorisation de juillet 2022, la référence législative mentionnée fait référence aux dispositifs faisant l'objet d'une revalorisation annuelle en application de l'article L. 161-25 du code de la sécurité sociale. Or, une revalorisation au titre de cet article est bien mentionnée pour la CEJ (cf. IV. de l'art. D5131-19 du Code du travail).
+  Pour les revalorisations de montant, les références législatives mentionnées font référence aux dispositifs faisant l'objet d'une revalorisation annuelle en application de l'article L. 161-25 du code de la sécurité sociale. Or, une revalorisation au titre de cet article est bien mentionnée pour le CEJ (cf. IV. de l'art. D5131-19 du Code du travail).

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '146.0.0',
+    version = '146.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Actualisation de paramètres.
* Périodes concernées : à partir du 01/04/2023.
* Zones impactées : `prestations/jeunes/contrat_engagement_jeune.py`.
* Détails :
  - Introduit la revalorisation de l'allocation du CEJ du 1er avril 2023.