### PR TITLE
Correction calcul base ressources aah : pensions alimentaires versées soustraites au lieu d'être ajoutées

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 149.4.2 [#2128](https://github.com/openfisca/openfisca-france/pull/2128)
+
+* Correction d'une erreur de calcul
+* Périodes concernées : toutes.
+* Zones impactées : 
+  - `openfisca_france/model/prestations/minima_sociaux/aah.py`
+  - `tests/formulas/aah/aah.yaml`
+* Détails :
+  - Correction du calcul  de `base_ressources_aah` : pensions alimentaires versées soustraites au lieu d'être ajoutées
+  - Lorsque que quelqu'un paie une pension alimentaire elle est considérée comme une ressource entrante
+
+
 ### 149.4.1 [#2126](https://github.com/openfisca/openfisca-france/pull/2126)
 
 * Changement mineur.

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -2,7 +2,7 @@ from openfisca_core.periods import Period
 
 from openfisca_france.model.base import *
 
-from numpy import datetime64, abs as abs_
+from numpy import datetime64, absolute as abs_
 
 # Références juridiques - Code de la sécurité sociale
 #
@@ -111,10 +111,10 @@ class aah_base_ressources(Variable):
             base_ressource_activite = individu('aah_base_ressources_activite_eval_trimestrielle', period) - individu('aah_base_ressources_activite_milieu_protege', three_previous_months, options = [ADD])
             base_ressource_hors_activite = individu('aah_base_ressources_hors_activite_eval_trimestrielle', period) + individu('aah_base_ressources_activite_milieu_protege', three_previous_months, options = [ADD])
 
-            base_ressource_demandeur = assiette_revenu_activite_demandeur(base_ressource_activite) + base_ressource_hors_activite
+            base_ressource_demandeur = max_(0, assiette_revenu_activite_demandeur(base_ressource_activite) + base_ressource_hors_activite)
 
-            base_ressource_demandeur_conjoint = individu.famille.demandeur('aah_base_ressources_activite_eval_trimestrielle', period) + individu.famille.demandeur('aah_base_ressources_hors_activite_eval_trimestrielle', period)
-            base_ressource_conjoint_conjoint = individu.famille.conjoint('aah_base_ressources_activite_eval_trimestrielle', period) + individu.famille.conjoint('aah_base_ressources_hors_activite_eval_trimestrielle', period)
+            base_ressource_demandeur_conjoint = max_(0, individu.famille.demandeur('aah_base_ressources_activite_eval_trimestrielle', period) + individu.famille.demandeur('aah_base_ressources_hors_activite_eval_trimestrielle', period))
+            base_ressource_conjoint_conjoint = max_(0, individu.famille.conjoint('aah_base_ressources_activite_eval_trimestrielle', period) + individu.famille.conjoint('aah_base_ressources_hors_activite_eval_trimestrielle', period))
             base_ressource_conjoint = base_ressource_conjoint_conjoint * individu.has_role(Famille.DEMANDEUR) + base_ressource_demandeur_conjoint * individu.has_role(Famille.CONJOINT)
 
             return base_ressource_demandeur + assiette_conjoint(base_ressource_conjoint)
@@ -157,10 +157,10 @@ class aah_base_ressources(Variable):
             base_ressource_activite = individu('aah_base_ressources_activite_eval_trimestrielle', period) - individu('aah_base_ressources_activite_milieu_protege', three_previous_months, options = [ADD])
             base_ressource_hors_activite = individu('aah_base_ressources_hors_activite_eval_trimestrielle', period) + individu('aah_base_ressources_activite_milieu_protege', three_previous_months, options = [ADD])
 
-            base_ressource_demandeur = assiette_revenu_activite_demandeur(base_ressource_activite) + base_ressource_hors_activite
+            base_ressource_demandeur = max_(0, assiette_revenu_activite_demandeur(base_ressource_activite) + base_ressource_hors_activite)
 
             base_ressource_demandeur_conjoint = individu.famille.demandeur('aah_base_ressources_activite_eval_trimestrielle', period) + individu.famille.demandeur('aah_base_ressources_hors_activite_eval_trimestrielle', period)
-            base_ressource_conjoint_conjoint = individu.famille.conjoint('aah_base_ressources_activite_eval_trimestrielle', period) + individu.famille.conjoint('aah_base_ressources_hors_activite_eval_trimestrielle', period)
+            base_ressource_conjoint_conjoint = max_(0, individu.famille.conjoint('aah_base_ressources_activite_eval_trimestrielle', period) + individu.famille.conjoint('aah_base_ressources_hors_activite_eval_trimestrielle', period))
             base_ressource_conjoint = base_ressource_conjoint_conjoint * individu.has_role(Famille.DEMANDEUR) + base_ressource_demandeur_conjoint * individu.has_role(Famille.CONJOINT)
 
             return base_ressource_demandeur + assiette_conjoint(base_ressource_conjoint)
@@ -198,7 +198,7 @@ class aah_base_ressources(Variable):
             base_ressource_activite = individu('aah_base_ressources_activite_eval_trimestrielle', period) - individu('aah_base_ressources_activite_milieu_protege', three_previous_months, options = [ADD])
             base_ressource_hors_activite = individu('aah_base_ressources_hors_activite_eval_trimestrielle', period) + individu('aah_base_ressources_activite_milieu_protege', three_previous_months, options = [ADD])
 
-            base_ressource_demandeur = assiette_revenu_activite_demandeur(base_ressource_activite) + base_ressource_hors_activite
+            base_ressource_demandeur = max_(0, assiette_revenu_activite_demandeur(base_ressource_activite) + base_ressource_hors_activite)
 
             return base_ressource_demandeur
 
@@ -318,7 +318,6 @@ class aah_base_ressources_hors_activite_eval_trimestrielle(Variable):
         ressources = sum(
             [individu(ressource, three_previous_months, options = [ADD]) for ressource in ressources_a_inclure]
             )
-        
         # On récupère le montant absolu des pensions alimentaires versées au cas où la valeur reçue est négative
         pensions_alimentaires_versees = abs_(individu(
             'pensions_alimentaires_versees_individu', three_previous_months, options = [ADD]))

--- a/openfisca_france/model/prestations/minima_sociaux/aah.py
+++ b/openfisca_france/model/prestations/minima_sociaux/aah.py
@@ -2,7 +2,7 @@ from openfisca_core.periods import Period
 
 from openfisca_france.model.base import *
 
-from numpy import datetime64
+from numpy import datetime64, abs as abs_
 
 # Références juridiques - Code de la sécurité sociale
 #
@@ -309,7 +309,6 @@ class aah_base_ressources_hors_activite_eval_trimestrielle(Variable):
             'bourse_recherche',
             'gains_exceptionnels',
             'pensions_alimentaires_percues',
-            'pensions_alimentaires_versees_individu',
             'pensions_invalidite',
             'prestation_compensatoire',
             'retraite_nette',
@@ -319,8 +318,13 @@ class aah_base_ressources_hors_activite_eval_trimestrielle(Variable):
         ressources = sum(
             [individu(ressource, three_previous_months, options = [ADD]) for ressource in ressources_a_inclure]
             )
+        
+        # On récupère le montant absolu des pensions alimentaires versées au cas où la valeur reçue est négative
+        pensions_alimentaires_versees = abs_(individu(
+            'pensions_alimentaires_versees_individu', three_previous_months, options = [ADD]))
 
-        return ressources * 4
+        # On soustrait le montant des pensions alimentaires versées à la base des ressources
+        return (ressources - pensions_alimentaires_versees) * 4
 
 
 class aah_base_ressources_activite_eval_annuelle(Variable):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '149.4.1',
+    version = '149.4.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/aah/aah.yaml
+++ b/tests/formulas/aah/aah.yaml
@@ -722,3 +722,34 @@
       2007-04:
         - 0
         - 0
+
+- name: AAH individu payant une pension
+  period: 2023-06
+  absolute_error_margin: 1
+  input:
+    menage:
+      personne_de_reference: [albert]
+      autres: [albertjr]
+    individus:
+      albert:
+        age: 45
+        taux_incapacite: 0.9
+        salaire_imposable:
+          2023-06: 1200
+          2023-05: 1200
+          2023-04: 1200
+          2023-03: 1200
+        pensions_alimentaires_versees_individu:
+          2023-06: 200
+          2023-05: 200
+          2023-04: 200
+          2023-03: 200
+      albertjr:
+        age: 10
+        pensions_alimentaires_percues:
+          2023-06: 200
+          2023-05: 200
+          2023-04: 200
+          2023-03: 200
+  output:
+    aah_base_ressources: [310, 0] # ((0.2 * 6290 + 0.6 * 8110) - (200 * 12))/12 ~= 310


### PR DESCRIPTION
* Correction d'une erreur de calcul
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/prestations/minima_sociaux/aah.py`.
* Détails :
  - Correction du calcul  de `base_ressources_aah` : pensions alimentaires versées soustraites au lieu d'être ajoutées
  - Lorsque que quelqu'un paie une pension alimentaire elle est considérée comme une ressource entrante

- - - -

Ces changements:

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
