### PR TITLE
Ajoute l'unité ratio au taux d'incapacité pris en compte pour l'AAH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 149.4.4 [#2149](https://github.com/openfisca/openfisca-france/pull/2149)
+
+* Changement mineur
+* Périodes concernées : toutes
+* Zones impactées :
+  - `/model/caracteristiques_socio_demographiques/capacite_travail.py`
+* Détails :
+  - Ajoute unité ratio à cette variable taux d'incapacité prise en compte dans l'AAH, permet d'éviter d'entrer une valeur telle que 80 alors que la valeur doit être entre 0 et 1.
+
+
 ### 149.4.3 [#2146](https://github.com/openfisca/openfisca-france/pull/2146)
 
 * Changement mineur

--- a/openfisca_france/model/caracteristiques_socio_demographiques/capacite_travail.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/capacite_travail.py
@@ -14,9 +14,10 @@ class taux_capacite_travail(Variable):
 class taux_incapacite(Variable):
     value_type = float
     entity = Individu
-    label = "Taux d'incapacité"
+    label = "Taux d'incapacité pris en compte pour l'AAH"
     definition_period = MONTH
     reference = 'https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=BD54F4B28313142C87FC8B96013E0441.tplgfr44s_1?idArticle=LEGIARTI000023097719&cidTexte=LEGITEXT000006073189&dateTexte=20190312'
-    documentation = "Taux d'incapacité retenu pour l'Allocation Adulte Handicapé (AAH)."
+    documentation = "Taux d'incapacité pris en compte pour l'allocation adulte handicapé (AAH)."
     is_period_size_independent = True
     set_input = set_input_dispatch_by_period
+    unit == '/1'

--- a/openfisca_france/model/caracteristiques_socio_demographiques/capacite_travail.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/capacite_travail.py
@@ -20,4 +20,4 @@ class taux_incapacite(Variable):
     documentation = "Taux d'incapacité pris en compte pour l'allocation adulte handicapé (AAH)."
     is_period_size_independent = True
     set_input = set_input_dispatch_by_period
-    unit == '/1'
+    unit = '/1'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '149.4.3',
+    version = '149.4.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur
* Périodes concernées : toutes
* Zones impactées :
  - `/model/caracteristiques_socio_demographiques/capacite_travail.py`
* Détails :
  - Ajoute unité ratio à cette variable taux d'incapacité prise en compte dans l'AAH, permet d'éviter d'entrer une valeur telle que 80 alors que la valeur doit être entre 0 et 1.
