### PR TITLE
fix divide by zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 168.0.3 [2339](https://github.com/openfisca/openfisca-france/pull/2339)
+
+* Changement mineur.
+* Périodes concernées : à partir du 01/01/2020
+* Zones impactées : `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py`.
+* Détails :
+  - Corrige une division par zero dans la formule de `maladie_maternite_artisan_commercant_taux`
+
+
 ## 168.0.2 [2336](https://github.com/openfisca/openfisca-france/pull/2336)
 
 * Changement mineur.

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
@@ -1,9 +1,8 @@
 import logging
-
+import numpy as np
 
 from openfisca_core.taxscales import MarginalRateTaxScale
 from openfisca_france.model.base import *
-import numpy as np
 
 # TODO:
 # Manquent:

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
@@ -3,7 +3,7 @@ import logging
 
 from openfisca_core.taxscales import MarginalRateTaxScale
 from openfisca_france.model.base import *
-
+import numpy as np
 
 # TODO:
 # Manquent:
@@ -193,11 +193,17 @@ class maladie_maternite_artisan_commercant_taux(Variable):
             ) * individu('rpns_imposables', period)
         assiette_pss = assiette / plafond_securite_sociale_annuel
 
-        taux = where(assiette_pss != 0, (
-            0.0085 + ((0.041 - 0.0085) * min_(max_(assiette_pss, 0), 0.4) / 0.4)
-            + ((0.072 - 0.041) * min_(max_((assiette_pss) - 0.4, 0), 0.7) / (1.1 - 0.4))
-            - (0.007 * (assiette_pss > 5) * ((assiette_pss - 5) / (assiette_pss + 1e-16)))
-            ), 0)
+        taux_nul = np.zeros(len(categorie_non_salarie))
+        taux = np.divide(
+            (
+                0.0085 + ((0.041 - 0.0085) * min_(max_(assiette_pss, 0), 0.4) / 0.4)
+                + ((0.072 - 0.041) * min_(max_((assiette_pss) - 0.4, 0), 0.7) / (1.1 - 0.4))
+                - (0.007 * (assiette_pss > 5) * (assiette_pss - 5))
+            ),
+            assiette_pss,
+            out = taux_nul,
+            where=assiette_pss != 0
+        )
 
         return artisan * taux
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
@@ -198,11 +198,11 @@ class maladie_maternite_artisan_commercant_taux(Variable):
                 0.0085 + ((0.041 - 0.0085) * min_(max_(assiette_pss, 0), 0.4) / 0.4)
                 + ((0.072 - 0.041) * min_(max_((assiette_pss) - 0.4, 0), 0.7) / (1.1 - 0.4))
                 - (0.007 * (assiette_pss > 5) * (assiette_pss - 5))
-            ),
+                ),
             assiette_pss,
             out = taux_nul,
             where=assiette_pss != 0
-        )
+            )
 
         return artisan * taux
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py
@@ -196,7 +196,7 @@ class maladie_maternite_artisan_commercant_taux(Variable):
         taux = where(assiette_pss != 0, (
             0.0085 + ((0.041 - 0.0085) * min_(max_(assiette_pss, 0), 0.4) / 0.4)
             + ((0.072 - 0.041) * min_(max_((assiette_pss) - 0.4, 0), 0.7) / (1.1 - 0.4))
-            - (0.007 * (assiette_pss > 5) * ((assiette_pss - 5) / assiette_pss))
+            - (0.007 * (assiette_pss > 5) * ((assiette_pss - 5) / (assiette_pss + 1e-16)))
             ), 0)
 
         return artisan * taux

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '168.0.2',
+    version = '168.0.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/2020
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_non_salarie.py`.
* Détails :
  - Corrige une division par zero dans la formule de `maladie_maternite_artisan_commercant_taux`

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.