### PR TITLE
Corrige les nouvelles erreurs de lint du à la montée de version du linter flake8 en v6.1.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
 # Changelog
 
-###  150.2.0 [#2129](https://github.com/openfisca/openfisca-france/pull/2129)
+### 150.2.1 [#2157](https://github.com/openfisca/openfisca-france/pull/2157)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées :
+    - `openfisca_france/model/prestations/agepi.py`
+    - `openfisca_france/model/prestations/aide_mobilite.py`
+    - `tests/test_basics.py`
+
+* Détails :
+  - La release de la version 6.1.0 ajoute de nouvelles règles de lint qui mettent en erreur notre CI.
+
+##  150.2.0 [#2129](https://github.com/openfisca/openfisca-france/pull/2129)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir de 01/01/2023 et 01/01/2022.
-* Zones impactées : 
+* Zones impactées :
 - `parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/`
 - `parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/`
 - `parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/`
@@ -19,7 +31,7 @@
   - Revalorisation du plafonds et majorations de plafonds du CF pour 01/01/2023 et 01/01/2022
   - Corrige la date dans le titre de l'arrêté pour 01/01/2023
 
-### 150.1.0 [#2130](https://github.com/openfisca/openfisca-france/pull/2130)
+## 150.1.0 [#2130](https://github.com/openfisca/openfisca-france/pull/2130)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/04/2022 et 01/07/2022.

--- a/openfisca_france/model/prestations/agepi.py
+++ b/openfisca_france/model/prestations/agepi.py
@@ -2,8 +2,13 @@ from numpy import fabs, timedelta64
 
 from openfisca_core.periods import Period
 
-from openfisca_france.model.base import Famille, Individu, Variable, Enum, MONTH, ADD, set_input_dispatch_by_period, set_input_divide_by_period, date, min_, not_
-from openfisca_france.model.revenus.activite.salarie import TypesContrat, TypesLieuEmploiFormation, TypesCategoriesDemandeurEmploi
+from openfisca_france.model.base import (
+    Famille, Individu, Variable, date, Enum, MONTH, ADD, min_, not_,
+    set_input_dispatch_by_period, set_input_divide_by_period,
+    )
+from openfisca_france.model.revenus.activite.salarie import (
+    TypesContrat, TypesLieuEmploiFormation, TypesCategoriesDemandeurEmploi
+    )
 
 
 class agepi_nbenf(Variable):

--- a/openfisca_france/model/prestations/aide_mobilite.py
+++ b/openfisca_france/model/prestations/aide_mobilite.py
@@ -2,9 +2,14 @@ from numpy import fabs, timedelta64
 
 from openfisca_core.periods import Period
 
-from openfisca_france.model.base import Individu, Variable, MONTH, Enum, not_, ADD, set_input_dispatch_by_period, set_input_divide_by_period, min_, date
+from openfisca_france.model.base import (
+    Variable, date, Enum, Individu, MONTH, ADD, min_, not_,
+    set_input_dispatch_by_period, set_input_divide_by_period,
+    )
 from openfisca_france.model.caracteristiques_socio_demographiques.logement import TypesLieuResidence
-from openfisca_france.model.revenus.activite.salarie import TypesContrat, TypesLieuEmploiFormation, TypesCategoriesDemandeurEmploi
+from openfisca_france.model.revenus.activite.salarie import (
+    TypesContrat, TypesLieuEmploiFormation, TypesCategoriesDemandeurEmploi
+    )
 
 
 class aide_mobilite_date_demande(Variable):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '150.2.0',
+    version = '150.2.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : 
    - `openfisca_france/model/prestations/agepi.py`
    - `openfisca_france/model/prestations/aide_mobilite.py`
    - `tests/test_basics.py`

* Détails :
  - La release de la version 6.1.0 ajoute de nouvelles règles de lint qui mettent en erreur notre CI.

- - - -
Ces changements :

- Corrigent ou améliorent un calcul déjà existant.