### PR TITLE
Met à jour PSS pour 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+
+### [2233](https://github.com/openfisca/openfisca-france/pull/2233)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2024
+* Zones impactées : openfisca_france/parameters/prelevements_sociaux/pss.
+* Détails :
+  - Met à jour les montant du plafond de la sécurité sociale pour 2024
+
 ### 155.1.6 [2231](https://github.com/openfisca/openfisca-france/pull/2231)
 
 Amélioration technique.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [2233](https://github.com/openfisca/openfisca-france/pull/2233)
+### 155.1.7[2233](https://github.com/openfisca/openfisca-france/pull/2233)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2024

--- a/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_annuel.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_annuel.yaml
@@ -168,6 +168,8 @@ values:
     value: 41136
   2023-01-01:
     value: 43992
+  2024-01-01:
+    value: 46368
 metadata:
   short_label: Annuel
   last_value_still_valid_on: "2021-01-01"
@@ -377,6 +379,9 @@ metadata:
     2023-01-01:
       title: Arrêté du 09/12/2022
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046745084
+    2024-01-01:
+      title: Arrêté du 19/12/2023
+      href : https://www.legifrance.gouv.fr/jorf/id/JORFARTI000048708695#JORFARTI000048708695
   official_journal_date:
     1938-07-01: "1938-06-15"
     1946-10-01: "1946-10-08"
@@ -454,6 +459,7 @@ metadata:
     2020-01-01: "2019-12-03"
     2021-01-01: "2020-12-29"
     2023-01-01: "2022-12-16"
+    2024-01-01: "2023-12-29"
   notes:
     1930-07-01:
     - title: Voir référence sur Gallica.bnf.fr

--- a/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_annuel.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_annuel.yaml
@@ -172,7 +172,7 @@ values:
     value: 46368
 metadata:
   short_label: Annuel
-  last_value_still_valid_on: "2021-01-01"
+  last_value_still_valid_on: "2024-01-05"
   label_en: Social security yearly ceiling
   ipp_csv_id: pss_a
   unit: currency

--- a/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_horaire.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_horaire.yaml
@@ -18,7 +18,7 @@ values:
     value: 29
 metadata:
   short_label: Plafond horaire
-  last_value_still_valid_on: "2015-01-01"
+  last_value_still_valid_on: "2024-01-05"
   label_en: Social security hourly ceiling
   unit: currency
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_horaire.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_horaire.yaml
@@ -14,6 +14,8 @@ values:
     value: 26
   2023-01-01:
     value: 27
+  2024-01-01:
+    value: 29
 metadata:
   short_label: Plafond horaire
   last_value_still_valid_on: "2015-01-01"
@@ -43,6 +45,11 @@ metadata:
     2023-01-01:
       title: Arrêté du 09/12/2022
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046745084
+    2024-01-01:
+    - title: Arrêté du 19/12/2023
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000048708695#JORFARTI000048708695
+    - title: Site de l'URSSAF
+      href: https://www.urssaf.fr/portail/home/taux-et-baremes/plafonds.html
   official_journal_date:
     2009-01-01: "2008-12-24"
     2010-01-01: "2009-11-26"
@@ -51,6 +58,7 @@ metadata:
     2018-01-01: "2017-12-09"
     2020-01-01: "2019-12-03"
     2023-01-01: "2022-12-16"
+    2024-01-01: "2023-12-29"
   notes:
     2015-01-01:
     - title: à partir de cette date, les montants ne sont plus explicitement dans la loi,  mais sont calculés à partir de https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000025103320/2012-01-01/ (montant_mensuel*12/nb_h_travaillee_de_ref, ce dernier valant 1607)

--- a/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_mensuel.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_mensuel.yaml
@@ -184,6 +184,8 @@ values:
     value: 3428
   2023-01-01:
     value: 3666
+  2024-01-01:
+    value: 3864
 metadata:
   short_label: Plafond mensuel
   last_value_still_valid_on: "2023-01-01"
@@ -425,6 +427,9 @@ metadata:
     2023-01-01:
       title: Arrêté du 09/12/2022
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046745084
+    2024-01-01:
+      title: Arrêté du 19/12/2023
+      href : https://www.legifrance.gouv.fr/jorf/id/JORFARTI000048708695#JORFARTI000048708695
   official_journal_date:
     1946-07-01: "1945-10-06"
     1946-10-01: "1946-10-08"
@@ -517,6 +522,7 @@ metadata:
     2020-01-01: "2019-12-03"
     2021-01-01: "2020-12-29"
     2023-01-01: "2022-12-16"
+    2024-01-01: "2023-12-29"
   notes:
     1930-07-01:
     - title: Voir référence sur Gallica.bnf.fr

--- a/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_mensuel.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_mensuel.yaml
@@ -188,7 +188,7 @@ values:
     value: 3864
 metadata:
   short_label: Plafond mensuel
-  last_value_still_valid_on: "2023-01-01"
+  last_value_still_valid_on: "2024-01-05"
   label_en: Social security monthly ceiling
   ipp_csv_id: pss_m
   unit: currency

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '155.1.6',
+    version = '155.1.7',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal. 
* Périodes concernées : à partir du 01/01/2024
* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/pss`.
* Détails :
  - Met à jour les montant du plafond de la sécurité sociale pour 2024

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.