### PR TITLE
ajout is_period_size_independent à effectif_entreprise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 153.3.1 [#2190](https://github.com/openfisca/openfisca-france/pull/2190)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/model/revenus/activite/salarie.py`.
+* Détails :
+  - Ajoute l'option `is_period_size_independent = True` à la variable effectif_entreprise
+
 ### 153.3.0 [#2181](https://github.com/openfisca/openfisca-france/pull/2186)
 
 * Évolution du système socio-fiscal. Amélioration technique

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -504,6 +504,7 @@ class effectif_entreprise(Variable):
     value_type = int
     label = "Effectif de l'entreprise"
     set_input = set_input_dispatch_by_period
+    is_period_size_independent = True
     definition_period = MONTH
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '153.3.0',
+    version = '153.3.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/revenus/activite/salarie.py`.
* Détails :
  - Ajoute l'option `is_period_size_independent = True` à la variable effectif_entreprise

- - - -

Ces changements:
- Corrigent ou améliorent un calcul déjà existant.
