### PR TITLE
Améliore la récupération de l'artifact conda

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -296,8 +296,7 @@ jobs:
 
   publish-to-conda:
     runs-on: "ubuntu-20.04"
-    # needs: [ deploy ] ######################################"" PUT IT BACK !!!!!!!!!!!!
-    needs: [ build ]
+    needs: [ deploy ]
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -311,7 +311,6 @@ jobs:
       - name: Get version
         run: echo "PACKAGE_VERSION=$(python3 ./setup.py --version)" >> $GITHUB_ENV
       - name: Build and Upload to Conda
-      - name: Conda upload
         # This shell is made necessary by https://github.com/conda-incubator/setup-miniconda/issues/128
         shell: bash -l {0}
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -327,6 +327,7 @@ jobs:
           commit: ${{steps.last_pr_commit.outputs.result}}
           name: conda-build-${{ env.PACKAGE_VERSION }}-${{steps.last_pr_commit.outputs.result}}
           path: conda-build-tmp
+          event: push  # to listen to commit events and avoid conflict with PR opening event
           if_no_artifact_found: fail
       - name: Conda upload
         # This shell is made necessary by https://github.com/conda-incubator/setup-miniconda/issues/128

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -313,6 +313,6 @@ jobs:
         # This shell is made necessary by https://github.com/conda-incubator/setup-miniconda/issues/128
         shell: bash -l {0}
         run: |
-          conda install -y conda-build anaconda-client
-          conda config --set anaconda_upload yes
-          conda build -c conda-forge -c openfisca --token ${{ secrets.ANACONDA_TOKEN }} --user openfisca .conda --force
+          conda install anaconda-client
+          conda info
+          anaconda -t ${{ secrets.ANACONDA_TOKEN }} upload -u openfisca ./conda-build-tmp/noarch/openfisca-france-*-py_0.tar.bz2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -296,42 +296,25 @@ jobs:
 
   publish-to-conda:
     runs-on: "ubuntu-20.04"
-    needs: [ deploy ]
+    # needs: [ deploy ] ######################################"" PUT IT BACK !!!!!!!!!!!!
+    needs: [ build ]
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           python-version: "3.9.9"
           # Add conda-forge for OpenFisca-Core
-          channels: conda-forge
+          channels: openfisca,conda-forge
           activate-environment: true
       - name: Get source code
         uses: actions/checkout@v3
       - name: Get version
         run: echo "PACKAGE_VERSION=$(python3 ./setup.py --version)" >> $GITHUB_ENV
-      # Get the last commit hash on the PR (-2 : before the merge commit)
-      - uses: actions/github-script@v6
-        id: last_pr_commit
-        with:
-          script: |
-            const commits = ${{ toJSON(github.event.commits) }}
-            return commits.at(-2).id;
-          result-encoding: string
-      # Default Download artifact don't see artifact of other workflow
-      # So we use dawidd6/action-download-artifact@v2 to do it.
-      - name: Download artifact
-        id: download-artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow_conclusion: success
-          commit: ${{steps.last_pr_commit.outputs.result}}
-          name: conda-build-${{ env.PACKAGE_VERSION }}-${{steps.last_pr_commit.outputs.result}}
-          path: conda-build-tmp
-          if_no_artifact_found: fail
+      - name: Build and Upload to Conda
       - name: Conda upload
         # This shell is made necessary by https://github.com/conda-incubator/setup-miniconda/issues/128
         shell: bash -l {0}
         run: |
-          conda install anaconda-client
-          conda info
-          anaconda -t ${{ secrets.ANACONDA_TOKEN }} upload -u openfisca ./conda-build-tmp/noarch/openfisca-france-*-py_0.tar.bz2 --force
+          conda install -y conda-build anaconda-client
+          conda config --set anaconda_upload yes
+          conda build -c conda-forge -c openfisca --token ${{ secrets.ANACONDA_TOKEN }} --user openfisca .conda --force

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -303,13 +303,32 @@ jobs:
           auto-update-conda: true
           python-version: "3.9.9"
           # Add conda-forge for OpenFisca-Core
-          channels: openfisca,conda-forge
+          channels: conda-forge
           activate-environment: true
       - name: Get source code
         uses: actions/checkout@v3
       - name: Get version
         run: echo "PACKAGE_VERSION=$(python3 ./setup.py --version)" >> $GITHUB_ENV
-      - name: Build and Upload to Conda
+      # Get the last commit hash on the PR (-2 : before the merge commit)
+      - uses: actions/github-script@v6
+        id: last_pr_commit
+        with:
+          script: |
+            const commits = ${{ toJSON(github.event.commits) }}
+            return commits.at(-2).id;
+          result-encoding: string
+      # Default Download artifact don't see artifact of other workflow
+      # So we use dawidd6/action-download-artifact@v2 to do it.
+      - name: Download artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow_conclusion: success
+          commit: ${{steps.last_pr_commit.outputs.result}}
+          name: conda-build-${{ env.PACKAGE_VERSION }}-${{steps.last_pr_commit.outputs.result}}
+          path: conda-build-tmp
+          if_no_artifact_found: fail
+      - name: Conda upload
         # This shell is made necessary by https://github.com/conda-incubator/setup-miniconda/issues/128
         shell: bash -l {0}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-### 155.0.9 [2211](https://github.com/openfisca/openfisca-france/pull/22101)
+### 155.0.9 [2211](https://github.com/openfisca/openfisca-france/pull/2211)
 
-* Changement mineur.
+* Amélioration technique.
 * Périodes concernées : non applicable.
 * Zones impactées : `.github/workflows/workflow.yml`.
 * Détails :

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 155.0.9 [2211](https://github.com/openfisca/openfisca-france/pull/22101)
+
+* Changement mineur.
+* Périodes concernées : non applicable.
+* Zones impactées : `.github/workflows/workflow.yml`.
+* Détails :
+  - Améliore la récupération d'[artifacts](https://docs.github.com/fr/actions/using-workflows/storing-workflow-data-as-artifacts) en intégration continue pour le `build` de librairie conda
+  -  Permet de trouver le paquet même si le merge de la PR est fait sans avoir réalisé de commit après son ouverture.
+
+
 ### 155.0.8 [2213](https://github.com/openfisca/openfisca-france/pull/2213)
 
 * Changement mineur.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '155.0.8',
+    version = '155.0.9',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : non applicable.
* Zones impactées : `.github/workflows/workflow.yml`.
* Détails :
  - Améliore la récupération d'[artifacts](https://docs.github.com/fr/actions/using-workflows/storing-workflow-data-as-artifacts) en intégration continue pour le `build` de librairie conda
  -  Permet de trouver le paquet même si le merge de la PR est fait sans avoir réalisé de commit après son ouverture.

Cette PR répond à une problématique sur la publication de librairies conda : lorsque tous les évènements de commits sont réalisés avant l'événement d'ouverture de PR, la librairie n'était pas trouvée. Avec cette PR la librairie conda est bien retrouvée.


- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus