### PR TITLE
Corrige la durée de validité du taux réduit de l'impôt sur les sociétés

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 150.4.6 [#2169](hhttps://github.com/openfisca/openfisca-france/pull/2169)
+
+* Correction de paramètres.
+* Périodes concernées : à partir de 2020.
+* Zones impactées : `parameters/taxation_societe`.
+* Détails :
+  - Correction de la valeur du taux réduit qui a été prolongée au delà de la période initialement prévue.
+  - Pas d'impact sur les variables car non affectées par ces paramètres.
+  - Voir aussi [Barèmes IPP](https://gitlab.com/ipp/partage-public-ipp/baremes-ipp/baremes-ipp-yaml/-/merge_requests/424).
+
 ### 150.4.5 [#2172](https://github.com/openfisca/openfisca-france/pull/2172)
 
 * Changement mineur.
@@ -11,15 +21,15 @@
 ### 150.4.4 [#2165](https://github.com/openfisca/openfisca-france/pull/2165/)
 
 * Évolution du système socio-fiscal
-* Périodes concernées : toutes 
+* Périodes concernées : toutes
 * Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py` et `/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/quotient_familial/enf1.yaml`
 * Détails :
-Actuellement, les parts de quotient familial se distinguent par 2 paramètres : le premier enf1, concerne les deux premiers enfants, le second enf2, concerne les enfants à partir du 3ème. 
-Cette PR a pour objectif de se rapprocher du fonctionnement de l'Article 194 du CGI, en proposant 3 paramètres : 
+Actuellement, les parts de quotient familial se distinguent par 2 paramètres : le premier enf1, concerne les deux premiers enfants, le second enf2, concerne les enfants à partir du 3ème.
+Cette PR a pour objectif de se rapprocher du fonctionnement de l'Article 194 du CGI, en proposant 3 paramètres :
     - enf1 :  part du premier enfant
     - enf2 : part du deuxième enfant
     - enf3_et_sup : parts à partir du 3ème enfant
-    
+
 Ces changements :
 - Modifient l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).
 - Corrigent ou améliorent un calcul déjà existant.

--- a/openfisca_france/parameters/taxation_societes/impot_societe/index.yaml
+++ b/openfisca_france/parameters/taxation_societes/impot_societe/index.yaml
@@ -1,6 +1,6 @@
-description: Seuils et taux d'imposition au titre de l'impôt sur les sociétés (1977-2022)
+description: Seuils et taux d'imposition au titre de l'impôt sur les sociétés
 metadata:
-  label_en: Thresholds and tax rates for corporate income tax (1977 - 2022)
+  label_en: Thresholds and tax rates for corporate income tax
   order:
   - taux_normal
   - taux_reduit

--- a/openfisca_france/parameters/taxation_societes/impot_societe/plafond_ca_taux_reduit.yaml
+++ b/openfisca_france/parameters/taxation_societes/impot_societe/plafond_ca_taux_reduit.yaml
@@ -19,4 +19,3 @@ metadata:
   notes:
     2002-03-31:
     - title: Référence 2002-03-31 parue dans JOCE et non JORF.
-documentation: Baisse prévue du taux normal pour les exercices fiscaux à venir par la Loi 2017-1837 du 30/12/2017 - art. 84.

--- a/openfisca_france/parameters/taxation_societes/impot_societe/seuil_superieur_benefices_taux_intermediaire.yaml
+++ b/openfisca_france/parameters/taxation_societes/impot_societe/seuil_superieur_benefices_taux_intermediaire.yaml
@@ -11,4 +11,3 @@ metadata:
       title: Article 219 CGI modifié par Loi 2016-1918 du 29/12/2016 - art. 91
   official_journal_date:
     2017-01-01: "2016-12-31"
-documentation: Baisse prévue du taux normal pour les exercices fiscaux à venir par la Loi 2017-1837 du 30/12/2017 - art. 84.

--- a/openfisca_france/parameters/taxation_societes/impot_societe/seuil_superieur_benefices_taux_reduit.yaml
+++ b/openfisca_france/parameters/taxation_societes/impot_societe/seuil_superieur_benefices_taux_reduit.yaml
@@ -11,7 +11,7 @@ metadata:
   unit: currency
   reference:
     2001-01-01:
-      title: Article 219 CGI modifié par Loi 2000-1352 du 30/12/2000 - art. 7-9 de Finances pour 2001
+      title: Article 219 CGI modifié par la loi 2000-1352 du 30/12/2000 de finances pour 2001, art. 7-9
     2002-03-31:
       title: Règlement CE 974-98 1998-05-03 - art. 14
     2022-01-01:
@@ -25,5 +25,4 @@ metadata:
     2022-01-01: "2022-12-31"
   notes:
     2002-03-31:
-    - title: Référence 2002-03-31 parue dans JOCE et non JORF.
-documentation: Baisse prévue du taux normal pour les exercices fiscaux à venir par la Loi 2017-1837 du 30/12/2017 - art. 84.
+    - title: Référence parue dans JOCE et non JORF.

--- a/openfisca_france/parameters/taxation_societes/impot_societe/taux_intermediaire.yaml
+++ b/openfisca_france/parameters/taxation_societes/impot_societe/taux_intermediaire.yaml
@@ -14,4 +14,3 @@ metadata:
   official_journal_date:
     2002-01-01: "2000-12-31"
     2020-01-01: "2017-12-31"
-documentation: Baisse prévue du taux normal pour les exercices fiscaux à venir par la Loi 2017-1837 du 30/12/2017 - art. 84.

--- a/openfisca_france/parameters/taxation_societes/impot_societe/taux_reduit.yaml
+++ b/openfisca_france/parameters/taxation_societes/impot_societe/taux_reduit.yaml
@@ -8,9 +8,11 @@ metadata:
   unit: /1
   reference:
     2001-01-01:
-      title: Article 219 CGI modifié par Loi 2000-1352 du 30/12/2000 - art. 7-9 de Finances pour 2001
+      title: Article 219 CGI, paragraphe I-2-b, modifié par la loi 2000-1352 du 30/12/2000 de finances pour 2001, art. 7-9
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046868562#:~:text=Par%20exception%20au%20deuxième%20alinéa%20du%20présent%20I%20et%20au%20premier%20alinéa%20du%20a%2C%20pour%20les%20redevables%20ayant%20réalisé%20un%20chiffre%20d%27affaires%20n%27excédant%20pas%2010%20millions%20d%27euros%20au%20cours%20de%20l%27exercice%20ou%20de%20la%20période%20d%27imposition%2C%20ramené%20s%27il%20y%20a%20lieu%20à%20douze%20mois%2C%20le%20taux%20de%20l%27impôt%20applicable%20au%20bénéfice%20imposable%20est%20fixé%2C%20dans%20la%20limite%20de%2042%20500%20€%20de%20bénéfice%20imposable%20par%20période%20de%20douze%20mois%2C%20à%2025%20%25%20pour%20les%20exercices%20ouverts%20en%202001%20et%20à%2015%20%25%20pour%20les%20exercices%20ouverts%20à%20compter%20du%201er%20janvier%202002.
     2002-01-01:
-      title: Article 219 CGI modifié par Loi 2000-1352 du 30/12/2000 - art. 7-9 de Finances pour 2001
+      title: Article 219 CGI, paragraphe I-2-b, modifié par la loi 2000-1352 du 30/12/2000 de finances pour 2001, art. 7-9
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046868562#:~:text=Par%20exception%20au%20deuxième%20alinéa%20du%20présent%20I%20et%20au%20premier%20alinéa%20du%20a%2C%20pour%20les%20redevables%20ayant%20réalisé%20un%20chiffre%20d%27affaires%20n%27excédant%20pas%2010%20millions%20d%27euros%20au%20cours%20de%20l%27exercice%20ou%20de%20la%20période%20d%27imposition%2C%20ramené%20s%27il%20y%20a%20lieu%20à%20douze%20mois%2C%20le%20taux%20de%20l%27impôt%20applicable%20au%20bénéfice%20imposable%20est%20fixé%2C%20dans%20la%20limite%20de%2042%20500%20€%20de%20bénéfice%20imposable%20par%20période%20de%20douze%20mois%2C%20à%2025%20%25%20pour%20les%20exercices%20ouverts%20en%202001%20et%20à%2015%20%25%20pour%20les%20exercices%20ouverts%20à%20compter%20du%201er%20janvier%202002.
   official_journal_date:
     2001-01-01: "2000-12-31"
     2002-01-01: "2000-12-31"

--- a/openfisca_france/parameters/taxation_societes/impot_societe/taux_reduit.yaml
+++ b/openfisca_france/parameters/taxation_societes/impot_societe/taux_reduit.yaml
@@ -4,8 +4,6 @@ values:
     value: 0.25
   2002-01-01:
     value: 0.15
-  2020-01-01:
-    value: null
 metadata:
   unit: /1
   reference:
@@ -13,10 +11,6 @@ metadata:
       title: Article 219 CGI modifié par Loi 2000-1352 du 30/12/2000 - art. 7-9 de Finances pour 2001
     2002-01-01:
       title: Article 219 CGI modifié par Loi 2000-1352 du 30/12/2000 - art. 7-9 de Finances pour 2001
-    2020-01-01:
-      title: Article 219 CGI modifié par Loi 2016-1918 du 29/12/2016 - art. 91 & Loi 2017-1837 du 30/12/2017 - art. 84
   official_journal_date:
     2001-01-01: "2000-12-31"
     2002-01-01: "2000-12-31"
-    2020-01-01: "2017-12-31"
-documentation: Baisse prévue du taux normal pour les exercices fiscaux à venir par la Loi 2017-1837 du 30/12/2017 - art. 84.

--- a/openfisca_france/parameters/taxation_societes/impot_societe/taux_reduit.yaml
+++ b/openfisca_france/parameters/taxation_societes/impot_societe/taux_reduit.yaml
@@ -1,4 +1,4 @@
-description: Taux réduit
+description: Taux réduit de l'impôt sur les bénéfices des sociétés et autres personnes morales
 values:
   2001-01-01:
     value: 0.25

--- a/openfisca_france/parameters/taxation_societes/index.yaml
+++ b/openfisca_france/parameters/taxation_societes/index.yaml
@@ -1,0 +1,4 @@
+metadata:
+  order:
+  - contributions_additionnelles
+  - impot_societe

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '150.4.5',
+    version = '150.4.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Correction de paramètres.
* Périodes concernées : toutes.
* Zones impactées : `parameters/taxation_societe`.
* Détails :
  - Correction de la valeur du taux réduit qui a été prolongée au-delà de la période initialement prévue.
  - Pas d'impact sur les variables, car elles ne sont  affectées par ces paramètres.
  - Voir aussi [Barèmes IPP](https://gitlab.com/ipp/partage-public-ipp/baremes-ipp/baremes-ipp-yaml/-/merge_requests/424).
