### PR TITLE
Revalorisations de janvier 2024 pour les aides au logement et la réduction de loyer de solidarité

### DIFF
--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux1pac.yaml
@@ -12,6 +12,8 @@ values:
     value: 8002.0
   2023-01-01:
     value: 8456
+  2024-01-01:
+    value: 8862
 metadata:
   short_label: Personne seule ou couple ayant une personne à charge
   last_value_still_valid_on: "2023-02-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux2pac.yaml
@@ -12,6 +12,8 @@ values:
     value: 8182.0
   2023-01-01:
     value: 8646
+  2024-01-01:
+    value: 9061
 metadata:
   short_label: Personne seule ou couple ayant deux personnes à charge
   last_value_still_valid_on: "2023-02-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux3pac.yaml
@@ -12,6 +12,8 @@ values:
     value: 8495.0
   2023-01-01:
     value: 8977
+  2024-01-01:
+    value: 9408
 metadata:
   short_label: Personne seule ou couple ayant trois personnes à charge
   last_value_still_valid_on: "2023-02-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux4pac.yaml
@@ -12,6 +12,8 @@ values:
     value: 8811.0
   2023-01-01:
     value: 9311
+  2024-01-01:
+    value: 9758
 metadata:
   short_label: Personne seule ou couple ayant quatre personnes à charge
   last_value_still_valid_on: "2023-02-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux5pac.yaml
@@ -12,6 +12,8 @@ values:
     value: 9124.0
   2023-01-01:
     value: 9642
+  2024-01-01:
+    value: 10105
 metadata:
   short_label: Personne seule ou couple ayant cinq personnes à charge
   last_value_still_valid_on: "2023-02-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux6pac.yaml
@@ -12,6 +12,8 @@ values:
     value: 9439.0
   2023-01-01:
     value: 9975
+  2024-01-01:
+    value: 10454
 metadata:
   short_label: Personne seule ou couple ayant six personnes à charge ou plus
   last_value_still_valid_on: "2023-02-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_couple.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_couple.yaml
@@ -12,6 +12,8 @@ values:
     value: 6709.0
   2023-01-01:
     value: 7090
+  2024-01-01:
+    value: 7430
 metadata:
   short_label: Couple sans personne à charge
   last_value_still_valid_on: "2023-02-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_pac_supp.yaml
@@ -12,6 +12,8 @@ values:
     value: 311.0
   2023-01-01:
     value: 328
+  2024-01-01:
+    value: 343
 metadata:
   short_label: Par personne à charge supplémentaire
   last_value_still_valid_on: "2023-02-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_seul.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_seul.yaml
@@ -12,6 +12,8 @@ values:
     value: 4683
   2023-01-01:
     value: 4949
+  2024-01-01:
+    value: 5186
 metadata:
   short_label: Personne seule sans personne à charge
   last_value_still_valid_on: "2023-02-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/couples.yaml
@@ -20,6 +20,8 @@ values:
     value: 63
   2023-10-01:
     value: 66.05
+  2024-01-01:
+    value: 66.73
 metadata:
   short_label: Couple sans personne à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/famille_1pac.yaml
@@ -20,6 +20,8 @@ values:
     value: 71.14
   2023-10-01:
     value: 74.43
+  2024-01-01:
+    value: 75.31
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 1 personne à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/majoration_par_pac_supp.yaml
@@ -20,6 +20,8 @@ values:
     value: 10.24
   2023-10-01:
     value: 10.48
+  2024-01-01:
+    value: 10.78
 metadata:
   short_label: Majoration par personne à charge supplémentaire
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/personnes_seules.yaml
@@ -20,6 +20,8 @@ values:
     value: 52.16
   2023-10-01:
     value: 54.51
+  2024-01-01:
+    value: 55.20
 metadata:
   short_label: Bénéficiaire isolé
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/couples.yaml
@@ -20,6 +20,8 @@ values:
     value: 55.79
   2023-10-01:
     value: 58.71
+  2024-01-01:
+    value: 59.15
 metadata:
   short_label: Couple sans personne à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/famille_1pac.yaml
@@ -20,6 +20,8 @@ values:
     value: 62.5
   2023-10-01:
     value: 65.00
+  2024-01-01:
+    value: 66.06
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 1 personne à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/majoration_par_pac_supp.yaml
@@ -20,6 +20,8 @@ values:
     value: 9.09
   2023-10-01:
     value: 9.44
+  2024-01-01:
+    value: 9.60
 metadata:
   short_label: Majoration par personne à charge supplémentaire
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/personnes_seules.yaml
@@ -20,6 +20,8 @@ values:
     value: 45.66
   2023-10-01:
     value: 48.22
+  2024-01-01:
+    value: 48.45
 metadata:
   short_label: Bénéficiaire isolé
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/couples.yaml
@@ -20,6 +20,8 @@ values:
     value: 51.8
   2023-10-01:
     value: 54.51
+  2024-01-01:
+    value: 54.92
 metadata:
   short_label: Couple sans personne à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/famille_1pac.yaml
@@ -20,6 +20,8 @@ values:
     value: 57.99
   2023-10-01:
     value: 60.80
+  2024-01-01:
+    value: 61.42
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 1 personne à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/majoration_par_pac_supp.yaml
@@ -20,6 +20,8 @@ values:
     value: 8.22
   2023-10-01:
     value: 8.39
+  2024-01-01:
+    value: 8.65
 metadata:
   short_label: Majoration par personne à charge supplémentaire
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/personnes_seules.yaml
@@ -20,6 +20,8 @@ values:
     value: 42.76
   2023-10-01:
     value: 45.08
+  2024-01-01:
+    value: 45.36
 metadata:
   short_label: Bénéficiaire isolé
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/couples.yaml
@@ -4,6 +4,8 @@ values:
     value: 1091
   2019-01-01:
     value: 1102
+  2024-01-01:
+    value: 1155
 metadata:
   short_label: Couple
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_1pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 1389
   2019-01-01:
     value: 1403
+  2024-01-01:
+    value: 1470
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 1 personne à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_2pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 1653
   2019-01-01:
     value: 1669
+  2024-01-01:
+    value: 1749
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 2 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_3pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 2023
   2019-01-01:
     value: 2043
+  2024-01-01:
+    value: 2141
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 3 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_4pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 2334
   2019-01-01:
     value: 2357
+  2024-01-01:
+    value: 2470
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 4 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_5pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 2598
   2019-01-01:
     value: 2624
+  2024-01-01:
+    value: 2750
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 5 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_6pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 2876
   2019-01-01:
     value: 2905
+  2024-01-01:
+    value: 3045
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 6 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/majoration_par_pac_supp.yaml
@@ -4,6 +4,8 @@ values:
     value: 280
   2019-01-01:
     value: 283
+  2024-01-01:
+    value: 297
 metadata:
   short_label: Majoration par personne à charge supplémentaire
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/personnes_seules.yaml
@@ -4,6 +4,8 @@ values:
     value: 906
   2019-01-01:
     value: 915
+  2024-01-01:
+    value: 959
 metadata:
   short_label: Bénéficiaire isolé
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/couples.yaml
@@ -4,6 +4,8 @@ values:
     value: 1032
   2019-01-01:
     value: 1042
+  2024-01-01:
+    value: 1092
 metadata:
   short_label: Couple sans personne à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_1pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 1316
   2019-01-01:
     value: 1329
+  2024-01-01:
+    value: 1393
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 1 personne à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_2pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 1567
   2019-01-01:
     value: 1583
+  2024-01-01:
+    value: 1659
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 2 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_3pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 1924
   2019-01-01:
     value: 1943
+  2024-01-01:
+    value: 2036
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 3 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_4pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 2221
   2019-01-01:
     value: 2243
+  2024-01-01:
+    value: 2351
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 4 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_5pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 2472
   2019-01-01:
     value: 2497
+  2024-01-01:
+    value: 2617
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 5 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_6pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 2737
   2019-01-01:
     value: 2764
+  2024-01-01:
+    value: 2897
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 6 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/majoration_par_pac_supp.yaml
@@ -4,6 +4,8 @@ values:
     value: 263
   2019-01-01:
     value: 266
+  2024-01-01:
+    value: 279
 metadata:
   short_label: Majoration par personne à charge supplémentaire
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/personnes_seules.yaml
@@ -4,6 +4,8 @@ values:
     value: 846
   2019-01-01:
     value: 854
+  2024-01-01:
+    value: 895
 metadata:
   short_label: Bénéficiaire isolé
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/couples.yaml
@@ -4,6 +4,8 @@ values:
     value: 998
   2019-01-01:
     value: 1008
+  2024-01-01:
+    value: 1056
 metadata:
   short_label: Couple sans personne à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_1pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 1276
   2019-01-01:
     value: 1289
+  2024-01-01:
+    value: 1351
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 1 personne à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_2pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 1521
   2019-01-01:
     value: 1536
+  2024-01-01:
+    value: 1610
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 2 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_3pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 1858
   2019-01-01:
     value: 1877
+  2024-01-01:
+    value: 1967
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 3 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_4pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 2148
   2019-01-01:
     value: 2169
+  2024-01-01:
+    value: 2273
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 4 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_5pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 2387
   2019-01-01:
     value: 2411
+  2024-01-01:
+    value: 2527
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 5 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_6pac.yaml
@@ -4,6 +4,8 @@ values:
     value: 2645
   2019-01-01:
     value: 2671
+  2024-01-01:
+    value: 2799
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 6 personnes à charge
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/majoration_par_pac_supp.yaml
@@ -4,6 +4,8 @@ values:
     value: 245
   2019-01-01:
     value: 247
+  2024-01-01:
+    value: 259
 metadata:
   short_label: Majoration par personne à charge supplémentaire
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/personnes_seules.yaml
@@ -4,6 +4,8 @@ values:
     value: 820
   2019-01-01:
     value: 828
+  2024-01-01:
+    value: 868
 metadata:
   short_label: Bénéficiaire isolé
   last_value_still_valid_on: "2023-05-24"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_11.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_11.yaml
@@ -20,6 +20,8 @@ values:
     value: 6000
   2022-08-01:
     value: 6200
+  2024-01-01:
+    value: 6400
 metadata:
   short_label: Forfait de ressources pour les étudiants en logement-foyer
   last_value_still_valid_on: "2023-02-20"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_4.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_4.yaml
@@ -22,6 +22,8 @@ values:
     value: 7800
   2022-08-01:
     value: 8100
+  2024-01-01:
+    value: 8400
 metadata:
   short_label: Forfait de ressources pour les étudiants en location
   last_value_still_valid_on: "2023-02-20"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_5.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_5.yaml
@@ -10,6 +10,8 @@ values:
     value: 1500
   2022-08-01:
     value: 1600
+  2024-01-01:
+    value: 1700
 metadata:
   short_label: Minoration du forfait de ressources pour les étudiants en location titulaires d'une bourse d'enseignement supérieur non-assujettie à l'impôt sur le revenu
   last_value_still_valid_on: "2023-02-20"

--- a/tests/formulas/aah/aah_couple.yaml
+++ b/tests/formulas/aah/aah_couple.yaml
@@ -120,7 +120,6 @@
       parents: [parent1, parent2]
     individus:
       parent1:
-        activite: inactif
         salaire_imposable:
           2019: 12000
         activite:

--- a/tests/formulas/aides_logement_assistant_mat_fam_journaliste.yaml
+++ b/tests/formulas/aides_logement_assistant_mat_fam_journaliste.yaml
@@ -1,245 +1,245 @@
 - name: "Cas 1, abattement journaliste sur 4 mois"
- period: 2021-01
- relative_error_margin: 0.01
- input:
-   famille:
-     parents: parent1
-   menage:
-     personne_de_reference: parent1
-     statut_occupation_logement: locataire_vide
-     zone_apl: zone_2
-     loyer: 750
-     charges_locatives: 50
-   individus:
-     parent1:
-       date_naissance: 1968-01-10
-       salaire_imposable:
-         2020-12: 2250
-         2020-11: 2250
-         2020-10: 2250
-         2020-09: 2250
-         2020-08: 2250
-         2020-07: 1100
-         2020-06: 1100
-         2020-05: 1100
-         2020-04: 1100
-         2020-03: 1100
-         2020-02: 1100
-         2020-01: 1100
-         2019-12: 1100
-       journaliste:
-         2020-12: true
-         2020-11: true
-         2020-10: true
-         2020-09: true
-         2020-08: true
-         2020-07: false
-         2020-06: false
-         2020-05: false
-         2020-04: false
-         2020-03: false
-         2020-02: false
-         2020-01: false
-         2019-12: false
-   foyer_fiscal:
-     declarants: parent1
- output:
-   aide_logement_base_ressources: 13725
-   aide_logement: 0
+  period: 2021-01
+  relative_error_margin: 0.01
+  input:
+    famille:
+      parents: parent1
+    menage:
+      personne_de_reference: parent1
+      statut_occupation_logement: locataire_vide
+      zone_apl: zone_2
+      loyer: 750
+      charges_locatives: 50
+    individus:
+      parent1:
+        date_naissance: 1968-01-10
+        salaire_imposable:
+          2020-12: 2250
+          2020-11: 2250
+          2020-10: 2250
+          2020-09: 2250
+          2020-08: 2250
+          2020-07: 1100
+          2020-06: 1100
+          2020-05: 1100
+          2020-04: 1100
+          2020-03: 1100
+          2020-02: 1100
+          2020-01: 1100
+          2019-12: 1100
+        journaliste:
+          2020-12: true
+          2020-11: true
+          2020-10: true
+          2020-09: true
+          2020-08: true
+          2020-07: false
+          2020-06: false
+          2020-05: false
+          2020-04: false
+          2020-03: false
+          2020-02: false
+          2020-01: false
+          2019-12: false
+    foyer_fiscal:
+      declarants: parent1
+  output:
+    aide_logement_base_ressources: 13725
+    aide_logement: 0
 
 - name: "Cas 2, abattement journaliste sur les 12 mois"
- period: 2021-01
- relative_error_margin: 0.01
- input:
-   famille:
-     parents: [parent1, parent2]
-     enfants: [enfant1, enfant2]
-   menage:
-     personne_de_reference: parent1
-     conjoint: parent2
-     enfants: [enfant1, enfant2]
-     statut_occupation_logement: locataire_vide
-     zone_apl: zone_2
-     loyer: 850
-     charges_locatives: 20
-   individus:
-     parent1:
-       date_naissance: 1985-01-10
-       salaire_imposable:
-         2020-12: 2600
-         2020-11: 2600
-         2020-10: 2600
-         2020-09: 2600
-         2020-08: 2600
-         2020-07: 2600
-         2020-06: 2600
-         2020-05: 2600
-         2020-04: 2600
-         2020-03: 2700
-         2020-02: 2700
-         2020-01: 2700
-         2019-12: 2700
-       journaliste:
-         2020-12: true
-         2020-11: true
-         2020-10: true
-         2020-09: true
-         2020-08: true
-         2020-07: true
-         2020-06: true
-         2020-05: true
-         2020-04: true
-         2020-03: true
-         2020-02: true
-         2020-01: true
-         2019-12: true
-     parent2:
-       date_naissance: 1988-01-01
-       salaire_imposable:
-         2020-12: 0
-         2020-11: 0
-         2020-10: 0
-         2020-09: 0
-         2020-08: 0
-         2020-07: 0
-         2020-06: 0
-         2020-05: 0
-         2020-04: 0
-         2020-03: 0
-         2020-02: 0
-         2020-01: 0
-         2019-12: 0
-     enfant1:
-       date_naissance: 2014-01-01
-     enfant2:
-       date_naissance: 2016-01-01
-   foyer_fiscal:
-     declarants: [parent1, parent2]
-     personnes_a_charge: [enfant1, enfant2]
- output:
-   aide_logement_base_ressources: 21465
-   aide_logement: 75.85
+  period: 2021-01
+  relative_error_margin: 0.01
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1, enfant2]
+      statut_occupation_logement: locataire_vide
+      zone_apl: zone_2
+      loyer: 850
+      charges_locatives: 20
+    individus:
+      parent1:
+        date_naissance: 1985-01-10
+        salaire_imposable:
+          2020-12: 2600
+          2020-11: 2600
+          2020-10: 2600
+          2020-09: 2600
+          2020-08: 2600
+          2020-07: 2600
+          2020-06: 2600
+          2020-05: 2600
+          2020-04: 2600
+          2020-03: 2700
+          2020-02: 2700
+          2020-01: 2700
+          2019-12: 2700
+        journaliste:
+          2020-12: true
+          2020-11: true
+          2020-10: true
+          2020-09: true
+          2020-08: true
+          2020-07: true
+          2020-06: true
+          2020-05: true
+          2020-04: true
+          2020-03: true
+          2020-02: true
+          2020-01: true
+          2019-12: true
+      parent2:
+        date_naissance: 1988-01-01
+        salaire_imposable:
+          2020-12: 0
+          2020-11: 0
+          2020-10: 0
+          2020-09: 0
+          2020-08: 0
+          2020-07: 0
+          2020-06: 0
+          2020-05: 0
+          2020-04: 0
+          2020-03: 0
+          2020-02: 0
+          2020-01: 0
+          2019-12: 0
+      enfant1:
+        date_naissance: 2014-01-01
+      enfant2:
+        date_naissance: 2016-01-01
+    foyer_fiscal:
+      declarants: [parent1, parent2]
+      personnes_a_charge: [enfant1, enfant2]
+  output:
+    aide_logement_base_ressources: 21465
+    aide_logement: 75.85
 
 - name: "Cas 3, abattement assistant maternel sur les 12 mois"
- period: 2021-01
- relative_error_margin: 0.01
- input:
-   famille:
-     parents: parent1
-   menage:
-     personne_de_reference: parent1
-     statut_occupation_logement: locataire_vide
-     zone_apl: zone_2
-     loyer: 500
-     charges_locatives: 50
-   individus:
-     parent1:
-       date_naissance: 1985-01-10
-       salaire_imposable:
-         2020-12: 1250
-         2020-11: 1250
-         2020-10: 1250
-         2020-09: 1250
-         2020-08: 1250
-         2020-07: 1250
-         2020-06: 1250
-         2020-05: 1250
-         2020-04: 1250
-         2020-03: 1250
-         2020-02: 1250
-         2020-01: 1250
-         2019-12: 1250
-       assistant_maternel:
-         2020-12: true
-         2020-11: true
-         2020-10: true
-         2020-09: true
-         2020-08: true
-         2020-07: true
-         2020-06: true
-         2020-05: true
-         2020-04: true
-         2020-03: true
-         2020-02: true
-         2020-01: true
-         2019-12: true
-   foyer_fiscal:
-     declarants: parent1
- output:
-   aide_logement: 270.26
+  period: 2021-01
+  relative_error_margin: 0.01
+  input:
+    famille:
+      parents: parent1
+    menage:
+      personne_de_reference: parent1
+      statut_occupation_logement: locataire_vide
+      zone_apl: zone_2
+      loyer: 500
+      charges_locatives: 50
+    individus:
+      parent1:
+        date_naissance: 1985-01-10
+        salaire_imposable:
+          2020-12: 1250
+          2020-11: 1250
+          2020-10: 1250
+          2020-09: 1250
+          2020-08: 1250
+          2020-07: 1250
+          2020-06: 1250
+          2020-05: 1250
+          2020-04: 1250
+          2020-03: 1250
+          2020-02: 1250
+          2020-01: 1250
+          2019-12: 1250
+        assistant_maternel:
+          2020-12: true
+          2020-11: true
+          2020-10: true
+          2020-09: true
+          2020-08: true
+          2020-07: true
+          2020-06: true
+          2020-05: true
+          2020-04: true
+          2020-03: true
+          2020-02: true
+          2020-01: true
+          2019-12: true
+    foyer_fiscal:
+      declarants: parent1
+  output:
+    aide_logement: 270.26
 
 - name: "Cas 4, couple avec 2 enfants, abattement assistant materenel sur les 12 mois"
- period: 2021-01
- relative_error_margin: 0.01
- input:
-   famille:
-     parents: [parent1, parent2]
-     enfants: [enfant1, enfant2]
-   menage:
-     personne_de_reference: parent1
-     conjoint: parent2
-     enfants: [enfant1, enfant2]
-     statut_occupation_logement: locataire_vide
-     zone_apl: zone_2
-     loyer: 700
-     charges_locatives: 100
-   individus:
-     parent1:
-       date_naissance: 1985-01-10
-       salaire_imposable:
-         2020-12: 916.67
-         2020-11: 916.67
-         2020-10: 916.67
-         2020-09: 916.67
-         2020-08: 916.67
-         2020-07: 916.67
-         2020-06: 916.67
-         2020-05: 916.67
-         2020-04: 916.67
-         2020-03: 916.67
-         2020-02: 916.67
-         2020-01: 916.67
-         2019-12: 916.67
-       assistant_maternel:
-         2020-12: true
-         2020-11: true
-         2020-10: true
-         2020-09: true
-         2020-08: true
-         2020-07: true
-         2020-06: true
-         2020-05: true
-         2020-04: true
-         2020-03: true
-         2020-02: true
-         2020-01: true
-         2019-12: true
-     parent2:
-       date_naissance: 1988-01-01
-       salaire_imposable:
-         2020-12: 1375
-         2020-11: 1375
-         2020-10: 1375
-         2020-09: 1375
-         2020-08: 1375
-         2020-07: 1375
-         2020-06: 1375
-         2020-05: 1375
-         2020-04: 1375
-         2020-03: 1375
-         2020-02: 1375
-         2020-01: 1375
-         2019-12: 1375
-     enfant1:
-       date_naissance: 2014-01-01
-     enfant2:
-       date_naissance: 2016-01-01
-   foyer_fiscal:
-     declarants: [parent1, parent2]
-     personnes_a_charge: [enfant1, enfant2]
- output:
-   aide_logement_base_ressources: 14755
-   aide_logement: 254.85
+  period: 2021-01
+  relative_error_margin: 0.01
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1, enfant2]
+      statut_occupation_logement: locataire_vide
+      zone_apl: zone_2
+      loyer: 700
+      charges_locatives: 100
+    individus:
+      parent1:
+        date_naissance: 1985-01-10
+        salaire_imposable:
+          2020-12: 916.67
+          2020-11: 916.67
+          2020-10: 916.67
+          2020-09: 916.67
+          2020-08: 916.67
+          2020-07: 916.67
+          2020-06: 916.67
+          2020-05: 916.67
+          2020-04: 916.67
+          2020-03: 916.67
+          2020-02: 916.67
+          2020-01: 916.67
+          2019-12: 916.67
+        assistant_maternel:
+          2020-12: true
+          2020-11: true
+          2020-10: true
+          2020-09: true
+          2020-08: true
+          2020-07: true
+          2020-06: true
+          2020-05: true
+          2020-04: true
+          2020-03: true
+          2020-02: true
+          2020-01: true
+          2019-12: true
+      parent2:
+        date_naissance: 1988-01-01
+        salaire_imposable:
+          2020-12: 1375
+          2020-11: 1375
+          2020-10: 1375
+          2020-09: 1375
+          2020-08: 1375
+          2020-07: 1375
+          2020-06: 1375
+          2020-05: 1375
+          2020-04: 1375
+          2020-03: 1375
+          2020-02: 1375
+          2020-01: 1375
+          2019-12: 1375
+      enfant1:
+        date_naissance: 2014-01-01
+      enfant2:
+        date_naissance: 2016-01-01
+    foyer_fiscal:
+      declarants: [parent1, parent2]
+      personnes_a_charge: [enfant1, enfant2]
+  output:
+    aide_logement_base_ressources: 14755
+    aide_logement: 254.85
 
 - name: "Cas 5, couple, abattement assistant materenel sur 12 mois"
   period: 2021-01


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2024.
* Zones impactées :
  * `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0`
  * `openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant`
  * `openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources`
  * `openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_11.yaml`
  * `openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_4.yaml`
  * `openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_5.yaml`
* Détails :
  * Mise à jour des paramètres pour le calcul de l'aide au logement et de la réduction de loyer de solidarité.
- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.