### PR TITLE
Corrige les gains de levée d'option

### DIFF
--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2301,9 +2301,9 @@ class glo(Variable):
         f1tx = individu('f1tx', period)
         f3vf = individu('f3vf', period)
         f3vi = individu('f3vi', period)
-        f3vj = individu('f3vj', period)
+        f3vd = individu('f3vd', period)
 
-        return f1tv + f1tw + f1tx + f3vf + f3vi + f3vj
+        return f1tv + f1tw + f1tx + f3vf + f3vi + f3vd
 
     def formula_2016_01_01(individu, period, parameters):
         '''
@@ -2312,9 +2312,9 @@ class glo(Variable):
         f1tx = individu('f1tx', period)
         f3vf = individu('f3vf', period)
         f3vi = individu('f3vi', period)
-        f3vj = individu('f3vj', period)
+        f3vd = individu('f3vd', period)
 
-        return f1tx + f3vf + f3vi + f3vj
+        return f1tx + f3vf + f3vi + f3vd
 
     def formula_2017_01_01(individu, period, parameters):
         '''
@@ -2322,9 +2322,9 @@ class glo(Variable):
         '''
         f3vf = individu('f3vf', period)
         f3vi = individu('f3vi', period)
-        f3vj = individu('f3vj', period)
+        f3vd = individu('f3vd', period)
 
-        return f3vf + f3vi + f3vj
+        return f3vf + f3vi + f3vd
 
 
 class credits_impot_sur_valeurs_etrangeres(Variable):


### PR DESCRIPTION
Merci de contribuer à OpenFisca ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)

* Changement mineur
* Périodes concernées : toutes.
* Zones impactées : `model/prelevements_obligatoires/impot_revenu/ir.py`.
* Détails :
  - Corrige des erreurs de code sur l'imposition des gains de levée d'option.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.


