### PR TITLE
Ajoute la condition d'indépendance fiscale dans le calcul d'eligibilite au rsa pour parent isole (`rsa_majore_eligibilite`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 150.4.3 [#2145](https://github.com/openfisca/openfisca-france/pull/2145)
+
+* Amélioration technique.
+* Périodes concernées : toutes.
+* Zones impactées : [
+    `openfisca_france/model/prestations/minima_sociaux/rsa.py`,
+    `tests/formulas/rsa/rsa_majore.yaml`
+]
+* Détails :
+  - Une personne à la charge de ses parents n'est pas une personne isolée.
+
 ### 150.4.2 [#2156](https://github.com/openfisca/openfisca-france/pull/2156)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -904,6 +904,7 @@ class rsa_majore_eligibilite(Variable):
     value_type = bool
     entity = Famille
     label = 'Eligibilité au RSA majoré pour parent isolé'
+    reference = 'https://www.service-public.fr/particuliers/vosdroits/F15553'
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
 
@@ -914,12 +915,14 @@ class rsa_majore_eligibilite(Variable):
         enceinte_fam = famille('enceinte_fam', period)
         nbenf = famille('rsa_nb_enfants', period)
         rsa_eligibilite_tns = famille('rsa_eligibilite_tns', period)
+        non_rattache_fiscalement = not_(famille.demandeur('enfant_a_charge', period.this_year))
 
         return (
             isole
             * (enceinte_fam | (nbenf > 0))
             * (enfant_moins_3_ans | isolement_recent | enceinte_fam)
             * rsa_eligibilite_tns
+            * non_rattache_fiscalement
             )
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '150.4.2',
+    version = '150.4.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/rsa/rsa_majore.yaml
+++ b/tests/formulas/rsa/rsa_majore.yaml
@@ -85,3 +85,26 @@
         enceinte: true
   output:
     rsa_majore_eligibilite: true
+
+- name: Pas de RSA majoré si demandeur à charge des parents
+  description: RSA majoré
+  period: 2015-01
+  absolute_error_margin: 0.03
+  input:
+    famille:
+      parents: [parent1]
+      enfants: []
+    foyer_fiscal:
+      declarants: [parent1]
+      personnes_a_charge: []
+    menage:
+      personne_de_reference: parent1
+      enfants: []
+    individus:
+      parent1:
+        age: 17
+        enceinte: true
+        enfant_a_charge:
+          2015: true
+  output:
+    rsa_majore_eligibilite: false

--- a/tests/mes-aides.gouv.fr/test_mes_aides_55b8811af0f7e3ac6b8f4d7a.yaml
+++ b/tests/mes-aides.gouv.fr/test_mes_aides_55b8811af0f7e3ac6b8f4d7a.yaml
@@ -1,4 +1,4 @@
-name: Personne isolée 2 enfts à charge salariée
+name: Personne celibataire, à charge de ses parents, avec 2 enfants à charge et salariée
 keywords:
 - recette
 - rsa
@@ -293,4 +293,4 @@ input:
     personne_de_reference: 55b8807e40cf7dab6b31aa21
     statut_occupation_logement: loge_gratuitement
 output:
-  rsa: 636.97
+  rsa: 462

--- a/tests/mes-aides.gouv.fr/test_mes_aides_55e6c2b70587579f04649960.yaml
+++ b/tests/mes-aides.gouv.fr/test_mes_aides_55e6c2b70587579f04649960.yaml
@@ -1,4 +1,4 @@
-name: personne isolée 1 enft salariée hébergement à titre gratuit
+name: Personne celibataire à charge de ses parents avec 1 enfant, salariée et hébergée à titre gratuit
 keywords:
 - recette
 - rsa
@@ -267,4 +267,4 @@ input:
     personne_de_reference: 55e6c292dc46199d042bb6e8
     statut_occupation_logement: loge_gratuitement
 output:
-  rsa: 590
+  rsa: 480


### PR DESCRIPTION
* Amélioration technique.
* Périodes concernées : toutes.
* Zones impactées : [
    `openfisca_france/model/prestations/minima_sociaux/rsa.py`,
    `tests/formulas/rsa/rsa_majore.yaml`
]
* Détails :
  - Avec l'expérience du terrain, nous constatons que le "RSA majoré pour personne isolé" n'est pas accordé pour une personne célibataire mais qui est elle-même à la charge de ses parents.
- - - -

Ces changements :
- Corrigent ou améliorent un calcul déjà existant.