### PR TITLE
Neutralise crédit impôt pour assurance loyer impayé `assloy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 168.0.11 [2343](https://github.com/openfisca/openfisca-france/pull2343)
+## 168.0.12 [2314](https://github.com/openfisca/openfisca-france/pull/2314)
+
+* Changement mineur.
+* Périodes concernées : A partir de 2017-01-01.
+* Zones impactées : `openfisca_france/parameters/impot_revenu/credits_impots/assloy/taux.yaml`.
+* Détails :
+  - Neutralise le crédit impôt pour assurance loyer impayé qui n'existe plus depuis la LF 2017.
+
+## 168.0.11 [2343](https://github.com/openfisca/openfisca-france/pull/2343)
 
 * Changement mineur.
 * Périodes concernées : toutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Périodes concernées : A partir de 2017-01-01.
 * Zones impactées : `openfisca_france/parameters/impot_revenu/credits_impots/assloy/taux.yaml`.
 * Détails :
-  - Neutralise le crédit impôt pour assurance loyer impayé qui n'existe plus depuis la LF 2017.
+  - Neutralise le crédit d'impôt pour assurance loyer impayé qui n'existe plus depuis la Lois de Finance 2017.
 
 ## 168.0.11 [2343](https://github.com/openfisca/openfisca-france/pull/2343)
 

--- a/openfisca_france/parameters/impot_revenu/credits_impots/assloy/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/assloy/taux.yaml
@@ -6,6 +6,17 @@ values:
     value: 0.45
   2012-01-01:
     value: 0.38
+  2017-01-01:
+    value : null
 metadata:
   short_label: Taux
   unit: /1
+  references:
+    2012-01-01:
+      title: Code général des impôts - Art Article 200 nonies
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000025746257/2012-04-26
+    2017-01-01:
+      title: LOI n° 2016-1917 du 29 décembre 2016 de finances pour 2017 - Art 32
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000033760848/2017-01-01
+documentation: |
+  Abrogé par la LF 2017 : https://bofip.impots.gouv.fr/bofip/10813-PGP.html/identifiant%3DACTU-2017-00011

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '168.0.11',
+    version = '168.0.12',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/calculateur_impots/yaml/credit_assloy.yaml
+++ b/tests/calculateur_impots/yaml/credit_assloy.yaml
@@ -122,3 +122,38 @@
     rbg: 65000.0
     rfr: 65000.0
     rni: 65000.0
+- name: credit_assloy_neutralise
+  period: 2017
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      caseF: false
+      caseG: false
+      caseL: false
+      caseP: false
+      caseS: false
+      caseT: false
+      caseW: false
+      declarants:
+      - ind0
+      f4ba: 20000
+      f4bf: 500
+      nbF: 0.0
+      nbG: 0.0
+      nbH: 0.0
+      nbI: 0.0
+      nbJ: 0
+      nbR: 0
+    individus:
+      ind0:
+        activite: actif
+        date_naissance: '1970-01-01'
+        salaire_imposable: 50000.0
+        statut_marital: celibataire
+    famille:
+      parents:
+      - ind0
+    menage:
+      personne_de_reference: ind0
+  output:
+    assloy: 0.0


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : A partir de 2017-01-01.
* Zones impactées : `openfisca_france/parameters/impot_revenu/credits_impots/assloy/taux.yaml`.
* Détails :
  - Neutralise le crédit impôt pour assurance loyer impayé qui n'existe plus depuis la LF 2017.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
