### PR TITLE
Ajoute date de fin prime exceptionnelle pouvoir d'achat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 163.0.1 [2275](https://github.com/openfisca/openfisca-france/pull/2275)
+
+* Changement mineur
+* Périodes concernées : à partir du 31/12/2023.
+* Zones impactées : openfisca_france/model/revenus/activite/salarie.py.
+* Détails : 
+  - La prime exceptionnelle de partage de la valeur (PEPV) s'est terminée le 31 décembre 2023, seule la version non exceptionnelle (PPV) persiste. Cette PR Ajoute une end date dans les formules.
+
 ### 163.0.0 [2272](https://github.com/openfisca/openfisca-france/pull/2272)
 
 * Amélioration technique.

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -642,6 +642,7 @@ class prime_partage_valeur_exceptionnelle(Variable):
     definition_period = (YEAR)  # La PPV est versée en fonction du salaire des 12 derniers mois
     reference = 'https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046188457/2022-08-18'
     set_input = set_input_divide_by_period
+    end = '2023-12-31'
 
 
 class prime_partage_valeur_exoneree_exceptionnelle(Variable):
@@ -650,6 +651,7 @@ class prime_partage_valeur_exoneree_exceptionnelle(Variable):
     label = 'Prime exceptionnelle de partage de la valeur (PPV), partie exonérée'
     definition_period = YEAR
     reference = 'https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046188457/2022-08-18'
+    end = '2023-12-31'
 
     set_input = set_input_divide_by_period
 
@@ -684,6 +686,7 @@ class prime_partage_valeur_non_exoneree_exceptionnelle(Variable):
     label = 'Prime exceptionnelle de partage de la valeur (PPV), partie non exonérée'
     definition_period = YEAR
     set_input = set_input_divide_by_period
+    end = '2023-12-31'
 
     def formula_2022_07_01(individu, period, parameters):
         prime_partage_valeur_exceptionnelle = individu('prime_partage_valeur_exceptionnelle', period)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '163.0.0',
+    version = '163.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Cette prime s'est terminée le 31 décembre 2023, seule la version non exceptionnelle persiste

* Changement mineur
* Périodes concernées : à partir du 31/12/2023.
* Zones impactées : `openfisca_france/model/revenus/activite/salarie.py`.
* Détails : Ajoute end date dans les formules
