### PR TITLE
Modifie la manière de s'authentifier à Pypi pour la publication de paquets

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -204,8 +204,8 @@ jobs:
     needs: [ check-for-functional-changes ]
     if: needs.check-for-functional-changes.outputs.status == 'success'
     env:
-      PYPI_USERNAME: openfisca-bot
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      PYPI_USERNAME: __token__
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -227,7 +227,7 @@ jobs:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}-ubuntu-20.04-${{ matrix.dependencies-version }}
       - name: Upload a Python package to PyPi
-        run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
+        run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_TOKEN
       - name: Publish a git tag
         run: "${GITHUB_WORKSPACE}/.github/publish-git-tag.sh"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+### 155.1.6 [2231](https://github.com/openfisca/openfisca-france/pull/2231)
+
+Amélioration technique.
+* Zones impactée : `.github/workflows/workflow.yml`.
+* Détail :
+  - Modifie l'authentification à Pypi pour se connecter via un token
 
 ## 155.1.5 [2227](https://github.com/openfisca/openfisca-france/pull/2227)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Amélioration technique.
 * Zones impactée : `.github/workflows/workflow.yml`.
 * Détail :
-  - Modifie l'authentification à Pypi pour se connecter via un token
+  - Modifie l'authentification à Pypi pour se connecter via un token suite à l'obligation d'utiliser la double authentification (2FA)
 
 ## 155.1.5 [2227](https://github.com/openfisca/openfisca-france/pull/2227)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '155.1.5',
+    version = '155.1.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Amélioration technique.
* Zones impactées : `.github/workflows/workflow.yml`.
* Détails :
  - Modifie l'authentification à Pypi pour se connecter via un token

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).