### PR TITLE
Prise en compte des statuts apprenti et stagiaire dans le calcul de l'éligibilité à la PPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 169.1.1 [2329](https://github.com/openfisca/openfisca-france/pull/2329)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : Toujours
+* Zones impactées :
+  - `openfisca_france/model/prestations/minima_sociaux/ppa.py`
+* Détails :
+  - Ajoute la prise en compte des statuts apprenti et stagiaire au calcul de l'éligibilité à la PPA.
+
 # 169.1.0 [2369](https://github.com/openfisca/openfisca-france/pull/2369)
 
 * Amélioration technique.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.1.0"
+version = "169.1.1"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/formulas/ppa/ppa.yaml
+++ b/tests/formulas/ppa/ppa.yaml
@@ -602,7 +602,7 @@
       2015-10: 900
     etudiant: true
   output:
-    ppa_eligibilite_etudiants: true
+    ppa_eligibilite_apprenants: true
     ppa: 244.21
 
 - name: 'PPA: étudiant non éligible (ressources < plancher)'
@@ -614,7 +614,31 @@
       2015-10: 890
     etudiant: true
   output:
-    ppa_eligibilite_etudiants: false
+    ppa_eligibilite_apprenants: false
+    ppa: 0
+
+- name: 'PPA: stagiaire non éligible (ressources < plancher)'
+  period: 2016-01
+  input:
+    salaire_net:
+      2015-12: 890
+      2015-11: 890
+      2015-10: 890
+    stagiaire: true
+  output:
+    ppa_eligibilite_apprenants: false
+    ppa: 0
+
+- name: 'PPA: apprenti non éligible (ressources < plancher)'
+  period: 2016-01
+  input:
+    salaire_net:
+      2015-12: 890
+      2015-11: 890
+      2015-10: 890
+    apprenti: true
+  output:
+    ppa_eligibilite_apprenants: false
     ppa: 0
 
 - name: 'PPA: étudiant éligible (majoré)'
@@ -627,7 +651,7 @@
     etudiant: true
     rsa_majore_eligibilite: true
   output:
-    ppa_eligibilite_etudiants: true
+    ppa_eligibilite_apprenants: true
 
 - name: 'PPA: étudiant non éligible car plancher non atteint pour un mois du trimestre de référence'
   period: 2016-01
@@ -638,7 +662,31 @@
       2015-10: 900
     etudiant: true
   output:
-    ppa_eligibilite_etudiants: false
+    ppa_eligibilite_apprenants: false
+    ppa: 0
+
+- name: 'PPA: stagiaire non éligible car plancher non atteint pour un mois du trimestre de référence'
+  period: 2016-01
+  input:
+    salaire_net:
+      2015-12: 800
+      2015-11: 900
+      2015-10: 900
+    stagiaire: true
+  output:
+    ppa_eligibilite_apprenants: false
+    ppa: 0
+
+- name: 'PPA: apprenti non éligible car plancher non atteint pour un mois du trimestre de référence'
+  period: 2016-01
+  input:
+    salaire_net:
+      2015-12: 800
+      2015-11: 900
+      2015-10: 900
+    apprenti: true
+  output:
+    ppa_eligibilite_apprenants: false
     ppa: 0
 
 - name: "PPA: couple d'étudiants avec enfant:  pas de ppa"


### PR DESCRIPTION
Prise en compte des statuts apprenti stagiaire dans le calcul de l'eligibilite a la prime d'activite

Correction d'un crash
Périodes concernées : toutes.
Zones impactées : openfisca_france/model/prestations/minima_sociaux/ppa.py.
Détails :
Selon ces articles:
- https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031087615
- https://www.service-public.fr/particuliers/vosdroits/F33375
Les apprenants (etudiants, apprentis et stagiaires) ne sont éligibles à la prime d'activité que s'ils ont des revenus professionnels qui dépassent un seuil. Cet aspect était bien pris en compte pour les étudiants, mais non pour les apprentis et les stagiaires.
Cette PR ajoute juste la prise en compte de ce seuil pour les apprentis et les stagiaires.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ x] Documentez votre contribution avec des références législatives.
- [ x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [ x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
