### PR TITLE
Mise à jour des _last_value_still_valid_on_ pour les prestations sociales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### 166.0.10 [2290](https://github.com/openfisca/openfisca-france/pull/2290)
+
+* Changement mineur.
+* Périodes concernées : aucune.
+* Zones impactées :
+    - /parameters/prestations_sociales/prestations_familiales/prestations_generales/af/*
+    - /parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/*
+    - /parameters/prestations_sociales/solidarite_insertion/minima_sociaux/accident_travail/rente/taux/taux_minimum.yaml
+    - /parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/*
+    - /parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/*
+    - /parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/*
+    - /parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_maj/*
+
+* Détails :
+  - Mise à jour des `last_value_still_valid_on` sur les paramètres des prestations sociales après vérification de la validité de l'article en référence.
+
 ### 166.0.9 [2305](https://github.com/openfisca/openfisca-france/pull/2305)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_taxe_alsace_moselle.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/apprentissage/apprentissage_taxe_alsace_moselle.yaml
@@ -16,7 +16,7 @@ brackets:
       value: 0.0044
 metadata:
   short_label: En Alsace-Moselle
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2023-01-30"
   label_en: Apprenticeship tax (tax for the financing of apprenticeship)
   ipp_csv_id: appren_am_p_0_
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_plein.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.2
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2023-01-30"
+  last_value_still_valid_on: "2024-04-26"
   label_en: Contribution levied on various earnings supplements ("Forfait social")
   ipp_csv_id: forf_soc_tx1
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_plein.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.068
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2021-07-22"
   ipp_csv_id: csg_pre_ded
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_plein.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_plein.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.068
 metadata:
   short_label: Taux plein
-  last_value_still_valid_on: "2021-07-22"
+  last_value_still_valid_on: "2024-04-26"
   ipp_csv_id: csg_pre_ded
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_reduit.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2021-07-22"
+  last_value_still_valid_on: "2024-04-26"
   ipp_csv_id: csg_pre_red
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_reduit.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/allocations_preretraite/deductible/taux_reduit.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.038
 metadata:
   short_label: Taux réduit
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2021-07-22"
   ipp_csv_id: csg_pre_red
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_cotisation_allocations_familiales/reduction.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_cotisation_allocations_familiales/reduction.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.018
 metadata:
   short_label: Taux d'allègement des cotisations famille
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2023-01-30"
   label_en: Reduction in SSCs for family benefits
   ipp_csv_id: tx_red_fam
   unit: /1

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age2.yaml
@@ -9,7 +9,7 @@ values:
   2000-02-01:
     value: 20
 metadata:
-  last_value_still_valid_on: "2022-02-21"
+  last_value_still_valid_on: "2024-04-26"
   unit: year
   reference:
     2000-02-01:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age3.yaml
@@ -4,7 +4,7 @@ values:
     value: 20
 metadata:
   short_label: Âge maximal de l'enfant
-  last_value_still_valid_on: "2022-03-01"
+  last_value_still_valid_on: "2024-04-26"
   unit: year
   reference:
     2003-07-01:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/facteur_garde_alternee.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/facteur_garde_alternee.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.5
 metadata:
   short_label: Facteur multiplicatif pour un enfant en cas de garde alternée
-  last_value_still_valid_on: "2022-03-01"
+  last_value_still_valid_on: "2024-04-26"
   unit: currency
   reference:
     2007-05-01:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/majoration_enfants/tranches_d_age/age_debut_de_la_premiere_tranche.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/majoration_enfants/tranches_d_age/age_debut_de_la_premiere_tranche.yaml
@@ -8,7 +8,7 @@ values:
     value: 14
 metadata:
   short_label: Âge seuil tranche 1
-  last_value_still_valid_on: "2023-02-02"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Family allowances (AF): Extra allowances"
   ipp_csv_id: maj_enf_age1
   unit: year

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/nb_enfants_min_pour_aine_donne_droit_a_majoration.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/nb_enfants_min_pour_aine_donne_droit_a_majoration.yaml
@@ -4,7 +4,7 @@ values:
     value: 3
 metadata:
   short_label: Nb d'enfant pour que l'aîné donne droit à majoration
-  last_value_still_valid_on: "2023-02-02"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Family allowances (AF): Extra allowances"
   ipp_csv_id: nb_enf_maj
   unit: year

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/tranches_age/age_debut_deuxieme_tranche.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/tranches_age/age_debut_deuxieme_tranche.yaml
@@ -6,7 +6,7 @@ values:
     value: 16
 metadata:
   short_label: Âge seuil de la tranche 2
-  last_value_still_valid_on: "2023-02-02"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Family allowances (AF): Extra allowances for oversea territories"
   unit: year
   reference:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/tranches_age/age_debut_premiere_tranche.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/tranches_age/age_debut_premiere_tranche.yaml
@@ -6,7 +6,7 @@ values:
     value: 11
 metadata:
   short_label: Âge seuil de la tranche 1
-  last_value_still_valid_on: "2022-02-02"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Family allowances (AF): Extra allowances for oversea territories"
   unit: year
   reference:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/montant_prime.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/montant_prime.yaml
@@ -4,7 +4,7 @@ values:
     value: 152.45
 metadata:
   short_label: Montant de base pour une personne seule
-  last_value_still_valid_on: "2021-09-28"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Exceptional end-of-year benefit (AEFA): amount"
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_2p.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_2p.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.5
 metadata:
   short_label: Majoration pour un couple
-  last_value_still_valid_on: "2021-10-04"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Exceptional end-of-year benefit (AEFA): amount"
   unit: /1
   reference:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_3pac.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.4
 metadata:
   short_label: Majoration à partir de la troisième personne à charge
-  last_value_still_valid_on: "2021-09-28"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Exceptional end-of-year benefit (AEFA): amount"
   unit: /1
   reference:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_supp.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.3
 metadata:
   short_label: Majoration par personne à charge jusqu'à la deuxième incluse
-  last_value_still_valid_on: "2021-09-28"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Exceptional end-of-year benefit (AEFA): amount"
   unit: /1
   reference:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/accident_travail/rente/taux/taux_minimum.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/accident_travail/rente/taux/taux_minimum.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.1
 metadata:
   short_label: Taux d'incapacité max
-  last_value_still_valid_on: "2022-03-14"
+  last_value_still_valid_on: "2024-04-26"
   unit: /1
   reference:
     1985-12-21:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_avec_al/taux_1p.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_avec_al/taux_1p.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.12
 metadata:
   short_label: Taux 1 personne
-  last_value_still_valid_on: "2022-10-17"
+  last_value_still_valid_on: "2024-04-26"
   unit: RSA
   reference:
     2019-11-01:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_avec_al/taux_2p.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_avec_al/taux_2p.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.16
 metadata:
   short_label: Taux 2 personnes
-  last_value_still_valid_on: "2022-10-17"
+  last_value_still_valid_on: "2024-04-26"
   unit: RSA
   reference:
     2019-11-01:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_avec_al/taux_3p_plus.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_avec_al/taux_3p_plus.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.165
 metadata:
   short_label: Taux 3 personnes
-  last_value_still_valid_on: "2022-10-17"
+  last_value_still_valid_on: "2024-04-26"
   unit: RSA
   reference:
     2019-11-01:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_sans_al/taux_1p.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_sans_al/taux_1p.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.12
 metadata:
   short_label: Taux 1 personne
-  last_value_still_valid_on: "2022-10-17"
+  last_value_still_valid_on: "2024-04-26"
   unit: RSA
   reference:
     2019-11-01:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_sans_al/taux_2p.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_sans_al/taux_2p.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.14
 metadata:
   short_label: Taux 2 personnes
-  last_value_still_valid_on: "2022-10-17"
+  last_value_still_valid_on: "2024-04-26"
   unit: RSA
   reference:
     2019-11-01:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_sans_al/taux_3p_plus.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_sans_al/taux_3p_plus.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.14
 metadata:
   short_label: Taux 3 personnes
-  last_value_still_valid_on: "2022-10-17"
+  last_value_still_valid_on: "2024-04-26"
   unit: RSA
   reference:
     2019-11-01:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/couple_1_enfant_2e_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/couple_1_enfant_2e_enfant.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.3
 metadata:
   short_label: Majoration par personne supplémentaire (au-delà de la 1ère)
-  last_value_still_valid_on: "2022-08-03"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_maj3
   unit: /1

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/couples_seul_avec_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/couples_seul_avec_enfant.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.5
 metadata:
   short_label: Majoration pour la 1ère personne supplémentaire
-  last_value_still_valid_on: "2022-08-03"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_maj1
   unit: /1

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/par_enfant_supplementaire.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/par_enfant_supplementaire.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.4
 metadata:
   short_label: Majoration par personne supplémentaire (au-delà de la 3ème)
-  last_value_still_valid_on: "2022-08-03"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_maj4
   unit: /1

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/age_max_rsa_jeune.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/age_max_rsa_jeune.yaml
@@ -6,7 +6,7 @@ values:
     value: 25
 metadata:
   short_label: Âge maximal RSA Jeune
-  last_value_still_valid_on: "2022-03-28"
+  last_value_still_valid_on: "2024-04-26"
   unit: year
   reference:
     2010-01-01:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/age_min_rsa_jeune.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/age_min_rsa_jeune.yaml
@@ -6,7 +6,7 @@ values:
     value: 18
 metadata:
   short_label: Âge minimal RSA Jeune
-  last_value_still_valid_on: "2022-03-28"
+  last_value_still_valid_on: "2024-04-26"
   unit: year
   reference:
     2010-01-01:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_maj/majoration_isolement_en_base_rsa/femmes_enceintes.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_maj/majoration_isolement_en_base_rsa/femmes_enceintes.yaml
@@ -6,7 +6,7 @@ values:
     value: 1.28412
 metadata:
   short_label: Parents isolés ou femmes enceintes
-  last_value_still_valid_on: "2022-03-29"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Active solidarity income (RSA): Extra allowance and minimal amount"
   ipp_csv_id: rsa_isole_enceinte
   unit: /1

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_maj/majoration_isolement_en_base_rsa/par_enfant_a_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_maj/majoration_isolement_en_base_rsa/par_enfant_a_charge.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.42804
 metadata:
   short_label: Majoration par enfant à charge
-  last_value_still_valid_on: "2022-03-29"
+  last_value_still_valid_on: "2024-04-26"
   label_en: "Active solidarity income (RSA): Extra allowance and minimal amount"
   ipp_csv_id: rsa_isole_enf
   unit: /1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '166.0.9',
+    version = '166.0.10',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : aucune.
* Zones impactées :
    * /parameters/prestations_sociales/prestations_familiales/prestations_generales/af/*
    * /parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/*
    * /parameters/prestations_sociales/solidarite_insertion/minima_sociaux/accident_travail/rente/taux/taux_minimum.yaml
    * /parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/*
    * /parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/*
    * /parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/*
    * /parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_maj/*

* Détails :
  - Mise à jour des `last_value_still_valid_on` sur les paramètres de l'impôt sur le revenu après vérification automatique de la validité de l'article en référence.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Méthodologie :
1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
1. Met à jour la `last_value_still_valid_on` à la date du jour.
1. Crée un tableau récapitulatif pour faciliter la revue.

- - - -

| Paramètre | last_value_still_valid_on | valeur | valeur trouvée dans le texte | Référence |  
| --- | --- | --- | --- | --- |  
| [prestations_sociales.prestations_familiales.prestations_generales.af.af_cm.age2](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age2.yaml)| 2022-02-21 | 20.0 |  l'âge de vingt ans sous réserve | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006750602/2000-01-29 |  
| [prestations_sociales.prestations_familiales.prestations_generales.af.af_cm.age3](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age3.yaml)| 2022-03-01 | 20.0 |  jusqu'à l'âge de vingt ans| https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006743276/1985-12-21/ |  
| [prestations_sociales.prestations_familiales.prestations_generales.af.af_cm.facteur_garde_alternee](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/facteur_garde_alternee.yaml)| 2022-03-01 | 0.5 |  1° Chaque enfant en résidence alternée compte pour 0,5 ;   | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006750610 |  
| [prestations_sociales.prestations_familiales.prestations_generales.af.af_maj.majoration_enfants.tranches_d_age.age_debut_de_la_premiere_tranche](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/majoration_enfants/tranches_d_age/age_debut_de_la_premiere_tranche.yaml)| 2023-02-02 | 14.0 |   la majoration des allocations familiales est fixé à 14 ans. | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018735853 |  
| [prestations_sociales.prestations_familiales.prestations_generales.af.af_maj.nb_enfants_min_pour_aine_donne_droit_a_majoration](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/nb_enfants_min_pour_aine_donne_droit_a_majoration.yaml)| 2023-02-02 | 3.0 |  pour le troisième enfant à charge| https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006769086&cidTexte=JORFTEXT000000518125 |  
| [prestations_sociales.prestations_familiales.prestations_generales.af.af_maj_dom.tranches_age.age_debut_deuxieme_tranche](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/tranches_age/age_debut_deuxieme_tranche.yaml)| 2023-02-02 | 16.0 |  à partir de seize ans.| https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000209409&categorieLien=id |  
| [prestations_sociales.prestations_familiales.prestations_generales.af.af_maj_dom.tranches_age.age_debut_premiere_tranche](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/tranches_age/age_debut_premiere_tranche.yaml)| 2022-02-02 | 11.0 |  à partir de onze ans | https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000209409&categorieLien=id |  
| [prestations_sociales.solidarite_insertion.autre_solidarite.aefa.montant_prime](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/montant_prime.yaml)| 2021-09-28 | 152.45 |   est égal à 152,45 Euros  | https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006226757 |  
| [prestations_sociales.solidarite_insertion.autre_solidarite.aefa.taux_majoration.tx_2p](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_2p.yaml)| 2021-10-04 | 0.5 | majoré de 50 % lorsque le foyer se compose de deux personnes | https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006226757 |  
| [prestations_sociales.solidarite_insertion.autre_solidarite.aefa.taux_majoration.tx_3pac](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_3pac.yaml)| 2021-09-28 | 0.4 |  40 % à partir du troisième enfant | https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006226757 |  
| [prestations_sociales.solidarite_insertion.autre_solidarite.aefa.taux_majoration.tx_supp](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/aefa/taux_majoration/tx_supp.yaml)| 2021-09-28 | 0.3 | 30 % pour chaque personne supplémentaire | https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006226757 |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.accident_travail.rente.taux.taux_minimum](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/accident_travail/rente/taux/taux_minimum.yaml)| 2022-03-14 | 0.1 | est fixé à 10 %. | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006750335 |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.cs.css.forfait_logement_avec_al.taux_1p](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_avec_al/taux_1p.yaml)| 2022-10-17 | 0.12 | A 12 % du montant forfaitaire | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006753243/2022-08-31/ |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.cs.css.forfait_logement_avec_al.taux_2p](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_avec_al/taux_2p.yaml)| 2022-10-17 | 0.16 |  16 % du montant forfaitaire | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038929244 |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.cs.css.forfait_logement_avec_al.taux_3p_plus](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_avec_al/taux_3p_plus.yaml)| 2022-10-17 | 0.165 |  16,5 % du montant forfaitaire  | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038929244 |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.cs.css.forfait_logement_sans_al.taux_1p](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_sans_al/taux_1p.yaml)| 2022-10-17 | 0.12 | A 12 % du montant forfaitaire | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006753243/2022-08-31/ |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.cs.css.forfait_logement_sans_al.taux_2p](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_sans_al/taux_2p.yaml)| 2022-10-17 | 0.14 | A 14 % du montant forfaitaire | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006753243/2022-08-31/ |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.cs.css.forfait_logement_sans_al.taux_3p_plus](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/css/forfait_logement_sans_al/taux_3p_plus.yaml)| 2022-10-17 | 0.14 | A 14 % du montant forfaitaire | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006753243/2022-08-31/ |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.ppa.pa_m.majoration_montant_maximal.couple_1_enfant_2e_enfant](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/couple_1_enfant_2e_enfant.yaml)| 2022-08-03 | 0.3 |  majoré de 30 % | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673885/ |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.ppa.pa_m.majoration_montant_maximal.couples_seul_avec_enfant](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/couples_seul_avec_enfant.yaml)| 2022-08-03 | 0.5 | est majoré de 50 % | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673885/ |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.ppa.pa_m.majoration_montant_maximal.par_enfant_supplementaire](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/par_enfant_supplementaire.yaml)| 2022-08-03 | 0.4 |  est portée à 40 % à partir de la troisième personne | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673885/ |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.ppa.pa_m.montant_minimum_verse](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/montant_minimum_verse.yaml)| 2022-08-03 | 15.0 | est fixé à 15 euros.  | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031674204/2020-08-28 |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.rsa.rsa_cond.age_max_rsa_jeune](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/age_max_rsa_jeune.yaml)| 2022-03-28 | 25.0 | vingt-cinq ans au plus| https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000021642861/ |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.rsa.rsa_cond.age_min_rsa_jeune](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/age_min_rsa_jeune.yaml)| 2022-03-28 | 18.0 |  âgée de dix-huit ans au moins | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000021642861/ |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.rsa.rsa_maj.majoration_isolement_en_base_rsa.femmes_enceintes](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_maj/majoration_isolement_en_base_rsa/femmes_enceintes.yaml)| 2022-03-29 | 1.28412 | égal à 128,412 % du montant forfaitaire | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673885/2016-01-014 |  
| [prestations_sociales.solidarite_insertion.minima_sociaux.rsa.rsa_maj.majoration_isolement_en_base_rsa.par_enfant_a_charge](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_maj/majoration_isolement_en_base_rsa/par_enfant_a_charge.yaml)| 2022-03-29 | 0.42804 |  égal à 42,804 % du montant forfaitaire | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673885/2016-01-01 |  


- - - -

Quelques conseils à prendre en compte :

- [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [X] Documentez votre contribution avec des références législatives.
- [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

