### PR TITLE
Ajoute la variable `service_civique`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 153.1.0 [#2180](https://github.com/openfisca/openfisca-france/pull/2180)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : 
+    - `openfisca_france/model/prestations/jeunes/service_civique.py`
+    - `openfisca_france/model/prestations/depart1825.py`
+    - `openfisca_france/model/prestations/enseignement_superieur/aide_merite.py`
+    - `openfisca_france/parameters/prestations_sociales/education/service_civique/`
+    - `tests/formulas/bourses_superieur/aide_merite.yaml`
+    - `tests/formulas/depart1825.yaml`
+* Détails :
+  - Ajoute une variable pour modéliser le service civique
+  - Modélise le cas du service_civique dans la variable `aide_merite_eligibilite`
+  - Modélise le cas du service_civique dans la variable `depart1825_eligibilite`
+  
 # 153.0.0 [#2177](https://github.com/openfisca/openfisca-france/pull/2177)
 
 * Tri de programmes.

--- a/openfisca_france/model/prestations/depart1825.py
+++ b/openfisca_france/model/prestations/depart1825.py
@@ -25,8 +25,9 @@ class depart1825_eligibilite(Variable):
         etudiant_boursier = (individu('activite', period) == TypesActivite.etudiant) * individu('boursier', period)
         alternant = individu('alternant', period)
         garantie_jeunes = individu('garantie_jeunes', period) > 0
+        en_service_civique = individu('service_civique', period) + individu('service_civique', period.last_month)
 
-        eligibilite_statut = etudiant_boursier + alternant + garantie_jeunes
+        eligibilite_statut = etudiant_boursier + alternant + garantie_jeunes + en_service_civique
 
         nbptr = individu.foyer_fiscal('nbptr', period.n_2)
         plafond_ressources = parameters(period).prestations_sociales.education.depart1825.plafond_ressources

--- a/openfisca_france/model/prestations/depart1825.py
+++ b/openfisca_france/model/prestations/depart1825.py
@@ -14,10 +14,7 @@ class depart1825_eligibilite(Variable):
     entity = Individu
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
-    reference = [
-        'https://programme-depart-1825.com/eligibilite/',
-        'https://www.ancv.com/actualites/le-magazine/depart-1825-un-nouveau-programme-pour-les-jeunes-de-18-25-ans'
-        ]
+    reference = ['https://depart1825.com/eligibilite/']
 
     def formula(individu, period, parameters):
         criteres_age = parameters(period).prestations_sociales.education.depart1825.age

--- a/openfisca_france/model/prestations/enseignement_superieur/aide_merite.py
+++ b/openfisca_france/model/prestations/enseignement_superieur/aide_merite.py
@@ -18,13 +18,11 @@ class aide_merite_eligibilite(Variable):
     ayant eu mention très bien au baccalauréat.
 
     Non modélisé :
-    L'étudiant respecte les conditions d'inscription pédagogique, d'assiduité
+    - L'étudiant respecte les conditions d'inscription pédagogique, d'assiduité
     et de présentation aux examens (non applicable si nouveau bachelier)
     ou redouble pour raisons médicales.
-    L'étudiant éligible à la bourse sur critères sociaux et éligible à une aide au mérite
-    en année universitaire N-1 et ayant réalisé un Service Civique
-    au titre de cette même année, peut percevoir son aide au mérite en N.
-    Un étudiant ne peut bénéficier de plus de 3 fois de l'aide au mérite.
+
+    - Un étudiant ne peut bénéficier de plus de 3 fois de l'aide au mérite.
     '''
 
     def formula(individu, period):
@@ -62,7 +60,20 @@ class aide_merite_eligibilite(Variable):
             options = [ADD]
             )
 
-        return etudiant * condition_ressources * (condition_mention + aide_merite_eligibilite_an_dernier)
+        # éligible accordée en N-2, année N-1 en Service Civique
+        service_civique_annee_passee = individu('service_civique', periode_universitaire_precedente, options = [ADD])
+        periode_universitaire_2_ans_avant = periode_universitaire_precedente.offset(-12, MONTH)
+        aide_merite_eligibilite_deux_ans_avant = individu('aide_merite_eligibilite',
+            periode_universitaire_2_ans_avant,
+            options = [ADD])
+        aide_merite_eligibile_mais_service_civique_annee_passee = (aide_merite_eligibilite_deux_ans_avant
+                                                    * service_civique_annee_passee)
+
+        return etudiant * condition_ressources * (
+            condition_mention
+            + aide_merite_eligibilite_an_dernier
+            + aide_merite_eligibile_mais_service_civique_annee_passee
+            )
 
 
 class aide_merite_montant(Variable):

--- a/openfisca_france/model/prestations/enseignement_superieur/aide_merite.py
+++ b/openfisca_france/model/prestations/enseignement_superieur/aide_merite.py
@@ -29,7 +29,7 @@ class aide_merite_eligibilite(Variable):
 
     def formula(individu, period):
 
-        def periode_universitaire_precedente(mois_calcul):
+        def calcul_periode_universitaire_precedente(mois_calcul):
             nb_mois_annee_courante = mois_calcul.date.month - mois_calcul.this_year.date.month + 1
 
             # https://www.campusfrance.org/fr/node/2176
@@ -55,7 +55,7 @@ class aide_merite_eligibilite(Variable):
             )
 
         # a déjà perçu l'aide l'année [universitaire] précédente
-        periode_universitaire_precedente = periode_universitaire_precedente(period)
+        periode_universitaire_precedente = calcul_periode_universitaire_precedente(period)
         aide_merite_eligibilite_an_dernier = individu(
             'aide_merite_eligibilite',
             periode_universitaire_precedente,

--- a/openfisca_france/model/prestations/jeunes/service_civique.py
+++ b/openfisca_france/model/prestations/jeunes/service_civique.py
@@ -1,0 +1,10 @@
+from openfisca_france.model.base import Variable, Individu, MONTH, set_input_dispatch_by_period
+
+
+class service_civique(Variable):
+    value_type = bool
+    label = 'Est en contrat de service civique'
+    entity = Individu
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+    reference = 'https://www.service-public.fr/particuliers/vosdroits/F13278'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '153.0.0',
+    version = '153.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/bourses_superieur/aide_merite.yaml
+++ b/tests/formulas/bourses_superieur/aide_merite.yaml
@@ -17,3 +17,15 @@
       month:2020-09:10: [true, false]
   output:
     aide_merite_montant: [900, 0]
+
+- name: Éligibilité à l'aide au mérite pour les personne ayant effectué un service civique l'année d'après le bac
+  period: 2023-09
+  input:
+    aide_merite_eligibilite:
+      2021-09: [true]
+    service_civique:
+      2022-09: [true]
+    etudiant: [true]
+    bourse_criteres_sociaux: [103.2]
+  output:
+    aide_merite_eligibilite: [true]

--- a/tests/formulas/depart1825.yaml
+++ b/tests/formulas/depart1825.yaml
@@ -1,16 +1,32 @@
 - period: 2021-03
   input:
-    activite: [etudiant, etudiant, inactif, inactif, actif]
-    boursier: [true, false, true, true, true]
-    alternant: [false, false, true, false, false]
-    garantie_jeunes: [0, 0, 0, 1, 1]
-    age: [18, 18, 18, 18, 18]
+    activite: [etudiant, etudiant, inactif, inactif, actif, actif]
+    boursier: [true, false, true, true, true, true]
+    alternant: [false, false, true, false, false, false]
+    service_civique: [false, false, false, false, false, true]
+    garantie_jeunes: [0, 0, 0, 1, 1, 0]
+    age: [18, 18, 18, 18, 18, 18]
     nbptr:
-      2019: [ 1, 1.5, 1, 1, 1 ]
+      2019: [1, 1.5, 1, 1, 1, 1]
     rfr:
-      2019: [ 17280, 30000, 17280, 17280, 17280 ]
+      2019: [17280, 30000, 17280, 17280, 17280, 97280]
   output:
-    depart1825_eligibilite: [true, false, true, true, true]
+    depart1825_eligibilite: [true, false, true, true, true, true]
+
+- period: 2021-03
+  name: Personne en service civique il y a moins d'un mois
+  input:
+    service_civique:
+      2021-02: [true, false]
+      2021-01: [true, true]
+    age: [18, 18]
+    garantie_jeunes: [0, 0]
+    nbptr:
+      2019: [1, 1]
+    rfr:
+      2019: [97280, 97280]
+  output:
+    depart1825_eligibilite: [true, false]
 
 - period: 2021-03
   input:


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées : 
    - `openfisca_france/model/prestations/jeunes/service_civique.py`
    - `openfisca_france/model/prestations/depart1825.py`
    - `openfisca_france/model/prestations/enseignement_superieur/aide_merite.py`
    - `openfisca_france/parameters/prestations_sociales/education/service_civique/`
    - `tests/formulas/bourses_superieur/aide_merite.yaml`
    - `tests/formulas/depart1825.yaml`
* Détails :
  - Ajoute une variable pour modéliser le service civique
  - Modélise le cas du service_civique dans la variable `aide_merite_eligibilite`
  - Modélise le cas du service_civique dans la variable `depart1825_eligibilite`

- - - -

Ces changements :
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
