### PR TITLE
Ajoute le Pass'Sport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,22 @@
 # Changelog
 
-## 155.0.13 [2220](https://github.com/openfisca/openfisca-france/pull/2220)
+## 155.1.0 [2221](https://github.com/openfisca/openfisca-france/pull/2221)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 2022/08/02.
+* Zones impactées :
+    - `openfisca_france/model/prestations/jeunes/pass_sport.py`
+    - `openfisca_france/parameters/prestations_sociales/education/pass_sport/*`
+* Détails :
+  - Ajoute le dispositif du Pass'Sport, dispositif de réduction des frais d'inscription à un club sportif.
+
+### 155.0.13 [2220](https://github.com/openfisca/openfisca-france/pull/2220)
 
 * Changement mineur.
 * Périodes concernées : toutes.
 * Zones impactées : `parameters/taxation_indirecte`.
 * Détails :
   - Nettoyage des descriptions et des documentations (notamment doublons)
-
 
 ### 155.0.12 [2219](https://github.com/openfisca/openfisca-france/pull/2219)
 

--- a/openfisca_france/model/prestations/jeunes/pass_sport.py
+++ b/openfisca_france/model/prestations/jeunes/pass_sport.py
@@ -13,27 +13,35 @@ class pass_sport(Variable):
         -  Etre un étudiant âgé au plus de 28 ans révolus et bénéficier, au plus tard le 15 octobre 2022, d'une aide annuelle sous conditions de ressources, dans le cadre des formations sanitaires et sociales en application des articles L. 4151-8 et L. 4383-4 du code de la santé publique ou de l'article L. 451-3 du code de l'action sociale et des familles.
     '''
 
-    def formula_2022_06_30(individu, period):
+    def formula_2022_06_30(individu, period, parameters):
+        parametres = parameters(period).prestations_sociales.education.pass_sport
 
         age = individu('age', period)
 
         boursier = individu('boursier', period)
-        eligibilite_age_profil_boursier = age <= 28
+        age_maximum_profil_boursier = parametres.critere_age.age_maximum_profil_boursier
+        eligibilite_age_profil_boursier = age <= age_maximum_profil_boursier
         eligibilite_profil_boursier = boursier * eligibilite_age_profil_boursier
 
         ars = individu.famille('ars', period.this_year)
-        eligibilite_age_profil_ars = (age >= 6) * (age <= 17)
+        age_maximum_profil_ars = parametres.critere_age.age_maximum_profil_ars
+        age_minimum_profil_ars = parametres.critere_age.age_minimum_profil_ars
+        eligibilite_age_profil_ars = (age >= age_minimum_profil_ars) * (age <= age_maximum_profil_ars)
         eligibilite_profil_ars = ars * eligibilite_age_profil_ars
 
         aeeh = individu.famille('aeeh', period)
-        eligibilite_age_profil_aeeh = (age >= 6) * (age <= 19)
+        age_maximum_profil_aeeh = parametres.critere_age.age_maximum_profil_aeeh
+        age_minimum_profil_aeeh = parametres.critere_age.age_minimum_profil_aeeh
+        eligibilite_age_profil_aeeh = (age >= age_minimum_profil_aeeh) * (age <= age_maximum_profil_aeeh)
         eligibilite_profil_aeeh = aeeh * eligibilite_age_profil_aeeh
 
         aah = individu('aah', period)
-        eligibilite_age_profil_aah = (age >= 16) * (age <= 30)
+        age_maximum_profil_aah = parametres.critere_age.age_maximum_profil_aah
+        age_minimum_profil_aah = parametres.critere_age.age_minimum_profil_aah
+        eligibilite_age_profil_aah = (age >= age_minimum_profil_aah) * (age <= age_maximum_profil_aah)
         eligibilite_profil_aah = (aah * eligibilite_age_profil_aah)
 
-        montant = 50
+        montant = parametres.montant
 
         eligibilite = (
             eligibilite_profil_boursier

--- a/openfisca_france/model/prestations/jeunes/pass_sport.py
+++ b/openfisca_france/model/prestations/jeunes/pass_sport.py
@@ -19,16 +19,27 @@ class pass_sport(Variable):
 
         boursier = individu('boursier', period)
         eligibilite_age_profil_boursier = age <= 28
+        eligibilite_profil_boursier = boursier * eligibilite_age_profil_boursier
 
         ars = individu.famille('ars', period.this_year)
         eligibilite_age_profil_ars = (age >= 6) * (age <= 17)
+        eligibilite_profil_ars = ars * eligibilite_age_profil_ars
 
         aeeh = individu.famille('aeeh', period)
         eligibilite_age_profil_aeeh = (age >= 6) * (age <= 19)
+        eligibilite_profil_aeeh = aeeh * eligibilite_age_profil_aeeh
 
         aah = individu('aah', period)
         eligibilite_age_profil_aah = (age >= 16) * (age <= 30)
+        eligibilite_profil_aah = (aah * eligibilite_age_profil_aah)
 
         montant = 50
 
-        return montant * ((boursier * eligibilite_age_profil_boursier) + (ars * eligibilite_age_profil_ars) + (aeeh * eligibilite_age_profil_aeeh) + (aah * eligibilite_age_profil_aah))
+        eligibilite = (
+            eligibilite_profil_boursier
+            + eligibilite_profil_ars
+            + eligibilite_profil_aeeh
+            + eligibilite_profil_aah
+            )
+
+        return montant * eligibilite

--- a/openfisca_france/model/prestations/jeunes/pass_sport.py
+++ b/openfisca_france/model/prestations/jeunes/pass_sport.py
@@ -1,0 +1,20 @@
+from openfisca_france.model.base import Variable, MONTH, Individu
+
+
+class pass_sport(Variable):
+    label = 'Éligibilité au Pass’Sport'
+    definition_period = MONTH
+    value_type = float
+    reference = ['https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046139655/2022-08-05#LEGIARTI000046139655',
+                 'https://www.etudiant.gouv.fr/fr/le-pass-sport-et-les-etudiants-2800']
+    entity = Individu
+
+    def formula_2022_06_30(individu, period):
+        boursier = individu('boursier', period)
+
+        age = individu('age', period)
+        eligibilite_age = age <= 28
+
+        montant = 50
+
+        return montant * boursier * eligibilite_age

--- a/openfisca_france/model/prestations/jeunes/pass_sport.py
+++ b/openfisca_france/model/prestations/jeunes/pass_sport.py
@@ -21,6 +21,10 @@ class pass_sport(Variable):
 
         aeeh = individu.famille('aeeh', period)
         eligibilite_age_profil_aeeh = (age >= 6) * (age <= 19)
+
+        aah = individu('aah', period)
+        eligibilite_age_profil_aah = (age >= 16) * (age <= 30)
+
         montant = 50
 
-        return montant * ((boursier * eligibilite_age_profil_boursier) + (ars * eligibilite_age_profil_ars) + (aeeh * eligibilite_age_profil_aeeh))
+        return montant * ((boursier * eligibilite_age_profil_boursier) + (ars * eligibilite_age_profil_ars) + (aeeh * eligibilite_age_profil_aeeh) + (aah * eligibilite_age_profil_aah))

--- a/openfisca_france/model/prestations/jeunes/pass_sport.py
+++ b/openfisca_france/model/prestations/jeunes/pass_sport.py
@@ -10,11 +10,15 @@ class pass_sport(Variable):
     entity = Individu
 
     def formula_2022_06_30(individu, period):
-        boursier = individu('boursier', period)
 
         age = individu('age', period)
-        eligibilite_age = age <= 28
+
+        boursier = individu('boursier', period)
+        eligibilite_age_profil_boursier = age <= 28
+
+        ars = individu.famille('ars', period.this_year)
+        eligibilite_age_profil_ars = (age >= 6) * (age <= 17)
 
         montant = 50
 
-        return montant * boursier * eligibilite_age
+        return montant * ((boursier * eligibilite_age_profil_boursier) + (ars * eligibilite_age_profil_ars))

--- a/openfisca_france/model/prestations/jeunes/pass_sport.py
+++ b/openfisca_france/model/prestations/jeunes/pass_sport.py
@@ -19,6 +19,8 @@ class pass_sport(Variable):
         ars = individu.famille('ars', period.this_year)
         eligibilite_age_profil_ars = (age >= 6) * (age <= 17)
 
+        aeeh = individu.famille('aeeh', period)
+        eligibilite_age_profil_aeeh = (age >= 6) * (age <= 19)
         montant = 50
 
-        return montant * ((boursier * eligibilite_age_profil_boursier) + (ars * eligibilite_age_profil_ars))
+        return montant * ((boursier * eligibilite_age_profil_boursier) + (ars * eligibilite_age_profil_ars) + (aeeh * eligibilite_age_profil_aeeh))

--- a/openfisca_france/model/prestations/jeunes/pass_sport.py
+++ b/openfisca_france/model/prestations/jeunes/pass_sport.py
@@ -8,6 +8,10 @@ class pass_sport(Variable):
     reference = ['https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046139655/2022-08-05#LEGIARTI000046139655',
                  'https://www.etudiant.gouv.fr/fr/le-pass-sport-et-les-etudiants-2800']
     entity = Individu
+    documentation = '''
+    Non modélisé (2023) :
+        -  Etre un étudiant âgé au plus de 28 ans révolus et bénéficier, au plus tard le 15 octobre 2022, d'une aide annuelle sous conditions de ressources, dans le cadre des formations sanitaires et sociales en application des articles L. 4151-8 et L. 4383-4 du code de la santé publique ou de l'article L. 451-3 du code de l'action sociale et des familles.
+    '''
 
     def formula_2022_06_30(individu, period):
 

--- a/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_maximum_profil_aah.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_maximum_profil_aah.yaml
@@ -1,0 +1,7 @@
+description: Critère d'âge maximum des profils AAH pour le Pass'Sport
+values:
+  2022-06-30:
+    value: 30
+metadata:
+  short_label: Maximum
+  unit: year

--- a/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_maximum_profil_aeeh.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_maximum_profil_aeeh.yaml
@@ -1,0 +1,7 @@
+description: Critère d'âge maximum des profils AEEH pour le Pass'Sport
+values:
+  2022-06-30:
+    value: 19
+metadata:
+  short_label: Maximum
+  unit: year

--- a/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_maximum_profil_ars.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_maximum_profil_ars.yaml
@@ -1,0 +1,7 @@
+description: Critère d'âge maximum des profils ARS pour le Pass'Sport
+values:
+  2022-06-30:
+    value: 17
+metadata:
+  short_label: Maximum
+  unit: year

--- a/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_maximum_profil_boursier.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_maximum_profil_boursier.yaml
@@ -1,0 +1,7 @@
+description: Critère d'âge maximum des profils boursiers pour le Pass'Sport
+values:
+  2022-06-30:
+    value: 28
+metadata:
+  short_label: Maximum
+  unit: year

--- a/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_minimum_profil_aah.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_minimum_profil_aah.yaml
@@ -1,0 +1,7 @@
+description: Critère d'âge minimum des profils AAH pour le Pass'Sport
+values:
+  2022-06-30:
+    value: 16
+metadata:
+  short_label: Minimum
+  unit: year

--- a/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_minimum_profil_aeeh.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_minimum_profil_aeeh.yaml
@@ -1,0 +1,7 @@
+description: Critère d'âge minimum des profils AEEH pour le Pass'Sport
+values:
+  2022-06-30:
+    value: 6
+metadata:
+  short_label: Minimum
+  unit: year

--- a/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_minimum_profil_ars.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/age_minimum_profil_ars.yaml
@@ -1,0 +1,7 @@
+description: Critère d'âge minimum des profils ARS pour le Pass'Sport
+values:
+  2022-06-30:
+    value: 6
+metadata:
+  short_label: Minimum
+  unit: year

--- a/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/pass_sport/critere_age/index.yaml
@@ -1,0 +1,11 @@
+description: Critères d'âge pour le Pass'Sport
+metadata:
+  short_label: Critères d'âge
+  order:
+  - age_maximum_profil_boursier
+  - age_minimum_profil_aah
+  - age_maximum_profil_aah
+  - age_minimum_profil_aeeh
+  - age_maximum_profil_aeeh
+  - age_minimum_profil_ars
+  - age_maximum_profil_ars

--- a/openfisca_france/parameters/prestations_sociales/education/pass_sport/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/pass_sport/index.yaml
@@ -1,0 +1,11 @@
+description: Pass'Sport
+metadata:
+  short_label: PassSport
+  order:
+  - montant
+  - critere_age
+
+  reference:
+    2022-08-02:
+      title: Décret n° 2022-1115 du 2 août 2022 relatif au « Pass'Sport »
+      href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046139655/2022-08-05#LEGIARTI000046139655

--- a/openfisca_france/parameters/prestations_sociales/education/pass_sport/montant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/pass_sport/montant.yaml
@@ -1,0 +1,7 @@
+description: Montant du Pass'Sport
+values:
+  2022-06-30:
+    value: 50
+metadata:
+  short_label: Montant
+  unit: currency

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '155.0.13',
+    version = '155.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/pass_sport.yaml
+++ b/tests/formulas/pass_sport.yaml
@@ -1,17 +1,17 @@
 - name: Eligibilité Pour les étudiants boursier
   period: 2023-12
-  input: 
-    boursier: [False, True, True]
+  input:
     age: [18, 18, 29]
+    boursier: [true, false, true]
   output:
-    pass_sport: [0, 50,0]
+    pass_sport: [50, 0, 0]
 
 - name: Eligibilité Pour les bénéficiaire de l'ARS
   period: 2023-12
   input:
     age: [6, 5, 18]
     ars:
-      2023: [True, True, True]
+      2023: [true, true, true]
   output:
     pass_sport: [50, 0, 0]
 
@@ -20,5 +20,13 @@
   input:
     age: [6, 5, 20]
     aeeh: [1, 1, 1]
+  output:
+    pass_sport: [50, 0, 0]
+
+- name: Eligibilité Pour les bénéficiaire de l'AAH
+  period: 2023-12
+  input:
+    age: [16, 15, 31]
+    aah: [1, 1, 1]
   output:
     pass_sport: [50, 0, 0]

--- a/tests/formulas/pass_sport.yaml
+++ b/tests/formulas/pass_sport.yaml
@@ -14,3 +14,11 @@
       2023: [True, True, True]
   output:
     pass_sport: [50, 0, 0]
+
+- name: Eligibilité Pour les bénéficiaire de l'AEEH
+  period: 2023-12
+  input:
+    age: [6, 5, 20]
+    aeeh: [1, 1, 1]
+  output:
+    pass_sport: [50, 0, 0]

--- a/tests/formulas/pass_sport.yaml
+++ b/tests/formulas/pass_sport.yaml
@@ -1,0 +1,7 @@
+- name: Eligibilité Pour les étudiants boursier
+  period: 2023-12
+  input: 
+    boursier: [False, True, True]
+    age: [18, 18, 29]
+  output:
+    pass_sport: [0, 50,0]

--- a/tests/formulas/pass_sport.yaml
+++ b/tests/formulas/pass_sport.yaml
@@ -5,3 +5,12 @@
     age: [18, 18, 29]
   output:
     pass_sport: [0, 50,0]
+
+- name: Eligibilité Pour les bénéficiaire de l'ARS
+  period: 2023-12
+  input:
+    age: [6, 5, 18]
+    ars:
+      2023: [True, True, True]
+  output:
+    pass_sport: [50, 0, 0]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 2022/08/02.
* Zones impactées : 
    - `openfisca_france/model/prestations/jeunes/pass_sport.py`
    - `openfisca_france/parameters/prestations_sociales/education/pass_sport/*`
* Détails :
  - Ajoute le dispositif du Pass'Sport, dispositif de réduction des frais d'inscription à un club sportif.

- - - -

Ces changements :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).