### PR TITLE
Maj parametres ir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 149.2.0 [#2138](https://github.com/openfisca/openfisca-france/pull/2138)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2022
+* Zones impactées : `openfisca_france/parameters/impot_revenu/`
+* Détails :
+  - Mets à jour certains paramètres de l'IR qui ont été revalorisés par le Décret n° 2023-422 du 31/05/2023
+  - Mets à jour certains paramètres qui n'avaient pas été mis à jour pour les revenus 2021
+  - Ajoute de la documentation sur la règle de revalorisation automatique des paramètres lorsqu'elle existe
+
+
 ### 149.1.3 [#2137](https://github.com/openfisca/openfisca-france/pull/2137)
 
 * Changement mineur.

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/abat_dom/plaf_GuadMarReu.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/abat_dom/plaf_GuadMarReu.yaml
@@ -5,7 +5,7 @@ values:
   2018-01-01:
     value: 2450
 metadata:
-  last_value_still_valid_on: "2022-08-08"
+  last_value_still_valid_on: "2023-07-05"
   unit: currency
   reference:
     0001-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/abat_dom/plaf_GuyMay.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/abat_dom/plaf_GuyMay.yaml
@@ -5,7 +5,7 @@ values:
   2018-01-01:
     value: 4050
 metadata:
-  last_value_still_valid_on: "2022-08-08"
+  last_value_still_valid_on: "2023-07-05"
   unit: currency
   reference:
     0001-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/abat_dom/taux_GuadMarReu.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/abat_dom/taux_GuadMarReu.yaml
@@ -3,7 +3,7 @@ values:
   2001-01-01:
     value: 0.3
 metadata:
-  last_value_still_valid_on: "2022-08-08"
+  last_value_still_valid_on: "2023-07-05"
   unit: /1
   reference:
     0001-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/abat_dom/taux_GuyMay.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/abat_dom/taux_GuyMay.yaml
@@ -3,7 +3,7 @@ values:
   2001-01-01:
     value: 0.4
 metadata:
-  last_value_still_valid_on: "2022-08-08"
+  last_value_still_valid_on: "2023-07-05"
   unit: /1
   reference:
     0001-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_assoc_cult.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_assoc_cult.yaml
@@ -2,10 +2,19 @@ description: Plafond des dépenses ouvrant à une réduction d'impôt de 75 % po
 values:
   2021-01-01:
     value: 554
+  2020-01-01:
+    value: 562
 metadata:
-  last_value_still_valid_on: "2021-12-31"
+  last_value_still_valid_on: "2023-07-05"
   unit: currency
   reference:
     2021-01-01:
       title: Loi  2021-953 du 19/07/2021 de finances rectificative pour 2021 - art.18 (modifie Art. 200 du CGI)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000043805926
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+documentation: |-
+  Notes :
+  Ref : Article 200, 1 ter du CGI.
+

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_assoc_cult.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_assoc_cult.yaml
@@ -15,7 +15,7 @@ metadata:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
     - title: Article 200, 1 ter du CGI
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018619914/2008-04-03
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018619914
 documentation: |-
   Notes :
   Ref : Article 200, 1 ter du CGI.

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_assoc_cult.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_assoc_cult.yaml
@@ -19,4 +19,5 @@ metadata:
 documentation: |-
   Notes :
   Ref : Article 200, 1 ter du CGI.
+  La limite de versements est relevée chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu de l'année précédant celle des versements. Le montant obtenu est arrondi, s'il y a lieu, à l'euro supérieur.
 

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_assoc_cult.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_assoc_cult.yaml
@@ -2,7 +2,7 @@ description: Plafond des dépenses ouvrant à une réduction d'impôt de 75 % po
 values:
   2021-01-01:
     value: 554
-  2020-01-01:
+  2022-01-01:
     value: 562
 metadata:
   last_value_still_valid_on: "2023-07-05"
@@ -12,8 +12,10 @@ metadata:
       title: Loi  2021-953 du 19/07/2021 de finances rectificative pour 2021 - art.18 (modifie Art. 200 du CGI)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000043805926
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title: Article 200, 1 ter du CGI
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018619914/2008-04-03
 documentation: |-
   Notes :
   Ref : Article 200, 1 ter du CGI.

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_coluche/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_coluche/plafond.yaml
@@ -62,6 +62,7 @@ values:
     value: 1000
 metadata:
   short_label: Plafond
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: plafcoluche
   unit: currency
   reference:
@@ -143,3 +144,4 @@ metadata:
 documentation: |-
   Notes :
   Dons Coluche (organismes d'aide aux personnes en difficulté): art. 200-1 ter du CGI
+  La limite de versements mentionnée au premier alinéa est relevée chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu de l'année précédant celle des versements. Le montant obtenu est arrondi, s'il y a lieu, à l'euro supérieur.

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_coluche/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_coluche/plafond.yaml
@@ -114,7 +114,9 @@ metadata:
     - title: Loi 2019-1479 du 28/12/2019
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000039683923&categorieLien=id
     2020-01-01:
-      title: Loi n° 2020-473 du 25/04/2020 de finances rectificative pour 2020, art. 14
+    - title : Article 200, 1.ter. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000045764695
+    - title: Loi n° 2020-473 du 25/04/2020 de finances rectificative pour 2020, art. 14
       href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000041820881
   official_journal_date:
     2002-01-01: "2003-08-02"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/enfant_marie/montant.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/enfant_marie/montant.yaml
@@ -94,7 +94,7 @@ values:
     value: 6368
 metadata:
   short_label: Abattement
-  last_value_still_valid_on: "2023-01-05"
+  last_value_still_valid_on: "2023-07-05"
   label_en: Tax allowance for net taxable income
   ipp_csv_id: abt_enfmaries
   unit: currency

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/index.yaml
@@ -7,5 +7,6 @@ metadata:
   - montant_2
   - plafond_1
   - plafond_2
-documentation: Les invalides qui bénéficient d'une pension militaire d'invalidité pour une invalidité d'au moins 40 % ou d'une pension d'invalidité pour un accident du travail d'au moins 40 % ou de la carte d'invalidité
-Les abattements et plafonds de revenus sont relevés chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. Les montants obtenus sont arrondis, s'il y a lieu, à l'euro supérieur en ce qui concerne les abattements et à la dizaine d'euros supérieure en ce qui concerne les plafonds de revenus.
+documentation: |-
+  Les invalides qui bénéficient d'une pension militaire d'invalidité pour une invalidité d'au moins 40 % ou d'une pension d'invalidité pour un accident du travail d'au moins 40 % ou de la carte d'invalidité
+  Les abattements et plafonds de revenus sont relevés chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. Les montants obtenus sont arrondis, s'il y a lieu, à l'euro supérieur en ce qui concerne les abattements et à la dizaine d'euros supérieure en ce qui concerne les plafonds de revenus.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/index.yaml
@@ -8,3 +8,4 @@ metadata:
   - plafond_1
   - plafond_2
 documentation: Les invalides qui bénéficient d'une pension militaire d'invalidité pour une invalidité d'au moins 40 % ou d'une pension d'invalidité pour un accident du travail d'au moins 40 % ou de la carte d'invalidité
+Les abattements et plafonds de revenus sont relevés chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. Les montants obtenus sont arrondis, s'il y a lieu, à l'euro supérieur en ce qui concerne les abattements et à la dizaine d'euros supérieure en ce qui concerne les plafonds de revenus.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_1.yaml
@@ -186,7 +186,7 @@ metadata:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
     - title: Article 157 bis du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_1.yaml
@@ -84,9 +84,11 @@ values:
     value: 2448
   2021-01-01:
     value: 2484
+  2022-01-01:
+    value: 2620
 metadata:
   short_label: Montant 1ère tranche
-  last_value_still_valid_on: "2022-12-26"
+  last_value_still_valid_on: "2023-07-05"
   label_en: Tax allowance for net taxable income
   ipp_csv_id: abt_pers_age1
   unit: currency
@@ -180,6 +182,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043641803
     - title: Code général des impôts, art. 157 bis
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"
@@ -217,6 +222,7 @@ metadata:
     2019-01-01: "2019-12-29"
     2020-01-01: 2020-12-30; 2020-07-24
     2021-01-01: 2021-12-31; 2021-06-11
+    2022-01-01: "2023-06-02"
   notes:
     2001-01-01:
     - title: Voir aussi Loi 2001-1276 du 28/12/2001 - art. 51 (LFR pour 2001)

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_1.yaml
@@ -185,7 +185,7 @@ metadata:
     2022-01-01:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
-    - title: Code général des impôts, art. 157 bis
+    - title: Article 157 bis du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
   official_journal_date:
     1984-01-01: "1984-12-30"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_1.yaml
@@ -183,8 +183,10 @@ metadata:
     - title: Code général des impôts, art. 157 bis
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title: Code général des impôts, art. 157 bis
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_2.yaml
@@ -186,7 +186,7 @@ metadata:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
     - title: Article 157 bis du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_2.yaml
@@ -185,7 +185,7 @@ metadata:
     2022-01-01:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
-    - title: Code général des impôts, art. 157 bis
+    - title: Article 157 bis du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
   official_journal_date:
     1984-01-01: "1984-12-30"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_2.yaml
@@ -84,9 +84,11 @@ values:
     value: 1224
   2021-01-01:
     value: 1242
+  2022-01-01:
+    value: 1310
 metadata:
   short_label: Montant 2e tranche
-  last_value_still_valid_on: "2022-12-26"
+  last_value_still_valid_on: "2023-07-05"
   label_en: Tax allowance for net taxable income
   ipp_csv_id: abt_pers_age2
   unit: currency
@@ -180,6 +182,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043641803
     - title: Code général des impôts, art. 157 bis
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"
@@ -217,6 +222,7 @@ metadata:
     2019-01-01: "2019-12-29"
     2020-01-01: 2020-12-30; 2020-07-24
     2021-01-01: 2021-12-31; 2021-06-11
+    2022-01-01: "2023-06-02"
   notes:
     2001-01-01:
     - title: Voir aussi Loi 2001-1276 du 28/12/2001 - art. 51 (LFR pour 2001)

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/montant_2.yaml
@@ -183,8 +183,10 @@ metadata:
     - title: Code général des impôts, art. 157 bis
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title: Code général des impôts, art. 157 bis
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_1.yaml
@@ -191,7 +191,7 @@ metadata:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
     - title: Article 157 bis du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_1.yaml
@@ -188,8 +188,10 @@ metadata:
     - title: Code général des impôts, art. 157 bis
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title: Code général des impôts, art. 157 bis
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_1.yaml
@@ -86,9 +86,11 @@ values:
     value: 15340
   2021-01-01:
     value: 15560
+  2022-01-01:
+    value: 16410
 metadata:
   short_label: Plafond de la 1ère tranche
-  last_value_still_valid_on: "2022-12-26"
+  last_value_still_valid_on: "2023-07-05"
   label_en: Tax allowance for net taxable income
   ipp_csv_id: plaf_pers_age1
   unit: currency
@@ -185,6 +187,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043641803
     - title: Code général des impôts, art. 157 bis
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"
@@ -223,6 +228,7 @@ metadata:
     2019-01-01: "2019-12-29"
     2020-01-01: 2020-12-30; 2020-07-24
     2021-01-01: 2021-12-31; 2021-06-11
+    2022-01-01: "2023-06-02"
   notes:
     2001-01-01:
     - title: Voir aussi Loi 2001-1276 du 28/12/2001 - art. 51 (LFR pour 2001)

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_1.yaml
@@ -190,7 +190,7 @@ metadata:
     2022-01-01:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
-    - title: Code général des impôts, art. 157 bis
+    - title: Article 157 bis du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
   official_journal_date:
     1984-01-01: "1984-12-30"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_2.yaml
@@ -191,7 +191,7 @@ metadata:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
     - title: Article 157 bis du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_2.yaml
@@ -188,8 +188,10 @@ metadata:
     - title: Code général des impôts, art. 157 bis
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title: Code général des impôts, art. 157 bis
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_2.yaml
@@ -190,7 +190,7 @@ metadata:
     2022-01-01:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
-    - title: Code général des impôts, art. 157 bis
+    - title: Article 157 bis du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
   official_journal_date:
     1984-01-01: "1984-12-30"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/personne_agee_ou_invalide/plafond_2.yaml
@@ -86,9 +86,11 @@ values:
     value: 24690
   2021-01-01:
     value: 25040
+  2022-01-01:
+    value: 26400
 metadata:
   short_label: Plafond de la 2e tranche
-  last_value_still_valid_on: "2022-12-26"
+  last_value_still_valid_on: "2023-07-05"
   label_en: Tax allowance for net taxable income
   ipp_csv_id: plaf_pers_age2
   unit: currency
@@ -185,6 +187,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043641803
     - title: Code général des impôts, art. 157 bis
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158963/2022-12-26/
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"
@@ -223,6 +228,7 @@ metadata:
     2019-01-01: "2019-12-29"
     2020-01-01: 2020-12-30; 2020-07-24
     2021-01-01: 2021-12-31; 2021-06-11
+    2022-01-01: "2023-06-02"
   notes:
     2001-01-01:
     - title: Voir aussi Loi 2001-1276 du 28/12/2001 - art. 51 (LFR pour 2001)

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/accueil_personne_agee/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/accueil_personne_agee/plafond.yaml
@@ -201,7 +201,7 @@ metadata:
     2022-01-01:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
-    - title: Article 156-II-2° ter du CGI
+    - title: Article 156, II-2° ter, du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046673952
   official_journal_date:
     1984-01-01: "1984-12-30"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/accueil_personne_agee/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/accueil_personne_agee/plafond.yaml
@@ -199,8 +199,10 @@ metadata:
       title: Décret n°2022-782 du 4/05/2022, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045757184
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title: Article 156-II-2° ter du CGI
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046673952
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"
@@ -243,3 +245,4 @@ documentation: |-
   https://www.ipp.eu/baremes-ipp/impot-sur-le-revenu/calcul_revenus_imposables/charg_deduc/
   http://bofip.impots.gouv.fr/bofip/1860-PGP.html#1860-PGP_80_027
   https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000037671023&cidTexte=LEGITEXT000006069577
+  Le montant de la déduction est relevé chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/accueil_personne_agee/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/accueil_personne_agee/plafond.yaml
@@ -70,8 +70,13 @@ values:
     value: 3535
   2020-01-01:
     value: 3542
+  2021-01-01:
+    value: 3592
+  2022-01-01:
+    value: 3786
 metadata:
   short_label: Plafond
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: plaf_frais
   unit: currency
   reference:
@@ -190,6 +195,12 @@ metadata:
     2020-01-01:
       title: Loi 2020-1721 du 29/12/2020 (LF pour 2021)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000042753591
+    2021-01-01:
+      title: Décret n°2022-782 du 4/05/2022, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045757184
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"
@@ -225,6 +236,8 @@ metadata:
     2018-01-01: "2018-12-30"
     2019-01-01: "2019-12-29"
     2020-01-01: "2020-12-30"
+    2021-01-01: "2021-05-06"
+    2022-01-01: "2023-06-02"
 documentation: |-
   Plafond frais personnes de plus de 75 ans : art. 156-II-2° ter du CGI
   https://www.ipp.eu/baremes-ipp/impot-sur-le-revenu/calcul_revenus_imposables/charg_deduc/

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/plafond.yaml
@@ -248,7 +248,7 @@ metadata:
     2022-01-01:
     - title: Article 2 de la loi n° 2022-1726 du 30/12/2022 (LF pour 2023)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046845640
-    - title: Code général des impôts, art. 196 B
+    - title: Article 196 B du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041464076
   official_journal_date:
     1974-01-01: "1974-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/plafond.yaml
@@ -94,7 +94,7 @@ values:
     value: 6368
 metadata:
   short_label: Plafond
-  last_value_still_valid_on: "2023-01-05"
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: plaf_penalim
   unit: currency
   reference:
@@ -246,8 +246,10 @@ metadata:
       title: Loi 2021-1900, art. 2 du 30/12/2021 (LF pour 2022)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044637640
     2022-01-01:
-      title: Article 2 de la loi n° 2022-1726 du 30/12/2022 (LF pour 2023)
+    - title: Article 2 de la loi n° 2022-1726 du 30/12/2022 (LF pour 2023)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046845640
+    - title: Code général des impôts, art. 196 B
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041464076/2023-07-05/
   official_journal_date:
     1974-01-01: "1974-12-31"
     1975-01-01: "1975-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/plafond.yaml
@@ -249,7 +249,7 @@ metadata:
     - title: Article 2 de la loi n° 2022-1726 du 30/12/2022 (LF pour 2023)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046845640
     - title: Code général des impôts, art. 196 B
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041464076/2023-07-05/
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041464076
   official_journal_date:
     1974-01-01: "1974-12-31"
     1975-01-01: "1975-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
@@ -173,7 +173,7 @@ metadata:
     2022-01-01:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
-    - title:  Article 158-5-a. du CGI 
+    - title:  Article 158, 5.a. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622551
   official_journal_date:
     1978-01-01: "1978-12-30"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
@@ -88,8 +88,11 @@ values:
     value: 3858
   2021-01-01:
     value: 3912
+  2022-01-01:
+    value: 4123
 metadata:
   short_label: Maximum
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: max_abtpen
   unit: currency
   reference:
@@ -167,6 +170,9 @@ metadata:
     - title: Revalorisation comme prevue dans l'article 83 de la Loi 2020-1721 du 29/12/2020 (LF pour 2021)
     - title: Art. 2 de la loi no 2021-1900 du 30 décembre 2021 de finances pour 2022
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044637653
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1978-01-01: "1978-12-30"
     1992-01-01: "1992-12-31"
@@ -193,6 +199,7 @@ metadata:
     2018-01-01: "2018-12-30"
     2019-01-01: "2019-12-29"
     2020-01-01: "2020-12-30"
+    2022-01-01: "2023-06-02"
   notes:
     1978-01-01:
     - title: Le maximum sur les pensions est pris en compte par foyer fiscal pour l'imposition des revenus de 1977 et 1978.
@@ -213,9 +220,5 @@ metadata:
     2021-01-01:
     - title: Les limites sont révisées chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. En 2021, l'augmentation était de 1,4 %.
 documentation: |-
-  Notes :
-  (1) Entre 1915 et 1944, des déductions du revenu imposable pour charges des familles étaient appliquées pour le calcul de l'impôt général sur le revenu (et de l'impôt cédulaire sur les salaires) sous forme d'abattement général dépendant du statut marital et du nombre d'enfant.
-  > Voir Annexe C-1 dans Thomas Piketty, Les hauts revenus en France au XXe siècle (Grasset, 2001) ; voir aussi note (3) de l'onglet sur le quotient familial concernant les réductions d'impôt pour charges de famille entre 1915 et 1947.
-  (2) La déduction forfaitaire de 10 % prévue par l'article 83 -3°, 2e alinéa du CGI pour la prise en compte des frais professionnels des salariés est plafonnée.
-  (3) Il n'y a pas de plafond à la déduction entre 1952 et 1978.Entre 1934 et 1942, la déduction de 10 % est aussi plafonnée à 20 000 FRF (colonne J).
-  > Voir Annexe C-3 dans Thomas Piketty, Les hauts revenus en France au XXe siècle (Grasset, 2001)
+  Notes : Chaque année, il est révisé selon les mêmes modalités que la limite supérieure de la première tranche du barème de l'impôt sur le revenu.
+  Ref : Article 158-5-a. du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622551

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
@@ -171,8 +171,10 @@ metadata:
     - title: Art. 2 de la loi no 2021-1900 du 30 décembre 2021 de finances pour 2022
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044637653
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title:  Article 158-5-a. du CGI 
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622551
   official_journal_date:
     1978-01-01: "1978-12-30"
     1992-01-01: "1992-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
@@ -139,7 +139,7 @@ metadata:
     2022-01-01:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
-    - title:  Article 158-5-a. du CGI 
+    - title:  Article 158, 5.a. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622551
   official_journal_date:
     1978-01-01: "1978-12-30"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
@@ -137,8 +137,10 @@ metadata:
     - title: Art. 2 de la loi no 2021-1900 du 30 décembre 2021 de finances pour 2022
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044637653
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title:  Article 158-5-a. du CGI 
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622551
   official_journal_date:
     1978-01-01: "1978-12-30"
     1992-01-01: "1992-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
@@ -54,8 +54,11 @@ values:
     value: 394
   2021-01-01:
     value: 400
+  2022-01-01:
+    value: 422
 metadata:
   short_label: Minimum
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: min_abtpen
   unit: currency
   reference:
@@ -133,6 +136,9 @@ metadata:
     - title: Revalorisation comme prevue dans l'article 83 de la Loi 2020-1721 du 29/12/2020 (LF pour 2021)
     - title: Art. 2 de la loi no 2021-1900 du 30 décembre 2021 de finances pour 2022
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044637653
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1978-01-01: "1978-12-30"
     1992-01-01: "1992-12-31"
@@ -159,6 +165,7 @@ metadata:
     2018-01-01: "2018-12-30"
     2019-01-01: "2019-12-29"
     2020-01-01: "2020-12-30"
+    2022-01-01: "2023-06-02"
   notes:
     1978-01-01:
     - title: Le maximum sur les pensions est pris en compte par foyer fiscal pour l'imposition des revenus de 1977 et 1978.
@@ -179,9 +186,5 @@ metadata:
     2021-01-01:
     - title: Les limites sont révisées chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. En 2021, l'augmentation était de 1,4 %.
 documentation: |-
-  Notes :
-  (1) Entre 1915 et 1944, des déductions du revenu imposable pour charges des familles étaient appliquées pour le calcul de l'impôt général sur le revenu (et de l'impôt cédulaire sur les salaires) sous forme d'abattement général dépendant du statut marital et du nombre d'enfant.
-  > Voir Annexe C-1 dans Thomas Piketty, Les hauts revenus en France au XXe siècle (Grasset, 2001) ; voir aussi note (3) de l'onglet sur le quotient familial concernant les réductions d'impôt pour charges de famille entre 1915 et 1947.
-  (2) La déduction forfaitaire de 10 % prévue par l'article 83 -3°, 2e alinéa du CGI pour la prise en compte des frais professionnels des salariés est plafonnée.
-  (3) Il n'y a pas de plafond à la déduction entre 1952 et 1978.Entre 1934 et 1942, la déduction de 10 % est aussi plafonnée à 20 000 FRF (colonne J).
-  > Voir Annexe C-3 dans Thomas Piketty, Les hauts revenus en France au XXe siècle (Grasset, 2001)
+  Notes : Chaque année, il est révisé selon les mêmes modalités que la limite supérieure de la première tranche du barème de l'impôt sur le revenu.
+  Ref : Article 158-5-a. du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622551

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
@@ -90,8 +90,11 @@ values:
     value: 12652
   2021-01-01:
     value: 12829
+  2022-01-01:
+    value: 13522
 metadata:
   short_label: Maximum
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: max_abtsal
   unit: currency
   reference:
@@ -197,6 +200,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000042753580/2021-01-22/
     2021-01-01:
       title: Revalorisation comme prevue dans l'article 83 de la Loi 2020-1721 du 29/12/2020 (LF pour 2021)
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1979-01-01: "1980-01-19"
     1980-01-01: "1980-12-31"
@@ -237,6 +243,7 @@ metadata:
     2018-01-01: "2018-12-30"
     2019-01-01: "2019-12-29"
     2020-01-01: "2020-12-30"
+    2022-01-01: "2023-06-02"
   notes:
     1952-01-01:
     - title: Au titre de l'imposition des revenus des années 1943-1952, les salariés avaient également droit à une déduction forfaitaire pour frais professionnels de 5% au-delà du plafond.
@@ -260,8 +267,5 @@ metadata:
     - title: Les limites sont révisées chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. En 2021, l'augmentation était de 1,4 %.
 documentation: |-
   Notes :
-  (1) Entre 1915 et 1944, des déductions du revenu imposable pour charges des familles étaient appliquées pour le calcul de l'impôt général sur le revenu (et de l'impôt cédulaire sur les salaires) sous forme d'abattement général dépendant du statut marital et du nombre d'enfant.
-  > Voir Annexe C-1 dans Thomas Piketty, Les hauts revenus en France au XXe siècle (Grasset, 2001) ; voir aussi note (3) de l'onglet sur le quotient familial concernant les réductions d'impôt pour charges de famille entre 1915 et 1947.
-  (2) La déduction forfaitaire de 10 % prévue par l'article 83 -3°, 2e alinéa du CGI pour la prise en compte des frais professionnels des salariés est plafonnée.
-  (3) Il n'y a pas de plafond à la déduction entre 1952 et 1978.Entre 1934 et 1942, la déduction de 10 % est aussi plafonnée à 20 000 FRF (colonne J).
-  > Voir Annexe C-3 dans Thomas Piketty, Les hauts revenus en France au XXe siècle (Grasset, 2001)
+  Ref: Article 83-3 du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622408
+  relevé dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
@@ -203,7 +203,7 @@ metadata:
     2022-01-01:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
-    - title: Article 83-3 du CGI 
+    - title: Article 83, 3. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622408
   official_journal_date:
     1979-01-01: "1980-01-19"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
@@ -201,8 +201,10 @@ metadata:
     2021-01-01:
       title: Revalorisation comme prevue dans l'article 83 de la Loi 2020-1721 du 29/12/2020 (LF pour 2021)
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title: Article 83-3 du CGI 
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622408
   official_journal_date:
     1979-01-01: "1980-01-19"
     1980-01-01: "1980-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
@@ -146,8 +146,10 @@ metadata:
     2021-01-01:
       title: Revalorisation comme prevue dans l'article 83 de la Loi 2020-1721 du 29/12/2020 (LF pour 2021)
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title: Article 83-3 du CGI 
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622408
   official_journal_date:
     1990-01-01: "1990-12-30"
     1991-01-01: "1991-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
@@ -148,7 +148,7 @@ metadata:
     2022-01-01:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
-    - title: Article 83-3 du CGI 
+    - title: Article 83, 3. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622408
   official_journal_date:
     1990-01-01: "1990-12-30"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
@@ -62,8 +62,11 @@ values:
     value: 442
   2021-01-01:
     value: 448
+  2022-01-01:
+    value: 472
 metadata:
   short_label: Minimum (cas général)
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: min_abtsal
   unit: currency
   reference:
@@ -142,6 +145,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000042753580/2021-01-22/
     2021-01-01:
       title: Revalorisation comme prevue dans l'article 83 de la Loi 2020-1721 du 29/12/2020 (LF pour 2021)
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1990-01-01: "1990-12-30"
     1991-01-01: "1991-12-31"
@@ -170,6 +176,7 @@ metadata:
     2018-01-01: "2018-12-30"
     2019-01-01: "2019-12-29"
     2020-01-01: "2020-12-30"
+    2022-01-01: "2023-06-02"
   notes:
     1993-01-01:
     - title: Montant révisé chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu
@@ -187,8 +194,5 @@ metadata:
     - title: Les limites sont révisées chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. En 2021, l'augmentation était de 1,4 %.
 documentation: |-
   Notes :
-  (1) Entre 1915 et 1944, des déductions du revenu imposable pour charges des familles étaient appliquées pour le calcul de l'impôt général sur le revenu (et de l'impôt cédulaire sur les salaires) sous forme d'abattement général dépendant du statut marital et du nombre d'enfant.
-  > Voir Annexe C-1 dans Thomas Piketty, Les hauts revenus en France au XXe siècle (Grasset, 2001) ; voir aussi note (3) de l'onglet sur le quotient familial concernant les réductions d'impôt pour charges de famille entre 1915 et 1947.
-  (2) La déduction forfaitaire de 10 % prévue par l'article 83 -3°, 2e alinéa du CGI pour la prise en compte des frais professionnels des salariés est plafonnée.
-  (3) Il n'y a pas de plafond à la déduction entre 1952 et 1978.Entre 1934 et 1942, la déduction de 10 % est aussi plafonnée à 20 000 FRF (colonne J).
-  > Voir Annexe C-3 dans Thomas Piketty, Les hauts revenus en France au XXe siècle (Grasset, 2001)
+  Ref: Article 83-3 du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622408
+  relevé dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/plafond_recettes.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/plafond_recettes.yaml
@@ -34,7 +34,7 @@ metadata:
     2022-01-01:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
-    - title: Article 69 I du CGI
+    - title: Article 69, I. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000028447731
   official_journal_date:
     1979-01-01: "1980-01-19"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/plafond_recettes.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/plafond_recettes.yaml
@@ -8,8 +8,11 @@ values:
     value: 82800
   2020-01-01:
     value: 85800
+  2022-01-01:
+    value: 91900
 metadata:
   ipp_csv_id: plaf_micro_ba
+  last_value_still_valid_on: "2023-07-05"
   unit: currency
   reference:
     1979-01-01:
@@ -28,19 +31,17 @@ metadata:
     2020-01-01:
       title: Décret n° 2020-897 du 22 juillet 2020, art. 1
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000042143201&idArticle=LEGIARTI000042143994&dateTexte=20200805&categorieLien=id#LEGIARTI000042143994
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1979-01-01: "1980-01-19"
     2016-01-01: "2017-05-04"
     2017-01-01: "2017-12-31"
+    2022-01-01: "2023-06-02"
   notes:
     1998-01-01:
     - title: Création du régime microfoncier
 documentation: |-
   Notes :
-  (1) Abattement concernant les entrepreneurs individuels. Pour les autoentrepreneurs, voir art. 151-0 du CGI
-  (2) BNC : bénéfices non commerciaux. Si soumis à la TVA voir art. 293-B du CGI
-  (3) Régime microfoncier : art. 32-1 du CGI
-  (4) Plafonnement de l'imputations des déficits agricoles: art. 156-I-1° du CGI
-  (5) Plafond déficits agricoles : art. 156-I-1° du CGI
-  (6) Plafond déficits fonciers : art. 156-I-3° du CGI
-  (7) Micro-BA : art. 64 bis du CGI. Définition des plafonds de ressources à l'art. 69 du CGI.
+  Ref : Article 69 I du CGI.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/plafond_recettes.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/plafond_recettes.yaml
@@ -32,8 +32,10 @@ metadata:
       title: Décret n° 2020-897 du 22 juillet 2020, art. 1
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000042143201&idArticle=LEGIARTI000042143994&dateTexte=20200805&categorieLien=id#LEGIARTI000042143994
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title: Article 69 I du CGI
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000028447731
   official_journal_date:
     1979-01-01: "1980-01-19"
     2016-01-01: "2017-05-04"
@@ -45,3 +47,4 @@ metadata:
 documentation: |-
   Notes :
   Ref : Article 69 I du CGI.
+  Les seuils sont actualisés tous les trois ans dans la même proportion que l'évolution triennale de la limite supérieure de la première tranche du barème de l'impôt sur le revenu et sont arrondis, respectivement, à la centaine d'euros la plus proche et au millier d'euros le plus proche.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/marchandises/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/marchandises/plafond.yaml
@@ -24,8 +24,11 @@ values:
     value: 170000
   2020-01-01:
     value: 176200
+  2022-01-01:
+    value: 188700
 metadata:
   short_label: Plafond
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: limit_micro
   unit: currency
   reference:
@@ -69,6 +72,9 @@ metadata:
     2020-01-01:
       title: Décret n° 2020-897 du 22 juillet 2020, art. 1
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000042143201&idArticle=LEGIARTI000042143994&dateTexte=20200805&categorieLien=id#LEGIARTI000042143994
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1979-01-01: "1980-01-19"
     1991-01-01: "1991-12-31"
@@ -81,6 +87,7 @@ metadata:
     2011-01-01: "2011-12-28"
     2013-01-01: "2013-12-30"
     2017-01-01: "2017-12-31"
+    2022-01-01: "2023-06-02"
   notes:
     1998-01-01:
     - title: Création du régime microfoncier
@@ -90,5 +97,4 @@ metadata:
     - title: "Création du régime d'autoentrepreneur : voir BOI-BIC-DECLA-10-40 du 09/12/2012"
 documentation: |-
   Notes :
-  (1) Abattement concernant les entrepreneurs individuels. Pour les autoentrepreneurs, voir art. 151-0 du CGI
-  (2) BNC : bénéfices non commerciaux. Si soumis à la TVA voir art. 293-B du CGI
+  REF : Article 50-0 1° du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622490

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/marchandises/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/marchandises/plafond.yaml
@@ -73,8 +73,10 @@ metadata:
       title: Décret n° 2020-897 du 22 juillet 2020, art. 1
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000042143201&idArticle=LEGIARTI000042143994&dateTexte=20200805&categorieLien=id#LEGIARTI000042143994
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title: Article 50-0 1° du CGI 
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622490
   official_journal_date:
     1979-01-01: "1980-01-19"
     1991-01-01: "1991-12-31"
@@ -98,3 +100,4 @@ metadata:
 documentation: |-
   Notes :
   REF : Article 50-0 1° du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622490
+  Les seuils sont actualisés tous les trois ans dans la même proportion que l'évolution triennale de la première tranche du barème de l'impôt sur le revenu et arrondis à la centaine d'euros la plus proche.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/services/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/services/plafond.yaml
@@ -68,8 +68,10 @@ metadata:
       title: Décret n° 2020-897 du 22 juillet 2020, art. 1
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000042143201&idArticle=LEGIARTI000042143994&dateTexte=20200805&categorieLien=id#LEGIARTI000042143994
     2022-01-01:
-      title: Décret n° 2023-422 du 31/05/2023, art. 1
+    - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    - title: Article 50-0 2° du CGI 
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622490
   official_journal_date:
     1991-01-01: "1991-12-31"
     1996-01-01: "1996-12-31"
@@ -92,3 +94,4 @@ metadata:
 documentation: |-
   Notes :
   REF : Article 50-0 2° du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622490
+  Les seuils sont actualisés tous les trois ans dans la même proportion que l'évolution triennale de la première tranche du barème de l'impôt sur le revenu et arrondis à la centaine d'euros la plus proche.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/services/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/services/plafond.yaml
@@ -70,7 +70,7 @@ metadata:
     2022-01-01:
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
-    - title: Article 50-0 2° du CGI 
+    - title: Article 50-0, 2° du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622490
   official_journal_date:
     1991-01-01: "1991-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/services/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/services/plafond.yaml
@@ -22,8 +22,11 @@ values:
     value: 70000
   2020-01-01:
     value: 72600
+  2022-01-01:
+    value: 77700
 metadata:
   short_label: Plafond
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: limit_micro_service
   unit: currency
   reference:
@@ -64,6 +67,9 @@ metadata:
     2020-01-01:
       title: Décret n° 2020-897 du 22 juillet 2020, art. 1
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000042143201&idArticle=LEGIARTI000042143994&dateTexte=20200805&categorieLien=id#LEGIARTI000042143994
+    2022-01-01:
+      title: Décret n° 2023-422 du 31/05/2023, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1991-01-01: "1991-12-31"
     1996-01-01: "1996-12-31"
@@ -75,6 +81,7 @@ metadata:
     2011-01-01: "2011-12-28"
     2013-01-01: "2013-12-30"
     2017-01-01: "2017-12-31"
+    2022-01-01: "2023-06-02"
   notes:
     1998-01-01:
     - title: Création du régime microfoncier
@@ -84,5 +91,4 @@ metadata:
     - title: "Création du régime d'autoentrepreneur : voir BOI-BIC-DECLA-10-40 du 09/12/2012"
 documentation: |-
   Notes :
-  (1) Abattement concernant les entrepreneurs individuels. Pour les autoentrepreneurs, voir art. 151-0 du CGI
-  (2) BNC : bénéfices non commerciaux. Si soumis à la TVA voir art. 293-B du CGI
+  REF : Article 50-0 2° du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622490

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '149.1.3',
+    version = '149.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2022
* Zones impactées : `openfisca_france/parameters/impot_revenu/`.
* Détails :
  - Mets à jour certains paramètres de l'IR qui ont été revalorisés par le Décret n° 2023-422 du 31/05/2023
  -  Mets à jour certains paramètres qui n'avaient pas été mis à jour pour les revenus 2021
  - Ajoute de la documentation sur la règle de revalorisation automatique des paramètres lorsqu'elle existe

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) : 

- Corrigent ou améliorent un calcul déjà existant.

- - - -
