### PR TITLE
Revalorisation de l'ASS au 01/07/2022, rattrapage au 01/04/2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,21 @@
 # Changelog
 
+### 150.1.0 [#2130](https://github.com/openfisca/openfisca-france/pull/2130)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/04/2022 et 01/07/2022.
+* Zones impactées : `parameters/chomage/allocations_assurance_chomage/ass/`.
+
+* Détails :
+  - Revalorisation de l'ASS pour 01/04/2022 et 01/07/2022
+
 ### 150.0.1 [#2132](https://github.com/openfisca/openfisca-france/pull/2132)
 
 * Changement mineur.
 * Périodes concernées : toutes.
 * Zones impactées :
     - `model/prestations/jeunes/contrat_engagement_jeune.py`.
-    - 'tests/formulas/contrat_engagement_jeune.yaml`
+    - `tests/formulas/contrat_engagement_jeune.yaml`
 * Détails :
   - Dans le cas de données d'entrée exprimant les revenus avec un RNI sur une période annuelle, le RNI était équivalent à 0 peut importe le montant.
 Le calcul se fait sur une période annuelle mais là formule actuelle effectue le calcule avec une période mensuelle (un offset de 12 mois).

--- a/openfisca_france/model/prestations/agepi.py
+++ b/openfisca_france/model/prestations/agepi.py
@@ -2,10 +2,8 @@ from numpy import fabs, timedelta64
 
 from openfisca_core.periods import Period
 
-from openfisca_france.model.base import Famille, Individu, Variable, Enum, MONTH, ADD,\
-    set_input_dispatch_by_period, set_input_divide_by_period, date, min_, not_
-from openfisca_france.model.revenus.activite.salarie import TypesContrat, TypesLieuEmploiFormation,\
-    TypesCategoriesDemandeurEmploi
+from openfisca_france.model.base import Famille, Individu, Variable, Enum, MONTH, ADD, set_input_dispatch_by_period, set_input_divide_by_period, date, min_, not_
+from openfisca_france.model.revenus.activite.salarie import TypesContrat, TypesLieuEmploiFormation, TypesCategoriesDemandeurEmploi
 
 
 class agepi_nbenf(Variable):

--- a/openfisca_france/model/prestations/aide_mobilite.py
+++ b/openfisca_france/model/prestations/aide_mobilite.py
@@ -2,11 +2,9 @@ from numpy import fabs, timedelta64
 
 from openfisca_core.periods import Period
 
-from openfisca_france.model.base import Individu, Variable, MONTH, Enum, not_, ADD,\
-    set_input_dispatch_by_period, set_input_divide_by_period, min_, date
+from openfisca_france.model.base import Individu, Variable, MONTH, Enum, not_, ADD, set_input_dispatch_by_period, set_input_divide_by_period, min_, date
 from openfisca_france.model.caracteristiques_socio_demographiques.logement import TypesLieuResidence
-from openfisca_france.model.revenus.activite.salarie import TypesContrat, TypesLieuEmploiFormation,\
-    TypesCategoriesDemandeurEmploi
+from openfisca_france.model.revenus.activite.salarie import TypesContrat, TypesLieuEmploiFormation, TypesCategoriesDemandeurEmploi
 
 
 class aide_mobilite_date_demande(Variable):

--- a/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/montant_plein.yaml
+++ b/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/montant_plein.yaml
@@ -74,6 +74,10 @@ values:
     value: 16.89
   2021-04-01:
     value: 16.91
+  2022-04-01:
+    value: 17.21
+  2022-07-01:
+    value: 17.90
 metadata:
   short_label: Montant journalier (Taux plein)
   label_en: Special UI scheme
@@ -194,6 +198,12 @@ metadata:
     2021-04-01:
       title: Décret n° 2021-523 du 29/04/2021
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043459270
+    2022-04-01:
+      title: Décret n° 2022-493 du 06/04/2022
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045522919
+    2022-07-01:
+      title: Loi n° 2022-1158 du 16/08/2022, Article 9
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046186749
   official_journal_date:
     1984-04-01: 1984-06-05; 1984-11-23
     1984-10-01: "1984-12-27"
@@ -231,6 +241,8 @@ metadata:
     2018-04-01: "2018-06-06"
     2019-04-01: "2019-05-18"
     2020-04-01: "2020-06-04"
+    2022-04-01: "2022-04-06"
+    2022-07-01: "2022-08-16"
   notes:
     1984-04-01:
     - title: "Nouvelle convention: création de l'ASS"

--- a/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/montant_plein_mayotte.yaml
+++ b/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/montant_plein_mayotte.yaml
@@ -36,6 +36,12 @@ values:
     value: 8.15
   2018-04-01:
     value: 8.23
+  2021-04-01:
+    value: 8.46
+  2022-04-01:
+    value: 8.61
+  2022-07-01:
+    value: 8.95
 metadata:
   short_label: Montant plein Mayotte
   label_en: Special UI scheme
@@ -55,4 +61,12 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000034678220&categorieLien=id
     2018-04-01:
       href: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031781118&cidTexte=LEGITEXT000006072050&dateTexte=20180420&fastPos=1&fastReqId=505933634&oldAction=rechCodeArticle
+    2021-04-01:
+      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000043415805&categorieLien=id
+    2022-04-01:
+      title: Décret n° 2022-494 du 06/04/2022
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045522929
+    2022-07-01:
+      title: Loi n° 2022-1158 du 16/08/2022, Article 9
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046186749
 documentation: Le prestations.minima_sociaux.ass.montant_plein de la métropole est pris par défaut lorsque la valeur spécifique à Mayotte est non répertoriée.

--- a/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/montant_plein_mayotte.yaml
+++ b/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/montant_plein_mayotte.yaml
@@ -62,6 +62,7 @@ metadata:
     2018-04-01:
       href: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000031781118&cidTexte=LEGITEXT000006072050&dateTexte=20180420&fastPos=1&fastReqId=505933634&oldAction=rechCodeArticle
     2021-04-01:
+      title: Décret n° 2021-496 du 23/04/2021, Article 1
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000043415805&categorieLien=id
     2022-04-01:
       title: Décret n° 2022-494 du 06/04/2022

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '150.0.1',
+    version = '150.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -41,5 +41,4 @@ def test_basics(scenario_arguments):
     simulation = scenario.new_simulation(debug = False)
     period = scenario_arguments['period']
     assert simulation.calculate('revenu_disponible', period = period) is not None, "Can't compute revenu_disponible on period {}".format(period)
-    assert simulation.calculate_add('salaire_super_brut', period = period) is not None,\
-        "Can't compute salaire_super_brut on period {}".format(period)
+    assert simulation.calculate_add('salaire_super_brut', period = period) is not None, "Can't compute salaire_super_brut on period {}".format(period)


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/04/2022 et 01/07/2022.
* Zones impactées : `parameters/chomage/allocations_assurance_chomage/ass/`.

* Détails :
  - Revalorisation de l'ASS pour 01/04/2022 et 01/07/2022

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.
