### PR TITLE
Rebuild conda on master

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -321,6 +321,6 @@ jobs:
         # This shell is made necessary by https://github.com/conda-incubator/setup-miniconda/issues/128
         shell: bash -l {0}
         run: |
-          conda install -y conda-build anaconda-client
+          conda install --yes conda-build anaconda-client
           conda config --set anaconda_upload yes
-          conda build -c conda-forge -c openfisca --token  ${{ secrets.ANACONDA_TOKEN }}  --user openfisca .conda
+          conda build --channel conda-forge --channel openfisca --token ${{ secrets.ANACONDA_TOKEN }} --user openfisca .conda

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -317,22 +317,10 @@ jobs:
             const commits = ${{ toJSON(github.event.commits) }}
             return commits.at(-2).id;
           result-encoding: string
-      # Default Download artifact don't see artifact of other workflow
-      # So we use dawidd6/action-download-artifact@v2 to do it.
-      - name: Download artifact
-        id: download-artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow_conclusion: success
-          commit: ${{steps.last_pr_commit.outputs.result}}
-          name: conda-build-${{ env.PACKAGE_VERSION }}-${{steps.last_pr_commit.outputs.result}}
-          path: conda-build-tmp
-          event: push  # to listen to commit events and avoid conflict with PR opening event
-          if_no_artifact_found: fail
-      - name: Conda upload
+      - name: Conda build and upload
         # This shell is made necessary by https://github.com/conda-incubator/setup-miniconda/issues/128
         shell: bash -l {0}
         run: |
-          conda install anaconda-client
-          conda info
-          anaconda -t ${{ secrets.ANACONDA_TOKEN }} upload -u openfisca ./conda-build-tmp/noarch/openfisca-france-*-py_0.tar.bz2
+          conda install -y conda-build anaconda-client
+          conda config --set anaconda_upload yes
+          conda build -c conda-forge -c openfisca --token  ${{ secrets.ANACONDA_TOKEN }}  --user openfisca .conda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,8 @@
 * Périodes concernées : non applicable.
 * Zones impactées : `.github/workflows/workflow.yml`.
 * Détails :
-
-Avant cette PR, nous construisions le build conda sur la branche de travail et tentions de le récupérer sur la branche `master` pour la publication sur les channels `conda-forge` et `openfisca`.
-
-Mais malgré la #2211, il restait une erreur sur le job `Download artifact` : `Error: no matching workflow run found with any artifacts?` comme, par exemple, sur [le job `publish-to-conda` du workflow #7085](https://github.com/openfisca/openfisca-france/actions/runs/7277379565/job/19830302514)
-
-Cette PR fait donc le choix de rebuilder sur `master` pour `conda`.
+    * Rebuilde sur la branche `master` pour `conda` afin de publier sur les channels `conda-forge` et `openfisca`. Auparavant, nous construisions le build conda sur la branche de travail et tentions de le récupérer sur la branche `master`.
+  * Corrige l'erreur de fichier de build introuvable du job `Download artifact` : `Error: no matching workflow run found with any artifacts?`
 
 ## 155.1.2 [2225](https://github.com/openfisca/openfisca-france/pull/2225)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### 155.1.3 [2226](https://github.com/openfisca/openfisca-france/pull/2226)
+
+* Amélioration technique.
+* Périodes concernées : non applicable.
+* Zones impactées : `.github/workflows/workflow.yml`.
+* Détails :
+
+Avant cette PR, nous construisions le build conda sur la branche de travail et tentions de le récupérer sur la branche `master` pour la publication sur les channels `conda-forge` et `openfisca`.
+
+Mais malgré la #2211, il restait une erreur sur le job `Download artifact` : `Error: no matching workflow run found with any artifacts?` comme, par exemple, sur [le job `publish-to-conda` du workflow #7085](https://github.com/openfisca/openfisca-france/actions/runs/7277379565/job/19830302514)
+
+Cette PR fait donc le choix de rebuilder sur `master` pour `conda`.
+
 ## 155.1.2 [2225](https://github.com/openfisca/openfisca-france/pull/2225)
 
 * Changement mineur.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '155.1.2',
+    version = '155.1.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : non applicable.
* Zones impactées : `.github/workflows/workflow.yml`.
* Détails :
  - La récupération d'[artifacts](https://docs.github.com/fr/actions/using-workflows/storing-workflow-data-as-artifacts) en intégration continue pour le `build` de librairie conda dans https://github.com/openfisca/openfisca-france/pull/2211 ne fonctionne malheureusement pas.
  -  Cette PR reconstruit le parquet sur la branche `master` avant de l'envoyer sur `conda`.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
