### PR TITLE
[IR] Libellé et référence des minimums de mise en recouvrement de l'IR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 153.2.1 [#2185](https://github.com/openfisca/openfisca-france/pull/2185)
+
+* Changement mineur.
+* Périodes concernées : toutes
+* Zones impactées : `impot_revenu/calcul_impot_revenu/recouvrement`.
+* Détails :
+  - Change libellés des paramètres "minimum de mise en recouvrement de l'IR" en suivant la formulation proposée par l'Insee dans cette étude : https://www.insee.fr/fr/statistiques/3584540
+  - Ajoute référence législative.
+
 ### 153.2.0 [#2181](https://github.com/openfisca/openfisca-france/pull/2181)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/recouvrement/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/recouvrement/index.yaml
@@ -1,6 +1,6 @@
-description: Mise en recouvrement de l'impôt
+description: Montants minimums de mise en recouvrement de l'impôt
 metadata:
-  short_label: Recouvrement
+  short_label: Montants minimums de mise en recouvrement de l'impôt
   order:
   - seuil
   - min

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/recouvrement/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/recouvrement/min.yaml
@@ -1,7 +1,13 @@
-description: Seuil de recouvrement de l'impôt après l'imputation des crédits d'impôt
+description: Montant minimum de mise en recouvrement de l'impôt sur le revenu après l'imputation des crédits d'impôt
 values:
   2002-01-01:
     value: 12
 metadata:
-  short_label: Seuil de recouvrement après imputations
+  short_label: Montant minimum après imputation des crédits d'impôts
+  last_value_still_valid_on: "2023-09-21"
   unit: currency_next_year
+  reference:
+    2002-01-01:
+      title: Article 1657 du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006312659
+

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/recouvrement/seuil.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/recouvrement/seuil.yaml
@@ -1,7 +1,12 @@
-description: Seuil de recouvrement de l'impôt avant l'imputation des crédits d'impôts
+description: Montant minimum de mise en recouvrement de l'impôt sur le revenu avant l'imputation des crédits d'impôts
 values:
   2002-01-01:
     value: 61
 metadata:
-  short_label: Seuil de recouvrement de l'impôt avant imputations
+  short_label: Montant minimum avant imputation des crédits d'impôts
+  last_value_still_valid_on: "2023-09-21"
   unit: currency_next_year
+  reference:
+    2002-01-01:
+      title: Article 1657 du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006312659

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '153.2.0',
+    version = '153.2.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes
* Zones impactées : `impot_revenu/calcul_impot_revenu/recouvrement`.
* Détails :
  - Change libellé en suivant celui proposé par l'Insee dans cette étude : https://www.insee.fr/fr/statistiques/3584540
  - Ajoute référence législative