### PR TITLE
Corrige calcul contrat engagement jeune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 150.0.1 [#2132](https://github.com/openfisca/openfisca-france/pull/2132)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées :
+    - `model/prestations/jeunes/contrat_engagement_jeune.py`.
+    - 'tests/formulas/contrat_engagement_jeune.yaml`
+* Détails :
+  - Dans le cas de données d'entrée exprimant les revenus avec un RNI sur une période annuelle, le RNI était équivalent à 0 peut importe le montant.
+Le calcul se fait sur une période annuelle mais là formule actuelle effectue le calcule avec une période mensuelle (un offset de 12 mois).
+  - La valeur de l'`ir_tranche` utilisée est modifiée à `n-2` pour affiner le calcul
+
 # 150.0.0 [#2148](https://github.com/openfisca/openfisca-france/pull/2148)
 
 * Amélioration technique.
@@ -38,7 +50,6 @@
 * Détails :
   - Correction du calcul  de `base_ressources_aah` : pensions alimentaires versées soustraites au lieu d'être ajoutées
   - Lorsque que quelqu'un paie une pension alimentaire elle est considérée comme une ressource entrante
-
 
 ### 149.4.1 [#2126](https://github.com/openfisca/openfisca-france/pull/2126)
 
@@ -104,6 +115,7 @@
   - Correction des noms à l'intérieur d'un champ "order"
   - Renommage d'un fichier .yml en .yaml
   - Nettoyage automatique de l'ensemble des paramètres
+
 
 ### 149.1.2 [#2135](https://github.com/openfisca/openfisca-france/pull/2135)
 
@@ -189,7 +201,7 @@
 * Détails :
   - Nettoyage et harmonisation avec les barèmes IPP
 
-## 147.2.1 [#2097](https://github.com/openfisca/openfisca-france/pull/2097)
+### 147.2.1 [#2097](https://github.com/openfisca/openfisca-france/pull/2097)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2023.
@@ -222,7 +234,7 @@
   - Documente le gel des plafonds de ressources de la réduction de loyer de solidarité
   - Renomme certains paramètres dans leur description/short_name
 
-## 147.0.1 [#2102](https://github.com/openfisca/openfisca-france/pull/2102)
+### 147.0.1 [#2102](https://github.com/openfisca/openfisca-france/pull/2102)
 
 * Amélioration technique.
 * Périodes concernées : toutes.

--- a/openfisca_france/model/prestations/jeunes/contrat_engagement_jeune.py
+++ b/openfisca_france/model/prestations/jeunes/contrat_engagement_jeune.py
@@ -1,5 +1,3 @@
-from openfisca_core.periods import Period
-
 from openfisca_france.model.base import *  # noqa analysis:ignore
 from numpy import (
     logical_not as not_,
@@ -21,8 +19,8 @@ class contrat_engagement_jeune_montant_forfaitaire(Variable):
     def formula_2022_03_01(individu, period, parameters):
         parameters_montants = parameters(period).prestations_sociales.aides_jeunes.contrat_engagement_jeune.montants
         majeur = individu('majeur', period)
-        previous_year = Period(('year', period.start, 1)).offset(-1)
-        tranche = individu.foyer_fiscal('ir_tranche', previous_year)
+
+        tranche = individu.foyer_fiscal('ir_tranche', period.n_2)
 
         montant_forfaitaire = (
             parameters_montants.montant_mineurs * not_(majeur) * (tranche <= 1)
@@ -52,8 +50,7 @@ class contrat_engagement_jeune_eligibilite(Variable):
         eligibilite_statut = activite != TypesActivite.etudiant
 
         # En fonction de l'imposition du foyer fiscal
-        previous_year = Period(('year', period.start, 1)).offset(-1)
-        tranche = individu.foyer_fiscal('ir_tranche', previous_year)
+        tranche = individu.foyer_fiscal('ir_tranche', period.n_2)
         eligibilite_ir = (tranche <= 1)
 
         # En fonction d'autres prestations et dispositifs

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '150.0.0',
+    version = '150.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/contrat_engagement_jeune.yaml
+++ b/tests/formulas/contrat_engagement_jeune.yaml
@@ -23,3 +23,16 @@
       2022-02: [0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0]
   output:
     contrat_engagement_jeune: [0, 200, 200, 500, 0, 0, 0, 0, 500, 347.3, 0, 0] # Calcul du 347.3: 500-(600-300)*500/(0.8*1603-300)
+
+- name: Calcul de l'égibilité et du montant du Contrat d'Engagement Jeune avec un RNI en entré
+  period: 2023-04
+  input:
+    age: ['18', '18']
+    handicap: [false, false]
+    activite: [inactif, inactif]
+    rni:
+      2021: ['500000', '0']
+    nbptr:
+      2021: ['1', '1']
+  output:
+    contrat_engagement_jeune: [0, 528]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : 
    - `model/prestations/jeunes/contrat_engagement_jeune.py`.
    - `tests/formulas/contrat_engagement_jeune.yaml`
* Détails :

Dans le cas de données d'entrée exprimant les revenus avec un RNI sur une période annuelle, le RNI était équivalent à 0 peut importe le montant.
Le calcul se fait sur une période annuelle mais là formule actuelle effectue le calcule avec une période mensuelle (un offset de 12 mois).

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.