### PR TITLE
Mise à jour des paramètres d'imposition des rentes viagères

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 168.0.1 [2332](https://github.com/openfisca/openfisca-france/pull/2332)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : 
+  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/*`
+
+* Détails :
+  - Met à jour la description
+  - Ajoute une référence, le `short_label` et `last_value_still_valid_on`
+
 ## 168.0.0 [2331](https://github.com/openfisca/openfisca-france/pull/2331)
 
 * Amélioration technique.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/index.yaml
@@ -1,1 +1,1 @@
-description: Rentes viagères à titre onéreux
+description: Taux de déduction des revenus imposables pour les rentes viagères à titre onéreux

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux1.yaml
@@ -1,14 +1,12 @@
-description: Moins de 50 ans
+description: Taux de déduction des revenus imposables pour les rentes viagères des personnes de moins de 50 ans
 values:
-  2002-01-01:
+  1979-07-01:
     value: 0.7
 metadata:
-  last_value_still_valid_on: "2024-05-21"
+  last_value_still_valid_on: "2024-07-30"
   unit: /1
+  short_label: Moins de 50 ans
   reference:
-    2002-01-01:
-      title: Code général des impôts - Art. 158
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/2002-01-01/
-  notes:
-    2002-01-01:
-    - title: Cette valeur semblent inchangée depuis au moins 1990
+    1979-07-01:
+      title: Art. 158 du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006307959/1979-07-01/

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux1.yaml
@@ -1,4 +1,4 @@
-description: Taux de déduction des revenus imposables pour les rentes viagères des personnes de moins de 50 ans
+description: Taux imposable pour les rentes viagères des personnes de moins de 50 ans
 values:
   1979-07-01:
     value: 0.7

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux1.yaml
@@ -3,4 +3,12 @@ values:
   2002-01-01:
     value: 0.7
 metadata:
+  last_value_still_valid_on: "2024-05-21"
   unit: /1
+  reference:
+    2002-01-01:
+      title: Code général des impôts - Art. 158
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/2002-01-01/
+  notes:
+    2002-01-01:
+    - title: Cette valeur semblent inchangée depuis au moins 1990

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux2.yaml
@@ -1,4 +1,4 @@
-description: Taux de déduction des revenus imposables pour les rentes viagères à titre onéreux des personnes âgées de 50 à 59 ans
+description: Taux imposable pour les rentes viagères à titre onéreux des personnes âgées de 50 à 59 ans
 values:
   1979-07-01:
     value: 0.5

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux2.yaml
@@ -1,14 +1,12 @@
-description: De 50 à 59 ans
+description: Taux de déduction des revenus imposables pour les rentes viagères à titre onéreux des personnes âgées de 50 à 59 ans
 values:
-  2002-01-01:
+  1979-07-01:
     value: 0.5
 metadata:
-  last_value_still_valid_on: "2024-05-21"
+  last_value_still_valid_on: "2024-07-30"
   unit: /1
+  short_label: De 50 à 59 ans
   reference:
-    2002-01-01:
-      title: Code général des impôts - Art. 158
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/2002-01-01/
-  notes:
-    2002-01-01:
-    - title: Cette valeur semblent inchangée depuis au moins 1990
+    1979-07-01:
+      title: Art. 158 du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/1979-07-01/

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux2.yaml
@@ -3,4 +3,12 @@ values:
   2002-01-01:
     value: 0.5
 metadata:
+  last_value_still_valid_on: "2024-05-21"
   unit: /1
+  reference:
+    2002-01-01:
+      title: Code général des impôts - Art. 158
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/2002-01-01/
+  notes:
+    2002-01-01:
+    - title: Cette valeur semblent inchangée depuis au moins 1990

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux3.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux3.yaml
@@ -1,4 +1,4 @@
-description: Taux de déduction des revenus imposables pour les rentes viagères à titre onéreux des personnes âgées de 60 à 69 ans
+description: Taux imposables pour les rentes viagères à titre onéreux des personnes âgées de 60 à 69 ans
 values:
   1979-07-01:
     value: 0.4

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux3.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux3.yaml
@@ -1,14 +1,12 @@
-description: De 60 à 69 ans
+description: Taux de déduction des revenus imposables pour les rentes viagères à titre onéreux des personnes âgées de 60 à 69 ans
 values:
-  2002-01-01:
+  1979-07-01:
     value: 0.4
 metadata:
-  last_value_still_valid_on: "2024-05-21"
+  last_value_still_valid_on: "2024-07-30"
   unit: /1
+  short_label: De 60 à 69 ans
   reference:
-    2002-01-01:
-      title: Code général des impôts - Art. 158
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/2002-01-01/
-  notes:
-    2002-01-01:
-    - title: Cette valeur semblent inchangée depuis au moins 1990
+    1979-07-01:
+      title: Art. 158 du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/1979-07-01/

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux3.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux3.yaml
@@ -3,4 +3,12 @@ values:
   2002-01-01:
     value: 0.4
 metadata:
+  last_value_still_valid_on: "2024-05-21"
   unit: /1
+  reference:
+    2002-01-01:
+      title: Code général des impôts - Art. 158
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/2002-01-01/
+  notes:
+    2002-01-01:
+    - title: Cette valeur semblent inchangée depuis au moins 1990

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux4.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux4.yaml
@@ -1,4 +1,4 @@
-description: Taux de déduction des revenus imposables pour les rentes viagères à titre onéreux des personnes âgées de plus de 70 ans
+description: Taux imposables pour les rentes viagères à titre onéreux des personnes âgées de plus de 70 ans
 values:
   1979-07-01:
     value: 0.3

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux4.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux4.yaml
@@ -1,14 +1,12 @@
-description: À partir de 70 ans
+description: Taux de déduction des revenus imposables pour les rentes viagères à titre onéreux des personnes âgées de plus de 70 ans
 values:
-  2002-01-01:
+  1979-07-01:
     value: 0.3
 metadata:
-  last_value_still_valid_on: "2024-05-21"
+  last_value_still_valid_on: "2024-07-30"
   unit: /1
+  short_label: A partir de 70 ans
   reference:
-    2002-01-01:
-      title: Code général des impôts - Art. 158
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/2002-01-01/
-  notes:
-    2002-01-01:
-    - title: Cette valeur semblent inchangée depuis au moins 1990
+    1979-07-01:
+      title: Art. 158 du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/1979-07-01/

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux4.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux4.yaml
@@ -3,4 +3,12 @@ values:
   2002-01-01:
     value: 0.3
 metadata:
+  last_value_still_valid_on: "2024-05-21"
   unit: /1
+  reference:
+    2002-01-01:
+      title: Code général des impôts - Art. 158
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/2002-01-01/
+  notes:
+    2002-01-01:
+    - title: Cette valeur semblent inchangée depuis au moins 1990

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '168.0.0',
+    version = '168.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : 
  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/*`

* Détails :
  - Met à jour la description
  - Ajoute une référence, le `short_label` et `last_value_still_valid_on`