### PR TITLE
Revalorisation du plafond de ressources pour la css au 01/04/2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 153.3.2 [#2158](https://github.com/openfisca/openfisca-france/pull/2158)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/04/2023.
+* Zones impactées : `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml`.
+* Détails :
+  - Changement du plafond de base de la css
+
 ### 153.3.1 [#2190](https://github.com/openfisca/openfisca-france/pull/2190)
 
 * Changement mineur.
@@ -8,7 +16,7 @@
 * Détails :
   - Ajoute l'option `is_period_size_independent = True` à la variable effectif_entreprise
 
-### 153.3.0 [#2181](https://github.com/openfisca/openfisca-france/pull/2186)
+## 153.3.0 [#2181](https://github.com/openfisca/openfisca-france/pull/2186)
 
 * Évolution du système socio-fiscal. Amélioration technique
 * Périodes concernées : toutes.
@@ -29,7 +37,7 @@
   - Change libellés des paramètres "minimum de mise en recouvrement de l'IR" en suivant la formulation proposée par l'Insee dans cette étude : https://www.insee.fr/fr/statistiques/3584540
   - Ajoute référence législative.
 
-### 153.2.0 [#2181](https://github.com/openfisca/openfisca-france/pull/2181)
+## 153.2.0 [#2181](https://github.com/openfisca/openfisca-france/pull/2181)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 07/2021.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml
@@ -55,12 +55,12 @@ metadata:
       title: Loi n° 2022-1158 du 16/08/2022
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046186723
     2023-04-01:
-      - title: Article L861-1, 1° du Code de la Sécurité sociale
-         href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037950247
-      - title: Décret n° 2023-236 31/03/2023
-        href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000047387345
-      - title: Arrêté du 30/03/2023
-        href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000047387932
+    - title: Article L861-1, 1° du Code de la Sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037950247
+    - title: Décret n° 2023-236 31/03/2023
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000047387345
+    - title: Arrêté du 30/03/2023
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000047387932
 
 documentation: |-
   Le plafond varie selon la composition du foyer. Il est revalorisé au 1er avril de chaque année.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml
@@ -38,6 +38,8 @@ values:
     value: 9203
   2022-07-01:
     value: 9571
+  2023-04-01:
+    value: 9719
 metadata:
   short_label: Plafond annuel
   last_value_still_valid_on: "2021-04-01"
@@ -52,6 +54,9 @@ metadata:
     2022-07-01:
       title: LOI n° 2022-1158 du 16/08/2022
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046186723
+    2023-04-01:
+      title: décret n° 2023-236 du 31 mars 2023
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000047387932
 documentation: |-
   Le plafond varie selon la composition du foyer. Il est revalorisé au 1er avril de chaque année.
   Le montant ainsi revalorisé est constaté par arrêté du ministre chargé de la sécurité sociale.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml
@@ -52,11 +52,14 @@ metadata:
       title: Arrêté du 29/03/2021, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043306326
     2022-07-01:
-      title: LOI n° 2022-1158 du 16/08/2022
+      title: Loi n° 2022-1158 du 16/08/2022
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046186723
     2023-04-01:
-      title: décret n° 2023-236 du 31 mars 2023
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000047387932
+      - title: Décret n° 2023-236 31/03/2023
+        href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000047387345
+      - title: Arrêté du 30/03/2023
+        href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000047387932
+
 documentation: |-
   Le plafond varie selon la composition du foyer. Il est revalorisé au 1er avril de chaque année.
   Le montant ainsi revalorisé est constaté par arrêté du ministre chargé de la sécurité sociale.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml
@@ -55,6 +55,8 @@ metadata:
       title: Loi n° 2022-1158 du 16/08/2022
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046186723
     2023-04-01:
+      - title: Article L861-1, 1° du Code de la Sécurité sociale
+         href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037950247
       - title: Décret n° 2023-236 31/03/2023
         href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000047387345
       - title: Arrêté du 30/03/2023

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '153.3.1',
+    version = '153.3.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/04/2023.
* Zones impactées : `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml`.
* Détails :
  - Changement du plafond de base de la css

- - - -

- Corrigent ou améliorent un calcul déjà existant.
