### PR TITLE
Corrige des doubles comptes plus-values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 150.3.30 [#2121](https://github.com/openfisca/openfisca-france/pull/212)
+## 150.3.0 [#2121](https://github.com/openfisca/openfisca-france/pull/2121)
 
 * Amélioration technique.
 * Périodes concernées : toutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 150.4.0 [#2166](hhttps://github.com/openfisca/openfisca-france/pull/2166)
+
+* Correction d'une erreur de formule
+* Périodes concernées : toutes.
+* Zones impactées : `prestations/prestations_familiales/base_ressource`.
+* Détails :
+  - La variable `prestations_familiales_base_ressources_individu` contenait les variables `glo` et `assiette_csg_plus_values`, alors que la variable `rev_coll`, utilisée dans `prestations_familiales_base_ressources_communes`, contenait `plus_values_prelevement_forfaitaire_unique_ir` et `revenu_categoriel_plus_values`. On corrige de ceci, et on met un commentaire pour expliquer le choix fait en termes de variable de plus-values.
+
 ## 150.3.0 [#2121](https://github.com/openfisca/openfisca-france/pull/2121)
 
 * Amélioration technique.

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -71,13 +71,11 @@ class prestations_familiales_base_ressources_individu(Variable):
 
         traitements_salaires_pensions_rentes = individu('traitements_salaires_pensions_rentes', annee_fiscale_n_2)
         hsup = individu('hsup', annee_fiscale_n_2, options = [ADD])
-        glo = individu('glo', annee_fiscale_n_2)
-        plus_values = individu.foyer_fiscal('assiette_csg_plus_values', annee_fiscale_n_2) * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
         rpns = individu('rpns_imposables', annee_fiscale_n_2)
         rpns_pvce = individu('rpns_pvce', annee_fiscale_n_2)
         rpns_exon = individu('rpns_exon', annee_fiscale_n_2)
 
-        return traitements_salaires_pensions_rentes + hsup + glo + plus_values + rpns + rpns_pvce + rpns_exon
+        return traitements_salaires_pensions_rentes + hsup + rpns + rpns_pvce + rpns_exon
 
 
 class biactivite(Variable):
@@ -135,9 +133,7 @@ class rev_coll(Variable):
         f7ga = foyer_fiscal('f7ga', period)
         f7gb = foyer_fiscal('f7gb', period)
         f7gc = foyer_fiscal('f7gc', period)
-        # est supprimée à partir de 2018
-        rev_cat_pv = foyer_fiscal('revenu_categoriel_plus_values', period)
-        plus_values_prelevement_forfaitaire_unique_ir = foyer_fiscal('plus_values_prelevement_forfaitaire_unique_ir', period)  # Apparait à partir de 2018
+        plus_values = foyer_fiscal('assiette_csg_plus_values', period) # Cette variable ne correspond probablement pas exactement à la législation exacte (revenus nets catégoriels retenus pour l'IR, à taux propostionnel ou libératoire : cf. art. R532-3 du CSS), que ce soit en termes de champ des plus-values (PV) et de leur mesure (abattements ou pas, etc.). Néanmoins, cette variable constitue une bonne approximation. Les autres contiennent d'autres limites (les PV au barème, via revenu_categoriel_plus_values ou au PFU, via plus_values_prelevement_forfaitaire_unique_ir, ne regroupent pas toutes les plus-values ; les variables rfr_plus_values_hors_rni et revenu_categoriel_plus_values non-plus (ex : gains de levée d'option assimilés salaires).
 
         # TODO: ajouter les revenus de l'étranger etr*0.9
         return (
@@ -147,8 +143,7 @@ class rev_coll(Variable):
             + rev_cat_rvcm
             + revenus_capitaux_prelevement_liberatoire
             + revenus_capitaux_prelevement_forfaitaire_unique_ir
-            + rev_cat_pv
-            + plus_values_prelevement_forfaitaire_unique_ir
+            + plus_values
             - abat_spe
             - f7ga
             - f7gb

--- a/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
+++ b/openfisca_france/model/prestations/prestations_familiales/base_ressource.py
@@ -133,7 +133,7 @@ class rev_coll(Variable):
         f7ga = foyer_fiscal('f7ga', period)
         f7gb = foyer_fiscal('f7gb', period)
         f7gc = foyer_fiscal('f7gc', period)
-        plus_values = foyer_fiscal('assiette_csg_plus_values', period) # Cette variable ne correspond probablement pas exactement à la législation exacte (revenus nets catégoriels retenus pour l'IR, à taux propostionnel ou libératoire : cf. art. R532-3 du CSS), que ce soit en termes de champ des plus-values (PV) et de leur mesure (abattements ou pas, etc.). Néanmoins, cette variable constitue une bonne approximation. Les autres contiennent d'autres limites (les PV au barème, via revenu_categoriel_plus_values ou au PFU, via plus_values_prelevement_forfaitaire_unique_ir, ne regroupent pas toutes les plus-values ; les variables rfr_plus_values_hors_rni et revenu_categoriel_plus_values non-plus (ex : gains de levée d'option assimilés salaires).
+        plus_values = foyer_fiscal('assiette_csg_plus_values', period)  # Cette variable ne correspond probablement pas exactement à la législation exacte (revenus nets catégoriels retenus pour l'IR, à taux propostionnel ou libératoire : cf. art. R532-3 du CSS), que ce soit en termes de champ des plus-values (PV) et de leur mesure (abattements ou pas, etc.). Néanmoins, cette variable constitue une bonne approximation. Les autres contiennent d'autres limites (les PV au barème, via revenu_categoriel_plus_values ou au PFU, via plus_values_prelevement_forfaitaire_unique_ir, ne regroupent pas toutes les plus-values ; les variables rfr_plus_values_hors_rni et revenu_categoriel_plus_values non-plus (ex : gains de levée d'option assimilés salaires).
 
         # TODO: ajouter les revenus de l'étranger etr*0.9
         return (

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '150.3.0',
+    version = '150.4.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Correction d'une erreur de formule
* Périodes concernées : toutes.
* Zones impactées : `prestations/prestations_familiales/base_ressource`.
* Détails :
  - La variable `prestations_familiales_base_ressources_individu` contenait les variables `glo` et `assiette_csg_plus_values`, alors que la variable `rev_coll`, utilisée dans `prestations_familiales_base_ressources_communes`, contenait `plus_values_prelevement_forfaitaire_unique_ir` et `revenu_categoriel_plus_values`. On corrige de ceci, et on met un commentaire pour expliquer le choix fait en termes de variable de plus-values.
