### PR TITLE
Fix unfold_parameter to work with tax_scales

### DIFF
--- a/openfisca_france/scripts/parameters/unfold_parameters.py
+++ b/openfisca_france/scripts/parameters/unfold_parameters.py
@@ -103,10 +103,11 @@ def unfold_parameter(
         # Parameter is a scale.
         brackets = source_parameter['brackets']
         dates = set()
-        for key in ('amount', 'average_rate', 'base', 'rate', 'threshold'):
-            value_by_date = brackets.get(key)
-            if value_by_date is not None:
-                dates.update(value_by_date.keys())
+        for bracket in brackets:
+            for key in ('amount', 'average_rate', 'base', 'rate', 'threshold'):
+                value_by_date = bracket.get(key)
+                if value_by_date is not None:
+                    dates.update(value_by_date.keys())
         add_dated_metadata_to_parameter(
             source_parameter,
             dates,


### PR DESCRIPTION

* Changement mineur.
* Périodes concernées : aucune.
* Zones impactées : aucune.
* Détails :
  - Corrige un problème dans le script de dépliage des paramètres pour les paramètres du type `TaxScale`.

- Modifient des éléments non fonctionnels de ce dépôt .

