### PR TITLE
Mets à jour les seuils de rfr pour la csg retraite pour 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 155.2.2 [2239](https://github.com/openfisca/openfisca-france/pull/2239)
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2024
+* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/`.
+* Détails :
+  - Met à jour les seuils de rfr pour le calcul de la csg sur les retraites à partir de 2024
+
 ### 155.2.1 [2237](https://github.com/openfisca/openfisca-france/pull/2237)
 
 * Amélioration technique. 

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/deductible/taux_median.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/deductible/taux_median.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.042
 metadata:
   short_label: Taux médian
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   ipp_csv_id: csg_pens_median_deductible
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/deductible/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/deductible/taux_plein.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.059
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   ipp_csv_id: csg_pens_ded
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/deductible/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/deductible/taux_reduit.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   ipp_csv_id: csg_pens_red_deductible
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/imposable/taux_median.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/imposable/taux_median.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.024
 metadata:
   short_label: Taux médian
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   unit: /1
   reference:
     1997-01-01:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/imposable/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/imposable/taux_plein.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.024
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   unit: /1
   reference:
     1997-01-01:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/imposable/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/imposable/taux_reduit.yaml
@@ -4,7 +4,7 @@ values:
     value: 0
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   label_en: CSG - rates on work incomes
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_median.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_median.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.066
 metadata:
   short_label: Taux médian global
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   label_en: CSG - rates on replacement incomes
   ipp_csv_id: csg_pens_median_total
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_plein.yaml
@@ -14,7 +14,7 @@ values:
     value: 0.083
 metadata:
   short_label: Taux plein global
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   label_en: CSG - rates on work incomes
   ipp_csv_id: csg_pens
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/pensions_retraite_invalidite/taux_reduit.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux réduit global
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   label_en: CSG - rates on work incomes
   ipp_csv_id: csg_pens_red
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/demi_part_suppl_rfr1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/demi_part_suppl_rfr1.yaml
@@ -20,9 +20,11 @@ values:
     value: 3052
   2023-01-01:
     value: 3101
+  2024-01-01:
+    value: 3265
 metadata:
   short_label: Majoration du seuil par demi-part de quotient familial supplémentaire
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red1_demip
   unit: currency
@@ -66,6 +68,9 @@ metadata:
     2023-01-01:
       title: Lettre ministérielle D-22-024221 du 12/12/2022
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_12122022.pdf
+    2024-01-01:
+      title: Lettre ministérielle D23-022880 du 23/11/2023
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_23112023.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/seuil_rfr1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/seuil_rfr1.yaml
@@ -20,9 +20,11 @@ values:
     value: 11431
   2023-01-01:
     value: 11614
+  2024-01-01:
+    value: 12230
 metadata:
   short_label: Seuil de RFR pour la première part de quotient familial
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red1
   unit: currency
@@ -66,6 +68,9 @@ metadata:
     2023-01-01:
       title: Lettre ministérielle D-22-024221 du 12/12/2022
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_12122022.pdf
+    2024-01-01:
+      title: Lettre ministérielle D23-022880 du 23/11/2023
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_23112023.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/demi_part_suppl_rfr2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/demi_part_suppl_rfr2.yaml
@@ -20,6 +20,8 @@ values:
     value: 3990
   2023-01-01:
     value: 4054
+  2024-01-01:
+    value: 4269
 metadata:
   short_label: Majoration du seuil par demi-part de quotient familial supplémentaire
   last_value_still_valid_on: "2023-07-05"
@@ -66,6 +68,9 @@ metadata:
     2023-01-01:
       title: Lettre ministérielle D-22-024221 du 12/12/2022
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_12122022.pdf
+    2024-01-01:
+      title: Lettre ministérielle D23-022880 du 23/11/2023
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_23112023.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/seuil_rfr2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/seuil_rfr2.yaml
@@ -20,9 +20,11 @@ values:
     value: 14944
   2023-01-01:
     value: 15183
+  2024-01-01:
+    value: 15988
 metadata:
   short_label: Seuil de RFR pour la première part de quotient familial
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red2
   unit: currency
@@ -66,6 +68,9 @@ metadata:
     2023-01-01:
       title: Lettre ministérielle D-22-024221 du 12/12/2022
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_12122022.pdf
+    2024-01-01:
+      title: Lettre ministérielle D23-022880 du 23/11/2023
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_23112023.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/demi_part_suppl_rfr3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/demi_part_suppl_rfr3.yaml
@@ -12,9 +12,11 @@ values:
     value: 6191
   2023-01-01:
     value: 6290
+  2024-01-01:
+    value: 6623
 metadata:
   short_label: Majoration du seuil par demi-part de quotient familial supplémentaire
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red3_demip
   unit: currency
@@ -41,6 +43,9 @@ metadata:
     2023-01-01:
       title: Lettre ministérielle D-22-024221 du 12/12/2022
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_12122022.pdf
+    2024-01-01:
+      title: Lettre ministérielle D23-022880 du 23/11/2023
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_23112023.pdf
   official_journal_date:
     2018-01-01: "2017-12-31"
     2019-01-01: "2018-12-26"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/seuil_rfr3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/seuil_rfr3.yaml
@@ -12,9 +12,11 @@ values:
     value: 23193
   2023-01-01:
     value: 23564
+  2024-01-01:
+    value: 24813
 metadata:
   short_label: Seuil de RFR pour la première part de quotient familial
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2024-01-15"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red3
   unit: currency
@@ -42,6 +44,9 @@ metadata:
     2023-01-01:
       title: Lettre ministérielle D-22-024221 du 12/12/2022
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_12122022.pdf
+    2024-01-01:
+      title: Lettre ministérielle D23-022880 du 23/11/2023
+      href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_23112023.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2019-01-01: "2018-12-26"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '155.2.1',
+    version = '155.2.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2024
* Zones impactées : `openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/`.
* Détails :
  - Met à jour les seuils de rfr pour le calcul de la csg sur les retraites à partir de 2024

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.