### PR TITLE
Définition de la période du chèque énergie à mensuelle

### DIFF
--- a/openfisca_france/model/prestations/cheque_energie.py
+++ b/openfisca_france/model/prestations/cheque_energie.py
@@ -31,7 +31,7 @@ class cheque_energie_eligibilite_logement(Variable):
         'https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=6A3717E70623B148432581CC8F585C5F.tplgfr31s_1?idArticle=LEGIARTI000006394061&cidTexte=LEGITEXT000006070633&dateTexte=20180316',
         ]
     label = 'Éligibilité du logement occupé au chèque énergie'
-    definition_period = YEAR
+    definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
     def formula_2017(menage, period, parameters):
@@ -79,7 +79,7 @@ class cheque_energie(Variable):
     value_type = float
     reference = 'https://chequeenergie.gouv.fr'
     label = 'Montant auquel le ménage peut prétendre au titre du chèque energie'
-    definition_period = YEAR
+    definition_period = MONTH
     set_input = set_input_divide_by_period
 
     def formula_2017(menage, period):

--- a/openfisca_france/model/prestations/cheque_energie.py
+++ b/openfisca_france/model/prestations/cheque_energie.py
@@ -35,8 +35,8 @@ class cheque_energie_eligibilite_logement(Variable):
     set_input = set_input_dispatch_by_period
 
     def formula_2017(menage, period, parameters):
-        statut_occupation_logement = menage('statut_occupation_logement', period.first_month)
-        residence_saint_martin = menage('residence_saint_martin', period.first_month)
+        statut_occupation_logement = menage('statut_occupation_logement', period)
+        residence_saint_martin = menage('residence_saint_martin', period)
 
         return (
             not_(residence_saint_martin) * (
@@ -84,8 +84,9 @@ class cheque_energie(Variable):
 
     def formula_2017(menage, period):
         eligible = menage('cheque_energie_eligibilite_logement', period)
-        declarant = menage.sum(menage.members('age', period.first_month) * 0 + 1, role = FoyerFiscal.DECLARANT) > 0  # une colocation de personnes à la charge de leurs parents n'est pas éligible aux chèques énergie, par exemple
+        declarant = menage.sum(menage.members('age', period) * 0 + 1, role = FoyerFiscal.DECLARANT) > 0  # une colocation de personnes à la charge de leurs parents n'est pas éligible aux chèques énergie, par exemple
         montant = menage('cheque_energie_montant', period.this_year)
+
         return declarant * eligible * montant
 
 

--- a/tests/formulas/cheque_energie/eligibilite_logement.yaml
+++ b/tests/formulas/cheque_energie/eligibilite_logement.yaml
@@ -1,12 +1,12 @@
 - name: Saint Martin n'est pas concerné par le chèque énergie
-  period: 2018
+  period: 2018-01
   input:
     depcom: 97801
     statut_occupation_logement: proprietaire
   output:
     cheque_energie_eligibilite_logement: false
 
-- period: 2021
+- period: 2021-01
   input:
     individus:
       _: {}


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées : `model/prestations/cheque_energie.py`.
* Détails :
  - Change la période de définition du chèque énergie à mensuelle
  - Impact le changement de période dans les tests

- - - -

Ces changements :

- Modifient l'API publique d'OpenFisca France (changement de period d'une variable).