### PR TITLE
Corrige le montant du pass sport pour les bénéficiaires de l'aah

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 164.1.5 [2282](https://github.com/openfisca/openfisca-france/pull/2282)
+
+* Changement mineur.
+* Périodes concernées : toutes. 
+* Zones impactées : `openfisca_france/model/prestations/jeunes/pass_sport`.
+* Détails :
+  - Corrige le calcul du montant de l'aide Pass Sport pour les bénéficiaires de l'aah
+
 ### 164.1.4 [2284](https://github.com/openfisca/openfisca-france/pull/2284)
 
 * Supprime un ensemble de paramètres non utilisés, et ne correspondant pas à un paramètre dans la loi. L'ajustement est fait côté barème aussi : https://gitlab.com/ipp/partage-public-ipp/baremes-ipp/baremes-ipp-yaml/-/merge_requests/485

--- a/openfisca_france/model/prestations/jeunes/pass_sport.py
+++ b/openfisca_france/model/prestations/jeunes/pass_sport.py
@@ -35,11 +35,11 @@ class pass_sport(Variable):
         eligibilite_age_profil_aeeh = (age >= age_minimum_profil_aeeh) * (age <= age_maximum_profil_aeeh)
         eligibilite_profil_aeeh = aeeh * eligibilite_age_profil_aeeh
 
-        aah = individu('aah', period)
+        aah_eligibilite = individu('aah', period) > 0
         age_maximum_profil_aah = parametres.critere_age.age_maximum_profil_aah
         age_minimum_profil_aah = parametres.critere_age.age_minimum_profil_aah
         eligibilite_age_profil_aah = (age >= age_minimum_profil_aah) * (age <= age_maximum_profil_aah)
-        eligibilite_profil_aah = (aah * eligibilite_age_profil_aah)
+        eligibilite_profil_aah = (aah_eligibilite * eligibilite_age_profil_aah)
 
         montant = parametres.montant
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '164.1.4',
+    version = '164.1.5',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/pass_sport.yaml
+++ b/tests/formulas/pass_sport.yaml
@@ -27,6 +27,6 @@
   period: 2023-12
   input:
     age: [16, 15, 31]
-    aah: [1, 1, 1]
+    aah: [970, 970, 970]
   output:
     pass_sport: [50, 0, 0]


### PR DESCRIPTION
Merci de contribuer à OpenFisca ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)

* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/prestations/jeunes/pass_sport`.
* Détails :
  - Corrige le calcul du montant de l'aide Pass Sport pour les bénéficiaires de l'aah
  
- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
