### PR TITLE
Correction de métadonnées invalides dans parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-### 146.2.0 [#2044](https://github.com/openfisca/openfisca-france/pull/2044)
+### 146.2.1 [#2100](https://github.com/openfisca/openfisca-france/pull/2100)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées :
+  * `parameters/impot_revenu/calcul_reductions_impots/pme/souscription_capital/taux.yaml`
+  * `parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources`
+* Détails :
+  - Renommage d'un last_review en last_value_still_valid_on
+  - Suppression de href invalides dans des références
+
+## 146.2.0 [#2044](https://github.com/openfisca/openfisca-france/pull/2044)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2015.
@@ -10,7 +21,7 @@
 * Détails :
   - Correction de la condition d'exonération de contributions sociales sur le chômage en cas de revenus inférieurs auSMIC mensuel brut : ajoute le cas du cumul d'allocations chômage et de revenus d'activité.
 
-### 146.1.0 [#2091](https://github.com/openfisca/openfisca-france/pull/2091)
+## 146.1.0 [#2091](https://github.com/openfisca/openfisca-france/pull/2091)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : toutes.
@@ -40,7 +51,7 @@
 * Détails :
   - Nettoyage des références pour passage de la validation des paramètres.
   
-# 146.0.5 [#2075](https://github.com/openfisca/openfisca-france/pull/2075)
+### 146.0.5 [#2075](https://github.com/openfisca/openfisca-france/pull/2075)
 
 * Périodes concernées : toutes
 * Zones impactées :
@@ -48,7 +59,7 @@
 * `prestations_sociales/prestations_familiales/prestations_generales/af/crds`
 * Détails : clarifie les labels des paramètres de la prime de Noël
 
-# 146.0.4 [#2076](https://github.com/openfisca/openfisca-france/pull/2076)
+### 146.0.4 [#2076](https://github.com/openfisca/openfisca-france/pull/2076)
 
 * Périodes concernées : toutes
 * Zones impactées : `prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age2` et `prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age3`

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/pme/souscription_capital/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/pme/souscription_capital/taux.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.18
 metadata:
   unit: /1
-  last_review: "2023-02-03"
+  last_value_still_valid_on: "2023-02-03"
   reference:
     1994-01-01:
       title: Article 199 terdecies-0 A, I du Code général des impôts

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_3.yaml
@@ -229,5 +229,4 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
     2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication !
-      href: A mettre à jour!
   type: single_amount

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources/echelon_4.yaml
@@ -229,5 +229,4 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046096036
     2023-03-15:
     - title: Aucun document officiel encore, à mettre à jour lors de la publication !
-      href: A mettre à jour!
   type: single_amount

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '146.2.0',
+    version = '146.2.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées :
  * `parameters/impot_revenu/calcul_reductions_impots/pme/souscription_capital/taux.yaml`
  * `parameters/prestations_sociales/aides_jeunes/bourses/bourses_enseignement_superieur/criteres_sociaux/plafond_ressources`
* Détails :
  - Renommage d'un last_review en last_value_still_valid_on
  - Suppression de href invalides dans des références
