### PR TITLE
Prise en compte des statuts apprenti et des stagiaire dans calcul de l'éligibilité à la PPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 155.2.5 [2337](https://github.com/openfisca/openfisca-france/pull/2337)
+### 155.2.6 [2337](https://github.com/openfisca/openfisca-france/pull/2337)
 
 * Corrigent ou améliorent un calcul déjà existant.
 * Périodes concernées : Après 2024/10/01
@@ -9,6 +9,15 @@
   - `openfisca_france/model/prestations/minima_sociaux/rsa.py.`
 * Détails :
   - Prise en compte du passe M-1 M-3 à M-2 à M-4 pour les aides PPA et RSA
+
+### 155.2.5 [2328](https://github.com/openfisca/openfisca-france/pull/2328)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : Toujours
+* Zones impactées :
+  - `openfisca_france/model/prestations/minima_sociaux/ppa.py`
+* Détails :
+  - Ajoute la prise en compte des statuts apprenti et stagiaire au calcul de l'éligibilité à la PPA.
 
 ### 155.2.4 [2279](https://github.com/openfisca/openfisca-france/pull/2279)
 

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -19,10 +19,10 @@ class ppa_eligibilite(Variable):
         return condition_age
 
 
-class ppa_plancher_revenu_activite_etudiant(Variable):
+class ppa_plancher_revenu_activite_apprenant(Variable):
     value_type = float
     entity = Individu
-    label = "Plancher des revenus d'activité pour être éligible à la PPA en tant qu'étudiant"
+    label = "Plancher des revenus d'activité pour être éligible à la PPA en tant qu'apprenant (étudiant/stagiaire ou apprenti)"
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
@@ -36,7 +36,7 @@ class ppa_plancher_revenu_activite_etudiant(Variable):
             )
 
 
-class ppa_eligibilite_etudiants(Variable):
+class ppa_eligibilite_apprenants(Variable):
     value_type = bool
     entity = Famille
     label = 'Eligibilité à la PPA (condition sur tout le trimestre)'
@@ -52,8 +52,8 @@ class ppa_eligibilite_etudiants(Variable):
     def formula(famille, period, parameters):
         ppa_majoree_eligibilite = famille('rsa_majore_eligibilite', period)
 
-        etudiant_i = famille.members('etudiant', period)
-        plancher_etudiant = famille.members('ppa_plancher_revenu_activite_etudiant', period)
+        apprenant_i = famille.members('etudiant', period) + famille.members('stagiaire', period) + famille.members('apprenti', period)
+        plancher_apprenant = famille.members('ppa_plancher_revenu_activite_apprenant', period)
 
         def condition_ressource(period2, plancher):
             revenu_activite = famille.members('ppa_revenu_activite_individu', period2)
@@ -63,21 +63,21 @@ class ppa_eligibilite_etudiants(Variable):
         m_2 = period.offset(-2, 'month')
         m_3 = period.offset(-3, 'month')
 
-        condition_etudiant_i = (
-            condition_ressource(m_1, plancher_etudiant)
-            * condition_ressource(m_2, plancher_etudiant)
-            * condition_ressource(m_3, plancher_etudiant)
+        condition_apprenant_i = (
+            condition_ressource(m_1, plancher_apprenant)
+            * condition_ressource(m_2, plancher_apprenant)
+            * condition_ressource(m_3, plancher_apprenant)
             )
 
-        condition_non_etudiant_i = (
-            not_(etudiant_i) * (
+        condition_non_apprenant_i = (
+            not_(apprenant_i) * (
                 condition_ressource(m_1, 0)
                 + condition_ressource(m_2, 0)
                 + condition_ressource(m_3, 0)
                 )
             )
 
-        condition_famille = famille.any(condition_non_etudiant_i + condition_etudiant_i, role = Famille.PARENT)
+        condition_famille = famille.any(condition_non_apprenant_i + condition_apprenant_i, role = Famille.PARENT)
         return ppa_majoree_eligibilite + condition_famille
 
 
@@ -582,8 +582,8 @@ def ppa_base_formula(famille, parameters, period, three_months_of_reference):
     seuil_non_versement = parameters(period).prestations_sociales.solidarite_insertion.minima_sociaux.ppa.pa_m.montant_minimum_verse
     # éligibilité étudiants
 
-    ppa_eligibilite_etudiants = famille('ppa_eligibilite_etudiants', period)
+    ppa_eligibilite_apprenants = famille('ppa_eligibilite_apprenants', period)
     ppa = famille('ppa_fictive', three_months_of_reference, options = [ADD]) / 3
-    ppa = ppa * ppa_eligibilite_etudiants * (ppa >= seuil_non_versement)
+    ppa = ppa * ppa_eligibilite_apprenants * (ppa >= seuil_non_versement)
 
     return ppa

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '155.2.5',
+    version = '155.2.6',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/ppa/ppa.yaml
+++ b/tests/formulas/ppa/ppa.yaml
@@ -602,7 +602,7 @@
       2015-10: 900
     etudiant: true
   output:
-    ppa_eligibilite_etudiants: true
+    ppa_eligibilite_apprenants: true
     ppa: 244.21
 
 - name: 'PPA: étudiant non éligible (ressources < plancher)'
@@ -614,7 +614,31 @@
       2015-10: 890
     etudiant: true
   output:
-    ppa_eligibilite_etudiants: false
+    ppa_eligibilite_apprenants: false
+    ppa: 0
+
+- name: 'PPA: stagiaire non éligible (ressources < plancher)'
+  period: 2016-01
+  input:
+    salaire_net:
+      2015-12: 890
+      2015-11: 890
+      2015-10: 890
+    stagiaire: true
+  output:
+    ppa_eligibilite_apprenants: false
+    ppa: 0
+
+- name: 'PPA: apprenti non éligible (ressources < plancher)'
+  period: 2016-01
+  input:
+    salaire_net:
+      2015-12: 890
+      2015-11: 890
+      2015-10: 890
+    apprenti: true
+  output:
+    ppa_eligibilite_apprenants: false
     ppa: 0
 
 - name: 'PPA: étudiant éligible (majoré)'
@@ -627,7 +651,7 @@
     etudiant: true
     rsa_majore_eligibilite: true
   output:
-    ppa_eligibilite_etudiants: true
+    ppa_eligibilite_apprenants: true
 
 - name: 'PPA: étudiant non éligible car plancher non atteint pour un mois du trimestre de référence'
   period: 2016-01
@@ -638,7 +662,31 @@
       2015-10: 900
     etudiant: true
   output:
-    ppa_eligibilite_etudiants: false
+    ppa_eligibilite_apprenants: false
+    ppa: 0
+
+- name: 'PPA: stagiaire non éligible car plancher non atteint pour un mois du trimestre de référence'
+  period: 2016-01
+  input:
+    salaire_net:
+      2015-12: 800
+      2015-11: 900
+      2015-10: 900
+    stagiaire: true
+  output:
+    ppa_eligibilite_apprenants: false
+    ppa: 0
+
+- name: 'PPA: apprenti non éligible car plancher non atteint pour un mois du trimestre de référence'
+  period: 2016-01
+  input:
+    salaire_net:
+      2015-12: 800
+      2015-11: 900
+      2015-10: 900
+    apprenti: true
+  output:
+    ppa_eligibilite_apprenants: false
     ppa: 0
 
 - name: "PPA: couple d'étudiants avec enfant:  pas de ppa"


### PR DESCRIPTION
Prise en compte des statuts apprenti stagiaire dans le calcul de l'eligibilite a la prime d'activite


* Correction d'un crash
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/prestations/minima_sociaux/ppa.py`.
* Détails :
 Selon ces articles:
 - https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031087615
 - https://www.service-public.fr/particuliers/vosdroits/F33375
 Les apprenants (etudiants, apprentis et stagiaires) ne sont éligibles à la prime d'activité que s'ils ont des revenus professionnels qui dépassent un seuil. Cet aspect était bien pris en compte pour les étudiants, mais non pour les apprentis et les stagiaires.
Cette PR ajoute juste la prise en compte de ce seuil pour les apprentis et les stagiaires.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [ x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ x] Documentez votre contribution avec des références législatives.
- [ x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

