### PR TITLE
ASS pour RSA dépendant des mois précédents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 159.0.2 [2259](https://github.com/openfisca/openfisca-france/pull/2259)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : toutes.
+* Zones impactées : `model/prestations/minima sociaux/rsa`
+* Détails :
+ - La base ressources du RSA comprenait l'ASS du mois de référence, et pas de la moyenne des trois mois précédents. Or, selon la caf (voir #2257), le calcul est bien effectué comme pour l'aah par exemple, sur cette moyenne.
+
 ### 159.0.1 [2258](https://github.com/openfisca/openfisca-france/pull/2258)
 
 * Changement mineur.

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -197,11 +197,11 @@ class rsa_base_ressources_minima_sociaux(Variable):
         three_previous_months = period.last_3_months
         aspa = famille('aspa', period)
 
-        ass_i = famille.members('ass', period)
+        ass_i = famille.members('ass', three_previous_months, options = [ADD])
         aah_i = famille.members('aah', three_previous_months, options = [ADD])
         asi_i = famille.members('asi', three_previous_months, options = [ADD])
         caah_i = famille.members('caah', three_previous_months, options = [ADD])
-        return aspa + famille.sum(ass_i) + famille.sum(aah_i + asi_i + caah_i) / 3
+        return aspa + famille.sum(ass_i, aah_i + asi_i + caah_i) / 3
 
 
 class rsa_base_ressources_prestations_familiales(Variable):

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -201,7 +201,7 @@ class rsa_base_ressources_minima_sociaux(Variable):
         aah_i = famille.members('aah', three_previous_months, options = [ADD])
         asi_i = famille.members('asi', three_previous_months, options = [ADD])
         caah_i = famille.members('caah', three_previous_months, options = [ADD])
-        return aspa + famille.sum(ass_i, aah_i + asi_i + caah_i) / 3
+        return aspa + famille.sum(ass_i + aah_i + asi_i + caah_i) / 3
 
 
 class rsa_base_ressources_prestations_familiales(Variable):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '159.0.1',
+    version = '159.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal. 
* Périodes concernées : toutes. 
* Zones impactées : `model/prestations/minima sociaux/rsa`.
* Détails :
  - La base ressources du RSA comprenait l'ASS du mois de référence, et pas de la moyenne des trois mois précédents. Or, selon la caf (voir [#2257](https://github.com/openfisca/openfisca-france/issues/2257)), le calcul est bien effectué comme pour l'aah par exemple, sur cette moyenne. 

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
