### PR TITLE
Nettoie paramètres inutilisés

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 155.0.2 [2202](https://github.com/openfisca/openfisca-france/pull/2202)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées :
+   -  `parameters/prestations_sociales/prestations_familiales`
+* Détails :
+  - Retrait de paramètres inutilisés
+
+
 ### 155.0.1 [2184](https://github.com/openfisca/openfisca-france/pull/2184)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/bmaf/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/bmaf/index.yaml
@@ -1,6 +1,6 @@
 description: Base mensuelle de calcul des allocations familiales (BMAF)
 metadata:
-  short_label: Familiales
+  short_label: BMAF
   label_en: Monthly basis for the computation of family allowances (BMAF)
   order:
   - bmaf

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh/cpl3b.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh/cpl3b.yaml
@@ -1,6 +1,0 @@
-description: Seuil dépense b complément de catégorie 3
-values:
-  2002-04-01:
-    value: 0.59
-metadata:
-  unit: /1

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh/cpl3c.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh/cpl3c.yaml
@@ -1,6 +1,0 @@
-description: Seuil dépense c complément de catégorie 3
-values:
-  2002-04-01:
-    value: 1.24
-metadata:
-  unit: /1

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh/cpl4b.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh/cpl4b.yaml
@@ -1,8 +1,0 @@
-description: Seuil dépense b complément de catégorie 4
-values:
-  1991-09-24:
-    value: 0
-  2002-04-01:
-    value: 0.8257
-metadata:
-  unit: /1

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh/cpl4c.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh/cpl4c.yaml
@@ -1,8 +1,0 @@
-description: Seuil dépense c complément de catégorie 4
-values:
-  1991-09-24:
-    value: 0
-  2002-04-01:
-    value: 1.0957
-metadata:
-  unit: /1

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh/cpl4d.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh/cpl4d.yaml
@@ -1,8 +1,0 @@
-description: Seuil dépense d complément de catégorie 4
-values:
-  1991-09-24:
-    value: 0
-  2002-04-01:
-    value: 1.7457
-metadata:
-  unit: /1

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh/cpl5a.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/aeeh/cpl5a.yaml
@@ -1,8 +1,0 @@
-description: Seuil dépense complément de catégorie 5
-values:
-  1991-09-24:
-    value: 0
-  2002-04-01:
-    value: 0.7164
-metadata:
-  unit: /1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '155.0.1',
+    version = '155.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes. 
* Zones impactées : 
   -  `parameters/prestations_sociales/prestations_familiales`
* Détails :
  - Retrait de paramètres inutilisés
