### PR TITLE
Renomme des last_review en last_value_still_valid_on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 150.2.2 [#2159](https://github.com/openfisca/openfisca-france/pull/2159)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cond_ress/`.
+* Détails :
+  - Fusionne des last_review qui étaient en doublon avec des last_value_still_valid_on
+
 ### 150.2.1 [#2157](https://github.com/openfisca/openfisca-france/pull/2157)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cond_ress/majoration_plafond_par_enfant_supplementaire.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cond_ress/majoration_plafond_par_enfant_supplementaire.yaml
@@ -18,7 +18,7 @@ values:
     value: 5932
 metadata:
   short_label: Majoration ressource par enfant supplémentaire
-  last_value_still_valid_on: "2022-02-25"
+  last_value_still_valid_on: "2023-01-31"
   label_en: "Family allowances (AF): Thresholds for means-testing"
   ipp_csv_id: plaf_enf_sup
   unit: currency
@@ -70,7 +70,6 @@ metadata:
     - title: Revalorisation des plafonds de 0,2%
     2019-01-01:
     - title: Revalorisation des plafonds de 1%
-  last_review: "2023-01-31"
 documentation: |-
   Notes :
   https://www.ipp.eu/baremes-ipp/prestations-sociales/0/3/prestations_generales/af_cond/

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cond_ress/plafond_tranche_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cond_ress/plafond_tranche_1.yaml
@@ -19,6 +19,7 @@ values:
 metadata:
   short_label: Plafond de ressources - Tranche 1
   label_en: "Family allowances (AF): Thresholds for means-testing"
+  last_value_still_valid_on: "2023-01-31"
   ipp_csv_id: plaf_t1_2enf
   unit: currency
   reference:
@@ -55,7 +56,6 @@ metadata:
     2023-01-01:
       title: Arrêté du 21 décembre 2022 relatif aux plafonds de ressources de certaines prestations familiales
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046794210
-    last_review: "2023-01-31"
   official_journal_date:
     2015-07-01: "2015-06-05"
     2016-01-01: "2015-12-12"

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cond_ress/plafond_tranche_1_base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cond_ress/plafond_tranche_1_base.yaml
@@ -17,7 +17,7 @@ values:
   2023-01-01:
     value: 59330
 metadata:
-  last_value_still_valid_on: "2022-02-24"
+  last_value_still_valid_on: "2023-01-31"
   reference:
     2016-01-01:
       title: Arrêté du 08/12/2015, art. 1
@@ -40,7 +40,6 @@ metadata:
     2023-01-01:
       title: Arrêté du 21 décembre 2022 relatif aux plafonds de ressources de certaines prestations familialess
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046794210
-  last_review: "2023-01-31"
 documentation: |-
   Notes :
   https://www.ipp.eu/baremes-ipp/prestations-sociales/0/3/prestations_generales/af_cond/

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cond_ress/plafond_tranche_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cond_ress/plafond_tranche_2.yaml
@@ -18,7 +18,7 @@ values:
     value: 94893
 metadata:
   short_label: Plafond de ressources - Tranche 2
-  last_value_still_valid_on: "2021-12-31"
+  last_value_still_valid_on: "2023-01-31"
   label_en: "Family allowances (AF): Thresholds for means-testing"
   ipp_csv_id: plaf_t2_2enf
   unit: currency
@@ -70,7 +70,6 @@ metadata:
     - title: Revalorisation des plafonds de 0,2%
     2019-01-01:
     - title: Revalorisation des plafonds de 1%
-  last_review: "2023-01-31"
 documentation: |-
   Précalcul du plafond annuel de ressources pour la deuxième tranche
   applicable pour l'attribution du montant modulé des allocations familiales.

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cond_ress/plafond_tranche_2_base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cond_ress/plafond_tranche_2_base.yaml
@@ -18,7 +18,7 @@ values:
     value: 83029
 metadata:
   short_label: Plafond nº2
-  last_value_still_valid_on: "2021-12-31"
+  last_value_still_valid_on: "2023-01-31"
   unit: currency
   reference:
     2016-01-01:
@@ -42,7 +42,6 @@ metadata:
     2023-01-01:
       title: Arrêté du 21 décembre 2022 relatif aux plafonds de ressources de certaines prestations familiales
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046794210
-  last_review: "2023-01-31"
 documentation: |-
   Notes :
   https://www.ipp.eu/baremes-ipp/prestations-sociales/0/3/prestations_generales/af_cond/

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '150.2.1',
+    version = '150.2.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes. 
* Zones impactées : `parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cond_ress/`.
* Détails :
  - Fusionne des last_review qui étaient en doublon avec des last_value_still_valid_on
