### PR TITLE
Mise à jour des last_value_still_valid_on pour la taxation indirecte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 166.0.6 [2293](https://github.com/openfisca/openfisca-france/pull/2293)
+
+* Changement mineur.
+* Périodes concernées : aucune.
+* Zones impactées :
+    * /parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/autres_tabacs_a_chauffer.yaml
+    * /parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/tabac_rouler.yaml
+    * /parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/tabacs_batonnets.yaml
+
+* Détails :
+  - Mise à jour des `last_value_still_valid_on` sur certains paramètres de la taxation indirecte après vérification de la validité de l'article en référence.
+
 ### 166.0.5 [2291](https://github.com/openfisca/openfisca-france/pull/2291)
 
 * Changement mineur.

--- a/openfisca_france/parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/autres_tabacs_a_chauffer.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/autres_tabacs_a_chauffer.yaml
@@ -12,7 +12,7 @@ values:
     value: 192.3
 metadata:
   short_label: Autres tabacs à chauffer
-  last_value_still_valid_on: "2022-12-28"
+  last_value_still_valid_on: "2024-04-26"
   unit: currency
   reference:
     2022-01-01:

--- a/openfisca_france/parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/tabac_rouler.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/tabac_rouler.yaml
@@ -22,7 +22,7 @@ values:
     value: 104.2
 metadata:
   short_label: Tabacs à rouler
-  last_value_still_valid_on: "2022-12-28"
+  last_value_still_valid_on: "2024-04-26"
   ipp_csv_id: tx_spec_tabac_rouler
   unit: currency
   reference:

--- a/openfisca_france/parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/tabacs_batonnets.yaml
+++ b/openfisca_france/parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/tabacs_batonnets.yaml
@@ -12,7 +12,7 @@ values:
     value: 50.9
 metadata:
   short_label: Tabacs en bâtonnets
-  last_value_still_valid_on: "2022-12-28"
+  last_value_still_valid_on: "2024-04-26"
   unit: currency
   reference:
     2022-01-01:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '166.0.5',
+    version = '166.0.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : aucune.
* Zones impactées :
        * /parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/autres_tabacs_a_chauffer.yaml
    * /parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/tabac_rouler.yaml
    * /parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/tabacs_batonnets.yaml

* Détails :
  - Mise à jour des `last_value_still_valid_on` sur les paramètres de l'impôt sur le revenu après vérification automatique de la validité de l'article en référence.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Méthodologie :
1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
1. Met à jour la `last_value_still_valid_on` à la date du jour.
1. Crée un tableau récapitulatif pour faciliter la revue.

- - - -

| Paramètre | last_value_still_valid_on | valeur | valeur trouvée dans le texte | Référence |  
| --- | --- | --- | --- | --- |  
| [taxation_indirecte.taxes_tabacs.taxes_specifiques.montants_apres_2015.autres_tabacs_a_chauffer](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/autres_tabacs_a_chauffer.yaml)| 2022-12-28 | 192.3 | 192,3 | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046816473/2024-01-01/ |  
| [taxation_indirecte.taxes_tabacs.taxes_specifiques.montants_apres_2015.tabac_rouler](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/tabac_rouler.yaml)| 2022-12-28 | 104.2 | 104,2 | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046816473/2024-01-01/ |  
| [taxation_indirecte.taxes_tabacs.taxes_specifiques.montants_apres_2015.tabacs_batonnets](https://github.com/openfisca/openfisca-france/blob/master/openfisca_france/parameters/taxation_indirecte/taxes_tabacs/taxes_specifiques/montants_apres_2015/tabacs_batonnets.yaml)| 2022-12-28 | 50.9 | 50,9 | https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046816473/2024-01-01/ |  


- - - -

Quelques conseils à prendre en compte :

- [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [X] Documentez votre contribution avec des références législatives.
- [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus