### PR TITLE
Ajout d'une référence pour l'abattement pour frais professionnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 168.0.8 [2338](https://github.com/openfisca/openfisca-france/pull/2338)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : 
+  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/taux_salaires_pensions.yaml`
+
+* Détails :
+  - Ajoute une référence et le `last_value_still_valid_on`
+
 ## 168.0.7 [2335](https://github.com/openfisca/openfisca-france/pull/2335)
 
 * Changement mineur.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/taux_salaires_pensions.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/taux_salaires_pensions.yaml
@@ -12,7 +12,5 @@ metadata:
   reference:
     1943-01-01:
     - title: Art. 83 du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049641925/1943-01-01/
-    - title: Décret n°2024-496 du 30 mai 2024 - art. 1
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000049629761
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048121510/1950-04-30/
 documentation: La déduction forfaitaire de 10 % prévue par l'article 83 -3°, 2e alinéa du CGI pour la prise en compte des frais professionnels des salariés est plafonnée.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/taux_salaires_pensions.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/taux_salaires_pensions.yaml
@@ -1,11 +1,18 @@
-description: Taux de l'abattement forfaitaire sur les salaires et pensions
+description: Taux de l'abattement forfaitaire sur les salaires et pensions pour frais professionels
 values:
   1942-01-01:
     value: null
   1943-01-01:
     value: 0.1
 metadata:
+  last_value_still_valid_on: "2024-07-30"
   short_label: Taux
   ipp_csv_id: tx_abt_sal
   unit: /1
+  reference:
+    1943-01-01:
+    - title: Art. 83 du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049641925/1943-01-01/
+    - title: Décret n°2024-496 du 30 mai 2024 - art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000049629761
 documentation: La déduction forfaitaire de 10 % prévue par l'article 83 -3°, 2e alinéa du CGI pour la prise en compte des frais professionnels des salariés est plafonnée.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '168.0.7',
+    version = '168.0.8',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : 
  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/taux_salaires_pensions.yaml`

* Détails :
  - Ajoute une référence et le `last_value_still_valid_on`