### PR TITLE
fix unit parametres ASS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 160.0.2 [2267](https://github.com/openfisca/openfisca-france/pull/2267)
+
+* Changement mineur.
+* Périodes concernées : toutes
+* Zones impactées : 
+  - `openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/plaf_seul.yaml`
+  - `openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/plaf_coup.yaml`
+* Détails :
+  - Supprime l'unité "/1" pour deux paramètres qui n'était pas des taux
+
 ### 160.0.1 [2266](https://github.com/openfisca/openfisca-france/pull/2266)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/plaf_coup.yaml
+++ b/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/plaf_coup.yaml
@@ -6,7 +6,6 @@ metadata:
   short_label: Multiple couple
   last_value_still_valid_on: "2024-03-12"
   label_en: Special UI scheme
-  unit: /1
   reference:
     2005-01-01:
       title: Code du Travail, Article R5423-1

--- a/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/plaf_seul.yaml
+++ b/openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/plaf_seul.yaml
@@ -6,7 +6,6 @@ metadata:
   short_label: Multiple personne seule
   last_value_still_valid_on: "2024-03-12"
   label_en: Special UI scheme
-  unit: /1
   reference:
     2005-01-01:
       title: Code du Travail, Article R5423-1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '160.0.1',
+    version = '160.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes
* Zones impactées : 
  - `openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/plaf_seul.yaml`
  - `openfisca_france/parameters/chomage/allocations_assurance_chomage/ass/plaf_coup.yaml`
* Détails :
  - Supprime l'unité "/1" pour deux paramètres qui n'était pas des taux

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).