### PR TITLE
feat(css): revalorisation plafond cmu, arrete du 2023-03-31 a effet le 2023-04-01

### DIFF
--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml
@@ -38,6 +38,8 @@ values:
     value: 9203
   2022-07-01:
     value: 9571
+  2023-04-01:
+    value: 9719
 metadata:
   short_label: Plafond annuel
   last_value_still_valid_on: "2021-04-01"
@@ -50,8 +52,16 @@ metadata:
       title: Arrêté du 29/03/2021, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043306326
     2022-07-01:
-      title: LOI n° 2022-1158 du 16/08/2022
+      title: Loi n° 2022-1158 du 16/08/2022
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046186723
+    2023-04-01:
+      - title: Article L861-1, 1° du Code de la Sécurité sociale
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037950247
+      - title: Décret n° 2023-236 31/03/2023
+        href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000047387345
+      - title: Arrêté du 30/03/2023
+        href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000047387932
+
 documentation: |-
   Le plafond varie selon la composition du foyer. Il est revalorisé au 1er avril de chaque année.
   Le montant ainsi revalorisé est constaté par arrêté du ministre chargé de la sécurité sociale.


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/04/2023.
* Zones impactées : `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/plafond_base.yaml`
* Détails :
  - Changement du plafond de base de la css

- - - -

* Corrigent ou améliorent un calcul déjà existant.
