### PR TITLE
Suppression CGA 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 158.0.0 [2230](https://github.com/openfisca/openfisca-france/pull/2230)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes
+Zones impactées :
+  - `model/prelevements_obligatoires/impot_revenu/ir`.
+  - `model/revenus/activite/non_salarie`.
+* Détails :
+  - La pénalité pour absence de CGA pour les revenus non-salariaux prend fin en 2023. Le taux associé prend donc fin, et de nombreuses formules sont reformulées dans une version 2023 un peu allégée. De nombreuses cases fiscales sont supprimées en conséquence.
+  - Renomme nacc_defs, qui n'était pas un déficit et dont le nom portait donc à confusion, en nacc_imps.
+
 ### 157.0.3 [2253](https://github.com/openfisca/openfisca-france/pull/2253)
 
 * Évolution du système socio-fiscal.Changement mineur.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1220,12 +1220,7 @@ class rbg(Variable):
         revenu_categoriel = foyer_fiscal('revenu_categoriel', period)
         deficit_ante = foyer_fiscal('deficit_ante', period)
         f6gh = foyer_fiscal('f6gh', period)
-
-        # (Total 17)
-        # sans les revenus au quotient
-        nacc_pvce = foyer_fiscal.sum(nacc_pvce_i)
-        return max_(0,
-                    revenu_categoriel + f6gh - deficit_ante)
+        return max_(0, revenu_categoriel + f6gh - deficit_ante)
 
 
 class csg_patrimoine_deductible_ir(Variable):
@@ -3504,9 +3499,8 @@ class revenu_non_salarie(Variable):
         coupe_bois = individu('coupe_bois', period)
         f5sq = individu('f5sq', period)
         arag_defi = individu('arag_defi', period)
-        nrag_defi = individu('nrag_defi', period)
         atimp = individu('atimp', period)
-        def_agri = f5sq + arag_defi + (1 + cga_taux2) * nrag_defi
+        def_agri = f5sq + arag_defi
         revenus_non_salaries = rpns_mrag + coupe_bois + atimp - def_agri
         return revenus_non_salaries
 
@@ -3690,7 +3684,6 @@ class taux_effectif(Variable):
         microentreprise = foyer_fiscal('microentreprise', period)
         abnc_proc_i = foyer_fiscal.members('abnc_proc', period)
         bareme = parameters(period).impot_revenu.bareme_ir_depuis_1945.bareme
-        cga = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.cga_taux2
         abnc_proc = foyer_fiscal.sum(abnc_proc_i)
         base_fictive = rni + microentreprise + abnc_proc
         trigger = (microentreprise != 0) | (abnc_proc != 0)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2767,7 +2767,7 @@ class defacc(Variable):
         aacc_impn = foyer_fiscal.sum(aacc_impn_i)
         macc_timp = abat_rpns(macc_impv, micro.microentreprise.regime_micro_bnc.marchandises) + abat_rpns(macc_imps, micro.microentreprise.regime_micro_bnc.services)
         return (
-            min_(f5rn + f5ro + f5rp + f5rq + f5rr + f5rw, aacc_impn + macc_pvct + macc_timp )
+            min_(f5rn + f5ro + f5rp + f5rq + f5rr + f5rw, aacc_impn + macc_pvct + macc_timp)
             )
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2574,7 +2574,6 @@ class rpns_exon(Variable):
         Plus values de cession
         '''
         frag_exon = individu('frag_exon', period)
-        mrag_exon = individu('mrag_exon', period)
         arag_exon = individu('arag_exon', period)
         nrag_exon = individu('nrag_exon', period)
         mbic_exon = individu('mbic_exon', period)
@@ -2595,7 +2594,7 @@ class rpns_exon(Variable):
         cga = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.cga_taux2
 
         return (
-            frag_exon + mrag_exon + arag_exon + nrag_exon + mbic_exon + abic_exon + nbnc_proc * (1 + cga)
+            frag_exon + arag_exon + nrag_exon + mbic_exon + abic_exon + nbnc_proc * (1 + cga)
             + nbic_exon + macc_exon + aacc_exon + nacc_exon + mbnc_exon + abnc_proc
             + abnc_exon + nbnc_exon + mncn_exon + cncn_jcre + nbic_pvce + nrag_pvce
             )
@@ -2605,6 +2604,35 @@ class rpns_exon(Variable):
         Plus values de cession
         '''
         frag_exon = individu('frag_exon', period)
+        arag_exon = individu('arag_exon', period)
+        nrag_exon = individu('nrag_exon', period)
+        mbic_exon = individu('mbic_exon', period)
+        abic_exon = individu('abic_exon', period)
+        nbnc_proc = individu('nbnc_proc', period)
+        nbic_exon = individu('nbic_exon', period)
+        macc_exon = individu('macc_exon', period)
+        aacc_exon = individu('aacc_exon', period)
+        nacc_exon = individu('nacc_exon', period)
+        mbnc_exon = individu('mbnc_exon', period)
+        abnc_proc = individu('abnc_proc', period)
+        abnc_exon = individu('abnc_exon', period)
+        nbnc_exon = individu('nbnc_exon', period)
+        mncn_exon = individu('mncn_exon', period)
+        cncn_exon = individu('cncn_exon', period)
+        cncn_jcre = individu('cncn_jcre', period)
+        nbic_pvce = individu('nbic_pvce', period)
+        cga = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.cga_taux2
+
+        return (
+            frag_exon + arag_exon + nrag_exon + mbic_exon + abic_exon + nbnc_proc * (1 + cga)
+            + nbic_exon + macc_exon + aacc_exon + nacc_exon + mbnc_exon + abnc_proc
+            + abnc_exon + nbnc_exon + mncn_exon + cncn_exon + cncn_jcre + nbic_pvce
+            )
+
+    def formula_2016_01_01(individu, period, parameters):
+        '''
+        Plus values de cession
+        '''
         mrag_exon = individu('mrag_exon', period)
         arag_exon = individu('arag_exon', period)
         nrag_exon = individu('nrag_exon', period)
@@ -2617,7 +2645,6 @@ class rpns_exon(Variable):
         nacc_exon = individu('nacc_exon', period)
         mbnc_exon = individu('mbnc_exon', period)
         abnc_proc = individu('abnc_proc', period)
-        nrag_pvce = individu('nrag_pvce', period)
         abnc_exon = individu('abnc_exon', period)
         nbnc_exon = individu('nbnc_exon', period)
         mncn_exon = individu('mncn_exon', period)
@@ -2627,9 +2654,38 @@ class rpns_exon(Variable):
         cga = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.cga_taux2
 
         return (
-            frag_exon + mrag_exon + arag_exon + nrag_exon + mbic_exon + abic_exon + nbnc_proc * (1 + cga)
+            mrag_exon + arag_exon + nrag_exon + mbic_exon + abic_exon + nbnc_proc * (1 + cga)
             + nbic_exon + macc_exon + aacc_exon + nacc_exon + mbnc_exon + abnc_proc
-            + abnc_exon + nbnc_exon + mncn_exon + cncn_exon + cncn_jcre + nbic_pvce + nrag_pvce
+            + abnc_exon + nbnc_exon + mncn_exon + cncn_exon + cncn_jcre + nbic_pvce
+            )
+
+    def formula_2018_01_01(individu, period, parameters):
+        '''
+        Plus values de cession
+        '''
+        mrag_exon = individu('mrag_exon', period)
+        arag_exon = individu('arag_exon', period)
+        nrag_exon = individu('nrag_exon', period)
+        mbic_exon = individu('mbic_exon', period)
+        abic_exon = individu('abic_exon', period)
+        nbic_exon = individu('nbic_exon', period)
+        macc_exon = individu('macc_exon', period)
+        aacc_exon = individu('aacc_exon', period)
+        nacc_exon = individu('nacc_exon', period)
+        mbnc_exon = individu('mbnc_exon', period)
+        abnc_proc = individu('abnc_proc', period)
+        abnc_exon = individu('abnc_exon', period)
+        nbnc_exon = individu('nbnc_exon', period)
+        mncn_exon = individu('mncn_exon', period)
+        cncn_exon = individu('cncn_exon', period)
+        cncn_jcre = individu('cncn_jcre', period)
+        nbic_pvce = individu('nbic_pvce', period)
+        cga = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.cga_taux2
+
+        return (
+            mrag_exon + arag_exon + nrag_exon + mbic_exon + abic_exon
+            + nbic_exon + macc_exon + aacc_exon + nacc_exon + mbnc_exon + abnc_proc
+            + abnc_exon + nbnc_exon + mncn_exon + cncn_exon + cncn_jcre + nbic_pvce
             )
 
     def formula_2023_01_01(individu, period, parameters):
@@ -2693,7 +2749,6 @@ class defrag(Variable):
         f5qo = foyer_fiscal('f5qo', period)
         f5qp = foyer_fiscal('f5qp', period)
         f5qq = foyer_fiscal('f5qq', period)
-        frag_impo_i = foyer_fiscal.members('frag_impo', period)
         mrag_impo_i = foyer_fiscal.members('mrag_impo', period)
         nrag_impg_i = foyer_fiscal.members('nrag_impg', period)
         coupe_bois_i = foyer_fiscal.members('coupe_bois', period)
@@ -2702,12 +2757,11 @@ class defrag(Variable):
         cga = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.cga_taux2
 
         coupe_bois = foyer_fiscal.sum(coupe_bois_i)
-        frag_impo = foyer_fiscal.sum(frag_impo_i)
         mrag_impo = foyer_fiscal.sum(mrag_impo_i)
         arag_impg = foyer_fiscal.sum(arag_impg_i)
         nrag_impg = foyer_fiscal.sum(nrag_impg_i)
         mrag_pvct = foyer_fiscal.sum(mrag_pvct_i)
-        return min_(f5qf + f5qg + f5qn + f5qo + f5qp + f5qq, (1 + cga) * (frag_impo + nrag_impg + mrag_pvct)
+        return min_(f5qf + f5qg + f5qn + f5qo + f5qp + f5qq, (1 + cga) * (nrag_impg + mrag_pvct)
                     + arag_impg + coupe_bois + mrag_impo)
 
     def formula_2023_01_01(foyer_fiscal, period, parameters):
@@ -3203,6 +3257,7 @@ class nbnc_timp(Variable):
     value_type = float
     entity = Individu
     label = 'Revenus des professions non salariées individuels sans abattement CGA (régime contrôlé)'
+    end = '2022-12-31'
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -3217,6 +3272,7 @@ class nacc_timp(Variable):
     value_type = float
     entity = Individu
     label = 'Revenus des professions non salariées individuels sans abattement CGA (régime réel)'
+    end = '2022-12-31'
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -3231,6 +3287,7 @@ class ntimp(Variable):
     value_type = float
     entity = Individu
     label = 'Revenus des professions non salariées individuels sans abattement'
+    end = '2022-12-31'
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -3508,7 +3565,7 @@ class taux_effectif(Variable):
         trigger = (microentreprise != 0) | (abnc_proc != 0) | (nbnc_proc != 0)
         return trigger * nbptr * bareme.calc(base_fictive / nbptr) / max_(1, base_fictive)
 
-    def formula_2023_01_01(foyer_fiscal, period, parameters):
+    def formula_2018_01_01(foyer_fiscal, period, parameters):
         rni = foyer_fiscal('rni', period)
         nbptr = foyer_fiscal('nbptr', period)
         microentreprise = foyer_fiscal('microentreprise', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2680,7 +2680,6 @@ class rpns_exon(Variable):
         cncn_exon = individu('cncn_exon', period)
         cncn_jcre = individu('cncn_jcre', period)
         nbic_pvce = individu('nbic_pvce', period)
-        cga = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.cga_taux2
 
         return (
             mrag_exon + arag_exon + nrag_exon + mbic_exon + abic_exon

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2655,7 +2655,6 @@ class rpns_exon(Variable):
             )
 
 
-
 class defrag(Variable):
     value_type = float
     entity = FoyerFiscal

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2590,6 +2590,37 @@ class rpns_exon(Variable):
         abnc_exon = individu('abnc_exon', period)
         nbnc_exon = individu('nbnc_exon', period)
         mncn_exon = individu('mncn_exon', period)
+        cncn_jcre = individu('cncn_jcre', period)
+        nbic_pvce = individu('nbic_pvce', period)
+        cga = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.cga_taux2
+
+        return (
+            frag_exon + mrag_exon + arag_exon + nrag_exon + mbic_exon + abic_exon + nbnc_proc * (1 + cga)
+            + nbic_exon + macc_exon + aacc_exon + nacc_exon + mbnc_exon + abnc_proc
+            + abnc_exon + nbnc_exon + mncn_exon + cncn_jcre + nbic_pvce + nrag_pvce
+            )
+
+    def formula_2008_01_01(individu, period, parameters):
+        '''
+        Plus values de cession
+        '''
+        frag_exon = individu('frag_exon', period)
+        mrag_exon = individu('mrag_exon', period)
+        arag_exon = individu('arag_exon', period)
+        nrag_exon = individu('nrag_exon', period)
+        mbic_exon = individu('mbic_exon', period)
+        abic_exon = individu('abic_exon', period)
+        nbnc_proc = individu('nbnc_proc', period)
+        nbic_exon = individu('nbic_exon', period)
+        macc_exon = individu('macc_exon', period)
+        aacc_exon = individu('aacc_exon', period)
+        nacc_exon = individu('nacc_exon', period)
+        mbnc_exon = individu('mbnc_exon', period)
+        abnc_proc = individu('abnc_proc', period)
+        nrag_pvce = individu('nrag_pvce', period)
+        abnc_exon = individu('abnc_exon', period)
+        nbnc_exon = individu('nbnc_exon', period)
+        mncn_exon = individu('mncn_exon', period)
         cncn_exon = individu('cncn_exon', period)
         cncn_jcre = individu('cncn_jcre', period)
         nbic_pvce = individu('nbic_pvce', period)
@@ -2605,28 +2636,22 @@ class rpns_exon(Variable):
         '''
         Plus values de cession
         '''
-        frag_exon = individu('frag_exon', period)
         mrag_exon = individu('mrag_exon', period)
         arag_exon = individu('arag_exon', period)
-        #nrag_exon = individu('nrag_exon', period)
         mbic_exon = individu('mbic_exon', period)
         abic_exon = individu('abic_exon', period)
-        nbic_exon = individu('nbic_exon', period)
         macc_exon = individu('macc_exon', period)
         aacc_exon = individu('aacc_exon', period)
         mbnc_exon = individu('mbnc_exon', period)
-        abnc_proc = individu('abnc_proc', period)
-        nrag_pvce = individu('nrag_pvce', period)
         abnc_exon = individu('abnc_exon', period)
         mncn_exon = individu('mncn_exon', period)
         cncn_exon = individu('cncn_exon', period)
         cncn_jcre = individu('cncn_jcre', period)
-        nbic_pvce = individu('nbic_pvce', period)
 
         return (
-            frag_exon + mrag_exon + arag_exon + nrag_exon + mbic_exon + abic_exon
-            + nbic_exon + macc_exon + aacc_exon + mbnc_exon + abnc_proc
-            + abnc_exon + mncn_exon + cncn_exon + cncn_jcre + nbic_pvce + nrag_pvce
+            mrag_exon + arag_exon + mbic_exon + abic_exon
+            + macc_exon + aacc_exon + mbnc_exon
+            + abnc_exon + mncn_exon + cncn_exon + cncn_jcre
             )
 
 
@@ -2845,45 +2870,6 @@ class defmeu(Variable):
         return min_(f5ga + f5gb + f5gc + f5gd + f5ge + f5gf + f5gg + f5gh + f5gi + f5gj, alnp_imps + nacc_pres)
 
 
-class rnc(Variable):
-    value_type = float
-    entity = Individu
-    label = 'Revenus non commerciaux individuels'
-    reference = 'http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&pageId=prof_bnc&impot=BNC&sfid=50'
-    definition_period = YEAR
-
-    def formula(individu, period, parameters):
-        '''
-        Revenus non commerciaux individuels
-        '''
-        mbnc_exon = individu('mbnc_exon', period)
-        mbnc_impo = individu('mbnc_impo', period)
-        abnc_exon = individu('abnc_exon', period)
-        nbnc_exon = individu('nbnc_exon', period)
-        abnc_impo = individu('abnc_impo', period)
-        nbnc_impo = individu('nbnc_impo', period)
-        abnc_defi = individu('abnc_defi', period)
-        nbnc_defi = individu('nbnc_defi', period)
-        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro.microentreprise
-
-        zbnc = (
-            mbnc_exon + mbnc_impo
-            + abnc_exon + nbnc_exon
-            + abnc_impo + nbnc_impo
-            - abnc_defi - nbnc_defi
-            )
-
-        cbnc = min_(
-            mbnc_exon + mbnc_impo,
-            max_(
-                micro.montant_minimum,
-                round_((mbnc_exon + mbnc_impo) * micro.regime_micro_bnc.taux)
-                )
-            )
-
-        return zbnc - cbnc
-
-
 class rpns_pvct(Variable):
     value_type = float
     entity = Individu
@@ -2994,7 +2980,7 @@ class rpns_revenus_forfait_agricole(Variable):
     entity = Individu
     label = 'Revenus du forfait agricole - Revenus des professions non salariées'
     definition_period = YEAR
-    end = '2015-12-31'  # TODO : le forfait agricole est remplaçé par le régime micro-bénéfices agricoles à partir de 2016
+    end = '2015-12-31'
 
     def formula(individu, period, parameters):
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2600,7 +2600,7 @@ class rpns_exon(Variable):
             + nbic_exon + macc_exon + aacc_exon + nacc_exon + mbnc_exon + abnc_proc
             + abnc_exon + nbnc_exon + mncn_exon + cncn_exon + cncn_jcre + nbic_pvce + nrag_pvce
             )
-    
+
     def formula_2023_01_01(individu, period, parameters):
         '''
         Plus values de cession
@@ -2608,18 +2608,16 @@ class rpns_exon(Variable):
         frag_exon = individu('frag_exon', period)
         mrag_exon = individu('mrag_exon', period)
         arag_exon = individu('arag_exon', period)
-        nrag_exon = individu('nrag_exon', period)
+        #nrag_exon = individu('nrag_exon', period)
         mbic_exon = individu('mbic_exon', period)
         abic_exon = individu('abic_exon', period)
         nbic_exon = individu('nbic_exon', period)
         macc_exon = individu('macc_exon', period)
         aacc_exon = individu('aacc_exon', period)
-        nacc_exon = individu('nacc_exon', period)
         mbnc_exon = individu('mbnc_exon', period)
         abnc_proc = individu('abnc_proc', period)
         nrag_pvce = individu('nrag_pvce', period)
         abnc_exon = individu('abnc_exon', period)
-        nbnc_exon = individu('nbnc_exon', period)
         mncn_exon = individu('mncn_exon', period)
         cncn_exon = individu('cncn_exon', period)
         cncn_jcre = individu('cncn_jcre', period)
@@ -2627,8 +2625,8 @@ class rpns_exon(Variable):
 
         return (
             frag_exon + mrag_exon + arag_exon + nrag_exon + mbic_exon + abic_exon
-            + nbic_exon + macc_exon + aacc_exon + nacc_exon + mbnc_exon + abnc_proc
-            + abnc_exon + nbnc_exon + mncn_exon + cncn_exon + cncn_jcre + nbic_pvce + nrag_pvce
+            + nbic_exon + macc_exon + aacc_exon + mbnc_exon + abnc_proc
+            + abnc_exon + mncn_exon + cncn_exon + cncn_jcre + nbic_pvce + nrag_pvce
             )
 
 
@@ -2840,160 +2838,11 @@ class defmeu(Variable):
         f5gi = foyer_fiscal('f5gi', period)
         f5gj = foyer_fiscal('f5gj', period)
         alnp_imps_i = foyer_fiscal.members('alnp_imps', period)
-        nacc_defs_i = foyer_fiscal.members('nacc_defs', period)
+        nacc_pres_i = foyer_fiscal.members('nacc_pres', period)
 
-        nacc_defs = foyer_fiscal.sum(nacc_defs_i)
+        nacc_pres = foyer_fiscal.sum(nacc_pres_i)
         alnp_imps = foyer_fiscal.sum(alnp_imps_i)
-        return min_(f5ga + f5gb + f5gc + f5gd + f5ge + f5gf + f5gg + f5gh + f5gi + f5gj, alnp_imps + nacc_defs)
-
-
-class rag(Variable):
-    value_type = float
-    entity = Individu
-    label = 'Revenus agricoles'
-    reference = 'http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&impot=BA&pageId=prof_ba&sfid=50'
-    definition_period = YEAR
-
-    def formula(individu, period, parameters):
-        '''
-        Revenus agricoles
-        '''
-        frag_exon = individu('frag_exon', period)
-        frag_impo = individu('frag_impo', period)
-        arag_exon = individu('arag_exon', period)
-        arag_impg = individu('arag_impg', period)
-        arag_defi = individu('arag_defi', period)
-        nrag_exon = individu('nrag_exon', period)
-        nrag_impg = individu('nrag_impg', period)
-        nrag_defi = individu('nrag_defi', period)
-        nrag_ajag = individu('nrag_ajag', period)
-
-        return (
-            frag_exon + frag_impo
-            + arag_exon + arag_impg - arag_defi
-            + nrag_exon + nrag_impg - nrag_defi
-            + nrag_ajag
-            )
-
-    def formula_2016_01_01(individu, period, parameters):
-        '''
-        Revenus agricoles
-        '''
-        mrag_exon = individu('mrag_exon', period)
-        mrag_impo = individu('mrag_impo', period)
-        arag_exon = individu('arag_exon', period)
-        arag_impg = individu('arag_impg', period)
-        arag_defi = individu('arag_defi', period)
-        nrag_exon = individu('nrag_exon', period)
-        nrag_impg = individu('nrag_impg', period)
-        nrag_defi = individu('nrag_defi', period)
-        nrag_ajag = individu('nrag_ajag', period)
-
-        return (
-            mrag_exon + mrag_impo
-            + arag_exon + arag_impg - arag_defi
-            + nrag_exon + nrag_impg - nrag_defi
-            + nrag_ajag
-            )
-
-
-class ric(Variable):
-    value_type = float
-    entity = Individu
-    label = 'Bénéfices industriels et commerciaux'
-    reference = 'http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?pageId=prof_bic&espId=2&impot=BIC&sfid=50'
-    definition_period = YEAR
-
-    def formula(individu, period, parameters):
-        '''
-        Bénéfices industriels et commerciaux
-        '''
-        mbic_exon = individu('mbic_exon', period)
-        mbic_impv = individu('mbic_impv', period)
-        mbic_imps = individu('mbic_imps', period)
-        abic_exon = individu('abic_exon', period)
-        nbic_exon = individu('nbic_exon', period)
-        abic_impn = individu('abic_impn', period)
-        nbic_impn = individu('nbic_impn', period)
-        abic_imps = individu('abic_imps', period)
-        nbic_imps = individu('nbic_imps', period)
-        abic_defn = individu('abic_defn', period)
-        nbic_defn = individu('nbic_defn', period)
-        abic_defs = individu('abic_defs', period)
-        nbic_defs = individu('nbic_defs', period)
-        nbic_apch = individu('nbic_apch', period)
-        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro
-
-        zbic = (
-            mbic_exon + mbic_impv + mbic_imps
-            + abic_exon + nbic_exon
-            + abic_impn + nbic_impn
-            + abic_imps + nbic_imps
-            + abic_defn - nbic_defn
-            + abic_defs - nbic_defs
-            + nbic_apch
-            )
-
-        cond = (mbic_impv > 0) & (mbic_imps == 0)
-        taux = micro.microentreprise.regime_micro_bnc.marchandises.taux * cond + micro.microentreprise.regime_micro_bnc.services.taux * not_(cond)
-
-        cbic = min_(
-            mbic_impv + mbic_imps + mbic_exon,
-            max_(
-                micro.microentreprise.montant_minimum,
-                round_(
-                    mbic_impv * micro.microentreprise.regime_micro_bnc.marchandises.taux + mbic_imps * micro.microentreprise.regime_micro_bnc.services.taux + mbic_exon * taux
-                    )
-                )
-            )
-        return zbic - cbic
-
-
-class rac(Variable):
-    value_type = float
-    entity = Individu
-    label = 'Revenus accessoires individuels'
-    reference = 'http://vosdroits.service-public.fr/particuliers/F1225.xhtml'
-    definition_period = YEAR
-
-    def formula(individu, period, parameters):
-        '''
-        Revenus accessoires individuels
-        '''
-        macc_exon = individu('macc_exon', period)
-        macc_impv = individu('macc_impv', period)
-        macc_imps = individu('macc_imps', period)
-        aacc_exon = individu('aacc_exon', period)
-        aacc_impn = individu('aacc_impn', period)
-        aacc_imps = individu('aacc_imps', period)
-        aacc_defn = individu('aacc_defn', period)
-        aacc_defs = individu('aacc_defs', period)
-        nacc_exon = individu('nacc_exon', period)
-        nacc_impn = individu('nacc_impn', period)
-        nacc_defn = individu('nacc_defn', period)
-        nacc_defs = individu('nacc_defs', period)
-        mncn_impo = individu('mncn_impo', period)
-        cncn_bene = individu('cncn_bene', period)
-        cncn_defi = individu('cncn_defi', period)
-        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro
-
-        zacc = (
-            macc_exon + macc_impv + macc_imps
-            + aacc_exon + aacc_impn + aacc_imps - aacc_defn - aacc_defs
-            + nacc_exon + nacc_impn - nacc_defn - nacc_defs
-            + mncn_impo + cncn_bene - cncn_defi
-            )
-
-    # TODO: aacc_imps aacc_defs
-        cond = (macc_impv > 0) & (macc_imps == 0)
-        taux = micro.microentreprise.regime_micro_bnc.marchandises.taux * cond + micro.microentreprise.regime_micro_bnc.services.taux * not_(cond)
-
-        cacc = min_(macc_impv + macc_imps + macc_exon + mncn_impo, max_(micro.microentreprise.montant_minimum, round_(
-            macc_impv * micro.microentreprise.regime_micro_bnc.marchandises.taux
-            + macc_imps * micro.microentreprise.regime_micro_bnc.services.taux + macc_exon * taux
-            + mncn_impo * micro.microentreprise.regime_micro_bnc.taux)))
-
-        return zacc - cacc
+        return min_(f5ga + f5gb + f5gc + f5gd + f5ge + f5gf + f5gg + f5gh + f5gi + f5gj, alnp_imps + nacc_pres)
 
 
 class rnc(Variable):
@@ -3266,7 +3115,7 @@ class aacc_timp(Variable):
         aacc_gits = individu('aacc_gits', period)
         aacc_imps = individu('aacc_imps', period)
         nacc_meup = individu('nacc_meup', period)
-        nacc_defs = individu('nacc_defs', period)
+        nacc_pres = individu('nacc_pres', period)
         alnp_defs = individu('alnp_defs', period)
         aacc_defn = individu('aacc_defn', period)
         micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro
@@ -3285,7 +3134,7 @@ class aacc_timp(Variable):
                     micro.microentreprise.montant_minimum,
                     nacc_meup * (1 - micro.microentreprise.regime_micro_bnc.marchandises.taux)
                     )
-                + max_(0, nacc_defs - alnp_defs) - aacc_defn
+                + max_(0, nacc_pres - alnp_defs) - aacc_defn
                 )
             )
         return aacc_timp
@@ -3296,7 +3145,7 @@ class aacc_timp(Variable):
         aacc_imps = individu('aacc_imps', period)
         nacc_meup = individu('nacc_meup', period)
         nacc_meuc = individu('nacc_meuc', period)
-        nacc_defs = individu('nacc_defs', period)
+        nacc_pres = individu('nacc_pres', period)
         alnp_defs = individu('alnp_defs', period)
         aacc_defn = individu('aacc_defn', period)
         micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro
@@ -3319,7 +3168,7 @@ class aacc_timp(Variable):
                     micro.microentreprise.montant_minimum,
                     nacc_meuc * (1 - micro.microentreprise.regime_micro_bnc.services.taux)
                     )
-                + max_(0, nacc_defs - alnp_defs) - aacc_defn
+                + max_(0, nacc_pres - alnp_defs) - aacc_defn
                 )
             )
         return aacc_timp
@@ -3343,7 +3192,7 @@ class atimp(Variable):
         aacc_timp = individu('aacc_timp', period)
         # Régime du bénéfice réel bénéficiant de l'abattement CGA
         abic_timp = abic_impn + abic_imps - (abic_defn + abic_defs)
-        # regime de la déclaration contrôlée bénéficiant de l'abattement association agréée
+        # regime de la déclaration contrôlée bénéficiant de l'abattement CGA
         abnc_timp = abnc_impo - abnc_defi
         # Total
         atimp = arag_impg + abic_timp + aacc_timp + abnc_timp
@@ -3359,7 +3208,7 @@ class atimp(Variable):
         aacc_timp = individu('aacc_timp', period)
         # Régime du bénéfice réel bénéficiant de l'abattement CGA
         abic_timp = abic_impn - abic_defn
-        # regime de la déclaration contrôlée bénéficiant de l'abattement association agréée
+        # regime de la déclaration contrôlée bénéficiant de l'abattement CGA
         abnc_timp = abnc_impo - abnc_defi
         # Total
         atimp = arag_impg + abic_timp + aacc_timp + abnc_timp
@@ -3369,13 +3218,13 @@ class atimp(Variable):
 class nbnc_timp(Variable):
     value_type = float
     entity = Individu
-    label = 'Revenus des professions non salariées individuels sans abattement association'
+    label = 'Revenus des professions non salariées individuels sans abattement CGA (régime contrôlé)'
     definition_period = YEAR
 
     def formula(individu, period, parameters):
         nbnc_impo = individu('nbnc_impo', period)
         nbnc_defi = individu('nbnc_defi', period)
-        # regime de la déclaration contrôlée ne bénéficiant pas de l'abattement association agréée
+        # regime de la déclaration contrôlée ne bénéficiant pas de l'abattement CGA
         nbnc_timp = nbnc_impo - nbnc_defi
         return nbnc_timp
 
@@ -3383,7 +3232,7 @@ class nbnc_timp(Variable):
 class nacc_timp(Variable):
     value_type = float
     entity = Individu
-    label = 'Revenus des professions non salariées individuels sans abattement CGA'
+    label = 'Revenus des professions non salariées individuels sans abattement CGA (régime réel)'
     definition_period = YEAR
 
     def formula(individu, period, parameters):
@@ -3482,14 +3331,13 @@ class revenu_non_salarie(Variable):
     def formula_2016_01_01(individu, period, parameters):
         rpns_mrag = individu('rpns_revenus_microBA_agricole', period)
         coupe_bois = individu('coupe_bois', period)
-        f5sq = individu('f5sq', period)
         arag_defi = individu('arag_defi', period)
         nrag_defi = individu('nrag_defi', period)
         atimp = individu('atimp', period)
         ntimp = individu('ntimp', period)
         cga_taux2 = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.cga_taux2
         majo_cga = max_(0, cga_taux2 * ntimp)  # Pour ne pas avoir à majorer les déficits
-        def_agri = f5sq + arag_defi + (1 + cga_taux2) * nrag_defi
+        def_agri = arag_defi + (1 + cga_taux2) * nrag_defi
         revenus_non_salaries = rpns_mrag + coupe_bois + atimp + ntimp + majo_cga - def_agri
         return revenus_non_salaries
 
@@ -3497,11 +3345,9 @@ class revenu_non_salarie(Variable):
         # Il n'y a plus de majoration pour absence de CGA (ntimp disparait)
         rpns_mrag = individu('rpns_revenus_microBA_agricole', period)
         coupe_bois = individu('coupe_bois', period)
-        f5sq = individu('f5sq', period)
         arag_defi = individu('arag_defi', period)
         atimp = individu('atimp', period)
-        def_agri = f5sq + arag_defi
-        revenus_non_salaries = rpns_mrag + coupe_bois + atimp - def_agri
+        revenus_non_salaries = rpns_mrag + coupe_bois + atimp - arag_defi
         return revenus_non_salaries
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1128,6 +1128,22 @@ class revenu_categoriel_non_salarial(Variable):
             - defmeu
             )
 
+    def formula_2023_01_01(foyer_fiscal, period, parameters):
+        rpns_i = foyer_fiscal.members('rpns_imposables', period)
+        rpns = foyer_fiscal.sum(rpns_i)
+        defrag = foyer_fiscal('defrag', period)
+        defacc = foyer_fiscal('defacc', period)
+        defncn = foyer_fiscal('defncn', period)
+        defmeu = foyer_fiscal('defmeu', period)
+
+        return (
+            rpns
+            - defrag
+            - defncn
+            - defacc
+            - defmeu
+            )
+
 
 class revenu_categoriel(Variable):
     value_type = float
@@ -1197,6 +1213,19 @@ class rbg(Variable):
         nacc_pvce = foyer_fiscal.sum(nacc_pvce_i)
         return max_(0,
                     revenu_categoriel + f6gh + (foyer_fiscal.sum(nbic_impm_i) + nacc_pvce) * (1 + cga) - deficit_ante)
+
+    def formula_2023_01_01(foyer_fiscal, period, parameters):
+        '''Revenu brut global
+        '''
+        revenu_categoriel = foyer_fiscal('revenu_categoriel', period)
+        deficit_ante = foyer_fiscal('deficit_ante', period)
+        f6gh = foyer_fiscal('f6gh', period)
+
+        # (Total 17)
+        # sans les revenus au quotient
+        nacc_pvce = foyer_fiscal.sum(nacc_pvce_i)
+        return max_(0,
+                    revenu_categoriel + f6gh - deficit_ante)
 
 
 class csg_patrimoine_deductible_ir(Variable):
@@ -2576,6 +2605,37 @@ class rpns_exon(Variable):
             + nbic_exon + macc_exon + aacc_exon + nacc_exon + mbnc_exon + abnc_proc
             + abnc_exon + nbnc_exon + mncn_exon + cncn_exon + cncn_jcre + nbic_pvce + nrag_pvce
             )
+    
+    def formula_2023_01_01(individu, period, parameters):
+        '''
+        Plus values de cession
+        '''
+        frag_exon = individu('frag_exon', period)
+        mrag_exon = individu('mrag_exon', period)
+        arag_exon = individu('arag_exon', period)
+        nrag_exon = individu('nrag_exon', period)
+        mbic_exon = individu('mbic_exon', period)
+        abic_exon = individu('abic_exon', period)
+        nbic_exon = individu('nbic_exon', period)
+        macc_exon = individu('macc_exon', period)
+        aacc_exon = individu('aacc_exon', period)
+        nacc_exon = individu('nacc_exon', period)
+        mbnc_exon = individu('mbnc_exon', period)
+        abnc_proc = individu('abnc_proc', period)
+        nrag_pvce = individu('nrag_pvce', period)
+        abnc_exon = individu('abnc_exon', period)
+        nbnc_exon = individu('nbnc_exon', period)
+        mncn_exon = individu('mncn_exon', period)
+        cncn_exon = individu('cncn_exon', period)
+        cncn_jcre = individu('cncn_jcre', period)
+        nbic_pvce = individu('nbic_pvce', period)
+
+        return (
+            frag_exon + mrag_exon + arag_exon + nrag_exon + mbic_exon + abic_exon
+            + nbic_exon + macc_exon + aacc_exon + nacc_exon + mbnc_exon + abnc_proc
+            + abnc_exon + nbnc_exon + mncn_exon + cncn_exon + cncn_jcre + nbic_pvce + nrag_pvce
+            )
+
 
 
 class defrag(Variable):
@@ -2633,6 +2693,23 @@ class defrag(Variable):
         return min_(f5qf + f5qg + f5qn + f5qo + f5qp + f5qq, (1 + cga) * (frag_impo + nrag_impg + mrag_pvct)
                     + arag_impg + coupe_bois + mrag_impo)
 
+    def formula_2023_01_01(foyer_fiscal, period, parameters):
+        # frag_fore est remplacé par coupe_bois, frag_pvct par mrag_pvct
+        f5qf = foyer_fiscal('f5qf', period)
+        f5qg = foyer_fiscal('f5qg', period)
+        f5qn = foyer_fiscal('f5qn', period)
+        f5qo = foyer_fiscal('f5qo', period)
+        f5qp = foyer_fiscal('f5qp', period)
+        f5qq = foyer_fiscal('f5qq', period)
+        mrag_impo_i = foyer_fiscal.members('mrag_impo', period)
+        coupe_bois_i = foyer_fiscal.members('coupe_bois', period)
+        arag_impg_i = foyer_fiscal.members('arag_impg', period)
+
+        coupe_bois = foyer_fiscal.sum(coupe_bois_i)
+        mrag_impo = foyer_fiscal.sum(mrag_impo_i)
+        arag_impg = foyer_fiscal.sum(arag_impg_i)
+        return min_(f5qf + f5qg + f5qn + f5qo + f5qp + f5qq, arag_impg + coupe_bois + mrag_impo)
+
 
 class defacc(Variable):
     value_type = float
@@ -2668,6 +2745,31 @@ class defacc(Variable):
             min_(f5rn + f5ro + f5rp + f5rq + f5rr + f5rw, aacc_impn + macc_pvct + macc_timp + (1 + cga) * nacc_impn)
             )
 
+    def formula_2023_01_01(foyer_fiscal, period, parameters):
+        f5rn = foyer_fiscal('f5rn', period)
+        f5ro = foyer_fiscal('f5ro', period)
+        f5rp = foyer_fiscal('f5rp', period)
+        f5rq = foyer_fiscal('f5rq', period)
+        f5rr = foyer_fiscal('f5rr', period)
+        f5rw = foyer_fiscal('f5rw', period)
+        macc_impv_i = foyer_fiscal.members('macc_impv', period)
+        macc_imps_i = foyer_fiscal.members('macc_imps', period)
+        macc_pvct_i = foyer_fiscal.members('macc_pvct', period)
+        aacc_impn_i = foyer_fiscal.members('aacc_impn', period)
+        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro
+
+        def abat_rpns(rev, P):
+            return max_(0, rev - min_(rev, max_(P.taux * min_(P.plafond, rev), micro.microentreprise.montant_minimum)))
+
+        macc_pvct = foyer_fiscal.sum(macc_pvct_i)
+        macc_impv = foyer_fiscal.sum(macc_impv_i)
+        macc_imps = foyer_fiscal.sum(macc_imps_i)
+        aacc_impn = foyer_fiscal.sum(aacc_impn_i)
+        macc_timp = abat_rpns(macc_impv, micro.microentreprise.regime_micro_bnc.marchandises) + abat_rpns(macc_imps, micro.microentreprise.regime_micro_bnc.services)
+        return (
+            min_(f5rn + f5ro + f5rp + f5rq + f5rr + f5rw, aacc_impn + macc_pvct + macc_timp )
+            )
+
 
 class defncn(Variable):
     value_type = float
@@ -2699,6 +2801,29 @@ class defncn(Variable):
         return min_(
             f5ht + f5it + f5jt + f5kt + f5lt + f5mt,
             abat_rpns(mncn_impo, specialbnc.services) + mncn_pvct + cncn_aimp + (1 + cga) * cncn_bene
+            )  # TODO check !
+
+    def formula_2023_01_01(foyer_fiscal, period, parameters):
+        f5ht = foyer_fiscal('f5ht', period)
+        f5it = foyer_fiscal('f5it', period)
+        f5jt = foyer_fiscal('f5jt', period)
+        f5kt = foyer_fiscal('f5kt', period)
+        f5lt = foyer_fiscal('f5lt', period)
+        f5mt = foyer_fiscal('f5mt', period)
+        mncn_impo_i = foyer_fiscal.members('mncn_impo', period)
+        mncn_pvct_i = foyer_fiscal.members('mncn_pvct', period)
+        cncn_aimp_i = foyer_fiscal.members('cncn_aimp', period)
+        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro
+        specialbnc = micro.microentreprise.regime_micro_bnc
+
+        def abat_rpns(rev, P):
+            return max_(0, rev - min_(rev, max_(P.taux * min_(P.plafond, rev), micro.microentreprise.montant_minimum)))
+        mncn_impo = foyer_fiscal.sum(mncn_impo_i)
+        mncn_pvct = foyer_fiscal.sum(mncn_pvct_i)
+        cncn_aimp = foyer_fiscal.sum(cncn_aimp_i)
+        return min_(
+            f5ht + f5it + f5jt + f5kt + f5lt + f5mt,
+            abat_rpns(mncn_impo, specialbnc.services) + mncn_pvct + cncn_aimp
             )  # TODO check !
 
 
@@ -3373,6 +3498,18 @@ class revenu_non_salarie(Variable):
         revenus_non_salaries = rpns_mrag + coupe_bois + atimp + ntimp + majo_cga - def_agri
         return revenus_non_salaries
 
+    def formula_2023_01_01(individu, period, parameters):
+        # Il n'y a plus de majoration pour absence de CGA (ntimp disparait)
+        rpns_mrag = individu('rpns_revenus_microBA_agricole', period)
+        coupe_bois = individu('coupe_bois', period)
+        f5sq = individu('f5sq', period)
+        arag_defi = individu('arag_defi', period)
+        nrag_defi = individu('nrag_defi', period)
+        atimp = individu('atimp', period)
+        def_agri = f5sq + arag_defi + (1 + cga_taux2) * nrag_defi
+        revenus_non_salaries = rpns_mrag + coupe_bois + atimp - def_agri
+        return revenus_non_salaries
+
 
 class locations_pro(Variable):
     value_type = float
@@ -3545,6 +3682,18 @@ class taux_effectif(Variable):
         nbnc_proc = foyer_fiscal.sum(nbnc_proc_i)
         base_fictive = rni + microentreprise + abnc_proc + nbnc_proc * (1 + cga)
         trigger = (microentreprise != 0) | (abnc_proc != 0) | (nbnc_proc != 0)
+        return trigger * nbptr * bareme.calc(base_fictive / nbptr) / max_(1, base_fictive)
+
+    def formula_2023_01_01(foyer_fiscal, period, parameters):
+        rni = foyer_fiscal('rni', period)
+        nbptr = foyer_fiscal('nbptr', period)
+        microentreprise = foyer_fiscal('microentreprise', period)
+        abnc_proc_i = foyer_fiscal.members('abnc_proc', period)
+        bareme = parameters(period).impot_revenu.bareme_ir_depuis_1945.bareme
+        cga = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.cga_taux2
+        abnc_proc = foyer_fiscal.sum(abnc_proc_i)
+        base_fictive = rni + microentreprise + abnc_proc
+        trigger = (microentreprise != 0) | (abnc_proc != 0)
         return trigger * nbptr * bareme.calc(base_fictive / nbptr) / max_(1, base_fictive)
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1128,7 +1128,7 @@ class revenu_categoriel_non_salarial(Variable):
             - defmeu
             )
 
-    def formula_2023_01_01(foyer_fiscal, period, parameters):
+    def formula_2016_01_01(foyer_fiscal, period, parameters):
         rpns_i = foyer_fiscal.members('rpns_imposables', period)
         rpns = foyer_fiscal.sum(rpns_i)
         defrag = foyer_fiscal('defrag', period)
@@ -2711,7 +2711,6 @@ class defrag(Variable):
                     + arag_impg + coupe_bois + mrag_impo)
 
     def formula_2023_01_01(foyer_fiscal, period, parameters):
-        # frag_fore est remplacé par coupe_bois, frag_pvct par mrag_pvct
         f5qf = foyer_fiscal('f5qf', period)
         f5qg = foyer_fiscal('f5qg', period)
         f5qn = foyer_fiscal('f5qn', period)

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -1156,7 +1156,7 @@ class bouclier_rev(Variable):
         cd_eparet = foyer_fiscal('cd_eparet', period)
 
         maj_cga_i = foyer_fiscal.members('maj_cga', period)  # noqa F841
-        maj_cga = foyer_fiscal.sum(maj_cga)  # noqa F841
+        maj_cga = foyer_fiscal.sum(maj_cga_i)  # noqa F841
 
         # TODO: réintégrer les déficits antérieur
         # TODO: intégrer les revenus soumis au prélèvement libératoire

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -561,6 +561,194 @@ class isf_ifi_avant_plaf(Variable):
 
 
 # # calcul du plafonnement ##
+
+class rag(Variable):
+    value_type = float
+    entity = Individu
+    label = 'Revenus agricoles'
+    reference = 'http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&impot=BA&pageId=prof_ba&sfid=50'
+    definition_period = YEAR
+
+    def formula(individu, period, parameters):
+        '''
+        Revenus agricoles
+        '''
+        frag_exon = individu('frag_exon', period)
+        frag_impo = individu('frag_impo', period)
+        arag_exon = individu('arag_exon', period)
+        arag_impg = individu('arag_impg', period)
+        arag_defi = individu('arag_defi', period)
+        nrag_exon = individu('nrag_exon', period)
+        nrag_impg = individu('nrag_impg', period)
+        nrag_defi = individu('nrag_defi', period)
+        nrag_ajag = individu('nrag_ajag', period)
+
+        return (
+            frag_exon + frag_impo
+            + arag_exon + arag_impg - arag_defi
+            + nrag_exon + nrag_impg - nrag_defi
+            + nrag_ajag
+            )
+
+    def formula_2016_01_01(individu, period, parameters):
+        '''
+        Revenus agricoles
+        '''
+        mrag_exon = individu('mrag_exon', period)
+        mrag_impo = individu('mrag_impo', period)
+        arag_exon = individu('arag_exon', period)
+        arag_impg = individu('arag_impg', period)
+        arag_defi = individu('arag_defi', period)
+        nrag_exon = individu('nrag_exon', period)
+        nrag_impg = individu('nrag_impg', period)
+        nrag_defi = individu('nrag_defi', period)
+        nrag_ajag = individu('nrag_ajag', period)
+
+        return (
+            mrag_exon + mrag_impo
+            + arag_exon + arag_impg - arag_defi
+            + nrag_exon + nrag_impg - nrag_defi
+            + nrag_ajag
+            )
+
+
+class ric(Variable):
+    value_type = float
+    entity = Individu
+    label = 'Bénéfices industriels et commerciaux'
+    reference = 'http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?pageId=prof_bic&espId=2&impot=BIC&sfid=50'
+    definition_period = YEAR
+
+    def formula(individu, period, parameters):
+        '''
+        Bénéfices industriels et commerciaux
+        '''
+        mbic_exon = individu('mbic_exon', period)
+        mbic_impv = individu('mbic_impv', period)
+        mbic_imps = individu('mbic_imps', period)
+        abic_exon = individu('abic_exon', period)
+        nbic_exon = individu('nbic_exon', period)
+        abic_impn = individu('abic_impn', period)
+        nbic_impn = individu('nbic_impn', period)
+        abic_imps = individu('abic_imps', period)
+        nbic_imps = individu('nbic_imps', period)
+        abic_defn = individu('abic_defn', period)
+        nbic_defn = individu('nbic_defn', period)
+        abic_defs = individu('abic_defs', period)
+        nbic_defs = individu('nbic_defs', period)
+        nbic_apch = individu('nbic_apch', period)
+        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro
+
+        zbic = (
+            mbic_exon + mbic_impv + mbic_imps
+            + abic_exon + nbic_exon
+            + abic_impn + nbic_impn
+            + abic_imps + nbic_imps
+            + abic_defn - nbic_defn
+            + abic_defs - nbic_defs
+            + nbic_apch
+            )
+
+        cond = (mbic_impv > 0) & (mbic_imps == 0)
+        taux = micro.microentreprise.regime_micro_bnc.marchandises.taux * cond + micro.microentreprise.regime_micro_bnc.services.taux * not_(cond)
+
+        cbic = min_(
+            mbic_impv + mbic_imps + mbic_exon,
+            max_(
+                micro.microentreprise.montant_minimum,
+                round_(
+                    mbic_impv * micro.microentreprise.regime_micro_bnc.marchandises.taux + mbic_imps * micro.microentreprise.regime_micro_bnc.services.taux + mbic_exon * taux
+                    )
+                )
+            )
+        return zbic - cbic
+
+
+class rac(Variable):
+    value_type = float
+    entity = Individu
+    label = 'Revenus accessoires individuels'
+    reference = 'http://vosdroits.service-public.fr/particuliers/F1225.xhtml'
+    definition_period = YEAR
+
+    def formula(individu, period, parameters):
+        '''
+        Revenus accessoires individuels
+        '''
+        macc_exon = individu('macc_exon', period)
+        macc_impv = individu('macc_impv', period)
+        macc_imps = individu('macc_imps', period)
+        aacc_exon = individu('aacc_exon', period)
+        aacc_impn = individu('aacc_impn', period)
+        aacc_imps = individu('aacc_imps', period)
+        aacc_defn = individu('aacc_defn', period)
+        aacc_defs = individu('aacc_defs', period)
+        nacc_exon = individu('nacc_exon', period)
+        nacc_impn = individu('nacc_impn', period)
+        nacc_defn = individu('nacc_defn', period)
+        alnp_imps = individu('alnp_imps', period)
+        mncn_impo = individu('mncn_impo', period)
+        cncn_bene = individu('cncn_bene', period)
+        cncn_defi = individu('cncn_defi', period)
+        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro
+
+        zacc = (
+            macc_exon + macc_impv + macc_imps
+            + aacc_exon + aacc_impn + aacc_imps - aacc_defn - aacc_defs
+            + nacc_exon + nacc_impn - nacc_defn - alnp_imps
+            + mncn_impo + cncn_bene - cncn_defi
+            )
+
+    # TODO: aacc_imps aacc_defs
+        cond = (macc_impv > 0) & (macc_imps == 0)
+        taux = micro.microentreprise.regime_micro_bnc.marchandises.taux * cond + micro.microentreprise.regime_micro_bnc.services.taux * not_(cond)
+
+        cacc = min_(macc_impv + macc_imps + macc_exon + mncn_impo, max_(micro.microentreprise.montant_minimum, round_(
+            macc_impv * micro.microentreprise.regime_micro_bnc.marchandises.taux
+            + macc_imps * micro.microentreprise.regime_micro_bnc.services.taux + macc_exon * taux
+            + mncn_impo * micro.microentreprise.regime_micro_bnc.taux)))
+
+        return zacc - cacc
+
+
+class rnc(Variable):
+    value_type = float
+    entity = Individu
+    label = 'Revenus non commerciaux individuels'
+    reference = 'http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&pageId=prof_bnc&impot=BNC&sfid=50'
+    definition_period = YEAR
+
+    def formula(individu, period, parameters):
+        '''
+        Revenus non commerciaux individuels
+        '''
+        mbnc_exon = individu('mbnc_exon', period)
+        mbnc_impo = individu('mbnc_impo', period)
+        abnc_exon = individu('abnc_exon', period)
+        nbnc_exon = individu('nbnc_exon', period)
+        abnc_impo = individu('abnc_impo', period)
+        nbnc_impo = individu('nbnc_impo', period)
+        abnc_defi = individu('abnc_defi', period)
+        nbnc_defi = individu('nbnc_defi', period)
+        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro.microentreprise
+
+        zbnc = (
+            mbnc_exon + mbnc_impo
+            + abnc_exon + nbnc_exon
+            + abnc_impo + nbnc_impo
+            - abnc_defi - nbnc_defi
+            )
+
+        cbnc = min_(
+            mbnc_exon + mbnc_impo,
+            max_(
+                micro.montant_minimum,
+                round_((mbnc_exon + mbnc_impo) * micro.regime_micro_bnc.taux)
+                )
+            )
+
+        return zbnc - cbnc
+
 class total_impots_plafonnement_isf_ifi(Variable):
     value_type = float
     entity = FoyerFiscal
@@ -743,6 +931,154 @@ class isf_ifi(Variable):
 
 # calcul de l'ensemble des revenus du contribuable
 
+class rag(Variable):
+    value_type = float
+    entity = Individu
+    label = 'Revenus agricoles'
+    reference = 'http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&impot=BA&pageId=prof_ba&sfid=50'
+    definition_period = YEAR
+
+    def formula(individu, period, parameters):
+        '''
+        Revenus agricoles
+        '''
+        frag_exon = individu('frag_exon', period)
+        frag_impo = individu('frag_impo', period)
+        arag_exon = individu('arag_exon', period)
+        arag_impg = individu('arag_impg', period)
+        arag_defi = individu('arag_defi', period)
+        nrag_exon = individu('nrag_exon', period)
+        nrag_impg = individu('nrag_impg', period)
+        nrag_defi = individu('nrag_defi', period)
+        nrag_ajag = individu('nrag_ajag', period)
+
+        return (
+            frag_exon + frag_impo
+            + arag_exon + arag_impg - arag_defi
+            + nrag_exon + nrag_impg - nrag_defi
+            + nrag_ajag
+            )
+
+    def formula_2016_01_01(individu, period, parameters):
+        '''
+        Revenus agricoles
+        '''
+        mrag_exon = individu('mrag_exon', period)
+        mrag_impo = individu('mrag_impo', period)
+        arag_exon = individu('arag_exon', period)
+        arag_impg = individu('arag_impg', period)
+        arag_defi = individu('arag_defi', period)
+        nrag_exon = individu('nrag_exon', period)
+        nrag_impg = individu('nrag_impg', period)
+        nrag_defi = individu('nrag_defi', period)
+        nrag_ajag = individu('nrag_ajag', period)
+
+        return (
+            mrag_exon + mrag_impo
+            + arag_exon + arag_impg - arag_defi
+            + nrag_exon + nrag_impg - nrag_defi
+            + nrag_ajag
+            )
+
+
+class ric(Variable):
+    value_type = float
+    entity = Individu
+    label = 'Bénéfices industriels et commerciaux'
+    reference = 'http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?pageId=prof_bic&espId=2&impot=BIC&sfid=50'
+    definition_period = YEAR
+
+    def formula(individu, period, parameters):
+        '''
+        Bénéfices industriels et commerciaux
+        '''
+        mbic_exon = individu('mbic_exon', period)
+        mbic_impv = individu('mbic_impv', period)
+        mbic_imps = individu('mbic_imps', period)
+        abic_exon = individu('abic_exon', period)
+        nbic_exon = individu('nbic_exon', period)
+        abic_impn = individu('abic_impn', period)
+        nbic_impn = individu('nbic_impn', period)
+        abic_imps = individu('abic_imps', period)
+        nbic_imps = individu('nbic_imps', period)
+        abic_defn = individu('abic_defn', period)
+        nbic_defn = individu('nbic_defn', period)
+        abic_defs = individu('abic_defs', period)
+        nbic_defs = individu('nbic_defs', period)
+        nbic_apch = individu('nbic_apch', period)
+        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro
+
+        zbic = (
+            mbic_exon + mbic_impv + mbic_imps
+            + abic_exon + nbic_exon
+            + abic_impn + nbic_impn
+            + abic_imps + nbic_imps
+            + abic_defn - nbic_defn
+            + abic_defs - nbic_defs
+            + nbic_apch
+            )
+
+        cond = (mbic_impv > 0) & (mbic_imps == 0)
+        taux = micro.microentreprise.regime_micro_bnc.marchandises.taux * cond + micro.microentreprise.regime_micro_bnc.services.taux * not_(cond)
+
+        cbic = min_(
+            mbic_impv + mbic_imps + mbic_exon,
+            max_(
+                micro.microentreprise.montant_minimum,
+                round_(
+                    mbic_impv * micro.microentreprise.regime_micro_bnc.marchandises.taux + mbic_imps * micro.microentreprise.regime_micro_bnc.services.taux + mbic_exon * taux
+                    )
+                )
+            )
+        return zbic - cbic
+
+
+class rac(Variable):
+    value_type = float
+    entity = Individu
+    label = 'Revenus accessoires individuels'
+    reference = 'http://vosdroits.service-public.fr/particuliers/F1225.xhtml'
+    definition_period = YEAR
+
+    def formula(individu, period, parameters):
+        '''
+        Revenus accessoires individuels
+        '''
+        macc_exon = individu('macc_exon', period)
+        macc_impv = individu('macc_impv', period)
+        macc_imps = individu('macc_imps', period)
+        aacc_exon = individu('aacc_exon', period)
+        aacc_impn = individu('aacc_impn', period)
+        aacc_imps = individu('aacc_imps', period)
+        aacc_defn = individu('aacc_defn', period)
+        aacc_defs = individu('aacc_defs', period)
+        nacc_exon = individu('nacc_exon', period)
+        nacc_impn = individu('nacc_impn', period)
+        nacc_defn = individu('nacc_defn', period)
+        nacc_pres = individu('nacc_pres', period)
+        mncn_impo = individu('mncn_impo', period)
+        cncn_bene = individu('cncn_bene', period)
+        cncn_defi = individu('cncn_defi', period)
+        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro
+
+        zacc = (
+            macc_exon + macc_impv + macc_imps
+            + aacc_exon + aacc_impn + aacc_imps - aacc_defn - aacc_defs
+            + nacc_exon + nacc_impn - nacc_defn + nacc_pres
+            + mncn_impo + cncn_bene - cncn_defi
+            )
+
+    # TODO: aacc_imps aacc_defs
+        cond = (macc_impv > 0) & (macc_imps == 0)
+        taux = micro.microentreprise.regime_micro_bnc.marchandises.taux * cond + micro.microentreprise.regime_micro_bnc.services.taux * not_(cond)
+
+        cacc = min_(macc_impv + macc_imps + macc_exon + mncn_impo, max_(micro.microentreprise.montant_minimum, round_(
+            macc_impv * micro.microentreprise.regime_micro_bnc.marchandises.taux
+            + macc_imps * micro.microentreprise.regime_micro_bnc.services.taux + macc_exon * taux
+            + mncn_impo * micro.microentreprise.regime_micro_bnc.taux)))
+
+        return zacc - cacc
+
 
 # TODO: à reintégrer dans impot_revenu_restant_a_payer
 class rvcm_plus_abat(Variable):
@@ -777,9 +1113,9 @@ class maj_cga(Variable):
         nbic_defn = individu('nbic_defn', period)
         nbic_defs = individu('nbic_defs', period)
         nacc_impn = individu('nacc_impn', period)
-        nacc_meup = individu('nacc_meup', period)
+        nlnp_defs = individu('nlnp_defs', period)
         nacc_defn = individu('nacc_defn', period)
-        nacc_defs = individu('nacc_defs', period)
+        nlnp_imps = individu('nlnp_imps', period)
         nbnc_impo = individu('nbnc_impo', period)
         nbnc_defi = individu('nbnc_defi', period)
         rpns = parameters(period).impot_revenu.calcul_revenus_imposables.rpns
@@ -788,7 +1124,7 @@ class maj_cga(Variable):
 
         # C revenus industriels et commerciaux non professionnels
         # (revenus accesoires du foyers en nomenclature INSEE)
-        nacc_timp = max_(0, (nacc_impn + nacc_meup) - (nacc_defn + nacc_defs))
+        nacc_timp = max_(0, (nacc_impn + nlnp_imps) - (nacc_defn + nlnp_defs))
 
         # régime de la déclaration contrôlée ne bénéficiant pas de l'abattement association agréée
         nbnc_timp = nbnc_impo - nbnc_defi

--- a/openfisca_france/model/prelevements_obligatoires/isf.py
+++ b/openfisca_france/model/prelevements_obligatoires/isf.py
@@ -562,193 +562,6 @@ class isf_ifi_avant_plaf(Variable):
 
 # # calcul du plafonnement ##
 
-class rag(Variable):
-    value_type = float
-    entity = Individu
-    label = 'Revenus agricoles'
-    reference = 'http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&impot=BA&pageId=prof_ba&sfid=50'
-    definition_period = YEAR
-
-    def formula(individu, period, parameters):
-        '''
-        Revenus agricoles
-        '''
-        frag_exon = individu('frag_exon', period)
-        frag_impo = individu('frag_impo', period)
-        arag_exon = individu('arag_exon', period)
-        arag_impg = individu('arag_impg', period)
-        arag_defi = individu('arag_defi', period)
-        nrag_exon = individu('nrag_exon', period)
-        nrag_impg = individu('nrag_impg', period)
-        nrag_defi = individu('nrag_defi', period)
-        nrag_ajag = individu('nrag_ajag', period)
-
-        return (
-            frag_exon + frag_impo
-            + arag_exon + arag_impg - arag_defi
-            + nrag_exon + nrag_impg - nrag_defi
-            + nrag_ajag
-            )
-
-    def formula_2016_01_01(individu, period, parameters):
-        '''
-        Revenus agricoles
-        '''
-        mrag_exon = individu('mrag_exon', period)
-        mrag_impo = individu('mrag_impo', period)
-        arag_exon = individu('arag_exon', period)
-        arag_impg = individu('arag_impg', period)
-        arag_defi = individu('arag_defi', period)
-        nrag_exon = individu('nrag_exon', period)
-        nrag_impg = individu('nrag_impg', period)
-        nrag_defi = individu('nrag_defi', period)
-        nrag_ajag = individu('nrag_ajag', period)
-
-        return (
-            mrag_exon + mrag_impo
-            + arag_exon + arag_impg - arag_defi
-            + nrag_exon + nrag_impg - nrag_defi
-            + nrag_ajag
-            )
-
-
-class ric(Variable):
-    value_type = float
-    entity = Individu
-    label = 'Bénéfices industriels et commerciaux'
-    reference = 'http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?pageId=prof_bic&espId=2&impot=BIC&sfid=50'
-    definition_period = YEAR
-
-    def formula(individu, period, parameters):
-        '''
-        Bénéfices industriels et commerciaux
-        '''
-        mbic_exon = individu('mbic_exon', period)
-        mbic_impv = individu('mbic_impv', period)
-        mbic_imps = individu('mbic_imps', period)
-        abic_exon = individu('abic_exon', period)
-        nbic_exon = individu('nbic_exon', period)
-        abic_impn = individu('abic_impn', period)
-        nbic_impn = individu('nbic_impn', period)
-        abic_imps = individu('abic_imps', period)
-        nbic_imps = individu('nbic_imps', period)
-        abic_defn = individu('abic_defn', period)
-        nbic_defn = individu('nbic_defn', period)
-        abic_defs = individu('abic_defs', period)
-        nbic_defs = individu('nbic_defs', period)
-        nbic_apch = individu('nbic_apch', period)
-        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro
-
-        zbic = (
-            mbic_exon + mbic_impv + mbic_imps
-            + abic_exon + nbic_exon
-            + abic_impn + nbic_impn
-            + abic_imps + nbic_imps
-            + abic_defn - nbic_defn
-            + abic_defs - nbic_defs
-            + nbic_apch
-            )
-
-        cond = (mbic_impv > 0) & (mbic_imps == 0)
-        taux = micro.microentreprise.regime_micro_bnc.marchandises.taux * cond + micro.microentreprise.regime_micro_bnc.services.taux * not_(cond)
-
-        cbic = min_(
-            mbic_impv + mbic_imps + mbic_exon,
-            max_(
-                micro.microentreprise.montant_minimum,
-                round_(
-                    mbic_impv * micro.microentreprise.regime_micro_bnc.marchandises.taux + mbic_imps * micro.microentreprise.regime_micro_bnc.services.taux + mbic_exon * taux
-                    )
-                )
-            )
-        return zbic - cbic
-
-
-class rac(Variable):
-    value_type = float
-    entity = Individu
-    label = 'Revenus accessoires individuels'
-    reference = 'http://vosdroits.service-public.fr/particuliers/F1225.xhtml'
-    definition_period = YEAR
-
-    def formula(individu, period, parameters):
-        '''
-        Revenus accessoires individuels
-        '''
-        macc_exon = individu('macc_exon', period)
-        macc_impv = individu('macc_impv', period)
-        macc_imps = individu('macc_imps', period)
-        aacc_exon = individu('aacc_exon', period)
-        aacc_impn = individu('aacc_impn', period)
-        aacc_imps = individu('aacc_imps', period)
-        aacc_defn = individu('aacc_defn', period)
-        aacc_defs = individu('aacc_defs', period)
-        nacc_exon = individu('nacc_exon', period)
-        nacc_impn = individu('nacc_impn', period)
-        nacc_defn = individu('nacc_defn', period)
-        alnp_imps = individu('alnp_imps', period)
-        mncn_impo = individu('mncn_impo', period)
-        cncn_bene = individu('cncn_bene', period)
-        cncn_defi = individu('cncn_defi', period)
-        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro
-
-        zacc = (
-            macc_exon + macc_impv + macc_imps
-            + aacc_exon + aacc_impn + aacc_imps - aacc_defn - aacc_defs
-            + nacc_exon + nacc_impn - nacc_defn - alnp_imps
-            + mncn_impo + cncn_bene - cncn_defi
-            )
-
-    # TODO: aacc_imps aacc_defs
-        cond = (macc_impv > 0) & (macc_imps == 0)
-        taux = micro.microentreprise.regime_micro_bnc.marchandises.taux * cond + micro.microentreprise.regime_micro_bnc.services.taux * not_(cond)
-
-        cacc = min_(macc_impv + macc_imps + macc_exon + mncn_impo, max_(micro.microentreprise.montant_minimum, round_(
-            macc_impv * micro.microentreprise.regime_micro_bnc.marchandises.taux
-            + macc_imps * micro.microentreprise.regime_micro_bnc.services.taux + macc_exon * taux
-            + mncn_impo * micro.microentreprise.regime_micro_bnc.taux)))
-
-        return zacc - cacc
-
-
-class rnc(Variable):
-    value_type = float
-    entity = Individu
-    label = 'Revenus non commerciaux individuels'
-    reference = 'http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&pageId=prof_bnc&impot=BNC&sfid=50'
-    definition_period = YEAR
-
-    def formula(individu, period, parameters):
-        '''
-        Revenus non commerciaux individuels
-        '''
-        mbnc_exon = individu('mbnc_exon', period)
-        mbnc_impo = individu('mbnc_impo', period)
-        abnc_exon = individu('abnc_exon', period)
-        nbnc_exon = individu('nbnc_exon', period)
-        abnc_impo = individu('abnc_impo', period)
-        nbnc_impo = individu('nbnc_impo', period)
-        abnc_defi = individu('abnc_defi', period)
-        nbnc_defi = individu('nbnc_defi', period)
-        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro.microentreprise
-
-        zbnc = (
-            mbnc_exon + mbnc_impo
-            + abnc_exon + nbnc_exon
-            + abnc_impo + nbnc_impo
-            - abnc_defi - nbnc_defi
-            )
-
-        cbnc = min_(
-            mbnc_exon + mbnc_impo,
-            max_(
-                micro.montant_minimum,
-                round_((mbnc_exon + mbnc_impo) * micro.regime_micro_bnc.taux)
-                )
-            )
-
-        return zbnc - cbnc
-
 class total_impots_plafonnement_isf_ifi(Variable):
     value_type = float
     entity = FoyerFiscal
@@ -1078,6 +891,45 @@ class rac(Variable):
             + mncn_impo * micro.microentreprise.regime_micro_bnc.taux)))
 
         return zacc - cacc
+
+
+class rnc(Variable):
+    value_type = float
+    entity = Individu
+    label = 'Revenus non commerciaux individuels'
+    reference = 'http://www.impots.gouv.fr/portal/dgi/public/professionnels.impot?espId=2&pageId=prof_bnc&impot=BNC&sfid=50'
+    definition_period = YEAR
+
+    def formula(individu, period, parameters):
+        '''
+        Revenus non commerciaux individuels
+        '''
+        mbnc_exon = individu('mbnc_exon', period)
+        mbnc_impo = individu('mbnc_impo', period)
+        abnc_exon = individu('abnc_exon', period)
+        nbnc_exon = individu('nbnc_exon', period)
+        abnc_impo = individu('abnc_impo', period)
+        nbnc_impo = individu('nbnc_impo', period)
+        abnc_defi = individu('abnc_defi', period)
+        nbnc_defi = individu('nbnc_defi', period)
+        micro = parameters(period).impot_revenu.calcul_revenus_imposables.rpns.micro.microentreprise
+
+        zbnc = (
+            mbnc_exon + mbnc_impo
+            + abnc_exon + nbnc_exon
+            + abnc_impo + nbnc_impo
+            - abnc_defi - nbnc_defi
+            )
+
+        cbnc = min_(
+            mbnc_exon + mbnc_impo,
+            max_(
+                micro.montant_minimum,
+                round_((mbnc_exon + mbnc_impo) * micro.regime_micro_bnc.taux)
+                )
+            )
+
+        return zbnc - cbnc
 
 
 # TODO: à reintégrer dans impot_revenu_restant_a_payer

--- a/openfisca_france/model/revenus/activite/non_salarie.py
+++ b/openfisca_france/model/revenus/activite/non_salarie.py
@@ -263,6 +263,7 @@ class nrag_exon(Variable):
     entity = Individu
     label = "Revenus agricoles exonérés yc plus-values (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur), activités exercées en Corse"
     # start_date = date(2007, 1, 1)
+    end = '2023-12-01'
     definition_period = YEAR
 
 
@@ -289,6 +290,7 @@ class nrag_defi(Variable):
     entity = Individu
     label = "Déficits agricoles (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
     # start_date = date(2007, 1, 1)
+    end = '2023-12-01'
     definition_period = YEAR
 
 
@@ -382,6 +384,7 @@ class nbic_exon(Variable):
     unit = 'currency'
     entity = Individu
     label = 'Revenus industriels et commerciaux nets exonérés yc plus-values sans CGA (régime du bénéfice réel)'
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -444,6 +447,7 @@ class nbic_impn(Variable):
     unit = 'currency'
     entity = Individu
     label = 'Revenus industriels et commerciaux professionnels imposables: régime normal ou simplifié sans CGA (régime du bénéfice réel)'
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -528,6 +532,7 @@ class nbic_defn(Variable):
     unit = 'currency'
     entity = Individu
     label = 'Déficits industriels et commerciaux: régime normal ou simplifié sans CGA (régime du bénéfice réel)'
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -539,8 +544,21 @@ class nbic_defs(Variable):
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = 'Locations déjà soumises aux prélèvements sociaux sans CGA (régime du bénéfice réel)'
+    label = 'Déficits industriels et commerciaux: régime normal ou simplifié sans CGA (régime simplifié du bénéfice réel)'
     end = '2009-12-31'
+    definition_period = YEAR
+
+#TODO : ajouter dans formules
+class nlnp_imps(Variable):
+    cerfa_field = {0: '5KM',
+        1: '5LM',
+        2: '5MM', }
+    value_type = int
+    unit = 'currency'
+    entity = Individu
+    label = "Locations meublées non professionnelles: Gîtes ruraux et chambres d'hôtes déjà soumis aux prélèvements sociaux sans CGA (régime du bénéfice réel)"
+    # start_date = date(2012, 1, 1)
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -603,6 +621,7 @@ class nacc_exon(Variable):
     unit = 'currency'
     entity = Individu
     label = 'Revenus industriels et commerciaux non professionnels exonérés yc plus-values sans CGA (régime du bénéfice réel)'
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -689,6 +708,7 @@ class nacc_impn(Variable):
     unit = 'currency'
     entity = Individu
     label = 'Revenus industriels et commerciaux non professionnels imposables: régime normal ou simplifié sans CGA (régime du bénéfice réel)'
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -713,7 +733,7 @@ class nacc_meup(Variable):
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = 'Locations meublées non professionnelles: Locations déjà soumises aux prélèvements sociaux (régime micro entreprise)'
+    label = "Locations meublées non professionnelles: Locations meublées et chambre d'hôtes déjà soumises aux prélèvements sociaux (régime micro entreprise)"
     # start_date = date(2012, 1, 1)
     definition_period = YEAR
 
@@ -740,11 +760,12 @@ class nacc_defn(Variable):
     unit = 'currency'
     entity = Individu
     label = 'Déficits industriels et commerciaux non professionnels: régime normal ou simplifié sans CGA (régime du bénéfice réel)'
+    end = '2022-12-31'
     definition_period = YEAR
 
 
 # (f5nm, f5om, f5pm)) #TODO autres 5NM
-class nacc_defs(Variable):
+class nacc_pres(Variable):
     cerfa_field = {0: '5NM',
         1: '5OM',
         2: '5PM', }
@@ -778,6 +799,7 @@ class cncn_bene(Variable):
     entity = Individu
     label = 'Revenus non commerciaux non professionnels imposables sans AA (régime de la déclaration controlée)'
     # start_date = date(2006, 1, 1)
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -792,6 +814,7 @@ class cncn_defi(Variable):
     entity = Individu
     label = 'Déficits non commerciaux non professionnels sans AA (régime de la déclaration controlée)'
     # start_date = date(2006, 1, 1)
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -828,6 +851,7 @@ class nbnc_exon(Variable):
     unit = 'currency'
     entity = Individu
     label = "Revenus non commerciaux professionnels exonérés (yc compris plus-values) (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -889,6 +913,7 @@ class nbnc_impo(Variable):
     unit = 'currency'
     entity = Individu
     label = "Revenus non commerciaux professionnels imposables (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -901,6 +926,7 @@ class nbnc_defi(Variable):
     unit = 'currency'
     entity = Individu
     label = "Déficits non commerciaux professionnels (régime de la déclaration controlée, revenus ne bénéficiant pas de l'abattement association agrée)"
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -1185,6 +1211,7 @@ class nbic_pvce(Variable):
     entity = Individu
     label = 'Revenus non commerciaux non professionnels exonérés sans AA (régime de la déclaration controlée)'
     # start_date = date(2008, 1, 1)
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -1222,6 +1249,7 @@ class nacc_pvce(Variable):
     entity = Individu
     label = 'Locations meublées non professionnelles: Revenus imposables sans CGA (régime du bénéfice réel)'
     # start_date = date(2009, 1, 1)
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -1310,6 +1338,7 @@ class arag_sjag(Variable):
     entity = Individu
     label = 'Abattement pour les jeunes agriculteurs des revenus agricoles sans CGA (régime du bénéfice réel)'
     # start_date = date(2011, 1, 1)
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -1385,8 +1414,7 @@ class nlnp_defs(Variable):
     entity = Individu
     label = 'Déficits de locations meublées non professionnelles imposables sans CGA (régime du bénéfice réel)'
     # start_date = date(2009, 1, 1)
-    end = '2010-12-31'
-    # TODO: Toujours present dans brochure 2019 par ex.
+    end = '2022-12-31'
     definition_period = YEAR
 
 

--- a/openfisca_france/model/revenus/activite/non_salarie.py
+++ b/openfisca_france/model/revenus/activite/non_salarie.py
@@ -277,6 +277,7 @@ class nrag_impg(Variable):
     entity = Individu
     label = "Revenus agricoles imposables, cas général moyenne triennale (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
     # start_date = date(2007, 1, 1)
+    end = '2022-12-31'
     definition_period = YEAR
 
 

--- a/openfisca_france/model/revenus/activite/non_salarie.py
+++ b/openfisca_france/model/revenus/activite/non_salarie.py
@@ -263,7 +263,7 @@ class nrag_exon(Variable):
     entity = Individu
     label = "Revenus agricoles exonérés yc plus-values (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur), activités exercées en Corse"
     # start_date = date(2007, 1, 1)
-    end = '2023-12-01'
+    end = '2022-12-31'
     definition_period = YEAR
 
 
@@ -290,7 +290,7 @@ class nrag_defi(Variable):
     entity = Individu
     label = "Déficits agricoles (Régime du bénéfice réel, revenus ne bénéficiant pas de l'abattement CGA ou viseur)"
     # start_date = date(2007, 1, 1)
-    end = '2023-12-01'
+    end = '2022-12-31'
     definition_period = YEAR
 
 

--- a/openfisca_france/model/revenus/activite/non_salarie.py
+++ b/openfisca_france/model/revenus/activite/non_salarie.py
@@ -548,7 +548,8 @@ class nbic_defs(Variable):
     end = '2009-12-31'
     definition_period = YEAR
 
-#TODO : ajouter dans formules
+
+# TODO : ajouter dans formules
 class nlnp_imps(Variable):
     cerfa_field = {0: '5KM',
         1: '5LM',

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/cga_taux2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/cga_taux2.yaml
@@ -10,6 +10,8 @@ values:
     value: 0.15
   2022-01-01:
     value: 0.1
+  2023-01-01:
+    value: null
 metadata:
   unit: /1
   reference:
@@ -18,6 +20,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044983195/2023-01-01
     - title: Loi de finances pour 2021, article 34
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042753625
+    2023-01-01:
+      title: Article 158 du CGI
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044983195/2024-01-03/
   official_journal_date:
     2020-01-01: "2020-12-30"
   notes:
@@ -25,3 +30,5 @@ metadata:
     - title: La modification du taux était programmée en 2020.
     2022-01-01:
     - title: La modification du taux était programmée en 2020.
+    2023-01-01:
+    - title: la modification du taux était programmée en 2020.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/cga_taux2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/cga_taux2.yaml
@@ -31,4 +31,4 @@ metadata:
     2022-01-01:
     - title: La modification du taux était programmée en 2020.
     2023-01-01:
-    - title: la modification du taux était programmée en 2020.
+    - title: la suppression de la pénalité était programmée en 2020.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/cga_taux2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/cga_taux2.yaml
@@ -21,7 +21,9 @@ metadata:
     - title: Loi de finances pour 2021, article 34
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042753625
     2023-01-01:
-      title: Article 158 du CGI
+    - title: Loi de finances pour 2021, article 34
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000042753625
+    - title: Article 158 du CGI
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044983195/2024-01-03/
   official_journal_date:
     2020-01-01: "2020-12-30"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '157.0.3',
+    version = '158.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/calculateur_impots/yaml/regime_benef_reel_BIC_location_avec_cga.yaml
+++ b/tests/calculateur_impots/yaml/regime_benef_reel_BIC_location_avec_cga.yaml
@@ -24,7 +24,7 @@
         alnp_defs: 500
         alnp_imps: 0
         date_naissance: '1970-01-01'
-        nacc_defs: 20000
+        nacc_pres: 20000
         statut_marital: celibataire
     famille:
       parents:
@@ -65,7 +65,7 @@
         alnp_defs: 500
         alnp_imps: 0
         date_naissance: '1970-01-01'
-        nacc_defs: 20000
+        nacc_pres: 20000
         statut_marital: celibataire
     famille:
       parents:
@@ -106,7 +106,7 @@
         alnp_defs: 500
         alnp_imps: 0
         date_naissance: '1970-01-01'
-        nacc_defs: 20000
+        nacc_pres: 20000
         statut_marital: celibataire
     famille:
       parents:

--- a/tests/calculateur_impots/yaml/regime_benef_reel_BIC_location_avec_cga.yaml
+++ b/tests/calculateur_impots/yaml/regime_benef_reel_BIC_location_avec_cga.yaml
@@ -122,3 +122,44 @@
     reduction_ss_condition_revenus: 123.0
     rfr: 19500.0
     rni: 19500.0
+- name: rpns_divers_apres_cga
+  period: 2023
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      caseF: false
+      caseG: false
+      caseL: false
+      caseP: false
+      caseS: false
+      caseT: false
+      caseW: false
+      declarants:
+      - ind0
+      nbF: 0.0
+      nbG: 0.0
+      nbH: 0.0
+      nbI: 0.0
+      nbJ: 0
+      nbR: 0
+    individus:
+      ind0:
+        activite: actif
+        arag_impg: 1000
+        abic_impn: 6000
+        aacc_impn: 10000
+        alnp_imps: 3000
+        abnc_impo: 15000
+        cncn_aimp: 2000
+        revimpres: 4000
+        date_naissance: '1970-01-01'
+        statut_marital: celibataire
+    famille:
+      parents:
+      - ind0
+    menage:
+      personne_de_reference: ind0
+  output:
+    impot_revenu_restant_a_payer: -4386.0
+    rfr: 37000.0
+    rni: 37000.0


### PR DESCRIPTION
* Évolution du système socio-fiscal. 
* Périodes concernées :  à partir du 01/01/2023.
* Zones impactées : `model/prelevements_obligatoires/impot_revenu/ir`.
* Détails :
  - La pénalité pour absence de CGA pour les revenus non-salariaux prend fin en 2023. Le taux associé prend donc fin, et de nombreuses formules sont reformulées dans une version 2023 un peu allégée. De nombreuses cases fiscales sont supprimées en conséquence.
  - Renomme `nacc_defs`, qui n'était pas un déficit et dont le nom portait donc à confusion, en  `nacc_imps`.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).
- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.
- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
