### PR TITLE
Références législatives de janvier 2024 pour les aides au logement et la réduction de loyer de solidarité

### DIFF
--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux1pac.yaml
@@ -41,6 +41,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
     - title: Article D823-17 du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
+    2024-01-01:
+      title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux2pac.yaml
@@ -41,6 +41,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
     - title: Article D823-17 du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
+    2024-01-01:
+      title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux3pac.yaml
@@ -41,6 +41,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
     - title: Article D823-17 du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
+    2024-01-01:
+      title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux4pac.yaml
@@ -41,6 +41,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
     - title: Article D823-17 du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
+    2024-01-01:
+      title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux5pac.yaml
@@ -41,6 +41,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
     - title: Article D823-17 du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
+    2024-01-01:
+      title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux6pac.yaml
@@ -41,6 +41,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
     - title: Article D823-17 du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
+    2024-01-01:
+      title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_couple.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_couple.yaml
@@ -41,6 +41,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
     - title: Article D823-17 du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
+    2024-01-01:
+      title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_pac_supp.yaml
@@ -41,6 +41,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
     - title: Article D823-17 du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
+    2024-01-01:
+      title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_seul.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_seul.yaml
@@ -41,6 +41,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
     - title: Article D823-17 du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
+    2024-01-01:
+      title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/couples.yaml
@@ -58,6 +58,9 @@ metadata:
     2023-10-01:
       title: Arrêté du 21/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048100093
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/famille_1pac.yaml
@@ -58,6 +58,9 @@ metadata:
     2023-10-01:
       title: Arrêté du 21/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048100093
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/majoration_par_pac_supp.yaml
@@ -58,6 +58,9 @@ metadata:
     2023-10-01:
       title: Arrêté du 21/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048100093
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/personnes_seules.yaml
@@ -58,6 +58,9 @@ metadata:
     2023-10-01:
       title: Arrêté du 21/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048100093
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/couples.yaml
@@ -58,6 +58,9 @@ metadata:
     2023-10-01:
       title: Arrêté du 21/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048100093
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/famille_1pac.yaml
@@ -58,6 +58,9 @@ metadata:
     2023-10-01:
       title: Arrêté du 21/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048100093
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/majoration_par_pac_supp.yaml
@@ -58,6 +58,9 @@ metadata:
     2023-10-01:
       title: Arrêté du 21/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048100093
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/personnes_seules.yaml
@@ -58,6 +58,9 @@ metadata:
     2023-10-01:
       title: Arrêté du 21/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048100093
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/couples.yaml
@@ -58,6 +58,9 @@ metadata:
     2023-10-01:
       title: Arrêté du 21/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048100093
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/famille_1pac.yaml
@@ -58,6 +58,9 @@ metadata:
     2023-10-01:
       title: Arrêté du 21/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048100093
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/majoration_par_pac_supp.yaml
@@ -58,6 +58,9 @@ metadata:
     2023-10-01:
       title: Arrêté du 21/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048100093
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/personnes_seules.yaml
@@ -58,6 +58,9 @@ metadata:
     2023-10-01:
       title: Arrêté du 21/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048100093
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/couples.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_1pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_2pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_3pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_4pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_5pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_6pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/majoration_par_pac_supp.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/personnes_seules.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/couples.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_1pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_2pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_3pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_4pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_5pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_6pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/majoration_par_pac_supp.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/personnes_seules.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/couples.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_1pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_2pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_3pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_4pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_5pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_6pac.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/majoration_par_pac_supp.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/personnes_seules.yaml
@@ -20,6 +20,9 @@ metadata:
     2019-01-01:
       title: Arrêté du 27/12/2018, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037880880
+    2024-01-01:
+      title: Arrêté du 29/12/2023 relatif à la revalorisation des plafonds de ressources et des montants de réduction de loyer de solidarité applicables, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048729702
   official_journal_date:
     2018-01-01: "2018-02-28"
     2019-01-01: "2018-12-29"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_11.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_11.yaml
@@ -39,4 +39,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419188
     - title: Arrêté du 27 septembre 2019, article 6
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046126949/2022-08-01
+    2024-01-01:
+      title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
 documentation: Plancher de ressources (avant 2021) puis forfait de ressources (depuis 2021) pour les étudiants dans un logement foyer (avant oct 2019, R.351-7-2 du CCH et art. 8 de l'arrêté du 30 juin 1979 ; oct 2019 - dec 2020, art. 6 de l'arrêté du 27 sept 2019 et art. R822-21 du CCH ; depuis janv 2021, même arrêté et art. R822-20 du CCH

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_4.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_4.yaml
@@ -49,4 +49,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419188
     - title: Arrêté du 27 septembre 2019, article 6
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046126949/2022-08-01
+    2024-01-01:
+      title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
 documentation: Plancher de ressources (avant 2021) puis forfait de ressources (depuis 2021) pour les étudiants (avant oct 2019, R.351-7-2 du CCH et art. 1 quater de l'arrêté du 3 juillet 1978 ; oct 2019 - dec 2020, art. 6 de l'arrêté du 27 sept 2019 et art. R822-21 du CCH ; depuis janv 2021, même arrêté et art. R822-20 du CCH

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_5.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_5.yaml
@@ -30,4 +30,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419188
     - title: Arrêté du 27 septembre 2019, article 6
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046126949/2022-08-01
+    2024-01-01:
+      title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
 documentation: Minoration du plancher de ressources étudiant (avant 2021) puis du forfait de ressources étudiant (depuis 2021) pour les boursiers (avant oct 2019, R.351-7-2 du CCH et art. 1 quater de l'arrêté du 3 juillet 1978 ; oct 2019 - dec 2020, art. 6 de l'arrêté du 27 sept 2019 et art. R822-21 du CCH ; depuis janv 2021, même arrêté et art. R822-20 du CCH


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/2024.
* Zones impactées :
  * `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0`
  * `openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant`
  * `openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources`
  * `openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_11.yaml`
  * `openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_4.yaml`
  * `openfisca_france/parameters/prestations_sociales/aides_logement/ressources/dar_5.yaml`
* Détails :
  * Mise à jour des références législatives pour les revalorisations de la PR #2224 .
- - - -

Ces changements :

- Apportent des informations supplémentaires sur les références législatives de revalorisations antérieures.