### PR TITLE
FIx 2 unit: pourcentage_de_bmaf en BMAF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 156.0.1 [2242](https://github.com/openfisca/openfisca-france/pull/2242)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : 
+  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/taux1.yaml`.
+  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/taux2.yaml`.
+* Détails :
+  - Corrige deux changements d'unités ajouter par erreur dans la PR #2235
+
 ### 156.0.0 [2235](https://github.com/openfisca/openfisca-france/pull/2235)
 
 * Amélioration technique.

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/taux1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/taux1.yaml
@@ -7,7 +7,7 @@ values:
 metadata:
   short_label: Taux de la majoration
   last_value_still_valid_on: "2024-01-05"
-  unit: pourcentage_de_bmaf
+  unit: BMAF
   reference:
     2008-05-01:
     - title: Décret 2008-410 du 28/04/2008

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/taux2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/taux2.yaml
@@ -7,7 +7,7 @@ values:
 metadata:
   short_label: Taux de la majoration augmentée à partir du deuxième seuil d'âge
   last_value_still_valid_on: "2024-01-05"
-  unit: pourcentage_de_bmaf
+  unit: BMAF
   reference:
     2008-05-01:
     - title: Décret 2008-410 du 28/04/2008

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '156.0.0',
+    version = '156.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
*  Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : 
  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/taux1.yaml`.
  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/taux2.yaml`.
* Détails :
  - Corrige deux changements d'unités ajouter par erreur dans la PR #2235

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.