### PR TITLE
Corrige/actualise variables PEL/CEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# 154.0.0 [2193](https://github.com/openfisca/openfisca-france/pull/2193)
+
+* Corrections/mises à jour
+* Zones impactées: 
+   - `measures.py`
+   - `prelevements_obligatoires/impots_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py`
+   - `prelevements_obligatoires/isf.py`
+   - `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py`
+* Détails :
+  - Lors du code des variables des PEL/CEL, on n'avait pas la brochure de l'IR sur les revenus 2018, ce qui nous avait amené à coder ces variables en fonction de la nomenclature des cases de la déclaration d'IR sur les revenus 2017. Cette PR actualise cela.
+
 ### 153.3.5 [2192](https://github.com/openfisca/openfisca-france/pull/2192)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/mesures.py
+++ b/openfisca_france/model/mesures.py
@@ -439,8 +439,8 @@ class revenus_capitaux_mobiliers_plus_values_bruts_menage(Variable):
         revenus_capitaux_prelevement_liberatoire_i = menage.members.foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
         revenus_capitaux_prelevement_liberatoire = menage.sum(revenus_capitaux_prelevement_liberatoire_i, role = FoyerFiscal.DECLARANT_PRINCIPAL)
 
-        interets_pel_moins_12_ans_cel_i = menage.members('interets_pel_moins_12_ans_cel', period)
-        interets_pel_moins_12_ans_cel = menage.sum(interets_pel_moins_12_ans_cel_i)
+        interets_pel_cel_non_soumis_IR_i = menage.members('interets_pel_cel_non_soumis_IR', period)
+        interets_pel_cel_non_soumis_IR = menage.sum(interets_pel_cel_non_soumis_IR_i)
         assurance_vie_ps_exoneree_irpp_pl_i = menage.members.foyer_fiscal('assurance_vie_ps_exoneree_irpp_pl', period)
         assurance_vie_ps_exoneree_irpp_pl = menage.sum(assurance_vie_ps_exoneree_irpp_pl_i, role = FoyerFiscal.DECLARANT_PRINCIPAL)
 
@@ -451,7 +451,7 @@ class revenus_capitaux_mobiliers_plus_values_bruts_menage(Variable):
             revenus_capitaux_prelevement_forfaitaire_unique_ir
             + revenus_capitaux_prelevement_bareme
             + revenus_capitaux_prelevement_liberatoire
-            + interets_pel_moins_12_ans_cel
+            + interets_pel_cel_non_soumis_IR
             + assurance_vie_ps_exoneree_irpp_pl
             + plus_values_base_large
             )

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -179,19 +179,11 @@ class prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_eta
             - produit_etats_non_cooperatif
             )
 
-        # Intérêts des PEL et CEL, hors intérêts des PEL de plus de 12 ans, qui sont déclarés dans la déclaration de revenus (attention, on ne connait pas le formulaire 2019 des revenus 2018 au moment de faire ce code)
-        interets_plan_epargne_logement_moins_de_12_ans_ouvert_a_partir_de_2018_i = foyer_fiscal.members('interets_plan_epargne_logement_moins_de_12_ans_ouvert_a_partir_de_2018', period)
-        interets_plan_epargne_logement_moins_de_12_ans_ouvert_a_partir_de_2018 = foyer_fiscal.sum(interets_plan_epargne_logement_moins_de_12_ans_ouvert_a_partir_de_2018_i)
-        interets_compte_epargne_logement_ouvert_a_partir_de_2018_i = foyer_fiscal.members('interets_compte_epargne_logement_ouvert_a_partir_de_2018', period)
-        interets_compte_epargne_logement_ouvert_a_partir_de_2018 = foyer_fiscal.sum(interets_compte_epargne_logement_ouvert_a_partir_de_2018_i)
-
         # Plus-values
         plus_values_prelevement_forfaitaire_unique_ir = foyer_fiscal('plus_values_prelevement_forfaitaire_unique_ir', period)
 
         assiette_pfu_hors_assurance_vie = (
             revenus_capitaux_prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs
-            + interets_plan_epargne_logement_moins_de_12_ans_ouvert_a_partir_de_2018
-            + interets_compte_epargne_logement_ouvert_a_partir_de_2018
             + plus_values_prelevement_forfaitaire_unique_ir
             )
 

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -621,7 +621,7 @@ class revenus_et_produits_plafonnement_isf_ifi(Variable):
         revenus_capitaux_prelevement_forfaitaire_unique_ir = foyer_fiscal('revenus_capitaux_prelevement_forfaitaire_unique_ir', period, options = [ADD])  # Existe à partir de 2018
         plus_values_base_large = foyer_fiscal('plus_values_base_large', period)
         assurance_vie_ps_exoneree_irpp_pl = foyer_fiscal('assurance_vie_ps_exoneree_irpp_pl', period)
-        interets_pel_moins_12_ans_cel_i = foyer_fiscal.members('interets_pel_moins_12_ans_cel', period)
+        interets_pel_cel_non_soumis_IR_i = foyer_fiscal.members('interets_pel_cel_non_soumis_IR', period)
         livret_a_i = foyer_fiscal.members('livret_a', period.last_month)
         taux_livret_a = parameters(period).taxation_capital.epargne.livret_a.taux
         interets_livret_a_i = livret_a_i * taux_livret_a
@@ -632,7 +632,7 @@ class revenus_et_produits_plafonnement_isf_ifi(Variable):
         rpns_exon = foyer_fiscal.sum(rpns_exon_i)
         rpns_pvct = foyer_fiscal.sum(rpns_pvct_i)
         revenu_assimile_salaire_apres_abattements = foyer_fiscal.sum(salcho_imp_i)
-        interets_pel_moins_12_ans_cel = foyer_fiscal.sum(interets_pel_moins_12_ans_cel_i)
+        interets_pel_cel_non_soumis_IR = foyer_fiscal.sum(interets_pel_cel_non_soumis_IR_i)
         interets_livret_a = foyer_fiscal.sum(interets_livret_a_i)
 
         montant = max_(
@@ -650,7 +650,7 @@ class revenus_et_produits_plafonnement_isf_ifi(Variable):
             + revenu_categoriel_foncier
             + plus_values_base_large
             + assurance_vie_ps_exoneree_irpp_pl
-            + interets_pel_moins_12_ans_cel
+            + interets_pel_cel_non_soumis_IR
             + interets_livret_a
             )
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -17,23 +17,11 @@ class interets_plan_epargne_logement_moins_de_12_ans_ouvert_avant_2018(Variable)
     '''
     NB :
     (1) Cette variable est définie indépendemment de epargne_revenus_non_imposables
-    (2) Les intérêts des PEL de plus de 12 ans sont imposables à l'impôt sur le revenu, et donc déjà présents dans les cases 2TR ou 2FA (attention: formulaire IR 2019 sur revenus 2018 non connu au moment de coder cette variable)
+    (2) Les intérêts des PEL de plus de 12 ans et ouverts avant 2018 sont imposables à l'impôt sur le revenu, et donc déjà présents dans la déclaration de revenus (ex : case 2TR pour les revenus de 2018)
     '''
     value_type = float
     entity = Individu
     label = 'Intérêts des plans épargne logement (PEL) de moins de 12 ans ouverts avant le 1er janvier 2018'
-    definition_period = YEAR
-
-
-class interets_plan_epargne_logement_moins_de_12_ans_ouvert_a_partir_de_2018(Variable):
-    '''
-    NB :
-    (1) Cette variable est définie indépendemment de epargne_revenus_non_imposables
-    (2) Les intérêts des PEL de plus de 12 ans sont imposables à l'impôt sur le revenu, et donc déjà présents dans les cases 2TR ou 2FA (attention: formulaire IR 2019 sur revenus 2018 non connu au moment de coder cette variable)
-    '''
-    value_type = float
-    entity = Individu
-    label = 'Intérêts des plans épargne logement (PEL) de moins de 12 ans ouverts à partir du 1er janvier 2018'
     definition_period = YEAR
 
 
@@ -45,19 +33,11 @@ class interets_compte_epargne_logement_ouvert_avant_2018(Variable):
     definition_period = YEAR
 
 
-class interets_compte_epargne_logement_ouvert_a_partir_de_2018(Variable):
+class interets_pel_cel_non_soumis_IR(Variable):
     ''' NB : Cette variable est définie indépendemment de epargne_revenus_non_imposables '''
     value_type = float
     entity = Individu
-    label = 'Intérêts des comptes épargne logement (CEL) ouverts à partir du 1er janvier 2018'
-    definition_period = YEAR
-
-
-class interets_pel_moins_12_ans_cel(Variable):
-    ''' NB : Cette variable est définie indépendemment de epargne_revenus_non_imposables '''
-    value_type = float
-    entity = Individu
-    label = 'Intérêts des plans épargne logement (PEL) de moins de 12 ans et des comptes épargne logement (CEL)'
+    label = "Intérêts des plans épargne logement (PEL) et des comptes épargne logement (CEL) non soumis à l'impôt sur le revenu"
     definition_period = YEAR
 
     def formula(individu, period):
@@ -68,20 +48,6 @@ class interets_pel_moins_12_ans_cel(Variable):
         return (
             interets_plan_epargne_logement_moins_de_12_ans_ouvert_avant_2018
             + interets_compte_epargne_logement_ouvert_avant_2018
-            )
-
-    def formula_2018_01_01(individu, period):
-
-        interets_plan_epargne_logement_moins_de_12_ans_ouvert_avant_2018 = individu('interets_plan_epargne_logement_moins_de_12_ans_ouvert_avant_2018', period)
-        interets_compte_epargne_logement_ouvert_avant_2018 = individu('interets_compte_epargne_logement_ouvert_avant_2018', period)
-        interets_plan_epargne_logement_moins_de_12_ans_ouvert_a_partir_de_2018 = individu('interets_plan_epargne_logement_moins_de_12_ans_ouvert_a_partir_de_2018', period)
-        interets_compte_epargne_logement_ouvert_a_partir_de_2018 = individu('interets_compte_epargne_logement_ouvert_a_partir_de_2018', period)
-
-        return (
-            interets_plan_epargne_logement_moins_de_12_ans_ouvert_avant_2018
-            + interets_compte_epargne_logement_ouvert_avant_2018
-            + interets_plan_epargne_logement_moins_de_12_ans_ouvert_a_partir_de_2018
-            + interets_compte_epargne_logement_ouvert_a_partir_de_2018
             )
 
 
@@ -305,8 +271,8 @@ class assiette_csg_revenus_capital(Variable):
         rente_viagere_titre_onereux_net = foyer_fiscal('rente_viagere_titre_onereux_net', period)
 
         # Revenus des produits d'épargne logement
-        interets_pel_moins_12_ans_cel_i = foyer_fiscal.members('interets_pel_moins_12_ans_cel', period)
-        interets_pel_moins_12_ans_cel = foyer_fiscal.sum(interets_pel_moins_12_ans_cel_i)
+        interets_pel_cel_non_soumis_IR_i = foyer_fiscal.members('interets_pel_cel_non_soumis_IR', period)
+        interets_pel_cel_non_soumis_IR = foyer_fiscal.sum(interets_pel_cel_non_soumis_IR_i)
 
         # Revenus fonciers
         rev_cat_rfon = foyer_fiscal('revenu_categoriel_foncier', period)
@@ -329,7 +295,7 @@ class assiette_csg_revenus_capital(Variable):
             + revenus_capitaux_prelevement_liberatoire
             + revenus_capitaux_prelevement_forfaitaire_unique_ir
             + rente_viagere_titre_onereux_net
-            + interets_pel_moins_12_ans_cel
+            + interets_pel_cel_non_soumis_IR
             + rev_cat_rfon
             + assiette_csg_plus_values
             + assurance_vie_ps_exoneree_irpp_pl

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '153.3.5',
+    version = '154.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -259,13 +259,12 @@
     f3sb: 30000 # Correspond à f3sa apres abattement. Pas besoin de spécifier f3sa car jamais utilisée dans OFF (vu que ces revenus sont juste utilisés pour l'IR, pour leur montant après abattement, mais n'entrent pas dans les revenus courants : voir explications dans docstring de plus_values_base_large)
     f3vg: 40000
     f3vd: 50000
-    interets_plan_epargne_logement_moins_de_12_ans_ouvert_a_partir_de_2018: 60000
-    interets_compte_epargne_logement_ouvert_a_partir_de_2018: 70000
+    f2tr: 130000
     rsa: 0
   output:
     prelevements_sociaux_revenus_capital: -41280
     revenus_nets_du_capital: (270000 - 30000) - 41280 # car les revenus associés à 3SA et 3SB ne sont pas dans les revenus courants : voir docstring de plus_values_base_large
-    prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs: -28160 #-(22000*0.128) 3VD est un gain taxé forfaitairement au taux de 18% et non au PFU
+    prelevement_forfaitaire_unique_ir_hors_assurance_vie_epargne_solidaire_etats_non_cooperatifs: -28160 #-(220000*0.128) 3VD est un gain taxé forfaitairement au taux de 18% et non au PFU
     taxation_plus_values_hors_bareme: 9000 #50000 * 0.18
     impots_directs: -28160 - 9000
     revenu_disponible: (270000 - 30000) - 41280 - 28160 - 9000 # car les revenus associés à 3SA et 3SB ne sont pas dans les revenus courants : voir docstring de plus_values_base_large


### PR DESCRIPTION
* Corrections/mises à jour
* Zones impactées: 
   - `measures.py`
   - `prelevements_obligatoires/impots_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py`
   - `prelevements_obligatoires/isf.py`
   - `prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py`
* Détails :
  - Lors du code des variables des PEL/CEL, on n'avait pas la brochure de l'IR sur les revenus 2018, ce qui nous avait amené à coder ces variables en fonction de la nomenclature des cases de la déclaration d'IR sur les revenus 2017. Cette PR actualise cela.
