### PR TITLE
Met à jour le nombre de séances du dispositif Santé Psy Etudiant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 149.4.3 [#2146](https://github.com/openfisca/openfisca-france/pull/2146)
+
+* Changement mineur
+* Périodes concernées : à partir du 06/01/2023.
+* Zones impactées :
+  - `openfisca_france/parameters/prestations_sociales/aides_jeunes/sante_psy/etudiant/seances_max.yaml`
+* Détails :
+  - Le dispositif santé psy étudiants passe de 6 à 8 séances.
+
+
 ### 149.4.2 [#2128](https://github.com/openfisca/openfisca-france/pull/2128)
 
 * Correction d'une erreur de calcul

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/sante_psy/etudiant/seances_max.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/sante_psy/etudiant/seances_max.yaml
@@ -11,7 +11,7 @@ metadata:
       href: https://www.service-public.fr/particuliers/actualites/A14726
     2023-01-06:
       href: https://www.service-public.fr/particuliers/actualites/A14726
-notes:     
+  notes:     
     2021-03-10:
     - title: 2 cycles de 3 séances au maximum
     2023-01-06:

--- a/openfisca_france/parameters/prestations_sociales/aides_jeunes/sante_psy/etudiant/seances_max.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_jeunes/sante_psy/etudiant/seances_max.yaml
@@ -2,11 +2,17 @@ description: Nombre maximum de séances prises en charge par le chèque santé p
 values:
   2021-03-10:
     value: 6
+  2023-01-06:
+    value: 8
 metadata:
   short_label: Nb max de séances
   reference:
     2021-03-10:
       href: https://www.service-public.fr/particuliers/actualites/A14726
-  notes:
+    2023-01-06:
+      href: https://www.service-public.fr/particuliers/actualites/A14726
+notes:     
     2021-03-10:
     - title: 2 cycles de 3 séances au maximum
+    2023-01-06:
+    - title: 8 séances gratuites de suivi avec un psychologue 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '149.4.2',
+    version = '149.4.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 06/01/2023.
* Zones impactées : `openfisca_france/parameters/prestations_sociales/aides_jeunes/sante_psy/etudiant/seances_max.yaml`.
* Détails :
  - Le dispositif santé psy étudiants passe de 6 à 8 séances.

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.

