### PR TITLE
Crée revenus non salarie nets pour simplifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 146.0.2 [#2080](https://github.com/openfisca/openfisca-france/pull/2080)
+
+* Crée une nouvelle variable intermédiaire
+* Périodes concernées : toutes.
+* Zones impactées: 
+   - `mesures.py`
+   - `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py`
+   - `prestations/jeunes/cotrat_engagement_jeune.py`
+   - `prestations/visale.py`
+* Détails :
+  - Crée une variable `revenus_non_salarie_nets`, plutôt que de copier-coller sa définition dans plusieurs formules.
+
 ### 146.0.1 [#2079](https://github.com/openfisca/openfisca-france/pull/2079)
 
 * Actualisation de paramètres.

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -98,18 +98,9 @@ class revenus_nets_du_travail(Variable):
     definition_period = YEAR
 
     def formula(individu, period):
-        # Salariés
         salaire_net = individu('salaire_net', period, options = [ADD])
-        # Non salariés
-        revenu_non_salarie = individu('rpns_imposables', period, options = [ADD])
-        csg_imposable_non_salarie = individu('csg_imposable_non_salarie', period)
-        crds_non_salarie = individu('crds_non_salarie', period)
-        revenu_non_salarie_net = (
-            revenu_non_salarie
-            + csg_imposable_non_salarie
-            + crds_non_salarie
-            )
-        return salaire_net + revenu_non_salarie_net
+        revenus_non_salarie_nets = individu('revenus_non_salarie_nets', period)
+        return salaire_net + revenus_non_salarie_nets
 
 
 class pensions_nettes(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -457,3 +457,16 @@ class crds_non_salarie(Variable):
         assiette_csg_crds_non_salarie = individu('assiette_csg_crds_non_salarie', period)
         taux = parameters(period).prelevements_sociaux.contributions_sociales.crds.activite.taux
         return - taux * assiette_csg_crds_non_salarie
+
+
+class revenus_non_salarie_nets(Variable):
+    value_type = float
+    entity = Individu
+    label = 'Revenus du travail non salariaux nets'
+    definition_period = YEAR
+
+    def formula(individu, period):
+        revenus_non_salarie = individu('rpns_imposables', period)
+        csg_imposable_non_salarie = individu('csg_imposable_non_salarie', period)
+        crds_non_salarie = individu('crds_non_salarie', period)
+        return revenus_non_salarie + csg_imposable_non_salarie + crds_non_salarie

--- a/openfisca_france/model/prestations/jeunes/contrat_engagement_jeune.py
+++ b/openfisca_france/model/prestations/jeunes/contrat_engagement_jeune.py
@@ -88,9 +88,7 @@ class contrat_engagement_jeune(Variable):
             'remuneration_apprenti',
             ]
         ressources_partiellement_deductibles_year = [
-            'rpns_imposables',
-            'csg_imposable_non_salarie',
-            'crds_non_salarie',
+            'revenus_non_salarie_nets',
             ]
 
         parameters_smic = parameters(period).marche_travail.salaire_minimum.smic

--- a/openfisca_france/model/prestations/visale.py
+++ b/openfisca_france/model/prestations/visale.py
@@ -167,12 +167,6 @@ class visale_base_ressources_individuelle(Variable):
 
         revenus_individu = sum(individu(ressource, period.last_month) for ressource in ressources_individu_mensuelles)  # les justificatifs des ressources sont demandés « sur le mois précédant la demande de visa »
 
-        ressources_individu_annuelles = [
-            'rpns_imposables',
-            'csg_imposable_non_salarie',
-            'crds_non_salarie',
-            ]
+        revenus_non_salarie_nets = individu('revenus_non_salarie_nets', period.last_year.first_month, options = [DIVIDE])
 
-        revenus_non_salarie = sum(individu(ressource, period.last_year.first_month, options = [DIVIDE]) for ressource in ressources_individu_annuelles)
-
-        return revenus_individu + revenus_non_salarie
+        return revenus_individu + revenus_non_salarie_nets

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '146.0.1',
+    version = '146.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Crée une nouvelle variable intermédiaire
* Périodes concernées : toutes.
* Zones impactées: 
   - `mesures.py`
   - `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py`
   - `prestations/jeunes/cotrat_engagement_jeune.py`
   - `prestations/visale.py`
* Détails :
  - Crée une variable `revenus_non_salarie_nets`, plutôt que de copier-coller sa définition dans plusieurs formules.