### PR TITLE
Complète et corrige le traitement des gains de levée d'options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+# 152.0.0 [#2178](https://github.com/openfisca/openfisca-france/pull/2178)
+
+* Correction et complétion de la législation
+* Périodes concernées : toutes.
+* Zones impactées:
+   - `mesures.py`
+   - `prelevements_obligatoires/impot_revenu/ir.py`
+   - `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py`
+   - `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py`
+   - `prestations/aides_logement.py`
+   - `revenus/capital/plus_values.py`
+* Détails :
+  - Ajoute les GLO taxés forfaitairement dans le revenu disponible (dans `plus_values_base_large`). Supprime ces GLO avant 2016 (car code faux).
+  - Ajoute ces GLO dans l'assiette CSG pour les années où ils n'y étaient pas injectés.
+  - Injecte dans le revenu disponible les GLO assimilés salaires et code les prélèvements associés à ces revenus. Il faut distinguer les GLO assimilés salaires pour l'IR (mais traités comme des revenus du capital pour les prélèvements sociaux), et ceux assimilés salaires à la fois pour l'IR et pour les prélèvements sociaux. Avant cette PR, n'était codé que l'IR associé à ces GLO, et pas les prélèvements sociaux. On ajoute les prélèvements sociaux, c'est-à-dire:
+     - pour ceux ayant les PS des revenus du capital (`f3vj`) : ajout dans l'assiette des PS des revenus du capital (donc, calcul de la CSG, CRDS et autres prélèvements)
+     - pour les autres (`f1tt`) : ils sont soumis à CSG et CRDS des revenus d'activité ainsi qu'à une contribution salariale de 10%. On code cela. Création de `csg_glo_assimile_salaire_ir_et_ps`, `crds_glo_assimile_salaire_ir_et_ps` et `contribution_salariale_glo_assimile_salaire` (qui implique de créer `f3vn`).
+   - Injecte les GLO assimilés salaires pour l'IR dans le revenu disponible (l'IR sur ces GLO y était injecté, mais pas les GLO eux-même).
+   - Suppression des formules de `taxation_plus_values_hors_bareme` avant 2012, qui étaient fausses.
+   - Enlève `f3vm` pour 2018, qui était mise à tord.
+   - Pour les GLO taxés forfaitairement, on code le changement d'entité en 2015 des cases qui y sont associées (passage de cases individuelles à foyer fiscal en 2015, pour `f3vd`, `f3vi` et `f3vf` : avant n'était codé que l'ancienne entité). Puis, pour simplifier les formules qui appellent ces revenus, création des variables `glo_taxation_ir_forfaitaire_taux2`, `glo_taxation_ir_forfaitaire_taux3` et `glo_taxation_ir_forfaitaire_taux4`. Renommage également de `glo` par `glo_taxation_ir_forfaitaire`
+
 ### 151.1.3 [#2164](https://github.com/openfisca/openfisca-france/pull/2164)
 
 * Tri de tests

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -161,11 +161,14 @@ class plus_values_base_large(Variable):
         f3we = foyer_fiscal('f3we', period)
         f3vz = foyer_fiscal('f3vz', period)
         f3vt = foyer_fiscal('f3vt', period)
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vf = foyer_fiscal('f3vf', period)
+        f3vi = foyer_fiscal('f3vi', period)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        intersection_v1_v2 = f3vg + f3we + f3vz + rpns_pvce + f3vt
+        intersection_v1_v2 = f3vg + f3we + f3vz + rpns_pvce + f3vt + f3vd + f3vf + f3vi
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2
 
@@ -182,11 +185,14 @@ class plus_values_base_large(Variable):
         f3vl = foyer_fiscal('f3vl', period)
         f3wb = foyer_fiscal('f3wb', period)
         f3vt = foyer_fiscal('f3vt', period)
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vf = foyer_fiscal('f3vf', period)
+        f3vi = foyer_fiscal('f3vi', period)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt
+        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt + f3vd + f3vf + f3vi
         ajouts_de_rev_cat_pv = f3vl + f3wb
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2 + ajouts_de_rev_cat_pv
@@ -203,11 +209,14 @@ class plus_values_base_large(Variable):
         f3vz = foyer_fiscal('f3vz', period)
         f3wb = foyer_fiscal('f3wb', period)
         f3vt = foyer_fiscal('f3vt', period)
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vf = foyer_fiscal('f3vf', period)
+        f3vi = foyer_fiscal('f3vi', period)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt
+        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt + f3vd + f3vf + f3vi
         ajouts_de_rev_cat_pv = f3wb
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2 + ajouts_de_rev_cat_pv
@@ -225,11 +234,14 @@ class plus_values_base_large(Variable):
         f3wb = foyer_fiscal('f3wb', period)
         f3vt = foyer_fiscal('f3vt', period)
         f3pi = foyer_fiscal('f3pi', period)
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vf = foyer_fiscal('f3vf', period)
+        f3vi = foyer_fiscal('f3vi', period)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt + f3pi
+        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt + f3pi + f3vd + f3vf + f3vi
         ajouts_de_rev_cat_pv = f3wb
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2 + ajouts_de_rev_cat_pv
@@ -280,22 +292,24 @@ class revenus_nets_du_capital(Variable):
         plus_values_base_large = foyer_fiscal('plus_values_base_large', period)
         rente_viagere_titre_onereux_net = foyer_fiscal('rente_viagere_titre_onereux_net', period)
 
-        revenus_du_capital_cap_avant_prelevements_sociaux = (
+        # Ajoute les gains de levée d'options qui, pour les prélèvements sociaux, sont soumis aux mêmes taux que les salaires
+        glo_assimiles_salaire_ir_et_ps = individu('f1tt', period)
+
+        revenus_du_capital_ff_avant_prelevements_sociaux = (
             assiette_csg_revenus_capital
             - assiette_csg_plus_values
             + plus_values_base_large
             - rente_viagere_titre_onereux_net
             )
+        revenus_du_capital_ind_avant_prelevements_sociaux = glo_assimiles_salaire_ir_et_ps
 
         prelevements_sociaux_revenus_capital = foyer_fiscal('prelevements_sociaux_revenus_capital', period)
 
-        revenus_foyer_fiscal = (
-            revenus_du_capital_cap_avant_prelevements_sociaux
-            + prelevements_sociaux_revenus_capital
+        return (
+            revenus_du_capital_ff_avant_prelevements_sociaux * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
+            + revenus_du_capital_ind_avant_prelevements_sociaux
+            + prelevements_sociaux_revenus_capital * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
             )
-        revenus_foyer_fiscal_projetes = revenus_foyer_fiscal * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
-
-        return revenus_foyer_fiscal_projetes
 
 
 class revenus_fonciers_bruts_menage(Variable):

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -161,14 +161,12 @@ class plus_values_base_large(Variable):
         f3we = foyer_fiscal('f3we', period)
         f3vz = foyer_fiscal('f3vz', period)
         f3vt = foyer_fiscal('f3vt', period)
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vf = foyer_fiscal('f3vf', period)
-        f3vi = foyer_fiscal('f3vi', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        intersection_v1_v2 = f3vg + f3we + f3vz + rpns_pvce + f3vt + f3vd + f3vf + f3vi
+        intersection_v1_v2 = f3vg + f3we + f3vz + rpns_pvce + f3vt + glo_taxation_ir_forfaitaire
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2
 
@@ -185,14 +183,12 @@ class plus_values_base_large(Variable):
         f3vl = foyer_fiscal('f3vl', period)
         f3wb = foyer_fiscal('f3wb', period)
         f3vt = foyer_fiscal('f3vt', period)
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vf = foyer_fiscal('f3vf', period)
-        f3vi = foyer_fiscal('f3vi', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt + f3vd + f3vf + f3vi
+        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt + glo_taxation_ir_forfaitaire
         ajouts_de_rev_cat_pv = f3vl + f3wb
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2 + ajouts_de_rev_cat_pv
@@ -209,14 +205,12 @@ class plus_values_base_large(Variable):
         f3vz = foyer_fiscal('f3vz', period)
         f3wb = foyer_fiscal('f3wb', period)
         f3vt = foyer_fiscal('f3vt', period)
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vf = foyer_fiscal('f3vf', period)
-        f3vi = foyer_fiscal('f3vi', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt + f3vd + f3vf + f3vi
+        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt + glo_taxation_ir_forfaitaire
         ajouts_de_rev_cat_pv = f3wb
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2 + ajouts_de_rev_cat_pv
@@ -234,14 +228,12 @@ class plus_values_base_large(Variable):
         f3wb = foyer_fiscal('f3wb', period)
         f3vt = foyer_fiscal('f3vt', period)
         f3pi = foyer_fiscal('f3pi', period)
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vf = foyer_fiscal('f3vf', period)
-        f3vi = foyer_fiscal('f3vi', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt + f3pi + f3vd + f3vf + f3vi
+        intersection_v1_v2 = f3we + f3vz + rpns_pvce + f3vt + f3pi + glo_taxation_ir_forfaitaire
         ajouts_de_rev_cat_pv = f3wb
 
         return v1_assiette_csg_plus_values + v2_rfr_plus_values_hors_rni - intersection_v1_v2 + ajouts_de_rev_cat_pv

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -292,7 +292,7 @@ class revenus_nets_du_capital(Variable):
         plus_values_base_large = foyer_fiscal('plus_values_base_large', period)
         rente_viagere_titre_onereux_net = foyer_fiscal('rente_viagere_titre_onereux_net', period)
 
-        # Ajoute les gains de levée d'options qui, pour les prélèvements sociaux, sont soumis aux mêmes taux que les salaires
+        # Ajoute les gains de levée d'options qui, pour les prélèvements sociaux, sont soumis aux mêmes taux que les salaires. Contrairement aux revenus ci-dessus, ces revenus sont individuels.
         glo_assimiles_salaire_ir_et_ps = individu('f1tt', period)
 
         revenus_du_capital_ff_avant_prelevements_sociaux = (
@@ -301,13 +301,12 @@ class revenus_nets_du_capital(Variable):
             + plus_values_base_large
             - rente_viagere_titre_onereux_net
             )
-        revenus_du_capital_ind_avant_prelevements_sociaux = glo_assimiles_salaire_ir_et_ps
 
         prelevements_sociaux_revenus_capital = foyer_fiscal('prelevements_sociaux_revenus_capital', period)
 
         return (
             revenus_du_capital_ff_avant_prelevements_sociaux * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
-            + revenus_du_capital_ind_avant_prelevements_sociaux
+            + glo_assimiles_salaire_ir_et_ps
             + prelevements_sociaux_revenus_capital * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
             )
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1671,9 +1671,9 @@ class taxation_plus_values_hors_bareme(Variable):
         f3vl = foyer_fiscal('f3vl', period)
         f3vt = foyer_fiscal('f3vt', period)
         f3vm = foyer_fiscal('f3vm', period)
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire_taux2 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux2', period)
+        glo_taxation_ir_forfaitaire_taux3 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux3', period)
+        glo_taxation_ir_forfaitaire_taux4 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux4', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         pv = parameters(period).impot_revenu.calcul_impot_revenu.pv
 
@@ -1682,13 +1682,13 @@ class taxation_plus_values_hors_bareme(Variable):
         return round_(
             pv.plus_values.pvce * rpns_pvce
             + pv.pv_cession_valeurs_mobilieres_pv_professionnelles.taux * max_(0, f3vg - f3vh)
-            + pv.actions_gratuites.taux2 * f3vd
+            + pv.actions_gratuites.taux2 * glo_taxation_ir_forfaitaire_taux2
             + pv.pv_cession_valeurs_mobilieres_pv_professionnelles.taux * f3vl
             + pv.pea.taux_avant_2_ans * f3vm
             + pv.pea.taux_posterieur * f3vt
             + pv.plus_values.taux_pv_entrep * f3sa_2012
-            + pv.actions_gratuites.taux3 * f3vi
-            + pv.actions_gratuites.taux4 * f3vf
+            + pv.actions_gratuites.taux3 * glo_taxation_ir_forfaitaire_taux3
+            + pv.actions_gratuites.taux4 * glo_taxation_ir_forfaitaire_taux4
             + pv.bspce.plus_3ans.pre_2018 * f3sj
             + pv.bspce.moins_3ans * f3sk
             )
@@ -1701,9 +1701,9 @@ class taxation_plus_values_hors_bareme(Variable):
         f3sk = foyer_fiscal('f3sk', period)
         f3vm = foyer_fiscal('f3vm', period)
         f3vt = foyer_fiscal('f3vt', period)
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire_taux2 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux2', period)
+        glo_taxation_ir_forfaitaire_taux3 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux3', period)
+        glo_taxation_ir_forfaitaire_taux4 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux4', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
@@ -1713,9 +1713,9 @@ class taxation_plus_values_hors_bareme(Variable):
             pv.plus_values.pvce * rpns_pvce
             + pv.pea.taux_avant_2_ans * f3vm
             + pv.pea.taux_posterieur * f3vt
-            + pv.actions_gratuites.taux2 * f3vd
-            + pv.actions_gratuites.taux3 * f3vi
-            + pv.actions_gratuites.taux4 * f3vf
+            + pv.actions_gratuites.taux2 * glo_taxation_ir_forfaitaire_taux2
+            + pv.actions_gratuites.taux3 * glo_taxation_ir_forfaitaire_taux3
+            + pv.actions_gratuites.taux4 * glo_taxation_ir_forfaitaire_taux4
             + pv.bspce.plus_3ans.pre_2018 * f3sj
             + pv.bspce.moins_3ans * f3sk
             )
@@ -1728,9 +1728,9 @@ class taxation_plus_values_hors_bareme(Variable):
         f3sk = foyer_fiscal('f3sk', period)
         f3vm = foyer_fiscal('f3vm', period)
         f3vt = foyer_fiscal('f3vt', period)
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire_taux2 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux2', period)
+        glo_taxation_ir_forfaitaire_taux3 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux3', period)
+        glo_taxation_ir_forfaitaire_taux4 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux4', period)
         f3wi = foyer_fiscal('f3wi', period)
         f3wj = foyer_fiscal('f3wj', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
@@ -1742,9 +1742,9 @@ class taxation_plus_values_hors_bareme(Variable):
             pv.plus_values.pvce * rpns_pvce
             + pv.pea.taux_avant_2_ans * f3vm
             + pv.pea.taux_posterieur * f3vt
-            + pv.actions_gratuites.taux2 * f3vd
-            + pv.actions_gratuites.taux3 * f3vi
-            + pv.actions_gratuites.taux4 * f3vf
+            + pv.actions_gratuites.taux2 * glo_taxation_ir_forfaitaire_taux2
+            + pv.actions_gratuites.taux3 * glo_taxation_ir_forfaitaire_taux3
+            + pv.actions_gratuites.taux4 * glo_taxation_ir_forfaitaire_taux4
             + pv.bspce.plus_3ans.pre_2018 * f3sj
             + pv.bspce.moins_3ans * f3sk
             + pv.plus_values.taux_plus_values_report * f3wi
@@ -1756,9 +1756,9 @@ class taxation_plus_values_hors_bareme(Variable):
         Taxation des plus-values (hors imposition au barÃ¨me), en excluant, à partir de 2018, celles imposées au PFU
         (qui sont à impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py)
         '''
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire_taux2 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux2', period)
+        glo_taxation_ir_forfaitaire_taux3 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux3', period)
+        glo_taxation_ir_forfaitaire_taux4 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux4', period)
         f3sj = foyer_fiscal('f3sj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3vm = foyer_fiscal('f3vm', period)
@@ -1773,9 +1773,9 @@ class taxation_plus_values_hors_bareme(Variable):
 
         return round_(
             pv.plus_values.pvce * rpns_pvce
-            + pv.actions_gratuites.taux2 * f3vd
-            + pv.actions_gratuites.taux3 * f3vi
-            + pv.actions_gratuites.taux4 * f3vf
+            + pv.actions_gratuites.taux2 * glo_taxation_ir_forfaitaire_taux2
+            + pv.actions_gratuites.taux3 * glo_taxation_ir_forfaitaire_taux3
+            + pv.actions_gratuites.taux4 * glo_taxation_ir_forfaitaire_taux4
             + pv.bspce.plus_3ans.pre_2018 * f3sj
             + pv.bspce.moins_3ans * f3sk
             + pv.pea.taux_avant_2_ans * f3vm
@@ -1790,9 +1790,9 @@ class taxation_plus_values_hors_bareme(Variable):
         Taxation des plus-values (hors imposition au barème), en excluant celles imposées au PFU
         (qui sont à impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py)
         '''
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire_taux2 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux2', period)
+        glo_taxation_ir_forfaitaire_taux3 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux3', period)
+        glo_taxation_ir_forfaitaire_taux4 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux4', period)
         f3sj = foyer_fiscal('f3sj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3wi = foyer_fiscal('f3wi', period)
@@ -1809,9 +1809,9 @@ class taxation_plus_values_hors_bareme(Variable):
 
         return round_(
             pv.plus_values.pvce * rpns_pvce
-            + pv.actions_gratuites.taux2 * f3vd
-            + pv.actions_gratuites.taux3 * f3vi
-            + pv.actions_gratuites.taux4 * f3vf
+            + pv.actions_gratuites.taux2 * glo_taxation_ir_forfaitaire_taux2
+            + pv.actions_gratuites.taux3 * glo_taxation_ir_forfaitaire_taux3
+            + pv.actions_gratuites.taux4 * glo_taxation_ir_forfaitaire_taux4
             + P.taux10 * rpns_info
             + pv.bspce.plus_3ans.pre_2018 * f3sj
             + pv.bspce.moins_3ans * f3sk
@@ -1833,9 +1833,7 @@ class rfr_plus_values_hors_rni(Variable):
         '''
         f3vc = foyer_fiscal('f3vc', period)
 
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         f3vg = foyer_fiscal('f3vg', period)
         f3vl = foyer_fiscal('f3vl', period)
@@ -1846,7 +1844,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3vc + f3vd + f3vf + f3vg + f3vi + f3vl + f3vm + f3vp + f3vy + f3vz + rpns_pvce
+        return f3vc + glo_taxation_ir_forfaitaire + f3vg + f3vl + f3vm + f3vp + f3vy + f3vz + rpns_pvce
 
     def formula_2012_01_01(foyer_fiscal, period):
         '''
@@ -1857,9 +1855,7 @@ class rfr_plus_values_hors_rni(Variable):
         f3sk = foyer_fiscal('f3sk', period)
         f3vc = foyer_fiscal('f3vc', period)
 
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         f3vg = foyer_fiscal('f3vg', period)
         f3vl = foyer_fiscal('f3vl', period)
@@ -1873,7 +1869,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3sa_2012 + f3sj + f3sk + f3vc + f3vd + f3vf + f3vg + f3vi + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz + f3we + rpns_pvce
+        return f3sa_2012 + f3sj + f3sk + f3vc + glo_taxation_ir_forfaitaire + f3vg + f3vl + f3vm + f3vp + f3vt + f3vy + f3vz + f3we + rpns_pvce
 
     def formula_2013_01_01(foyer_fiscal, period):
         '''
@@ -1883,9 +1879,7 @@ class rfr_plus_values_hors_rni(Variable):
         f3sk = foyer_fiscal('f3sk', period)
         f3vc = foyer_fiscal('f3vc', period)
 
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         f3vm = foyer_fiscal('f3vm', period)
         f3vp = foyer_fiscal('f3vp', period)
@@ -1899,7 +1893,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3sj + f3sk + f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + rpns_pvce
+        return f3sj + f3sk + f3vc + glo_taxation_ir_forfaitaire + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + rpns_pvce
 
     def formula_2016_01_01(foyer_fiscal, period):
         '''
@@ -1910,9 +1904,7 @@ class rfr_plus_values_hors_rni(Variable):
         f3tz = foyer_fiscal('f3tz', period)
         f3vc = foyer_fiscal('f3vc', period)
 
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         f3vm = foyer_fiscal('f3vm', period)
         f3vp = foyer_fiscal('f3vp', period)
@@ -1928,7 +1920,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + f3wi + f3wj + rpns_pvce
+        return f3sj + f3sk + f3tz + f3vc + glo_taxation_ir_forfaitaire + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + f3wi + f3wj + rpns_pvce
 
     def formula_2017_01_01(foyer_fiscal, period):
         '''
@@ -1939,9 +1931,7 @@ class rfr_plus_values_hors_rni(Variable):
         f3tz = foyer_fiscal('f3tz', period)
         f3vc = foyer_fiscal('f3vc', period)
 
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         f3vm = foyer_fiscal('f3vm', period)
         f3vp = foyer_fiscal('f3vp', period)
@@ -1958,7 +1948,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3sj + f3sk + f3tz + f3vc + f3vd + f3vf + f3vi + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3pi
+        return f3sj + f3sk + f3tz + f3vc + glo_taxation_ir_forfaitaire + f3vm + f3vp + (f3vq - f3vr) + f3vt + f3vy + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3pi
 
     def formula_2018_01_01(foyer_fiscal, period):
         '''
@@ -1971,9 +1961,7 @@ class rfr_plus_values_hors_rni(Variable):
         f3sk = foyer_fiscal('f3sk', period)
         f3vc = foyer_fiscal('f3vc', period)
 
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         f3vm = foyer_fiscal('f3vm', period)
         f3vq = foyer_fiscal('f3vq', period)
@@ -1988,7 +1976,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3vg + f3ua + f3sj + f3sk + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3tj + f3pi
+        return f3vg + f3ua + f3sj + f3sk + f3vc + glo_taxation_ir_forfaitaire + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3tj + f3pi
 
     def formula_2019_01_01(foyer_fiscal, period):
         '''
@@ -2001,9 +1989,7 @@ class rfr_plus_values_hors_rni(Variable):
         f3sk = foyer_fiscal('f3sk', period)
         f3vc = foyer_fiscal('f3vc', period)
 
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         f3vq = foyer_fiscal('f3vq', period)
         f3vr = foyer_fiscal('f3vr', period)
@@ -2018,7 +2004,7 @@ class rfr_plus_values_hors_rni(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3vg + f3ua + f3sj + f3sk + f3vc + f3vd + f3vf + f3vi + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3tj + f3an + f3pi
+        return f3vg + f3ua + f3sj + f3sk + f3vc + glo_taxation_ir_forfaitaire + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3tj + f3an + f3pi
 
 
 class iai(Variable):
@@ -2192,21 +2178,93 @@ class rfr(Variable):
         # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)
 
 
+class glo_taxation_ir_forfaitaire_taux2(Variable):
+    value_type = float
+    entity = FoyerFiscal
+    label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 18 %"
+    definition_period = YEAR
+
+    def formula(foyer_fiscal, period):
+        '''
+        On crée cette variable étant donné que ces revenus sont renseignés jusqu'à 2014 dans des cases individuelles, et à partir de 2015 dans
+        des cases à l'échelle du foyer fiscal. Créer cette variable intermédiaire permet d'alléger le code dans les formules dépendant de ces
+        revenus.
+        NB : la législation sur les GLO a été checkée en août 2023 à partir de 2017 seulement.
+        '''
+        f3vd_i = foyer_fiscal.members('f3vd_2014', period)
+        f3vd = foyer_fiscal.sum(f3vd_i)
+        
+        return f3vd
+
+    def formula_2015_01_01(foyer_fiscal, period):
+        f3vd = foyer_fiscal('f3vd', period)
+
+        return f3vd
+
+
+class glo_taxation_ir_forfaitaire_taux3(Variable):
+    value_type = float
+    entity = FoyerFiscal
+    label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 30 %"
+    definition_period = YEAR
+
+    def formula(foyer_fiscal, period):
+        '''
+        On crée cette variable étant donné que ces revenus sont renseignés jusqu'à 2014 dans des cases individuelles, et à partir de 2015 dans
+        des cases à l'échelle du foyer fiscal. Créer cette variable intermédiaire permet d'alléger le code dans les formules dépendant de ces
+        revenus.
+        NB : la législation sur les GLO a été checkée en août 2023 à partir de 2017 seulement.
+        '''
+        f3vi_i = foyer_fiscal.members('f3vi_2014', period)
+        f3vi = foyer_fiscal.sum(f3vi_i)
+        
+        return f3vi
+
+    def formula_2015_01_01(foyer_fiscal, period):
+        f3vi = foyer_fiscal('f3vi', period)
+
+        return f3vi
+
+
+class glo_taxation_ir_forfaitaire_taux4(Variable):
+    value_type = float
+    entity = FoyerFiscal
+    label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 41 %"
+    definition_period = YEAR
+
+    def formula(foyer_fiscal, period):
+        '''
+        On crée cette variable étant donné que ces revenus sont renseignés jusqu'à 2014 dans des cases individuelles, et à partir de 2015 dans
+        des cases à l'échelle du foyer fiscal. Créer cette variable intermédiaire permet d'alléger le code dans les formules dépendant de ces
+        revenus.
+        NB : la législation sur les GLO a été checkée en août 2023 à partir de 2017 seulement.
+        '''
+        f3vf_i = foyer_fiscal.members('f3vf_2014', period)
+        f3vf = foyer_fiscal.sum(f3vf_i)
+        
+        return f3vf
+
+    def formula_2015_01_01(foyer_fiscal, period):
+        f3vf = foyer_fiscal('f3vf', period)
+
+        return f3vf
+
+
 class glo_taxation_ir_forfaitaire(Variable):
     value_type = float
     entity = FoyerFiscal
     label = "Gains de levée d'options taxés forfaitairement à l'IR"
     definition_period = YEAR
 
-    def formula_2017_01_01(foyer_fiscal, period):
+    def formula(foyer_fiscal, period):
         '''
-        Existante avant 2017, mais on a fait le suivi à partir de 2017.
+        NB : la législation sur les GLO a été checkée en août 2023 à partir de 2017 seulement.
         '''
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire_taux2 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux2', period)
+        glo_taxation_ir_forfaitaire_taux3 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux3', period)
+        glo_taxation_ir_forfaitaire_taux4 = foyer_fiscal('glo_taxation_ir_forfaitaire_taux4', period)
 
-        return f3vd + f3vi + f3vf
+        return glo_taxation_ir_forfaitaire_taux2 + glo_taxation_ir_forfaitaire_taux3 + glo_taxation_ir_forfaitaire_taux4
 
 
 class credits_impot_sur_valeurs_etrangeres(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1913,7 +1913,7 @@ class rfr_plus_values_hors_rni(Variable):
         f3vd = foyer_fiscal('f3vd', period)
         f3vi = foyer_fiscal('f3vi', period)
         f3vf = foyer_fiscal('f3vf', period)
-        
+
         f3vm = foyer_fiscal('f3vm', period)
         f3vp = foyer_fiscal('f3vp', period)
         f3vq = foyer_fiscal('f3vq', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1659,67 +1659,6 @@ class taxation_plus_values_hors_bareme(Variable):
     reference = 'http://bofip.impots.gouv.fr/bofip/6957-PGP'
     definition_period = YEAR
 
-    def formula_2007_01_01(foyer_fiscal, period, parameters):  # f3sd is in f3vd holder
-        '''
-        Taxation des plus-values
-        '''
-        f3vg = foyer_fiscal('f3vg', period)
-        f3vh = foyer_fiscal('f3vh', period)
-        f3vl = foyer_fiscal('f3vl', period)
-        f3vm = foyer_fiscal('f3vm', period)
-        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
-        pv = parameters(period).impot_revenu.calcul_impot_revenu.pv
-
-        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        f3vd = foyer_fiscal.declarant_principal('f3vd', period)  # noqa F841
-        f3sd = foyer_fiscal.conjoint('f3vd', period)  # noqa F841
-        f3vi = foyer_fiscal.declarant_principal('f3vi', period)
-        f3si = foyer_fiscal.conjoint('f3vi', period)  # noqa F841
-        f3vf = foyer_fiscal.declarant_principal('f3vf', period)
-        f3sf = foyer_fiscal.conjoint('f3vf', period)  # noqa F841
-        #  TODO: remove this todo use sum for all fields after checking
-        # revenus taxés à un taux proportionnel
-
-        return round_(
-            pv.plus_values.pvce * rpns_pvce
-            + pv.pv_cession_valeurs_mobilieres_pv_professionnelles.taux * max_(0, f3vg - f3vh)
-            + pv.pv_cession_valeurs_mobilieres_pv_professionnelles.taux * f3vl
-            + pv.pea.taux_avant_2_ans * f3vm
-            + pv.actions_gratuites.taux3 * f3vi
-            + pv.actions_gratuites.taux4 * f3vf
-            )
-
-    def formula_2008_01_01(foyer_fiscal, period, parameters):  # f3sd is in f3vd holder
-        '''
-        Taxation des plus values
-        '''
-        f3vg = foyer_fiscal('f3vg', period)
-        f3vh = foyer_fiscal('f3vh', period)
-        f3vl = foyer_fiscal('f3vl', period)
-        f3vm = foyer_fiscal('f3vm', period)
-        rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
-        pv = parameters(period).impot_revenu.calcul_impot_revenu.pv
-
-        rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        f3vd = foyer_fiscal.declarant_principal('f3vd', period)
-        f3sd = foyer_fiscal.conjoint('f3vd', period)  # noqa F841
-        f3vi = foyer_fiscal.declarant_principal('f3vi', period)
-        f3si = foyer_fiscal.conjoint('f3vi', period)  # noqa F841
-        f3vf = foyer_fiscal.declarant_principal('f3vf', period)
-        f3sf = foyer_fiscal.conjoint('f3vf', period)  # noqa F841
-        #  TODO: remove this todo use sum for all fields after checking
-        # revenus taxés à un taux proportionnel
-
-        return round_(
-            pv.plus_values.pvce * rpns_pvce
-            + pv.pv_cession_valeurs_mobilieres_pv_professionnelles.taux * max_(0, f3vg - f3vh)
-            + pv.pv_cession_valeurs_mobilieres_pv_professionnelles.taux * f3vl
-            + pv.pea.taux_avant_2_ans * f3vm
-            + pv.actions_gratuites.taux3 * f3vi
-            + pv.actions_gratuites.taux4 * f3vf
-            + pv.actions_gratuites.taux2 * f3vd
-            )
-
     def formula_2012_01_01(foyer_fiscal, period, parameters):
         '''
         Taxation des plus values
@@ -1732,16 +1671,13 @@ class taxation_plus_values_hors_bareme(Variable):
         f3vl = foyer_fiscal('f3vl', period)
         f3vt = foyer_fiscal('f3vt', period)
         f3vm = foyer_fiscal('f3vm', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         pv = parameters(period).impot_revenu.calcul_impot_revenu.pv
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
 
         return round_(
             pv.plus_values.pvce * rpns_pvce
@@ -1765,15 +1701,12 @@ class taxation_plus_values_hors_bareme(Variable):
         f3sk = foyer_fiscal('f3sk', period)
         f3vm = foyer_fiscal('f3vm', period)
         f3vt = foyer_fiscal('f3vt', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
         pv = parameters(period).impot_revenu.calcul_impot_revenu.pv
 
         return round_(
@@ -1795,17 +1728,14 @@ class taxation_plus_values_hors_bareme(Variable):
         f3sk = foyer_fiscal('f3sk', period)
         f3vm = foyer_fiscal('f3vm', period)
         f3vt = foyer_fiscal('f3vt', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
         f3wi = foyer_fiscal('f3wi', period)
         f3wj = foyer_fiscal('f3wj', period)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
         pv = parameters(period).impot_revenu.calcul_impot_revenu.pv
 
         return round_(
@@ -1826,9 +1756,9 @@ class taxation_plus_values_hors_bareme(Variable):
         Taxation des plus-values (hors imposition au barÃ¨me), en excluant, à partir de 2018, celles imposées au PFU
         (qui sont à impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py)
         '''
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
         f3sj = foyer_fiscal('f3sj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3vm = foyer_fiscal('f3vm', period)
@@ -1839,9 +1769,6 @@ class taxation_plus_values_hors_bareme(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
         pv = parameters(period).impot_revenu.calcul_impot_revenu.pv
 
         return round_(
@@ -1863,9 +1790,9 @@ class taxation_plus_values_hors_bareme(Variable):
         Taxation des plus-values (hors imposition au barème), en excluant celles imposées au PFU
         (qui sont à impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py)
         '''
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
         f3sj = foyer_fiscal('f3sj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3wi = foyer_fiscal('f3wi', period)
@@ -1877,9 +1804,6 @@ class taxation_plus_values_hors_bareme(Variable):
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
         rpns_info = foyer_fiscal.sum(rpns_info_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
         pv = parameters(period).impot_revenu.calcul_impot_revenu.pv
         P = parameters(period).impot_revenu.calcul_revenus_imposables.rpns
 
@@ -1908,18 +1832,17 @@ class rfr_plus_values_hors_rni(Variable):
         Plus-values 2011 entrant dans le calcul du revenu fiscal de référence
         '''
         f3vc = foyer_fiscal('f3vc', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
+
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
+
         f3vg = foyer_fiscal('f3vg', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
         f3vl = foyer_fiscal('f3vl', period)
         f3vm = foyer_fiscal('f3vm', period)
         f3vp = foyer_fiscal('f3vp', period)
         f3vy = foyer_fiscal('f3vy', period)
         f3vz = foyer_fiscal('f3vz', period)
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
@@ -1933,10 +1856,12 @@ class rfr_plus_values_hors_rni(Variable):
         f3sj = foyer_fiscal('f3sj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3vc = foyer_fiscal('f3vc', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
+
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
+
         f3vg = foyer_fiscal('f3vg', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
         f3vl = foyer_fiscal('f3vl', period)
         f3vm = foyer_fiscal('f3vm', period)
         f3vp = foyer_fiscal('f3vp', period)
@@ -1944,10 +1869,6 @@ class rfr_plus_values_hors_rni(Variable):
         f3vy = foyer_fiscal('f3vy', period)
         f3vz = foyer_fiscal('f3vz', period)
         f3we = foyer_fiscal('f3we', period)
-
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
@@ -1961,9 +1882,11 @@ class rfr_plus_values_hors_rni(Variable):
         f3sj = foyer_fiscal('f3sj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3vc = foyer_fiscal('f3vc', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
+
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
+
         f3vm = foyer_fiscal('f3vm', period)
         f3vp = foyer_fiscal('f3vp', period)
         f3vq = foyer_fiscal('f3vq', period)
@@ -1972,10 +1895,6 @@ class rfr_plus_values_hors_rni(Variable):
         f3vy = foyer_fiscal('f3vy', period)
         f3vz = foyer_fiscal('f3vz', period)
         f3we = foyer_fiscal('f3we', period)
-
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
@@ -1990,9 +1909,11 @@ class rfr_plus_values_hors_rni(Variable):
         f3sk = foyer_fiscal('f3sk', period)
         f3tz = foyer_fiscal('f3tz', period)
         f3vc = foyer_fiscal('f3vc', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
+
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
+        
         f3vm = foyer_fiscal('f3vm', period)
         f3vp = foyer_fiscal('f3vp', period)
         f3vq = foyer_fiscal('f3vq', period)
@@ -2003,10 +1924,6 @@ class rfr_plus_values_hors_rni(Variable):
         f3we = foyer_fiscal('f3we', period)
         f3wi = foyer_fiscal('f3wi', period)
         f3wj = foyer_fiscal('f3wj', period)
-
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
@@ -2021,9 +1938,11 @@ class rfr_plus_values_hors_rni(Variable):
         f3sk = foyer_fiscal('f3sk', period)
         f3tz = foyer_fiscal('f3tz', period)
         f3vc = foyer_fiscal('f3vc', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
+
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
+
         f3vm = foyer_fiscal('f3vm', period)
         f3vp = foyer_fiscal('f3vp', period)
         f3vq = foyer_fiscal('f3vq', period)
@@ -2035,10 +1954,6 @@ class rfr_plus_values_hors_rni(Variable):
         f3wi = foyer_fiscal('f3wi', period)
         f3wj = foyer_fiscal('f3wj', period)
         f3pi = foyer_fiscal('f3pi', period)
-
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
@@ -2055,9 +1970,11 @@ class rfr_plus_values_hors_rni(Variable):
         f3tj = foyer_fiscal('f3tj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3vc = foyer_fiscal('f3vc', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
+
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
+
         f3vm = foyer_fiscal('f3vm', period)
         f3vq = foyer_fiscal('f3vq', period)
         f3vr = foyer_fiscal('f3vr', period)
@@ -2067,10 +1984,6 @@ class rfr_plus_values_hors_rni(Variable):
         f3wi = foyer_fiscal('f3wi', period)
         f3wj = foyer_fiscal('f3wj', period)
         f3pi = foyer_fiscal('f3pi', period)
-
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
 
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
@@ -2087,10 +2000,11 @@ class rfr_plus_values_hors_rni(Variable):
         f3tj = foyer_fiscal('f3tj', period)
         f3sk = foyer_fiscal('f3sk', period)
         f3vc = foyer_fiscal('f3vc', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
-        f3vm = foyer_fiscal('f3vm', period)
+
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
+
         f3vq = foyer_fiscal('f3vq', period)
         f3vr = foyer_fiscal('f3vr', period)
         f3vt = foyer_fiscal('f3vt', period)
@@ -2101,14 +2015,10 @@ class rfr_plus_values_hors_rni(Variable):
         f3an = foyer_fiscal('f3an', period)
         f3pi = foyer_fiscal('f3pi', period)
 
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
-
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        return f3vg + f3ua + f3sj + f3sk + f3vc + f3vd + f3vf + f3vi + f3vm + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3tj + f3an + f3pi
+        return f3vg + f3ua + f3sj + f3sk + f3vc + f3vd + f3vf + f3vi + (f3vq - f3vr) + f3vt + f3vz + f3we + f3wi + f3wj + rpns_pvce + f3tj + f3an + f3pi
 
 
 class iai(Variable):
@@ -2282,46 +2192,21 @@ class rfr(Variable):
         # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)
 
 
-class glo(Variable):
+class glo_taxation_ir_forfaitaire(Variable):
     value_type = float
-    entity = Individu
-    label = "Gain de levée d'options"
-    reference = 'http://www.officeo.fr/imposition-au-bareme-progressif-de-l-impot-sur-le-revenu-des-gains-de-levee-d-options-sur-actions-et-attributions-d-actions-gratuites'
+    entity = FoyerFiscal
+    label = "Gains de levée d'options taxés forfaitairement à l'IR"
     definition_period = YEAR
 
-    def formula(individu, period, parameters):
+    def formula_2017_01_01(foyer_fiscal, period):
         '''
-        Gains de levée d'option
+        Existante avant 2017, mais on a fait le suivi à partir de 2017.
         '''
-        f1tv = individu('f1tv', period)
-        f1tw = individu('f1tw', period)
-        f1tx = individu('f1tx', period)
-        f3vf = individu('f3vf', period)
-        f3vi = individu('f3vi', period)
-        f3vj = individu('f3vj', period)
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
 
-        return f1tv + f1tw + f1tx + f3vf + f3vi + f3vj
-
-    def formula_2016_01_01(individu, period, parameters):
-        '''
-        Gains de levée d'option
-        '''
-        f1tx = individu('f1tx', period)
-        f3vf = individu('f3vf', period)
-        f3vi = individu('f3vi', period)
-        f3vj = individu('f3vj', period)
-
-        return f1tx + f3vf + f3vi + f3vj
-
-    def formula_2017_01_01(individu, period, parameters):
-        '''
-        Gains de levée d'option
-        '''
-        f3vf = individu('f3vf', period)
-        f3vi = individu('f3vi', period)
-        f3vj = individu('f3vj', period)
-
-        return f3vf + f3vi + f3vj
+        return f3vd + f3vi + f3vf
 
 
 class credits_impot_sur_valeurs_etrangeres(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2193,7 +2193,7 @@ class glo_taxation_ir_forfaitaire_taux2(Variable):
         '''
         f3vd_i = foyer_fiscal.members('f3vd_2014', period)
         f3vd = foyer_fiscal.sum(f3vd_i)
-        
+
         return f3vd
 
     def formula_2015_01_01(foyer_fiscal, period):
@@ -2217,7 +2217,7 @@ class glo_taxation_ir_forfaitaire_taux3(Variable):
         '''
         f3vi_i = foyer_fiscal.members('f3vi_2014', period)
         f3vi = foyer_fiscal.sum(f3vi_i)
-        
+
         return f3vi
 
     def formula_2015_01_01(foyer_fiscal, period):
@@ -2241,7 +2241,7 @@ class glo_taxation_ir_forfaitaire_taux4(Variable):
         '''
         f3vf_i = foyer_fiscal.members('f3vf_2014', period)
         f3vf = foyer_fiscal.sum(f3vf_i)
-        
+
         return f3vf
 
     def formula_2015_01_01(foyer_fiscal, period):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -148,9 +148,7 @@ class assiette_csg_plus_values(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
@@ -159,7 +157,7 @@ class assiette_csg_plus_values(Variable):
         pveximpres_i = foyer_fiscal.members('pveximpres', period)
         pveximpres = foyer_fiscal.sum(pveximpres_i)
 
-        return f3vg + f3sg + f3sl + f3va_2014 + f3vz + f3we + f3vt + rpns_pvce + f3vd + f3vi + f3vf + pveximpres
+        return f3vg + f3sg + f3sl + f3va_2014 + f3vz + f3we + f3vt + rpns_pvce + glo_taxation_ir_forfaitaire + pveximpres
 
     def formula_2015_01_01(foyer_fiscal, period, parameters):
         '''
@@ -177,9 +175,7 @@ class assiette_csg_plus_values(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
@@ -188,7 +184,7 @@ class assiette_csg_plus_values(Variable):
         pveximpres_i = foyer_fiscal.members('pveximpres', period)
         pveximpres = foyer_fiscal.sum(pveximpres_i)
 
-        return f3vg + f3sg + f3sl + f3va_2016 + f3vz + f3we + f3vt + rpns_pvce + f3vd + f3vi + f3vf + pveximpres
+        return f3vg + f3sg + f3sl + f3va_2016 + f3vz + f3we + f3vt + rpns_pvce + glo_taxation_ir_forfaitaire + pveximpres
 
     def formula_2017_01_01(foyer_fiscal, period, parameters):
         '''
@@ -207,9 +203,7 @@ class assiette_csg_plus_values(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
@@ -218,7 +212,7 @@ class assiette_csg_plus_values(Variable):
         pveximpres_i = foyer_fiscal.members('pveximpres', period)
         pveximpres = foyer_fiscal.sum(pveximpres_i)
 
-        return f3vg + f3sg + f3sl + f3va + f3ua + f3vz + f3we + f3vt + f3pi + rpns_pvce + f3vd + f3vi + f3vf + pveximpres
+        return f3vg + f3sg + f3sl + f3va + f3ua + f3vz + f3we + f3vt + f3pi + rpns_pvce + glo_taxation_ir_forfaitaire + pveximpres
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
 
@@ -238,9 +232,7 @@ class assiette_csg_plus_values(Variable):
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
@@ -249,7 +241,7 @@ class assiette_csg_plus_values(Variable):
         pveximpres_i = foyer_fiscal.members('pveximpres', period)
         pveximpres = foyer_fiscal.sum(pveximpres_i)
 
-        return f3vg + f3ua + f3vz + f3we + rpns_pvce + f3sj + f3sk + f3vm + f3vt + f3wi + f3wj + f3pi + f3tj + f3vd + f3vi + f3vf + pveximpres
+        return f3vg + f3ua + f3vz + f3we + rpns_pvce + f3sj + f3sk + f3vm + f3vt + f3wi + f3wj + f3pi + f3tj + glo_taxation_ir_forfaitaire + pveximpres
 
     def formula_2019_01_01(foyer_fiscal, period, parameters):
 
@@ -269,9 +261,7 @@ class assiette_csg_plus_values(Variable):
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
-        f3vd = foyer_fiscal('f3vd', period)
-        f3vi = foyer_fiscal('f3vi', period)
-        f3vf = foyer_fiscal('f3vf', period)
+        glo_taxation_ir_forfaitaire = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
@@ -280,7 +270,7 @@ class assiette_csg_plus_values(Variable):
         pveximpres_i = foyer_fiscal.members('pveximpres', period)
         pveximpres = foyer_fiscal.sum(pveximpres_i)
 
-        return f3vg + f3ua + f3vz + f3we + rpns_pvce + f3sj + f3sk + f3vt + f3wi + f3wj + f3pi + f3tj + f3an + f3vd + f3vi + f3vf + pveximpres
+        return f3vg + f3ua + f3vz + f3we + rpns_pvce + f3sj + f3sk + f3vt + f3wi + f3wj + f3pi + f3tj + f3an + glo_taxation_ir_forfaitaire + pveximpres
 
 
 class assiette_csg_revenus_capital(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -384,7 +384,7 @@ class crds_glo_assimile_salaire_ir_et_ps(Variable):
 class contribution_salariale_glo_assimile_salaire(Variable):
     calculate_output = calculate_output_add
     value_type = float
-    label = "Contribution salariale sur GLO"
+    label = 'Contribution salariale sur GLO'
     entity = FoyerFiscal
     definition_period = YEAR
     set_input = set_input_divide_by_period
@@ -462,7 +462,7 @@ class prelevements_sociaux_revenus_capital_hors_csg_crds(Variable):
             + P.caps.produits_de_placement
             + P.prelevements_solidarite.produits_de_placement
             )
-        
+
         contribution_salariale_glo_assimile_salaire = foyer_fiscal('contribution_salariale_glo_assimile_salaire', period)
 
         return -assiette_csg_revenus_capital * total + contribution_salariale_glo_assimile_salaire
@@ -477,7 +477,7 @@ class prelevements_sociaux_revenus_capital_hors_csg_crds(Variable):
             + P.prelevements_solidarite.produits_de_placement
             + P.caps.rsa
             )
-        
+
         contribution_salariale_glo_assimile_salaire = foyer_fiscal('contribution_salariale_glo_assimile_salaire', period)
 
         return -assiette_csg_revenus_capital * total + contribution_salariale_glo_assimile_salaire
@@ -491,7 +491,7 @@ class prelevements_sociaux_revenus_capital_hors_csg_crds(Variable):
             + P.caps.produits_de_placement
             + P.prelevements_solidarite.produits_de_placement
             )
-        
+
         contribution_salariale_glo_assimile_salaire = foyer_fiscal('contribution_salariale_glo_assimile_salaire', period)
 
         return -assiette_csg_revenus_capital * total + contribution_salariale_glo_assimile_salaire

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -148,6 +148,10 @@ class assiette_csg_plus_values(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
+
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
 
@@ -155,7 +159,7 @@ class assiette_csg_plus_values(Variable):
         pveximpres_i = foyer_fiscal.members('pveximpres', period)
         pveximpres = foyer_fiscal.sum(pveximpres_i)
 
-        return f3vg + f3sg + f3sl + f3va_2014 + f3vz + f3we + f3vt + rpns_pvce + pveximpres
+        return f3vg + f3sg + f3sl + f3va_2014 + f3vz + f3we + f3vt + rpns_pvce + f3vd + f3vi + f3vf + pveximpres
 
     def formula_2015_01_01(foyer_fiscal, period, parameters):
         '''
@@ -173,6 +177,10 @@ class assiette_csg_plus_values(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
+
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
 
@@ -180,7 +188,7 @@ class assiette_csg_plus_values(Variable):
         pveximpres_i = foyer_fiscal.members('pveximpres', period)
         pveximpres = foyer_fiscal.sum(pveximpres_i)
 
-        return f3vg + f3sg + f3sl + f3va_2016 + f3vz + f3we + f3vt + rpns_pvce + pveximpres
+        return f3vg + f3sg + f3sl + f3va_2016 + f3vz + f3we + f3vt + rpns_pvce + f3vd + f3vi + f3vf + pveximpres
 
     def formula_2017_01_01(foyer_fiscal, period, parameters):
         '''
@@ -199,6 +207,10 @@ class assiette_csg_plus_values(Variable):
         rpns_pvce_i = foyer_fiscal.members('rpns_pvce', period)
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
 
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
+
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
 
@@ -206,7 +218,7 @@ class assiette_csg_plus_values(Variable):
         pveximpres_i = foyer_fiscal.members('pveximpres', period)
         pveximpres = foyer_fiscal.sum(pveximpres_i)
 
-        return f3vg + f3sg + f3sl + f3va + f3ua + f3vz + f3we + f3vt + f3pi + rpns_pvce + pveximpres
+        return f3vg + f3sg + f3sl + f3va + f3ua + f3vz + f3we + f3vt + f3pi + rpns_pvce + f3vd + f3vi + f3vf + pveximpres
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
 
@@ -214,9 +226,6 @@ class assiette_csg_plus_values(Variable):
         f3vg = foyer_fiscal('f3vg', period)
         f3we = foyer_fiscal('f3we', period)
         f3ua = foyer_fiscal('f3ua', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
         f3sj = foyer_fiscal('f3sj', period)
         f3tj = foyer_fiscal('f3tj', period)
         f3sk = foyer_fiscal('f3sk', period)
@@ -228,9 +237,10 @@ class assiette_csg_plus_values(Variable):
         f3pi = foyer_fiscal('f3pi', period)
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
+
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
 
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
@@ -247,13 +257,9 @@ class assiette_csg_plus_values(Variable):
         f3vg = foyer_fiscal('f3vg', period)
         f3we = foyer_fiscal('f3we', period)
         f3ua = foyer_fiscal('f3ua', period)
-        f3vd_i = foyer_fiscal.members('f3vd', period)
-        f3vi_i = foyer_fiscal.members('f3vi', period)
-        f3vf_i = foyer_fiscal.members('f3vf', period)
         f3sj = foyer_fiscal('f3sj', period)
         f3tj = foyer_fiscal('f3tj', period)
         f3sk = foyer_fiscal('f3sk', period)
-        f3vm = foyer_fiscal('f3vm', period)
         f3vt = foyer_fiscal('f3vt', period)
         f3wi = foyer_fiscal('f3wi', period)
         f3wj = foyer_fiscal('f3wj', period)
@@ -262,9 +268,10 @@ class assiette_csg_plus_values(Variable):
         f3an = foyer_fiscal('f3an', period)
 
         rpns_pvce = foyer_fiscal.sum(rpns_pvce_i)
-        f3vd = foyer_fiscal.sum(f3vd_i)
-        f3vi = foyer_fiscal.sum(f3vi_i)
-        f3vf = foyer_fiscal.sum(f3vf_i)
+
+        f3vd = foyer_fiscal('f3vd', period)
+        f3vi = foyer_fiscal('f3vi', period)
+        f3vf = foyer_fiscal('f3vf', period)
 
         # Plus-values immobilières
         f3vz = foyer_fiscal('f3vz', period)
@@ -273,7 +280,7 @@ class assiette_csg_plus_values(Variable):
         pveximpres_i = foyer_fiscal.members('pveximpres', period)
         pveximpres = foyer_fiscal.sum(pveximpres_i)
 
-        return f3vg + f3ua + f3vz + f3we + rpns_pvce + f3sj + f3sk + f3vm + f3vt + f3wi + f3wj + f3pi + f3tj + f3an + f3vd + f3vi + f3vf + pveximpres
+        return f3vg + f3ua + f3vz + f3we + rpns_pvce + f3sj + f3sk + f3vt + f3wi + f3wj + f3pi + f3tj + f3an + f3vd + f3vi + f3vf + pveximpres
 
 
 class assiette_csg_revenus_capital(Variable):
@@ -320,6 +327,10 @@ class assiette_csg_revenus_capital(Variable):
         # produits d'assurance-vie exonérés d'impôt sur le revenu et de prélèvement forfaitaire libératoire (et donc non présents dans revenus_capitaux_prelevement_bareme et revenus_capitaux_prelevement_liberatoire)
         assurance_vie_ps_exoneree_irpp_pl = foyer_fiscal('assurance_vie_ps_exoneree_irpp_pl', period)
 
+        # Gains de levée d'option assimilées salaires pour l'IR et soumis aux prélèvements sociaux des revenus du patrimoine
+        f3vj_i = foyer_fiscal.members('f3vj', period)
+        f3vj = foyer_fiscal.sum(f3vj_i)
+
         # Crédits d'impôt sur valeurs étrangères déduits de la base CSG
         credits_impot_sur_valeurs_etrangeres = foyer_fiscal('credits_impot_sur_valeurs_etrangeres', period)
 
@@ -332,12 +343,63 @@ class assiette_csg_revenus_capital(Variable):
             + rev_cat_rfon
             + assiette_csg_plus_values
             + assurance_vie_ps_exoneree_irpp_pl
+            + f3vj
             - credits_impot_sur_valeurs_etrangeres,
             0
             )
 
 
 # 3. Variables de prélèvements sociaux sur les revenus du capital
+
+class csg_glo_assimile_salaire_ir_et_ps(Variable):
+    calculate_output = calculate_output_add
+    value_type = float
+    label = "CSG sur GLO assimilés salaires pour les prélèvements sociaux, en plus de l'être pour l'IR (cases 1TT et similaires)"
+    entity = Individu
+    definition_period = YEAR
+    set_input = set_input_divide_by_period
+
+    def formula(individu, period, parameters):
+        f1tt = individu('f1tt', period)
+        P = parameters(period).prelevements_sociaux.contributions_sociales.csg.activite
+        taux = P.imposable.taux + P.deductible.taux
+        return - f1tt * taux
+
+
+class crds_glo_assimile_salaire_ir_et_ps(Variable):
+    calculate_output = calculate_output_add
+    value_type = float
+    label = "CRDS sur GLO assimilés salaires pour les prélèvements sociaux, en plus de l'être pour l'IR (cases 1TT et similaires)"
+    entity = Individu
+    definition_period = YEAR
+    set_input = set_input_divide_by_period
+
+    def formula(individu, period, parameters):
+        f1tt = individu('f1tt', period)
+        return - f1tt * (
+            parameters(period).prelevements_sociaux.contributions_sociales.crds.activite.taux
+            )
+
+
+class contribution_salariale_glo_assimile_salaire(Variable):
+    calculate_output = calculate_output_add
+    value_type = float
+    label = "Contribution salariale sur GLO"
+    entity = FoyerFiscal
+    definition_period = YEAR
+    set_input = set_input_divide_by_period
+
+    def formula_2013_01_01(foyer_fiscal, period, parameters):
+        '''
+        Existe avant 2013, mais pas codé pour cette période antérieure.
+        '''
+        f1tt_i = foyer_fiscal.members('f1tt', period)
+        f1tt = foyer_fiscal.sum(f1tt_i)
+        f3vn = foyer_fiscal('f3vn', period)
+        return - (f1tt + f3vn) * (
+            parameters(period).prelevements_sociaux.contribution_salariale_glo
+            )
+
 
 class csg_revenus_capital(Variable):
     value_type = float
@@ -353,10 +415,16 @@ class csg_revenus_capital(Variable):
         assiette_csg_revenus_capital = foyer_fiscal('assiette_csg_revenus_capital', period)
         csg = parameters(period).taxation_capital.prelevements_sociaux.csg
 
+        csg_glo_assimile_salaire_ir_et_ps_i = foyer_fiscal.members('csg_glo_assimile_salaire_ir_et_ps', period)
+        csg_glo_assimile_salaire_ir_et_ps = foyer_fiscal.sum(csg_glo_assimile_salaire_ir_et_ps_i)
+
         # Pour les revenus du patrimoine, le changement de CSG se fait à partir des revenus de 2017,
         # mais le taux de CSG déductible se fait à partir des revenus 2018. Pour les revenus de placement le timing est différent,
         # et reste à être pris en compte ici : cf. II.B de l'art. 67 de loi 2017-1837 et 3° et 4° du V.A de l'art. 8 de loi 2017-1836
-        return -assiette_csg_revenus_capital * csg.taux_global.produits_de_placement
+        return (
+            - assiette_csg_revenus_capital * csg.taux_global.produits_de_placement
+            + csg_glo_assimile_salaire_ir_et_ps
+            )
 
 
 class crds_revenus_capital(Variable):
@@ -369,7 +437,13 @@ class crds_revenus_capital(Variable):
         assiette_csg_revenus_capital = foyer_fiscal('assiette_csg_revenus_capital', period)
         P = parameters(period).taxation_capital.prelevements_sociaux
 
-        return -assiette_csg_revenus_capital * P.crds.produits_de_placement
+        crds_glo_assimile_salaire_ir_et_ps_i = foyer_fiscal.members('crds_glo_assimile_salaire_ir_et_ps', period)
+        crds_glo_assimile_salaire_ir_et_ps = foyer_fiscal.sum(crds_glo_assimile_salaire_ir_et_ps_i)
+
+        return (
+            - assiette_csg_revenus_capital * P.crds.produits_de_placement
+            + crds_glo_assimile_salaire_ir_et_ps
+            )
 
 
 class prelevements_sociaux_revenus_capital_hors_csg_crds(Variable):
@@ -388,8 +462,10 @@ class prelevements_sociaux_revenus_capital_hors_csg_crds(Variable):
             + P.caps.produits_de_placement
             + P.prelevements_solidarite.produits_de_placement
             )
+        
+        contribution_salariale_glo_assimile_salaire = foyer_fiscal('contribution_salariale_glo_assimile_salaire', period)
 
-        return -assiette_csg_revenus_capital * total
+        return -assiette_csg_revenus_capital * total + contribution_salariale_glo_assimile_salaire
 
     def formula_2009_01_01(foyer_fiscal, period, parameters):
         assiette_csg_revenus_capital = foyer_fiscal('assiette_csg_revenus_capital', period)
@@ -401,8 +477,10 @@ class prelevements_sociaux_revenus_capital_hors_csg_crds(Variable):
             + P.prelevements_solidarite.produits_de_placement
             + P.caps.rsa
             )
+        
+        contribution_salariale_glo_assimile_salaire = foyer_fiscal('contribution_salariale_glo_assimile_salaire', period)
 
-        return -assiette_csg_revenus_capital * total
+        return -assiette_csg_revenus_capital * total + contribution_salariale_glo_assimile_salaire
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         assiette_csg_revenus_capital = foyer_fiscal('assiette_csg_revenus_capital', period)
@@ -413,8 +491,10 @@ class prelevements_sociaux_revenus_capital_hors_csg_crds(Variable):
             + P.caps.produits_de_placement
             + P.prelevements_solidarite.produits_de_placement
             )
+        
+        contribution_salariale_glo_assimile_salaire = foyer_fiscal('contribution_salariale_glo_assimile_salaire', period)
 
-        return -assiette_csg_revenus_capital * total
+        return -assiette_csg_revenus_capital * total + contribution_salariale_glo_assimile_salaire
 
     def formula_2019_01_01(foyer_fiscal, period, parameters):
         assiette_csg_revenus_capital = foyer_fiscal('assiette_csg_revenus_capital', period)
@@ -422,7 +502,9 @@ class prelevements_sociaux_revenus_capital_hors_csg_crds(Variable):
 
         total = P.prelevements_solidarite.produits_de_placement
 
-        return -assiette_csg_revenus_capital * total
+        contribution_salariale_glo_assimile_salaire = foyer_fiscal('contribution_salariale_glo_assimile_salaire', period)
+
+        return -assiette_csg_revenus_capital * total + contribution_salariale_glo_assimile_salaire
 
 
 class prelevements_sociaux_revenus_capital(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py
@@ -19,6 +19,7 @@ class csg(Variable):
         csg_deductible_retraite = individu('csg_deductible_retraite', period, options = [ADD])
         csg_imposable_non_salarie = individu('csg_imposable_non_salarie', period, options = [ADD])
         csg_deductible_non_salarie = individu('csg_deductible_non_salarie', period, options = [ADD])
+        csg_glo_assimile_salaire_ir_et_ps = individu('csg_glo_assimile_salaire_ir_et_ps', period)
         # CSG sur revenus du capital, définie à l'échelle du foyer fiscal, mais projetée sur le déclarant principal
         csg_revenus_capital = individu.foyer_fiscal('csg_revenus_capital', period)
         csg_revenus_capital_projetee = csg_revenus_capital * individu.has_role(FoyerFiscal.DECLARANT_PRINCIPAL)
@@ -32,6 +33,7 @@ class csg(Variable):
             + csg_deductible_retraite
             + csg_imposable_non_salarie
             + csg_deductible_non_salarie
+            + csg_glo_assimile_salaire_ir_et_ps
             + csg_revenus_capital_projetee
             )
 
@@ -54,7 +56,8 @@ class crds(Variable):
         crds_retraite = individu('crds_retraite', period, options = [ADD])
         crds_chomage = individu('crds_chomage', period, options = [ADD])
         crds_non_salarie = individu('crds_non_salarie', period, options = [ADD])
-        crds_individu = crds_salaire + crds_retraite + crds_chomage + crds_non_salarie
+        crds_glo_assimile_salaire_ir_et_ps = individu('crds_glo_assimile_salaire_ir_et_ps', period)
+        crds_individu = crds_salaire + crds_retraite + crds_chomage + crds_non_salarie + crds_glo_assimile_salaire_ir_et_ps
         # CRDS sur revenus de la famille, projetés seulement sur la première personne
         crds_pfam = individu.famille('crds_pfam', period)
         crds_logement = individu.famille('crds_logement', period, options = [ADD])

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -611,9 +611,7 @@ class aide_logement_base_ressources_individu(Variable):
 
         revenus = revenus * (1 - aide_logement_condition_neutralisation)
 
-        glo = individu('glo', period.last_year)
-
-        return revenus + revenu_assimile_pension + glo
+        return revenus + revenu_assimile_pension
 
     def formula_2018_01_01(individu, period, parameters):
 
@@ -653,9 +651,7 @@ class aide_logement_base_ressources_individu(Variable):
 
         revenus = revenus * (1 - aide_logement_condition_neutralisation)
 
-        glo = individu('glo', period.n_2)
-
-        return revenus + revenu_assimile_pension_apres_abattements + glo
+        return revenus + revenu_assimile_pension_apres_abattements
 
     def formula(individu, period, parameters):
 
@@ -698,9 +694,8 @@ class aide_logement_base_ressources_individu(Variable):
         revenus = revenus * (1 - aide_logement_condition_neutralisation)
 
         hsup = individu('hsup', period.n_2, options = [ADD])
-        glo = individu('glo', period.n_2)
 
-        return revenus + revenu_assimile_pension_apres_abattements + hsup + glo
+        return revenus + revenu_assimile_pension_apres_abattements + hsup
 
 
 class aide_logement_base_revenus_fiscaux(Variable):
@@ -733,6 +728,8 @@ class aide_logement_base_revenus_fiscaux(Variable):
         rev_cat_pv = foyer_fiscal('revenu_categoriel_plus_values', period)
         # Apparait à partir de 2018
         plus_values_prelevement_forfaitaire_unique_ir = foyer_fiscal('plus_values_prelevement_forfaitaire_unique_ir', period)
+        # glo taxés forfaitairement. NB : peut-être faudrait-il ajouter toutes les plus-values taxées forfaitairement à l'IR, hors PFU ? A vérifier.
+        glo = foyer_fiscal('glo_taxation_ir_forfaitaire', period)
 
         return (
             + revenu_categoriel_foncier
@@ -742,6 +739,7 @@ class aide_logement_base_revenus_fiscaux(Variable):
             + revenus_capitaux_prelevement_forfaitaire_unique_ir
             + rev_cat_pv
             + plus_values_prelevement_forfaitaire_unique_ir
+            + glo
             - f7ga
             - f7gb
             - f7gc

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -409,6 +409,7 @@ class abattements_plus_values(Variable):
 # Plus values et gains taxables à des taux forfaitaires
 
 class f3vd(Variable):
+    cerfa_field = '3VD'
     value_type = float
     unit = 'currency'
     entity = FoyerFiscal
@@ -418,6 +419,7 @@ class f3vd(Variable):
 
 
 class f3vi(Variable):
+    cerfa_field = '3VI'
     value_type = float
     unit = 'currency'
     entity = FoyerFiscal
@@ -427,6 +429,7 @@ class f3vi(Variable):
 
 
 class f3vf(Variable):
+    cerfa_field = '3VF'
     value_type = float
     unit = 'currency'
     entity = FoyerFiscal
@@ -436,6 +439,7 @@ class f3vf(Variable):
 
 
 class f3vn(Variable):
+    cerfa_field = '3VN'
     value_type = float
     unit = 'currency'
     entity = FoyerFiscal

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -409,42 +409,38 @@ class abattements_plus_values(Variable):
 # Plus values et gains taxables à des taux forfaitaires
 
 class f3vd(Variable):
-    ''' ATTENTION : à partir des revenus 2015, la case 3SD est supprimée : seule la case 3VD reste et recense les montants à l'échelle du foyer fiscal. Avec le code actuel, le seul problème serait si la case 3SD était réutilisée un jour pour autre chose dans le formulaire, ce qui n'est pas le cas aujourd'hui '''
-    cerfa_field = {
-        0: '3VD',
-        1: '3SD',
-        }
-    value_type = int
+    value_type = float
     unit = 'currency'
-    entity = Individu
+    entity = FoyerFiscal
     label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 18 %"
-    # start_date = date(2008, 1, 1)
+    # Investiguée qu'à partir des revenus 2017
     definition_period = YEAR
 
 
 class f3vi(Variable):
-    ''' ATTENTION : à partir des revenus 2015, la case 3SI est supprimée : seule la case 3VI reste et recense les montants à l'échelle du foyer fiscal. Avec le code actuel, le seul problème serait si la case 3SI était réutilisée un jour pour autre chose dans le formulaire, ce qui n'est pas le cas aujourd'hui '''
-    cerfa_field = {
-        0: '3VI',
-        1: '3SI',
-        }
-    value_type = int
+    value_type = float
     unit = 'currency'
-    entity = Individu
+    entity = FoyerFiscal
     label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 30 %"
+    # Investiguée qu'à partir des revenus 2017
     definition_period = YEAR
 
 
 class f3vf(Variable):
-    ''' ATTENTION : à partir des revenus 2015, la case 3SF est supprimée : seule la case 3VF reste et recense les montants à l'échelle du foyer fiscal. Avec le code actuel, le seul problème serait si la case 3SF était réutilisée un jour pour autre chose dans le formulaire, ce qui n'est pas le cas aujourd'hui '''
-    cerfa_field = {
-        0: '3VF',
-        1: '3SF',
-        }
-    value_type = int
+    value_type = float
     unit = 'currency'
-    entity = Individu
+    entity = FoyerFiscal
     label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 41 %"
+    # Investiguée qu'à partir des revenus 2017
+    definition_period = YEAR
+
+
+class f3vn(Variable):
+    value_type = float
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = "Gains sur options et acquisitions gratuites attribuées à compter du 16.10.2007, soumis à la contribution salariale de 10%"
+    # Investiguée qu'à partir des revenus 2017
     definition_period = YEAR
 
 

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -439,7 +439,7 @@ class f3vn(Variable):
     value_type = float
     unit = 'currency'
     entity = FoyerFiscal
-    label = "Gains sur options et acquisitions gratuites attribuées à compter du 16.10.2007, soumis à la contribution salariale de 10%"
+    label = 'Gains sur options et acquisitions gratuites attribuées à compter du 16.10.2007, soumis à la contribution salariale de 10%'
     # Investiguée qu'à partir des revenus 2017
     definition_period = YEAR
 

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -439,7 +439,7 @@ class f3vn(Variable):
     value_type = float
     unit = 'currency'
     entity = FoyerFiscal
-    label = 'Gains sur options et acquisitions gratuites attribuées à compter du 16.10.2007, soumis à la contribution salariale de 10%'
+    label = 'Gains sur options et acquisitions gratuites attribuées à compter du 16/10/2007, soumis à la contribution salariale de 10%'
     # Investiguée qu'à partir des revenus 2017
     definition_period = YEAR
 

--- a/openfisca_france/model/revenus/capital/plus_value.py
+++ b/openfisca_france/model/revenus/capital/plus_value.py
@@ -408,14 +408,72 @@ class abattements_plus_values(Variable):
 
 # Plus values et gains taxables à des taux forfaitaires
 
+class f3vd_2014(Variable):
+    cerfa_field = {
+        0: '3VD',
+        1: '3SD',
+        }
+    value_type = int
+    unit = 'currency'
+    entity = Individu
+    label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 18 %"
+    # start_date = date(2008, 1, 1)
+    end = '2014-12-31'
+    definition_period = YEAR
+    # NB : la législation sur les GLO a été checkée en août 2023 à partir de 2017 seulement.
+
+
+class f3vi_2014(Variable):
+    cerfa_field = {
+        0: '3VI',
+        1: '3SI',
+        }
+    value_type = int
+    unit = 'currency'
+    entity = Individu
+    label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 30 %"
+    end = '2014-12-31'
+    definition_period = YEAR
+    # NB : la législation sur les GLO a été checkée en août 2023 à partir de 2017 seulement.
+
+
+class f3vf_2014(Variable):
+    cerfa_field = {
+        0: '3VF',
+        1: '3SF',
+        }
+    value_type = int
+    unit = 'currency'
+    entity = Individu
+    label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 41 %"
+    end = '2014-12-31'
+    definition_period = YEAR
+    # NB : la législation sur les GLO a été checkée en août 2023 à partir de 2017 seulement.
+
+
+class f3vn_2014(Variable):
+    cerfa_field = {
+        0: '3VN',
+        1: '3SN',
+        }
+    value_type = int
+    unit = 'currency'
+    entity = Individu
+    label = 'Gains sur options et acquisitions gratuites attribuées à compter du 16/10/2007, soumis à la contribution salariale de 10%'
+    # start_date = date(2013, 1, 1) : elle existe avant 2013 mais pour ces années avant, la législation n'a pas été codée. Voir variable contribution_salariale_glo_assimile_salaire
+    end = '2014-12-31'
+    definition_period = YEAR
+
+
 class f3vd(Variable):
     cerfa_field = '3VD'
     value_type = float
     unit = 'currency'
     entity = FoyerFiscal
     label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 18 %"
-    # Investiguée qu'à partir des revenus 2017
+    # start_date = date(2015, 1, 1)
     definition_period = YEAR
+    # NB : la législation sur les GLO a été checkée en août 2023 à partir de 2017 seulement.
 
 
 class f3vi(Variable):
@@ -424,8 +482,9 @@ class f3vi(Variable):
     unit = 'currency'
     entity = FoyerFiscal
     label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 30 %"
-    # Investiguée qu'à partir des revenus 2017
+    # start_date = date(2015, 1, 1)
     definition_period = YEAR
+    # NB : la législation sur les GLO a été checkée en août 2023 à partir de 2017 seulement.
 
 
 class f3vf(Variable):
@@ -434,8 +493,9 @@ class f3vf(Variable):
     unit = 'currency'
     entity = FoyerFiscal
     label = "Gains de levée d'options sur titres et gains d'acquisition d'actions taxables à 41 %"
-    # Investiguée qu'à partir des revenus 2017
+    # start_date = date(2015, 1, 1)
     definition_period = YEAR
+    # NB : la législation sur les GLO a été checkée en août 2023 à partir de 2017 seulement.
 
 
 class f3vn(Variable):
@@ -444,6 +504,7 @@ class f3vn(Variable):
     unit = 'currency'
     entity = FoyerFiscal
     label = 'Gains sur options et acquisitions gratuites attribuées à compter du 16/10/2007, soumis à la contribution salariale de 10%'
+    # start_date = date(2015, 1, 1)
     # Investiguée qu'à partir des revenus 2017
     definition_period = YEAR
 

--- a/openfisca_france/parameters/prelevements_sociaux/contribution_salariale_glo.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contribution_salariale_glo.yaml
@@ -3,11 +3,11 @@ values:
   2012-09-01:
     value: 0.10
 metadata:
-  unit: currency
+  unit: /1
   reference:
     2012-09-01:
-      href: 
-      title: ... 
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000033812493
+      title: Article L137-14 du Code de la sécurité sociale.
 documentation: |-
   Notes :
   Ce paramètre existe avant septembre 2012, mais pas rempli pour ces périodes.

--- a/openfisca_france/parameters/prelevements_sociaux/contribution_salariale_glo.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contribution_salariale_glo.yaml
@@ -1,0 +1,13 @@
+description: Contribution salariale sur gains de levée d'options
+values:
+  2012-09-01:
+    value: 0.10
+metadata:
+  unit: currency
+  reference:
+    2012-09-01:
+      href: 
+      title: ... 
+documentation: |-
+  Notes :
+  Ce paramètre existe avant septembre 2012, mais pas rempli pour ces périodes.

--- a/openfisca_france/parameters/prelevements_sociaux/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/index.yaml
@@ -14,3 +14,4 @@ metadata:
   - cotisations_taxes_independants_artisans_commercants
   - professions_liberales
   - reductions_cotisations_sociales
+  - contribution_salariale_glo

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '151.1.3',
+    version = '152.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/calculateur_impots/yaml/pv_pfu.yaml
+++ b/tests/calculateur_impots/yaml/pv_pfu.yaml
@@ -61,12 +61,12 @@
       - ind0
       f3sk: 20000.0
       f3vt: 20000.0
+      f3vi: 10000.0
     individus:
       ind0:
         activite: actif
         date_naissance: '1970-01-01'
         statut_marital: celibataire
-        f3vi: 10000.0
     famille:
       parents:
       - ind0

--- a/tests/formulas/glo.yaml
+++ b/tests/formulas/glo.yaml
@@ -12,11 +12,11 @@
   output:
     assiette_csg_revenus_capital: 60000 # 30000 + 15000 + 8000 + 7000
     plus_values_base_large: 30000 # 15000 + 8000 + 7000
-    contribution_salariale_glo_assimile_salaire: -8000 # 0.1*80000
-    prelevements_sociaux_revenus_capital: -18320 # 0.172*(30000 + 15000 + 8000 + 7000) + 8000
-    csg_glo_assimile_salaire_ir_et_ps: -1840 # 0.092*20000
-    crds_glo_assimile_salaire_ir_et_ps: -100 # 0.005*20000
-    revenus_nets_du_capital: 59740 # 80000 - (18320 + 1840 + 100)
+    contribution_salariale_glo_assimile_salaire: -8000 # -0.1*80000
+    csg_glo_assimile_salaire_ir_et_ps: -1840 # -0.092*20000
+    crds_glo_assimile_salaire_ir_et_ps: -100 # -0.005*20000
+    prelevements_sociaux_revenus_capital: -20260 # -( 0.172*(30000 + 15000 + 8000 + 7000) + 8000 + 1840 + 100 )
+    revenus_nets_du_capital: 59740 # 80000 - 20260
     revenus_nets_du_travail: 0
     taxation_plus_values_hors_bareme: 7970 # 0.18*15000 + 0.30*8000 + 0.41*7000
     rfr: 75000 # 0.9*(20000 + 30000) + 15000 + 8000 + 7000

--- a/tests/formulas/glo.yaml
+++ b/tests/formulas/glo.yaml
@@ -1,0 +1,22 @@
+- name: glo_2019
+  description: Test du traitement des différents types de glo (assimilés salaires pour l'IR seulement, pour l'IR et les PS, pour aucun prélèvement) hors injection dans le barème progressif de l'IR (injection dans le revenu disponible, calcul des prélèvements sociaux, taxation forfaitaire à l'IR)
+  period: 2019
+  absolute_error_margin: 1
+  input:
+    f1tt: 20000
+    f3vj: 30000
+    f3vd: 15000
+    f3vi: 8000
+    f3vf: 7000
+    f3vn: 60000 # On prend ici la somme de f3vj, f3vd, f3vi et f3vf
+  output:
+    assiette_csg_revenus_capital: 60000 # 30000 + 15000 + 8000 + 7000
+    plus_values_base_large: 30000 # 15000 + 8000 + 7000
+    contribution_salariale_glo_assimile_salaire: -8000 # 0.1*80000
+    prelevements_sociaux_revenus_capital: -18320 # 0.172*(30000 + 15000 + 8000 + 7000) + 8000
+    csg_glo_assimile_salaire_ir_et_ps: -1840 # 0.092*20000
+    crds_glo_assimile_salaire_ir_et_ps: -100 # 0.005*20000
+    revenus_nets_du_capital: 59740 # 80000 - (18320 + 1840 + 100)
+    revenus_nets_du_travail: 0
+    taxation_plus_values_hors_bareme: 7970 # 0.18*15000 + 0.30*8000 + 0.41*7000
+    rfr: 75000 # 0.9*(20000 + 30000) + 15000 + 8000 + 7000

--- a/tests/formulas/irpp.yaml
+++ b/tests/formulas/irpp.yaml
@@ -641,51 +641,6 @@
   output:
     irpp: -48036
 
-
-- name: IRPP - Célibataire ayant des revenus de plus-values mobilières (3VG) de 20 000 €
-  period: 2010
-  absolute_error_margin: 0.5
-  input:
-    f3vg: 20000
-  output:
-    irpp: -3600
-- name: IRPP - Célibataire ayant des revenus de plus-values mobilières (3VG) de 50 000 €
-  period: 2010
-  absolute_error_margin: 0.5
-  input:
-    f3vg: 50000
-  output:
-    irpp: -9000
-- name: IRPP - Célibataire ayant des revenus de plus-values mobilières (3VG) de 150 000 €
-  period: 2010
-  absolute_error_margin: 0.5
-  input:
-    f3vg: 150000
-  output:
-    irpp: -27000
-
-- name: IRPP - Célibataire ayant des revenus de plus-values mobilières (3VG) de 20 000 €
-  period: 2011
-  absolute_error_margin: 0.5
-  input:
-    f3vg: 20000
-  output:
-    irpp: -3800
-- name: IRPP - Célibataire ayant des revenus de plus-values mobilières (3VG) de 50 000 €
-  period: 2011
-  absolute_error_margin: 0.5
-  input:
-    f3vg: 50000
-  output:
-    irpp: -9500
-- name: IRPP - Célibataire ayant des revenus de plus-values mobilières (3VG) de 150 000 €
-  period: 2011
-  absolute_error_margin: 0.5
-  input:
-    f3vg: 150000
-  output:
-    irpp: -28500
-
 - name: IRPP - Célibataire ayant des revenus de plus-values mobilières (3VG) de 20 000 €
   period: 2012
   absolute_error_margin: 0.5


### PR DESCRIPTION
* Correction et complétion de la législation
* Périodes concernées : toutes.
* Zones impactées:
   - `mesures.py`
   - `prelevements_obligatoires/impot_revenu/ir.py`
   - `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py`
   - `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/csg_crds.py`
   - `prestations/aides_logement.py`
   - `revenus/capital/plus_values.py`
* Détails :
  - Ajoute les GLO taxés forfaitairement dans le revenu disponible (dans `plus_values_base_large`). Supprime ces GLO avant 2016 (car code faux).
  - Ajoute ces GLO dans l'assiette CSG pour les années où ils n'y étaient pas injectés.
  - Injecte dans le revenu disponible les GLO assimilés salaires et code les prélèvements associés à ces revenus. Il faut distinguer les GLO assimilés salaires pour l'IR (mais traités comme des revenus du capital pour les prélèvements sociaux), et ceux assimilés salaires à la fois pour l'IR et pour les prélèvements sociaux. Avant cette PR, n'était codé que l'IR associé à ces GLO, et pas les prélèvements sociaux. On ajoute les prélèvements sociaux, c'est-à-dire:
     - pour ceux ayant les PS des revenus du capital (`f3vj`) : ajout dans l'assiette des PS des revenus du capital (donc, calcul de la CSG, CRDS et autres prélèvements)
     - pour les autres (`f1tt`) : ils sont soumis à CSG et CRDS des revenus d'activité ainsi qu'à une contribution salariale de 10%. On code cela. Création de `csg_glo_assimile_salaire_ir_et_ps`, `crds_glo_assimile_salaire_ir_et_ps` et `contribution_salariale_glo_assimile_salaire` (qui implique de créer `f3vn`).
   - Injecte les GLO assimilés salaires pour l'IR dans le revenu disponible (l'IR sur ces GLO y était injecté, mais pas les GLO eux-même).
   - Suppression des formules de `taxation_plus_values_hors_bareme` avant 2012, qui étaient fausses.
   - Enlève `f3vm` pour 2018, qui était mise à tord.
   - Pour les GLO taxés forfaitairement, on code le changement d'entité en 2015 des cases qui y sont associées (passage de cases individuelles à foyer fiscal en 2015, pour `f3vd`, `f3vi` et `f3vf` : avant n'était codé que l'ancienne entité). Puis, pour simplifier les formules qui appellent ces revenus, création des variables `glo_taxation_ir_forfaitaire_taux2`, `glo_taxation_ir_forfaitaire_taux3` et `glo_taxation_ir_forfaitaire_taux4`. Renommage également de `glo` par `glo_taxation_ir_forfaitaire`