### PR TITLE
Update seuils rfr calcul csg remplacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 149.3.0 [#2139](https://github.com/openfisca/openfisca-france/pull/2139)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2022
+* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils`.
+* Détails :
+  - Mets à jour les seuils de rfr pour le calcul des taux de csg sur les revenus de remplacement pour les années 2022 et 2023
+
 ### 149.2.1 [#2033](https://github.com/openfisca/openfisca-france/pull/2033)
 
 * Évolution du système socio-fiscal. Changement mineur.
@@ -11,7 +19,6 @@
   - Mets à jour l'abattement maximal sur le déficit agricole
   - Met en forme les dons coluche
 
-
 ### 149.2.0 [#2138](https://github.com/openfisca/openfisca-france/pull/2138)
 
 * Évolution du système socio-fiscal.
@@ -21,7 +28,6 @@
   - Mets à jour certains paramètres de l'IR qui ont été revalorisés par le Décret n° 2023-422 du 31/05/2023
   - Mets à jour certains paramètres qui n'avaient pas été mis à jour pour les revenus 2021
   - Ajoute de la documentation sur la règle de revalorisation automatique des paramètres lorsqu'elle existe
-
 
 ### 149.1.3 [#2137](https://github.com/openfisca/openfisca-france/pull/2137)
 

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/crds/activite/abattement.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/crds/activite/abattement.yaml
@@ -18,7 +18,7 @@ brackets:
       value: 0
 metadata:
   short_label: Abattement frais professionnels
-  last_value_still_valid_on: "2023-01-27"
+  last_value_still_valid_on: "2023-07-05"
   reference:
     1998-01-01:
       title: Article L136-2 I du Code de la sécurité sociale

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/crds/activite/taux.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/crds/activite/taux.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.005
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "2023-02-02"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CRDS
   ipp_csv_id: crds
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/crds/retraite/taux.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/crds/retraite/taux.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.005
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "2021-12-15"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CRDS
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/crds/taux_global.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/crds/taux_global.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.005
 metadata:
   short_label: Taux global
-  last_value_still_valid_on: "2023-01-30"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CRDS
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/deductible/taux.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/deductible/taux.yaml
@@ -10,7 +10,7 @@ values:
     value: 0.068
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "2021-10-06"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on work incomes
   ipp_csv_id: csg_act_ded
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/imposable/taux.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/imposable/taux.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.024
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "2023-02-02"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on work incomes
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/taux_global.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/taux_global.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.092
 metadata:
   short_label: Taux global
-  last_value_still_valid_on: "2023-02-02"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on work incomes
   ipp_csv_id: csg_act
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/deductible/abattement.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/deductible/abattement.yaml
@@ -18,7 +18,7 @@ brackets:
       value: 0
 metadata:
   short_label: Abattement
-  last_value_still_valid_on: "2021-12-15"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on work incomes
   reference:
     1991-02-01:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/deductible/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/deductible/taux_plein.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2021-12-15"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on unemployment incomes
   ipp_csv_id: csg_cho_ded
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/deductible/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/deductible/taux_reduit.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2021-10-06"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on unemployment incomes
   ipp_csv_id: csg_cho_red
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/abattement.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/abattement.yaml
@@ -18,7 +18,7 @@ brackets:
       value: null
 metadata:
   short_label: Abattement
-  last_value_still_valid_on: "2021-12-15"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on work incomes
   reference:
     1991-02-01:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/taux_plein.yaml
@@ -1,4 +1,4 @@
-description: Taux plein de la de la contribution sociale généralisée (CSG) imposable sur les allocations chômage
+description: Taux plein de la contribution sociale généralisée (CSG) imposable sur les allocations chômage
 values:
   1997-01-01:
     value: 0.024
@@ -9,7 +9,11 @@ metadata:
   unit: /1
   reference:
     1997-01-01:
-      title: Loi 96-1160 du 27/12/1996, art. 9 à 17 (LFSS pour 1997)
+    - title: Loi 96-1160 du 27/12/1996, art. 9 à 17 (LFSS pour 1997)
+    - title: Article L136-8 du Code de la sécurité sociale (taux global)
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036390220
+    - title: Article 154 quinquies du Code général des impôts (taux déductible)
+      href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000047288608/
   official_journal_date:
     1997-01-01: "1996-12-29"
 documentation: |-

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/taux_plein.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.024
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2021-07-22"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on unemployment incomes
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/taux_reduit.yaml
@@ -4,7 +4,7 @@ values:
     value: 0
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2021-07-22"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on work incomes
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/imposable/taux_reduit.yaml
@@ -9,7 +9,11 @@ metadata:
   unit: /1
   reference:
     1997-01-01:
-      title: Loi 96-1160 du 27/12/1996, art. 9 à 17 (LFSS pour 1997)
+    - title: Loi 96-1160 du 27/12/1996, art. 9 à 17 (LFSS pour 1997)
+    - title: Article L136-8 du Code de la sécurité sociale (taux global)
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036390220
+    - title: Article 154 quinquies du Code général des impôts (taux déductible)
+      href: https://www.legifrance.gouv.fr/codes/id/LEGIARTI000047288608/
   official_journal_date:
     1997-01-01: "1996-12-29"
 documentation: |-

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/taux_global.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_chomage/taux_global.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.062
 metadata:
   short_label: Taux global
-  last_value_still_valid_on: "2021-12-15"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on unemployement incomes
   ipp_csv_id: csg_cho
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_plein.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.068
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2021-07-22"
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: csg_pre_ded
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_plein.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.068
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2021-07-22"
   ipp_csv_id: csg_pre_ded
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_reduit.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2008-01-01"
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: csg_pre_red
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_reduit.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2021-07-22"
   ipp_csv_id: csg_pre_red
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/imposable/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/imposable/taux_plein.yaml
@@ -4,5 +4,5 @@ values:
     value: 0.024
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2021-07-22"
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/imposable/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/imposable/taux_plein.yaml
@@ -4,5 +4,5 @@ values:
     value: 0.024
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2021-07-22"
+  last_value_still_valid_on: "2023-07-05"
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/imposable/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/imposable/taux_reduit.yaml
@@ -4,7 +4,7 @@ values:
     value: 0
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2021-07-22"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on work incomes
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/imposable/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/imposable/taux_reduit.yaml
@@ -4,7 +4,7 @@ values:
     value: 0
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2021-07-22"
   label_en: CSG - rates on work incomes
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/deductible/taux_median.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/deductible/taux_median.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.042
 metadata:
   short_label: Taux médian
-  last_value_still_valid_on: "2023-04-03"
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: csg_pens_median_deductible
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/deductible/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/deductible/taux_plein.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.059
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2023-04-03"
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: csg_pens_ded
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/deductible/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/deductible/taux_reduit.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2023-04-03"
+  last_value_still_valid_on: "2023-07-05"
   ipp_csv_id: csg_pens_red_deductible
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/imposable/taux_median.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/imposable/taux_median.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.024
 metadata:
   short_label: Taux médian
-  last_value_still_valid_on: "2023-04-03"
+  last_value_still_valid_on: "2023-07-05"
   unit: /1
   reference:
     1997-01-01:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/imposable/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/imposable/taux_plein.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.024
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2023-04-03"
+  last_value_still_valid_on: "2023-07-05"
   unit: /1
   reference:
     1997-01-01:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/imposable/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/imposable/taux_reduit.yaml
@@ -4,7 +4,7 @@ values:
     value: 0
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2023-04-03"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on work incomes
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_median.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_median.yaml
@@ -1,4 +1,4 @@
-description: Taux médian de la contribution sociale généralisée (CSG) imposable sur les pensions de retraite et d'invalidité
+description: Taux médian de la contribution sociale généralisée (CSG) sur les pensions de retraite et d'invalidité
 values:
   1991-02-01:
     value: null

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_median.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_median.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.066
 metadata:
   short_label: Taux médian global
-  last_value_still_valid_on: "2023-04-03"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on replacement incomes
   ipp_csv_id: csg_pens_median_total
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_plein.yaml
@@ -1,4 +1,4 @@
-description: Taux plein global de la contribution sociale généralisée (CSG) imposable sur les pensions de retraite et d'invalidité
+description: Taux plein global de la contribution sociale généralisée (CSG) sur les pensions de retraite et d'invalidité
 values:
   1991-02-01:
     value: 0.011

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_plein.yaml
@@ -14,7 +14,7 @@ values:
     value: 0.083
 metadata:
   short_label: Taux plein global
-  last_value_still_valid_on: "2023-04-03"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on work incomes
   ipp_csv_id: csg_pens
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_reduit.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux réduit global
-  last_value_still_valid_on: "2023-04-03"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on work incomes
   ipp_csv_id: csg_pens_red
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_reduit.yaml
@@ -1,4 +1,4 @@
-description: Taux réduit global de la contribution sociale généralisée (CSG) imposable sur les pensions de retraite et d'invalidité
+description: Taux réduit global de la contribution sociale généralisée (CSG) sur les pensions de retraite et d'invalidité
 values:
   1991-02-01:
     value: null

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/index.yaml
@@ -6,3 +6,4 @@ metadata:
   - seuil_rfr1
   - seuil_rfr2
   - seuil_rfr3
+documentation: Les seuils sont revalorisés au 1er janvier de chaque année, conformément à l'évolution en moyenne annuelle des prix à la consommation, hors tabac, constatée pour l'avant-dernière année et arrondis à l'euro le plus proche, la fraction d'euro égale à 0,50 étant comptée pour 1.

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/demi_part_suppl_rfr1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/demi_part_suppl_rfr1.yaml
@@ -65,7 +65,7 @@ metadata:
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_2021_028198_20122021.pdf
     2023-01-01:
       title: Lettre ministérielle D-22-024221 du 12/12/2022
-      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_12122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/demi_part_suppl_rfr1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/demi_part_suppl_rfr1.yaml
@@ -16,9 +16,13 @@ values:
     value: 3019
   2021-01-01:
     value: 3046
+  2022-01-01:
+    value: 3052
+  2023-01-01:
+    value: 3101
 metadata:
   short_label: Majoration du seuil par demi-part de quotient familial supplémentaire
-  last_value_still_valid_on: "2021-07-23"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red1_demip
   unit: currency
@@ -56,6 +60,16 @@ metadata:
     2021-01-01:
       title: Lettre ministérielle D-20-021991 du 04/12/2020
       href: https://www.legislation.cnav.fr/Documents/lettre_ministerielle_04122020.pdf
+    2022-01-01:
+    - title: Barème sur le site de l'assurance retraite
+      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2022_bar.aspx 
+    - title: Circulaire Cnav 2021/35 du 21/12/2021
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2021_35_21122021.pdf
+    2023-01-01:
+    - title: Barème sur le site de l'assurance retraite
+      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2023_bar.aspx
+    - title: Circulaire Cnav 2022/36 du 19/12/2022
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/demi_part_suppl_rfr1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/demi_part_suppl_rfr1.yaml
@@ -61,14 +61,10 @@ metadata:
       title: Lettre ministérielle D-20-021991 du 04/12/2020
       href: https://www.legislation.cnav.fr/Documents/lettre_ministerielle_04122020.pdf
     2022-01-01:
-    - title: Barème sur le site de l'assurance retraite
-      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2022_bar.aspx 
-    - title: Circulaire Cnav 2021/35 du 21/12/2021
-      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2021_35_21122021.pdf
+      title: Lettre ministérielle D-21-028198 du 20/12/2021
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_2021_028198_20122021.pdf
     2023-01-01:
-    - title: Barème sur le site de l'assurance retraite
-      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2023_bar.aspx
-    - title: Circulaire Cnav 2022/36 du 19/12/2022
+      title: Lettre ministérielle D-22-024221 du 12/12/2022
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/seuil_rfr1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/seuil_rfr1.yaml
@@ -16,9 +16,13 @@ values:
     value: 11306
   2021-01-01:
     value: 11408
+  2022-01-01:
+    value: 11431
+  2023-01-01:
+    value: 11614
 metadata:
   short_label: Seuil de RFR pour la première part de quotient familial
-  last_value_still_valid_on: "2021-07-23"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red1
   unit: currency
@@ -56,6 +60,16 @@ metadata:
     2021-01-01:
       title: Lettre ministérielle D-20-021991 du 04/12/2020
       href: https://www.legislation.cnav.fr/Documents/lettre_ministerielle_04122020.pdf
+    2022-01-01:
+    - title: Barème sur le site de l'assurance retraite
+      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2022_bar.aspx 
+    - title: Circulaire Cnav 2021/35 du 21/12/2021
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2021_35_21122021.pdf
+    2023-01-01:
+    - title: Barème sur le site de l'assurance retraite
+      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2023_bar.aspx
+    - title: Circulaire Cnav 2022/36 du 19/12/2022
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/seuil_rfr1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/seuil_rfr1.yaml
@@ -65,7 +65,7 @@ metadata:
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_2021_028198_20122021.pdf
     2023-01-01:
       title: Lettre ministérielle D-22-024221 du 12/12/2022
-      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_12122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/seuil_rfr1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/seuil_rfr1.yaml
@@ -61,14 +61,10 @@ metadata:
       title: Lettre ministérielle D-20-021991 du 04/12/2020
       href: https://www.legislation.cnav.fr/Documents/lettre_ministerielle_04122020.pdf
     2022-01-01:
-    - title: Barème sur le site de l'assurance retraite
-      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2022_bar.aspx 
-    - title: Circulaire Cnav 2021/35 du 21/12/2021
-      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2021_35_21122021.pdf
+      title: Lettre ministérielle D-21-028198 du 20/12/2021
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_2021_028198_20122021.pdf
     2023-01-01:
-    - title: Barème sur le site de l'assurance retraite
-      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2023_bar.aspx
-    - title: Circulaire Cnav 2022/36 du 19/12/2022
+      title: Lettre ministérielle D-22-024221 du 12/12/2022
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/demi_part_suppl_rfr2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/demi_part_suppl_rfr2.yaml
@@ -65,7 +65,7 @@ metadata:
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_2021_028198_20122021.pdf
     2023-01-01:
       title: Lettre ministérielle D-22-024221 du 12/12/2022
-      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_12122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/demi_part_suppl_rfr2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/demi_part_suppl_rfr2.yaml
@@ -61,14 +61,10 @@ metadata:
       title: Lettre ministérielle D-20-021991 du 04/12/2020
       href: https://www.legislation.cnav.fr/Documents/lettre_ministerielle_04122020.pdf
     2022-01-01:
-    - title: Barème sur le site de l'assurance retraite
-      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2022_bar.aspx 
-    - title: Circulaire Cnav 2021/35 du 21/12/2021
-      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2021_35_21122021.pdf
+      title: Lettre ministérielle D-21-028198 du 20/12/2021
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_2021_028198_20122021.pdf
     2023-01-01:
-    - title: Barème sur le site de l'assurance retraite
-      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2023_bar.aspx
-    - title: Circulaire Cnav 2022/36 du 19/12/2022
+      title: Lettre ministérielle D-22-024221 du 12/12/2022
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/demi_part_suppl_rfr2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/demi_part_suppl_rfr2.yaml
@@ -16,9 +16,13 @@ values:
     value: 3946
   2021-01-01:
     value: 3982
+  2022-01-01:
+    value: 3990
+  2023-01-01:
+    value: 4054
 metadata:
   short_label: Majoration du seuil par demi-part de quotient familial supplémentaire
-  last_value_still_valid_on: "2021-07-23"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red2_demip
   unit: currency
@@ -56,6 +60,16 @@ metadata:
     2021-01-01:
       title: Lettre ministérielle D-20-021991 du 04/12/2020
       href: https://www.legislation.cnav.fr/Documents/lettre_ministerielle_04122020.pdf
+    2022-01-01:
+    - title: Barème sur le site de l'assurance retraite
+      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2022_bar.aspx 
+    - title: Circulaire Cnav 2021/35 du 21/12/2021
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2021_35_21122021.pdf
+    2023-01-01:
+    - title: Barème sur le site de l'assurance retraite
+      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2023_bar.aspx
+    - title: Circulaire Cnav 2022/36 du 19/12/2022
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/seuil_rfr2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/seuil_rfr2.yaml
@@ -65,7 +65,7 @@ metadata:
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_2021_028198_20122021.pdf
     2023-01-01:
       title: Lettre ministérielle D-22-024221 du 12/12/2022
-      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_12122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/seuil_rfr2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/seuil_rfr2.yaml
@@ -61,14 +61,10 @@ metadata:
       title: Lettre ministérielle D-20-021991 du 04/12/2020
       href: https://www.legislation.cnav.fr/Documents/lettre_ministerielle_04122020.pdf
     2022-01-01:
-    - title: Barème sur le site de l'assurance retraite
-      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2022_bar.aspx 
-    - title: Circulaire Cnav 2021/35 du 21/12/2021
-      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2021_35_21122021.pdf
+      title: Lettre ministérielle D-21-028198 du 20/12/2021
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_2021_028198_20122021.pdf
     2023-01-01:
-    - title: Barème sur le site de l'assurance retraite
-      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2023_bar.aspx
-    - title: Circulaire Cnav 2022/36 du 19/12/2022
+      title: Lettre ministérielle D-22-024221 du 12/12/2022
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/seuil_rfr2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/seuil_rfr2.yaml
@@ -16,9 +16,13 @@ values:
     value: 14781
   2021-01-01:
     value: 14914
+  2022-01-01:
+    value: 14944
+  2023-01-01:
+    value: 15183
 metadata:
   short_label: Seuil de RFR pour la première part de quotient familial
-  last_value_still_valid_on: "2021-07-23"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red2
   unit: currency
@@ -56,6 +60,16 @@ metadata:
     2021-01-01:
       title: Lettre ministérielle D-20-021991 du 04/12/2020
       href: https://www.legislation.cnav.fr/Documents/lettre_ministerielle_04122020.pdf
+    2022-01-01:
+    - title: Barème sur le site de l'assurance retraite
+      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2022_bar.aspx 
+    - title: Circulaire Cnav 2021/35 du 21/12/2021
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2021_35_21122021.pdf
+    2023-01-01:
+    - title: Barème sur le site de l'assurance retraite
+      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2023_bar.aspx
+    - title: Circulaire Cnav 2022/36 du 19/12/2022
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/demi_part_suppl_rfr3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/demi_part_suppl_rfr3.yaml
@@ -36,14 +36,10 @@ metadata:
       title: Lettre ministérielle D-20-021991 du 04/12/2020
       href: https://www.legislation.cnav.fr/Documents/lettre_ministerielle_04122020.pdf
     2022-01-01:
-    - title: Barème sur le site de l'assurance retraite
-      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2022_bar.aspx 
-    - title: Circulaire Cnav 2021/35 du 21/12/2021
-      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2021_35_21122021.pdf
+      title: Lettre ministérielle D-21-028198 du 20/12/2021
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_2021_028198_20122021.pdf
     2023-01-01:
-    - title: Barème sur le site de l'assurance retraite
-      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2023_bar.aspx
-    - title: Circulaire Cnav 2022/36 du 19/12/2022
+      title: Lettre ministérielle D-22-024221 du 12/12/2022
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
   official_journal_date:
     2018-01-01: "2017-12-31"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/demi_part_suppl_rfr3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/demi_part_suppl_rfr3.yaml
@@ -40,7 +40,7 @@ metadata:
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_2021_028198_20122021.pdf
     2023-01-01:
       title: Lettre ministérielle D-22-024221 du 12/12/2022
-      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_12122022.pdf
   official_journal_date:
     2018-01-01: "2017-12-31"
     2019-01-01: "2018-12-26"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/demi_part_suppl_rfr3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/demi_part_suppl_rfr3.yaml
@@ -8,9 +8,13 @@ values:
     value: 6124
   2021-01-01:
     value: 6179
+  2022-01-01:
+    value: 6191
+  2023-01-01:
+    value: 6290
 metadata:
   short_label: Majoration du seuil par demi-part de quotient familial supplémentaire
-  last_value_still_valid_on: "2021-07-23"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red3_demip
   unit: currency
@@ -31,6 +35,16 @@ metadata:
     2021-01-01:
       title: Lettre ministérielle D-20-021991 du 04/12/2020
       href: https://www.legislation.cnav.fr/Documents/lettre_ministerielle_04122020.pdf
+    2022-01-01:
+    - title: Barème sur le site de l'assurance retraite
+      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2022_bar.aspx 
+    - title: Circulaire Cnav 2021/35 du 21/12/2021
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2021_35_21122021.pdf
+    2023-01-01:
+    - title: Barème sur le site de l'assurance retraite
+      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2023_bar.aspx
+    - title: Circulaire Cnav 2022/36 du 19/12/2022
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
   official_journal_date:
     2018-01-01: "2017-12-31"
     2019-01-01: "2018-12-26"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/seuil_rfr3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/seuil_rfr3.yaml
@@ -41,7 +41,7 @@ metadata:
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_2021_028198_20122021.pdf
     2023-01-01:
       title: Lettre ministérielle D-22-024221 du 12/12/2022
-      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_12122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2019-01-01: "2018-12-26"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/seuil_rfr3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/seuil_rfr3.yaml
@@ -8,9 +8,13 @@ values:
     value: 22941
   2021-01-01:
     value: 23147
+  2022-01-01:
+    value: 23193
+  2023-01-01:
+    value: 23564
 metadata:
   short_label: Seuil de RFR pour la première part de quotient familial
-  last_value_still_valid_on: "2021-07-23"
+  last_value_still_valid_on: "2023-07-05"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red3
   unit: currency
@@ -32,6 +36,16 @@ metadata:
     2021-01-01:
       title: Lettre ministérielle D-20-021991 du 04/12/2020
       href: https://www.legislation.cnav.fr/Documents/lettre_ministerielle_04122020.pdf
+    2022-01-01:
+    - title: Barème sur le site de l'assurance retraite
+      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2022_bar.aspx 
+    - title: Circulaire Cnav 2021/35 du 21/12/2021
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2021_35_21122021.pdf
+    2023-01-01:
+    - title: Barème sur le site de l'assurance retraite
+      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2023_bar.aspx
+    - title: Circulaire Cnav 2022/36 du 19/12/2022
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2019-01-01: "2018-12-26"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/seuil_rfr3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/seuil_rfr3.yaml
@@ -37,14 +37,10 @@ metadata:
       title: Lettre ministérielle D-20-021991 du 04/12/2020
       href: https://www.legislation.cnav.fr/Documents/lettre_ministerielle_04122020.pdf
     2022-01-01:
-    - title: Barème sur le site de l'assurance retraite
-      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2022_bar.aspx 
-    - title: Circulaire Cnav 2021/35 du 21/12/2021
-      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2021_35_21122021.pdf
+      title: Lettre ministérielle D-21-028198 du 20/12/2021
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_2021_028198_20122021.pdf
     2023-01-01:
-    - title: Barème sur le site de l'assurance retraite
-      href: https://legislation.lassuranceretraite.fr/#/bareme?file_leaf_ref=csg%2Fprelevement_sur_retraite_seuil_revenu_assujettissement_taux_csg_2023_bar.aspx
-    - title: Circulaire Cnav 2022/36 du 19/12/2022
+      title: Lettre ministérielle D-22-024221 du 12/12/2022
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2022_36_19122022.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '149.2.1',
+    version = '149.3.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2022
* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils`.
* Détails :
  - Mets à jour les seuils de rfr pour le calcul des taux de csg sur les revenus de remplacement pour les années 2022 et 2023

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.