### PR TITLE
Met à jour les montants d'aspa pour 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 155.1.8[2234](https://github.com/openfisca/openfisca-france/pull/2234)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2024.
+* Zones impactées : `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa`.
+* Détails :
+  - Met à jour les montant de l'aspa à partir du 01/01/2024
+
 ### 155.1.7[2233](https://github.com/openfisca/openfisca-france/pull/2233)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/montant_maximum_annuel/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/montant_maximum_annuel/couples.yaml
@@ -110,7 +110,7 @@ metadata:
       title: Circulaire Cnav 2023/3 du 09/01/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_03_09012023.pdf
     2024-01-01:
-      title: Circulaire Cnav 2023-34 du 29/12/2023 p10.
+      title: Circulaire Cnav 2023-34 du 29/12/2023 (page 10).
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_34_29122023.pdf
   official_journal_date:
     2006-01-01: "2007-01-13"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/montant_maximum_annuel/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/montant_maximum_annuel/couples.yaml
@@ -40,9 +40,11 @@ values:
     value: 17762.96
   2023-01-01:
     value: 17905.06
+  2024-01-01:
+    value: 18854.02
 metadata:
   short_label: Couple
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-05"
   label_en: Solidarity income for elderly (ASPA)
   ipp_csv_id: aspa_men
   unit: currency
@@ -107,6 +109,9 @@ metadata:
     2023-01-01:
       title: Circulaire Cnav 2023/3 du 09/01/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_03_09012023.pdf
+    2024-01-01:
+      title: Circulaire Cnav 2023-34 du 29/12/2023 p10.
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_34_29122023.pdf
   official_journal_date:
     2006-01-01: "2007-01-13"
     2007-01-01: "2006-12-30"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/montant_maximum_annuel/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/montant_maximum_annuel/personnes_seules.yaml
@@ -110,7 +110,7 @@ metadata:
       title: Circulaire Cnav 2023/3 du 09/01/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_03_09012023.pdf
     2024-01-01:
-      title: Circulaire Cnav 2023-34 du 29/12/2023 p10.
+      title: Circulaire Cnav 2023-34 du 29/12/2023 (page 10).
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_34_29122023.pdf
   official_journal_date:
     2006-01-01: "2007-01-13"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/montant_maximum_annuel/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/montant_maximum_annuel/personnes_seules.yaml
@@ -40,9 +40,11 @@ values:
     value: 11441.5
   2023-01-01:
     value: 11533.02
+  2024-01-01:
+    value: 12144.27
 metadata:
   short_label: Personnes seules
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-05"
   label_en: Solidarity income for elderly (ASPA)
   ipp_csv_id: aspa_seul
   unit: currency
@@ -107,6 +109,9 @@ metadata:
     2023-01-01:
       title: Circulaire Cnav 2023/3 du 09/01/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_03_09012023.pdf
+    2024-01-01:
+      title: Circulaire Cnav 2023-34 du 29/12/2023 p10.
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_34_29122023.pdf
   official_journal_date:
     2006-01-01: "2007-01-13"
     2007-01-01: "2006-12-30"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/plafond_ressources/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/plafond_ressources/couples.yaml
@@ -110,7 +110,7 @@ metadata:
       title: Circulaire Cnav 2023/3 du 09/01/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_03_09012023.pdf
     2024-01-01:
-      title: Circulaire Cnav 2023-34 du 29/12/2023 p10.
+      title: Circulaire Cnav 2023-34 du 29/12/2023 (page 10).
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_34_29122023.pdf
   official_journal_date:
     2006-01-01: "2007-01-13"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/plafond_ressources/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/plafond_ressources/couples.yaml
@@ -40,9 +40,11 @@ values:
     value: 17762.96
   2023-01-01:
     value: 17905.06
+  2024-01-01:
+    value: 18854.02
 metadata:
   short_label: Couple
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-05"
   label_en: Solidarity income for elderly (ASPA)
   ipp_csv_id: plaf_mv_men_aspa
   unit: currency
@@ -107,6 +109,9 @@ metadata:
     2023-01-01:
       title: Circulaire Cnav 2023/3 du 09/01/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_03_09012023.pdf
+    2024-01-01:
+      title: Circulaire Cnav 2023-34 du 29/12/2023 p10.
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_34_29122023.pdf
   official_journal_date:
     2006-01-01: "2007-01-13"
     2007-01-01: "2006-12-30"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/plafond_ressources/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/plafond_ressources/personnes_seules.yaml
@@ -48,9 +48,11 @@ values:
     value: 11441.5
   2023-01-01:
     value: 11533.02
+  2024-01-01:
+    value: 12144.27
 metadata:
   short_label: Personne seule
-  last_value_still_valid_on: "2021-01-01"
+  last_value_still_valid_on: "2024-01-05"
   label_en: Solidarity income for elderly (ASPA)
   ipp_csv_id: plaf_mv_seul_aspa
   unit: currency
@@ -115,6 +117,9 @@ metadata:
     2023-01-01:
       title: Circulaire Cnav 2023/3 du 09/01/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_03_09012023.pdf
+    2024-01-01:
+      title: Circulaire Cnav 2023-34 du 29/12/2023 p10.
+      href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_34_29122023.pdf
   official_journal_date:
     2006-01-01: "2007-01-13"
     2007-01-01: "2006-12-30"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/plafond_ressources/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa/plafond_ressources/personnes_seules.yaml
@@ -118,7 +118,7 @@ metadata:
       title: Circulaire Cnav 2023/3 du 09/01/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_03_09012023.pdf
     2024-01-01:
-      title: Circulaire Cnav 2023-34 du 29/12/2023 p10.
+      title: Circulaire Cnav 2023-34 du 29/12/2023 (page 10).
       href: https://legislation.lassuranceretraite.fr/Pdf/circulaire_cnav_2023_34_29122023.pdf
   official_journal_date:
     2006-01-01: "2007-01-13"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '155.1.7',
+    version = '155.1.8',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2024.
* Zones impactées : `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minimum_vieillesse/aspa`.
* Détails :
  - Met à jour les montant de l'aspa à partir du 01/01/2024

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.