### PR TITLE
Ajoute la variable crous_repas_montant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 153.2.0 [#2181](https://github.com/openfisca/openfisca-france/pull/2181)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 07/2021.
+* Zones impactées : 
+  - `openfisca_france/model/prestations/alimentation.py`.
+  - `openfisca_france/parameters/prestations_sociales/education/alimentation/montant_repas_non_boursier.yaml`.
+* Détails :
+  - Ajoute le dispositif permettant aux étudiant du supérieur de béneficier de repas à 3,30 euros dans les restaurant du crous.
+  - Ajoute une variable qui détermine le prix d'un repas au restaurant universitaire pour les étudiants
+
 ## 153.1.0 [#2180](https://github.com/openfisca/openfisca-france/pull/2180)
 
 * Évolution du système socio-fiscal
@@ -15,7 +26,7 @@
   - Ajoute une variable pour modéliser le service civique
   - Modélise le cas du service_civique dans la variable `aide_merite_eligibilite`
   - Modélise le cas du service_civique dans la variable `depart1825_eligibilite`
-  
+
 # 153.0.0 [#2177](https://github.com/openfisca/openfisca-france/pull/2177)
 
 * Tri de programmes.

--- a/openfisca_france/model/prestations/alimentation.py
+++ b/openfisca_france/model/prestations/alimentation.py
@@ -8,7 +8,7 @@ class crous_repas_un_euro_eligibilite(Variable):
     entity = Individu
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
-    reference = 'https://www.etudiant.gouv.fr/fr/crous-resto-c-est-bon-de-s-y-retrouver-1195'
+    reference = 'https://www.service-public.fr/particuliers/actualites/A16017'
 
     def formula_2021_01(individu, period):
         return individu('scolarite', period) == TypesScolarite.enseignement_superieur
@@ -26,7 +26,7 @@ class crous_repas_tarif_non_boursiers_eligibilite(Variable):
     entity = Individu
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
-    reference = 'https://www.etudiant.gouv.fr/fr/crous-resto-c-est-bon-de-s-y-retrouver-1195'
+    reference = 'https://www.service-public.fr/particuliers/actualites/A16017'
 
     def formula_2021_07(individu, period):
         enseignement_superieur = individu('scolarite', period) == TypesScolarite.enseignement_superieur
@@ -40,7 +40,7 @@ class crous_repas_montant(Variable):
     entity = Individu
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
-    reference = 'https://www.etudiant.gouv.fr/fr/crous-resto-c-est-bon-de-s-y-retrouver-1195'
+    reference = 'https://www.service-public.fr/particuliers/actualites/A16017'
 
     def formula(individu, period, parameters):
         etudiant_non_boursier = individu('crous_repas_tarif_non_boursiers_eligibilite', period)

--- a/openfisca_france/model/prestations/alimentation.py
+++ b/openfisca_france/model/prestations/alimentation.py
@@ -8,15 +8,7 @@ class crous_repas_un_euro_eligibilite(Variable):
     entity = Individu
     definition_period = MONTH
     set_input = set_input_dispatch_by_period
-    reference = 'https://www.etudiant.gouv.fr/sites/default/files/2021-01/le-repas-un-euro-4977.pdf'
-    documentation = '''
-    Suite à la crise Covid-19, tous les étudiants, boursiers ou non, peuvent bénéficier
-    de deux repas par jour au tarif de 1 euro.
-    Pour en bénéficier, il suffit d’activer son compte Izly.
-    Pour les étudiants déjà titulaires d’un compte Izly,
-    la modification de tarif a été effectuée à partir du vendredi 22 janvier
-    et jusqu’au début de la semaine du 25 janvier.
-    '''
+    reference = 'https://www.etudiant.gouv.fr/fr/crous-resto-c-est-bon-de-s-y-retrouver-1195'
 
     def formula_2021_01(individu, period):
         return individu('scolarite', period) == TypesScolarite.enseignement_superieur

--- a/openfisca_france/model/prestations/alimentation.py
+++ b/openfisca_france/model/prestations/alimentation.py
@@ -32,3 +32,22 @@ class crous_repas_tarif_non_boursiers_eligibilite(Variable):
         enseignement_superieur = individu('scolarite', period) == TypesScolarite.enseignement_superieur
         boursier = individu('boursier', period)
         return not_(boursier) * enseignement_superieur
+
+
+class crous_repas_montant(Variable):
+    value_type = float
+    label = 'Montant du repas au restaurant universitaire'
+    entity = Individu
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+    reference = 'https://www.etudiant.gouv.fr/fr/crous-resto-c-est-bon-de-s-y-retrouver-1195'
+
+    def formula(individu, period, parameters):
+        etudiant_non_boursier = individu('crous_repas_tarif_non_boursiers_eligibilite', period)
+        tarif_repas_non_boursier = parameters(period).prestations_sociales.education.alimentation.montant_repas_non_boursier
+
+        eligibilite_repas_un_euro = individu('crous_repas_un_euro_eligibilite', period)
+
+        montant_repas = eligibilite_repas_un_euro * 1 + (etudiant_non_boursier * tarif_repas_non_boursier)
+
+        return montant_repas

--- a/openfisca_france/model/prestations/alimentation.py
+++ b/openfisca_france/model/prestations/alimentation.py
@@ -1,4 +1,4 @@
-from openfisca_france.model.base import Individu, Variable, MONTH, set_input_dispatch_by_period
+from openfisca_france.model.base import Individu, Variable, MONTH, set_input_dispatch_by_period, not_
 from openfisca_france.model.prestations.education import TypesScolarite
 
 
@@ -18,3 +18,17 @@ class crous_repas_un_euro_eligibilite(Variable):
         detention_carte_des_metiers = individu('detention_carte_des_metiers', period)
         boursier = individu('boursier', period)
         return boursier * (enseignement_superieur + detention_carte_des_metiers)
+
+
+class crous_repas_tarif_non_boursiers_eligibilite(Variable):
+    value_type = bool
+    label = 'Éligibilité au repas Crous au tarif pour les non-boursiers'
+    entity = Individu
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+    reference = 'https://www.etudiant.gouv.fr/fr/crous-resto-c-est-bon-de-s-y-retrouver-1195'
+
+    def formula_2021_07(individu, period):
+        enseignement_superieur = individu('scolarite', period) == TypesScolarite.enseignement_superieur
+        boursier = individu('boursier', period)
+        return not_(boursier) * enseignement_superieur

--- a/openfisca_france/parameters/prestations_sociales/education/alimentation/montant_repas_non_boursier.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/alimentation/montant_repas_non_boursier.yaml
@@ -1,0 +1,12 @@
+description: Montant du repas pour un etudiant sans condition de ressource particulière
+values:
+  2013-09-01:
+    value: 3.1
+  2015-09-01:
+    value: 3.3
+metadata:
+  short_label: Montant repas etudiant
+  unit: currency
+  reference:
+    2013-09-01:
+      href: https://fr.wikipedia.org/wiki/Restaurant_universitaire

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '153.1.0',
+    version = '153.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/crous_repas_montant.yaml
+++ b/tests/formulas/crous_repas_montant.yaml
@@ -1,0 +1,7 @@
+- name: Montant du repas au restaurant universitaire
+  period: 2023-09
+  input:
+    scolarite: [non_renseigne, enseignement_superieur, enseignement_superieur]
+    boursier: [false, false, true]
+  output:
+    crous_repas_montant: [0, 3.30, 1]

--- a/tests/formulas/crous_repas_tarif_non_boursiers_eligibilite.yaml
+++ b/tests/formulas/crous_repas_tarif_non_boursiers_eligibilite.yaml
@@ -1,0 +1,7 @@
+- name: Prix d'un repas au crous pour un étudiant non-boursier
+  period: 2023-01
+  input:
+    scolarite: [enseignement_superieur, non_renseigne, enseignement_superieur]
+    boursier: [false, false, true]
+  output:
+    crous_repas_tarif_non_boursiers_eligibilite: [true, false, false]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 07/2021.
* Zones impactées : `openfisca_france/model/prestations/alimentation.py`.
* Détails :
  - Ajoute le dispositif permettant aux étudiant du supérieur de béneficier de repas à 3,30 euros dans les restaurant du crous.

- - - -

Ces changements:

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
