### PR TITLE
Corrige plus_values_base_large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-# 151.1.0 [#2179](https://github.com/openfisca/openfisca-france/pull/2179)
+### 151.1.1 [#2163](https://github.com/openfisca/openfisca-france/pull/2163)
+
+* Correction d'une formule.
+* Périodes concernées : toutes.
+* Zones impactées : `measures.py`.
+* Détails :
+  - Corrige `plus_values_base_large` suite à une modification de `assiette_csg_plus_values` introduite dans la PR #2126.
+
+## 151.1.0 [#2179](https://github.com/openfisca/openfisca-france/pull/2179)
 
 * Changement mineur.
 * Périodes concernées : depuis 2023-08-01.
@@ -11,7 +19,7 @@
   - Mise à jour du taux du livret A
   - Mise à jour de la formule du taux du livret d'épargne populaire (taux fixé désormais)
 
-# 151.0.1 [#2175](hhttps://github.com/openfisca/openfisca-france/pull/2175)
+### 151.0.1 [#2175](hhttps://github.com/openfisca/openfisca-france/pull/2175)
 
 * Changement mineur.
 * Périodes concernées : toutes.

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -237,14 +237,16 @@ class plus_values_base_large(Variable):
     def formula_2018_01_01(foyer_fiscal, period):
         '''
         Cf. docstring période précédente
-        Pour 2018 et 2019, assiette_csg_plus_values est inclus dans rfr_plus_values_hors_rni
+        Pour 2018 et 2019, seule variable de assiette_csg_plus_values n'étant pas dans rfr_plus_values_hors_rni : pveximpres
         '''
         f3wb = foyer_fiscal('f3wb', period)
 
         rfr_plus_values_hors_rni = foyer_fiscal('rfr_plus_values_hors_rni', period)
+        pveximpres_i = foyer_fiscal.members('pveximpres', period)
+        pveximpres = foyer_fiscal.sum(pveximpres_i)
         ajouts_de_rev_cat_pv = f3wb
 
-        return rfr_plus_values_hors_rni + ajouts_de_rev_cat_pv
+        return rfr_plus_values_hors_rni + pveximpres + ajouts_de_rev_cat_pv
 
 
 class revenus_nets_du_capital(Variable):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '151.1.0',
+    version = '151.1.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/plus_values.yaml
+++ b/tests/formulas/plus_values.yaml
@@ -1,0 +1,12 @@
+- name: pveximpres
+  description: Plus-values d'entreprises exonérées d'IR suite à départ à la retraite (mais non exonérées de prélèvements sociaux)
+  period: 2018
+  absolute_error_margin: 1
+  input:
+    pveximpres: 100000
+  output:
+    assiette_csg_plus_values: 100000
+    plus_values_base_large: 100000
+    prelevements_sociaux_revenus_capital: -17200 # 17200 *0.172*100000
+    revenus_nets_du_capital: 82800 # 100000-17200
+    impots_directs: 0


### PR DESCRIPTION
* Correction d'une formule.
* Périodes concernées : toutes.
* Zones impactées : `measures.py`.
* Détails :
  - Corrige `plus_values_base_large` suite à une modification de `assiette_csg_plus_values` introduite dans la PR #2126.