### PR TITLE
Enlève des paramètres en dur dans certaines formules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 168.0.13 [2344](https://github.com/openfisca/openfisca-france/pull/2344)
+
+* Évolution du système socio-fiscal. | Amélioration technique. Ces changements modifient l'API publique d'OpenFisca France et ajoutent une fonctionnalité : la possibilité de modifier des paramètres actuellement en dur dans les formules.
+
+* Périodes concernées : à partir du 01/01/2011.
+* Zones impactées : 
+      * Modification formules dans `prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py`.
+      * Modification formules dans `prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py`
+      * Création d'un nouveau dossier de paramètre dans `prelevements_sociaux/contributions_sociales/csg/activite` pour l'`indemnite_compensatrice_fonctionnaires`
+      * Création d'un nouveau dossier de paramètre dans `prelevements_sociaux/reductions_cotisations_sociales` pour les `exonerations_geographiques_cotis` et `jei`
+      
+* Détails : Retire une partie des paramètres en dur de l'indémnité compensatrice CSG, de l'exonération JEI, et des exonération zonnées ZRR et ZRD
+
 ## 168.0.12 [2314](https://github.com/openfisca/openfisca-france/pull/2314)
 
 * Changement mineur.

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -457,9 +457,9 @@ class exoneration_cotisations_employeur_zrd(Variable):
         t_max_parameters = parameters(period).prelevements_sociaux
 
         eligible = zone_restructuration_defense
-        
+
         # Paramètre T mis en dur initialement dans la formule et laissé tel quel car le paramètre reductions_cotisations_sociales.alleg_gen.mmid.taux existe uniquement depuis 2019.
-        
+
         taux_max = .281 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie.rates[0] - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille.rates[0] - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
 
         seuil_max = seuils.plafond_part_remuneration
@@ -506,7 +506,7 @@ class exoneration_cotisations_employeur_zrr(Variable):
     # ou non.
     #
     # L'employeur ne doit avoir procédé à aucun licenciement économique durant les 12 mois précédant l'embauche.
-    
+
     def formula_1997_01_01(individu, period, parameters):
         assiette_allegement = individu('assiette_allegement', period)
         contrat_de_travail_type = individu('contrat_de_travail_type', period)
@@ -517,7 +517,6 @@ class exoneration_cotisations_employeur_zrr(Variable):
         smic_proratise = individu('smic_proratise', period)
         zone_revitalisation_rurale = individu('zone_revitalisation_rurale', period)
         seuils = parameters(period).prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrr
-        t_max_parameters = parameters(period).prelevements_sociaux
 
         duree_cdd_eligible = contrat_de_travail_fin > contrat_de_travail_debut + timedelta64(365, 'D')
         # TODO: move to parameters file

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -453,7 +453,7 @@ class exoneration_cotisations_employeur_zrd(Variable):
 
         eligible = zone_restructuration_defense
 
-        taux_max = .281 if period.start.year < 2015 else .2655 if period.start.year < 2019 else(t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
+        taux_max = .281 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
 
         seuil_max = seuils.plafond_part_remuneration
         seuil_min = seuils.plafond_exoneration_integrale_part_remuneration
@@ -527,7 +527,7 @@ class exoneration_cotisations_employeur_zrr(Variable):
             * duree_validite
             )
 
-        taux_max = .281 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
+        taux_max = .281 if period.start.year < 2015 else .2655 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
 
         seuil_max = seuils.plafond_part_remuneration
         seuil_min = seuils.plafond_exoneration_integrale_part_remuneration

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -207,7 +207,6 @@ class exoneration_cotisations_employeur_jei(Variable):
 
         return - exoneration * jeune_entreprise_innovante
 
-
     def formula_2011_01_01(individu, period, parameters):
         assiette_allegement = individu('assiette_allegement', period)
         jei_date_demande = individu('jei_date_demande', period)
@@ -528,11 +527,11 @@ class exoneration_cotisations_employeur_zrr(Variable):
             * duree_validite
             )
 
-        taux_max  = (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
-        
+        taux_max = (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
+
         seuil_max = seuils.plafond_part_remuneration
         seuil_min = seuils.plafond_exoneration_integrale_part_remuneration
-        
+
         taux_exoneration = compute_taux_exoneration(assiette_allegement, smic_proratise, taux_max, seuil_max, seuil_min)
         exoneration_cotisations_zrr = taux_exoneration * assiette_allegement * eligible
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -444,7 +444,9 @@ class exoneration_cotisations_employeur_zrd(Variable):
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
-    def formula(individu, period, parameters):
+    # L'exonération a été créée en 2009 par la loi de finances rectificative du 30 décembre 2008 
+
+    def formula_2009_01_01(individu, period, parameters):
         assiette_allegement = individu('assiette_allegement', period)
         entreprise_creation = individu('entreprise_creation', period)
         smic_proratise = individu('smic_proratise', period)
@@ -454,10 +456,10 @@ class exoneration_cotisations_employeur_zrd(Variable):
 
         eligible = zone_restructuration_defense
 
-        taux_max = .281 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie.rates[0] - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille.rates[0] - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
+        taux_max = t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie.rates[0] - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille.rates[0] - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction
 
-        seuil_max = 2.4 if period.start.year < 2009 else seuils.plafond_part_remuneration
-        seuil_min = 1.4 if period.start.year < 2009 else seuils.plafond_exoneration_integrale_part_remuneration
+        seuil_max = seuils.plafond_part_remuneration
+        seuil_min = seuils.plafond_exoneration_integrale_part_remuneration
 
         taux_exoneration = compute_taux_exoneration(assiette_allegement, smic_proratise, taux_max, seuil_max, seuil_min)
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -168,6 +168,8 @@ class exoneration_cotisations_employeur_jei(Variable):
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
+    # Cette formule ne tient pas compte du montant maximal d'exonération dont chaque établissement peut bénéficier et qui est de 5 PSS (231 840 € en 2024).
+
     def formula(individu, period, parameters):
         assiette_allegement = individu('assiette_allegement', period)
         jei_date_demande = individu('jei_date_demande', period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -168,7 +168,7 @@ class exoneration_cotisations_employeur_jei(Variable):
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
-    # Cette formule ne tient pas compte du montant maximal d'exonération dont chaque établissement peut bénéficier et qui est de 5 PSS (231 840 € en 2024).
+    # Cette formule ne tient pas compte du montant maximal d'exonération dont chaque établissement peut bénéficier et qui est de 5 PSS (231 840 € en 2024)
 
     def formula(individu, period, parameters):
         assiette_allegement = individu('assiette_allegement', period)
@@ -482,8 +482,8 @@ class exoneration_cotisations_employeur_zrr(Variable):
             )
 
         taux_max = .281 if period.start.year < 2015 else .2655  # TODO: move to parameters file
-        seuil_max = 2.4
-        seuil_min = 1.5
+        seuil_max = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrr.plafond_part_remuneration
+        seuil_min = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrr.plafond_exoneration_integrale_part_remuneration
         taux_exoneration = compute_taux_exoneration(assiette_allegement, smic_proratise, taux_max, seuil_max, seuil_min)
         exoneration_cotisations_zrr = taux_exoneration * assiette_allegement * eligible
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -472,7 +472,6 @@ class exoneration_cotisations_employeur_zrr(Variable):
         zone_revitalisation_rurale = individu('zone_revitalisation_rurale', period)
         seuils = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrr
         t_max_parameters = parameters(period)prelevements_sociaux
-        taux_versement_transport = individu('taux_versement_transport', period)
 
         duree_cdd_eligible = contrat_de_travail_fin > contrat_de_travail_debut + timedelta64(365, 'D')
         # TODO: move to parameters file
@@ -489,13 +488,8 @@ class exoneration_cotisations_employeur_zrr(Variable):
             * duree_validite
             )
 
-        base_taux_max = (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction + taux_versement_transport )
+        taux_max  = (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
         
-        fnal_taux = (t_max_parameters.autres_taxes_participations_assises_salaires.fnal.contribution_moins_de_50_salaries.rates[0])
-        if effectif_entreprise < 50 else (t_max_parameters.autres_taxes_participations_assises_salaires.fnal.contribution_plus_de_50_salaries)
-
-        taux_max = base_taux_max + fnal_taux
-
         seuil_max = seuils.plafond_part_remuneration
         seuil_min = seuils.plafond_exoneration_integrale_part_remuneration
         

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -453,7 +453,7 @@ class exoneration_cotisations_employeur_zrd(Variable):
 
         eligible = zone_restructuration_defense
 
-        taux_max = (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
+        taux_max = .281 if period.start.year < 2015 else .2655 if period.start.year < 2019 else(t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
 
         seuil_max = seuils.plafond_part_remuneration
         seuil_min = seuils.plafond_exoneration_integrale_part_remuneration
@@ -527,7 +527,7 @@ class exoneration_cotisations_employeur_zrr(Variable):
             * duree_validite
             )
 
-        taux_max = (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
+        taux_max = .281 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
 
         seuil_max = seuils.plafond_part_remuneration
         seuil_min = seuils.plafond_exoneration_integrale_part_remuneration

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -454,7 +454,7 @@ class exoneration_cotisations_employeur_zrd(Variable):
 
         eligible = zone_restructuration_defense
 
-        taux_max = .281 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
+        taux_max = .281 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie.rates[0] - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille.rates[0] - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
 
         seuil_max = 2.4 if period.start.year < 2009 else seuils.plafond_part_remuneration
         seuil_min = 1.4 if period.start.year < 2009 else seuils.plafond_exoneration_integrale_part_remuneration
@@ -528,7 +528,7 @@ class exoneration_cotisations_employeur_zrr(Variable):
             * duree_validite
             )
 
-        taux_max = .281 if period.start.year < 2015 else .2655 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
+        taux_max = .281 if period.start.year < 2015 else .2655 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie.rates[0] - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille.rates[0] - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
 
         seuil_max = 2.4 if period.start.year < 2009 else seuils.plafond_part_remuneration
         seuil_min = 1.5 if period.start.year < 2009 else seuils.plafond_exoneration_integrale_part_remuneration

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -168,7 +168,7 @@ class exoneration_cotisations_employeur_jei(Variable):
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
-    def formula(individu, period, parameters):
+    def formula_2004_01_01(individu, period, parameters):
         assiette_allegement = individu('assiette_allegement', period)
         jei_date_demande = individu('jei_date_demande', period)
         jeune_entreprise_innovante = individu('jeune_entreprise_innovante', period)
@@ -207,6 +207,8 @@ class exoneration_cotisations_employeur_jei(Variable):
                 exoneration[condition_on_year_passed] = rate * exoneration
 
         return - exoneration * jeune_entreprise_innovante
+
+    # À compter de 2011, l'exonération JEI est modifiée avec l'introduction, par l'article 175 de la LOI n° 2010-1657 du 29 décembre 2010 de finances pour 2011, d'une double limite de l'exonération. L'exonération s'applique uniquement sur la part de la rémunération inférieur à 4,5 fois le Smic, et un montant maximal par établissement est instauré.
 
     def formula_2011_01_01(individu, period, parameters):
         assiette_allegement = individu('assiette_allegement', period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -178,6 +178,7 @@ class exoneration_cotisations_employeur_jei(Variable):
 
         bareme_by_type_sal_name = parameters(period).cotsoc.cotisations_employeur
         bareme_names = ['vieillesse_deplafonnee', 'vieillesse_plafonnee', 'maladie', 'famille']
+        plafond_part_remuneration = parameters(period).prelevements_sociaux.reductions_cotisations_sociales.jei.plafond_part_remuneration
 
         exoneration = smic_proratise * 0.0
         for bareme_name in bareme_names:
@@ -185,7 +186,7 @@ class exoneration_cotisations_employeur_jei(Variable):
                 bareme_by_type_sal_name = bareme_by_type_sal_name,
                 bareme_name = bareme_name,
                 categorie_salarie = categorie_salarie,
-                base = min_(assiette_allegement, 4.5 * smic_proratise),
+                base = min_(assiette_allegement, plafond_part_remuneration * smic_proratise),
                 plafond_securite_sociale = plafond_securite_sociale,
                 round_base_decimals = 2,
                 )

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -449,8 +449,8 @@ class exoneration_cotisations_employeur_zrd(Variable):
         entreprise_creation = individu('entreprise_creation', period)
         smic_proratise = individu('smic_proratise', period)
         zone_restructuration_defense = individu('zone_restructuration_defense', period)
-        seuils = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrd
-        t_max_parameters = parameters(period)prelevements_sociaux
+        seuils = parameters(period).prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrd
+        t_max_parameters = parameters(period).prelevements_sociaux
 
         eligible = zone_restructuration_defense
 
@@ -510,8 +510,8 @@ class exoneration_cotisations_employeur_zrr(Variable):
         effectif_entreprise = individu('effectif_entreprise', period)
         smic_proratise = individu('smic_proratise', period)
         zone_revitalisation_rurale = individu('zone_revitalisation_rurale', period)
-        seuils = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrr
-        t_max_parameters = parameters(period)prelevements_sociaux
+        seuils = parameters(period).prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrr
+        t_max_parameters = parameters(period).prelevements_sociaux
 
         duree_cdd_eligible = contrat_de_travail_fin > contrat_de_travail_debut + timedelta64(365, 'D')
         # TODO: move to parameters file

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -168,7 +168,7 @@ class exoneration_cotisations_employeur_jei(Variable):
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
-    def formula (individu, period, parameters):
+    def formula(individu, period, parameters):
         assiette_allegement = individu('assiette_allegement', period)
         jei_date_demande = individu('jei_date_demande', period)
         jeune_entreprise_innovante = individu('jeune_entreprise_innovante', period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -501,7 +501,7 @@ class exoneration_cotisations_employeur_zrr(Variable):
     #
     # L'employeur ne doit avoir procédé à aucun licenciement économique durant les 12 mois précédant l'embauche.
     
-     def formula_1997_01_01(individu, period, parameters):
+    def formula_1997_01_01(individu, period, parameters):
         assiette_allegement = individu('assiette_allegement', period)
         contrat_de_travail_type = individu('contrat_de_travail_type', period)
         TypesContrat = contrat_de_travail_type.possible_values

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -455,8 +455,8 @@ class exoneration_cotisations_employeur_zrd(Variable):
 
         taux_max = .281 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
 
-        seuil_max = seuils.plafond_part_remuneration
-        seuil_min = seuils.plafond_exoneration_integrale_part_remuneration
+        seuil_max = 2.4 if period.start.year < 2009 else seuils.plafond_part_remuneration
+        seuil_min = 1.4 if period.start.year < 2009 else seuils.plafond_exoneration_integrale_part_remuneration
 
         taux_exoneration = compute_taux_exoneration(assiette_allegement, smic_proratise, taux_max, seuil_max, seuil_min)
 
@@ -529,8 +529,8 @@ class exoneration_cotisations_employeur_zrr(Variable):
 
         taux_max = .281 if period.start.year < 2015 else .2655 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
 
-        seuil_max = seuils.plafond_part_remuneration
-        seuil_min = seuils.plafond_exoneration_integrale_part_remuneration
+        seuil_max = 2.4 if period.start.year < 2009 else seuils.plafond_part_remuneration
+        seuil_min = 1.5 if period.start.year < 2009 else seuils.plafond_exoneration_integrale_part_remuneration
 
         taux_exoneration = compute_taux_exoneration(assiette_allegement, smic_proratise, taux_max, seuil_max, seuil_min)
         exoneration_cotisations_zrr = taux_exoneration * assiette_allegement * eligible

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -471,6 +471,8 @@ class exoneration_cotisations_employeur_zrr(Variable):
         smic_proratise = individu('smic_proratise', period)
         zone_revitalisation_rurale = individu('zone_revitalisation_rurale', period)
         seuils = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrr
+        t_max_parameters = parameters(period)prelevements_sociaux
+        taux_versement_transport = individu('taux_versement_transport', period)
 
         duree_cdd_eligible = contrat_de_travail_fin > contrat_de_travail_debut + timedelta64(365, 'D')
         # TODO: move to parameters file
@@ -487,9 +489,16 @@ class exoneration_cotisations_employeur_zrr(Variable):
             * duree_validite
             )
 
-        taux_max = .281 if period.start.year < 2015 else .2655  # TODO: move to parameters file
+        base_taux_max = (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction + taux_versement_transport )
+        
+        fnal_taux = (t_max_parameters.autres_taxes_participations_assises_salaires.fnal.contribution_moins_de_50_salaries.rates[0])
+        if effectif_entreprise < 50 else (t_max_parameters.autres_taxes_participations_assises_salaires.fnal.contribution_plus_de_50_salaries)
+
+        taux_max = base_taux_max + fnal_taux
+
         seuil_max = seuils.plafond_part_remuneration
         seuil_min = seuils.plafond_exoneration_integrale_part_remuneration
+        
         taux_exoneration = compute_taux_exoneration(assiette_allegement, smic_proratise, taux_max, seuil_max, seuil_min)
         exoneration_cotisations_zrr = taux_exoneration * assiette_allegement * eligible
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -409,11 +409,12 @@ class exoneration_cotisations_employeur_zrd(Variable):
         entreprise_creation = individu('entreprise_creation', period)
         smic_proratise = individu('smic_proratise', period)
         zone_restructuration_defense = individu('zone_restructuration_defense', period)
+        seuils = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrd
 
         eligible = zone_restructuration_defense
         taux_max = .281  # TODO: move to parameters file
-        seuil_max = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrd.plafond_part_remuneration
-        seuil_min = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrd.plafond_exoneration_integrale_part_remuneration
+        seuil_max = seuils.plafond_part_remuneration
+        seuil_min = seuils.plafond_exoneration_integrale_part_remuneration
         taux_exoneration = compute_taux_exoneration(assiette_allegement, smic_proratise, taux_max, seuil_max, seuil_min)
 
         exoneration_relative_year_passed = exoneration_relative_year(period, entreprise_creation)
@@ -465,6 +466,7 @@ class exoneration_cotisations_employeur_zrr(Variable):
         effectif_entreprise = individu('effectif_entreprise', period)
         smic_proratise = individu('smic_proratise', period)
         zone_revitalisation_rurale = individu('zone_revitalisation_rurale', period)
+        seuils = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrr
 
         duree_cdd_eligible = contrat_de_travail_fin > contrat_de_travail_debut + timedelta64(365, 'D')
         # TODO: move to parameters file
@@ -482,8 +484,8 @@ class exoneration_cotisations_employeur_zrr(Variable):
             )
 
         taux_max = .281 if period.start.year < 2015 else .2655  # TODO: move to parameters file
-        seuil_max = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrr.plafond_part_remuneration
-        seuil_min = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrr.plafond_exoneration_integrale_part_remuneration
+        seuil_max = seuils.plafond_part_remuneration
+        seuil_min = seuils.plafond_exoneration_integrale_part_remuneration
         taux_exoneration = compute_taux_exoneration(assiette_allegement, smic_proratise, taux_max, seuil_max, seuil_min)
         exoneration_cotisations_zrr = taux_exoneration * assiette_allegement * eligible
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -174,6 +174,7 @@ class exoneration_cotisations_employeur_jei(Variable):
         jeune_entreprise_innovante = individu('jeune_entreprise_innovante', period)
         plafond_securite_sociale = individu('plafond_securite_sociale', period)
         categorie_salarie = individu('categorie_salarie', period)
+        smic_proratise = individu('smic_proratise', period)
 
         bareme_by_type_sal_name = parameters(period).cotsoc.cotisations_employeur
         bareme_names = ['vieillesse_deplafonnee', 'vieillesse_plafonnee', 'maladie', 'famille']

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -410,11 +410,15 @@ class exoneration_cotisations_employeur_zrd(Variable):
         smic_proratise = individu('smic_proratise', period)
         zone_restructuration_defense = individu('zone_restructuration_defense', period)
         seuils = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrd
+        t_max_parameters = parameters(period)prelevements_sociaux
 
         eligible = zone_restructuration_defense
-        taux_max = .281  # TODO: move to parameters file
+
+        taux_max = (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
+
         seuil_max = seuils.plafond_part_remuneration
         seuil_min = seuils.plafond_exoneration_integrale_part_remuneration
+
         taux_exoneration = compute_taux_exoneration(assiette_allegement, smic_proratise, taux_max, seuil_max, seuil_min)
 
         exoneration_relative_year_passed = exoneration_relative_year(period, entreprise_creation)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -446,7 +446,7 @@ class exoneration_cotisations_employeur_zrd(Variable):
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
-    # L'exonération a été créée en 2009 par la loi de finances rectificative du 30 décembre 2008 
+    # L'exonération a été créée en 2009 par la loi de finances rectificative du 30 décembre 2008.
 
     def formula_2009_01_01(individu, period, parameters):
         assiette_allegement = individu('assiette_allegement', period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -457,8 +457,10 @@ class exoneration_cotisations_employeur_zrd(Variable):
         t_max_parameters = parameters(period).prelevements_sociaux
 
         eligible = zone_restructuration_defense
-
-        taux_max = t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie.rates[0] - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille.rates[0] - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction
+        
+        # Paramètre T mis en dur initialement dans la formule et laissé tel quel car le paramètre reductions_cotisations_sociales.alleg_gen.mmid.taux existe uniquement depuis 2019.
+        
+        taux_max = .281 if period.start.year < 2019 else (t_max_parameters.cotisations_securite_sociale_regime_general.mmid.employeur.maladie.rates[0] - t_max_parameters.reductions_cotisations_sociales.alleg_gen.mmid.taux + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_plafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.cnav.employeur.vieillesse_deplafonnee.rates[0] + t_max_parameters.cotisations_securite_sociale_regime_general.famille.employeur.famille.rates[0] - t_max_parameters.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction)
 
         seuil_max = seuils.plafond_part_remuneration
         seuil_min = seuils.plafond_exoneration_integrale_part_remuneration
@@ -543,8 +545,6 @@ class exoneration_cotisations_employeur_zrr(Variable):
         exoneration_cotisations_zrr = taux_exoneration * assiette_allegement * eligible
 
         return exoneration_cotisations_zrr
-
-
 
     def formula_2008_03_01(individu, period, parameters):
         assiette_allegement = individu('assiette_allegement', period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py
@@ -412,8 +412,8 @@ class exoneration_cotisations_employeur_zrd(Variable):
 
         eligible = zone_restructuration_defense
         taux_max = .281  # TODO: move to parameters file
-        seuil_max = 2.4
-        seuil_min = 1.4
+        seuil_max = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrd.plafond_part_remuneration
+        seuil_min = parameters(period)prelevements_sociaux.reductions_cotisations_sociales.exonerations_geographiques_cotis.zrd.plafond_exoneration_integrale_part_remuneration
         taux_exoneration = compute_taux_exoneration(assiette_allegement, smic_proratise, taux_max, seuil_max, seuil_min)
 
         exoneration_relative_year_passed = exoneration_relative_year(period, entreprise_creation)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
@@ -116,7 +116,9 @@ class indemnite_compensatrice_csg(Variable):
         remuneration_principale = individu('remuneration_principale', period)
         categorie_salarie = individu('categorie_salarie', period)
         eligible = ((categorie_salarie == TypesCategorieSalarie.public_titulaire_etat) + (categorie_salarie == TypesCategorieSalarie.public_titulaire_militaire) + (categorie_salarie == TypesCategorieSalarie.public_titulaire_territoriale) + (categorie_salarie == TypesCategorieSalarie.public_titulaire_hospitaliere)) > 0
-        indem = remuneration_principale * 0.0076
+        parameters = parameters(period).prelevements_sociaux.contributions_sociales.csg.activite
+
+        indem = remuneration_principale * parameters.indemnite_compensatrice_fonctionnaires.taux
 
         return indem * eligible
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
@@ -116,7 +116,7 @@ class indemnite_compensatrice_csg(Variable):
         remuneration_principale = individu('remuneration_principale', period)
         categorie_salarie = individu('categorie_salarie', period)
         eligible = ((categorie_salarie == TypesCategorieSalarie.public_titulaire_etat) + (categorie_salarie == TypesCategorieSalarie.public_titulaire_militaire) + (categorie_salarie == TypesCategorieSalarie.public_titulaire_territoriale) + (categorie_salarie == TypesCategorieSalarie.public_titulaire_hospitaliere)) > 0
-        taux_indemnite = parameters(period).prelevements_sociaux.contributions_sociales.csg.activiteindemnite_compensatrice_fonctionnaires.taux
+        taux_indemnite = parameters(period).prelevements_sociaux.contributions_sociales.csg.activite.indemnite_compensatrice_fonctionnaires.taux
 
         indem = remuneration_principale * taux_indemnite
 

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py
@@ -116,9 +116,9 @@ class indemnite_compensatrice_csg(Variable):
         remuneration_principale = individu('remuneration_principale', period)
         categorie_salarie = individu('categorie_salarie', period)
         eligible = ((categorie_salarie == TypesCategorieSalarie.public_titulaire_etat) + (categorie_salarie == TypesCategorieSalarie.public_titulaire_militaire) + (categorie_salarie == TypesCategorieSalarie.public_titulaire_territoriale) + (categorie_salarie == TypesCategorieSalarie.public_titulaire_hospitaliere)) > 0
-        parameters = parameters(period).prelevements_sociaux.contributions_sociales.csg.activite
+        taux_indemnite = parameters(period).prelevements_sociaux.contributions_sociales.csg.activiteindemnite_compensatrice_fonctionnaires.taux
 
-        indem = remuneration_principale * parameters.indemnite_compensatrice_fonctionnaires.taux
+        indem = remuneration_principale * taux_indemnite
 
         return indem * eligible
 

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/indemnite_compensatrice_fonctionnaires/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/indemnite_compensatrice_fonctionnaires/index.yaml
@@ -1,0 +1,9 @@
+description: Indemnité compensatrice de CSG de la fonction publique
+metadata:
+  label_en: CSG compensatory allowance 
+  reference:
+    2018-01-01:
+    - title: Article 113 de la LOI n° 2017-1837 du 30 décembre 2017 de finances pour 2018 (1)
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036377692
+documentation: |-
+    Cette indémnité compensatrice concerne les agents publics civils et les militairs, mais « n'est pas versée aux agents [...] qui sont affiliés au régime général de la sécurité sociale au titre des prestations en espèces de l'assurance maladie.» II. de l'article 2 du Décret n° 2017-1889 du 30 décembre 2017

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/indemnite_compensatrice_fonctionnaires/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/indemnite_compensatrice_fonctionnaires/index.yaml
@@ -6,4 +6,4 @@ metadata:
     - title: Article 113 de la LOI n° 2017-1837 du 30 décembre 2017 de finances pour 2018 (1)
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036377692
 documentation: |-
-    Cette indémnité compensatrice concerne les agents publics civils et les militairs, mais « n'est pas versée aux agents [...] qui sont affiliés au régime général de la sécurité sociale au titre des prestations en espèces de l'assurance maladie.» II. de l'article 2 du Décret n° 2017-1889 du 30 décembre 2017
+    Cette indemnité compensatrice concerne les agents publics civils et les militaires, mais « n'est pas versée aux agents [...] qui sont affiliés au régime général de la sécurité sociale au titre des prestations en espèces de l'assurance maladie.» II. de l'article 2 du Décret n° 2017-1889 du 30 décembre 2017

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/indemnite_compensatrice_fonctionnaires/taux.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/indemnite_compensatrice_fonctionnaires/taux.yaml
@@ -1,0 +1,16 @@
+description: Taux de l'indémnité compensatrice de CSG versée aux fonctionnaires civils et militaires
+values:
+  2018-01-01:
+    value: 0.0076
+metadata:
+  short_label: Taux indémnité compensatrice
+  last_value_still_valid_on: "2024-08-12"
+  label_en: CSG compensatory allowance rate
+  ipp_csv_id: csg_act
+  unit: /1
+  reference:
+    2018-01-01:
+    - title: Article 2 du décret n° 2017-1889 du 30 décembre 2017 pris en application de l'article 113 de la loi n° 2017-1837 du 30 décembre 2017 de finances pour 2018
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036501673
+  official_journal_date:
+    2018-01-01: "2017-12-31"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/indemnite_compensatrice_fonctionnaires/taux.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/activite/indemnite_compensatrice_fonctionnaires/taux.yaml
@@ -1,9 +1,9 @@
-description: Taux de l'indémnité compensatrice de CSG versée aux fonctionnaires civils et militaires
+description: Taux de l'indemnité compensatrice de CSG versée aux fonctionnaires civils et militaires
 values:
   2018-01-01:
     value: 0.0076
 metadata:
-  short_label: Taux indémnité compensatrice
+  short_label: Taux indemnité compensatrice
   last_value_still_valid_on: "2024-08-12"
   label_en: CSG compensatory allowance rate
   ipp_csv_id: csg_act

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/index.yaml
@@ -1,0 +1,6 @@
+description: Exonérations géographiques de cotisations employeur
+metadata:
+  reference:
+    0001-01-01:
+    - title: BOSS.gouv.fr
+      href: https://boss.gouv.fr/portail/accueil/exonerations/exonerations-zonees.html

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrd/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrd/index.yaml
@@ -1,0 +1,9 @@
+description: Exonération de cotisations employeur applicable en zone de restructuration de la défence (ZRD)
+metadata:
+  short_label: Exonération en zone de restructuration de la défense (ZRD)
+  reference:
+    0001-01-01:
+    - title: Article 34 de la loi n° 2008-1443 du 30 décembre 2008 de finances rectificative pour 2008 (1)
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037075159/
+    - title: BOSS.gouv.fr
+      href: https://boss.gouv.fr/portail/accueil/exonerations/exonerations-zonees.html#titre-chapitre-3--exoneration-applicab

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrd/plafond_exoneration_integrale_part_remuneration.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrd/plafond_exoneration_integrale_part_remuneration.yaml
@@ -1,0 +1,15 @@
+description: Plafond de rémunération (en nombre de Smic) de l'exonération intégrale de cotisations employeur en zone de restructuration de la défense (ZRD)
+values:
+  2009-01-01:
+    value: 1.4
+metadata:
+  short_label: Plafond de rémunération de l'exonération intégrale
+  last_value_still_valid_on: "2024-08-12"
+  label_en: Remuneration ceiling for full exemption
+  unit: smic
+  reference:
+    2009-01-01:
+    - title: Article 34 de la loi n° 2008-1443 du 30 décembre 2008 de finances rectificative pour 2008 (1)
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037075159/
+    - title: BOSS.gouv.fr
+      href: https://boss.gouv.fr/portail/accueil/exonerations/exonerations-zonees.html#titre-chapitre-3--exoneration-applicab

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrd/plafond_part_remuneration.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrd/plafond_part_remuneration.yaml
@@ -1,0 +1,15 @@
+description: Plafond de rémunération (en nombre de Smic) de l'exonération de cotisations employeur au titre des embauches en zone de restructuration de la défense (ZRD)
+values:
+  2009-01-01:
+    value: 2.4
+metadata:
+  short_label: Plafond de rémunération de l'exonération (Point d'annulation)
+  last_value_still_valid_on: "2024-08-12"
+  label_en: Remuneration ceiling for exemption
+  unit: smic
+  reference:
+    2009-01-01:
+    - title: Article 34 de la loi n° 2008-1443 du 30 décembre 2008 de finances rectificative pour 2008 (1)
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037075159/
+    - title: BOSS.gouv.fr
+      href: https://boss.gouv.fr/portail/accueil/exonerations/exonerations-zonees.html#titre-chapitre-3--exoneration-applicab

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/index.yaml
@@ -1,0 +1,9 @@
+description: Exonérations de cotisations employeur au titre des embauches en zone de revitalisation rurale (ZRR)
+metadata:
+  short_label: Exonération en zone de revitalisation rurale (ZRR)
+  reference:
+    0001-01-01:
+    - title: Article L241-19 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038610258
+    - title: BOSS.gouv.fr
+      href: https://boss.gouv.fr/portail/accueil/exonerations/exonerations-zonees.html#titre-chapitre-1--exoneration-applicab

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/plafond_exoneration_integrale_part_remuneration.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/plafond_exoneration_integrale_part_remuneration.yaml
@@ -1,6 +1,6 @@
-description: Plafond de rémunération (en nombre de Smic) d'exonération intégrale de cotisations employeur au titre des embauches en zone de revitalisation rurale (ZRR)
+description: Plafond de rémunération (en nombre de Smic) de l'exonération intégrale de cotisations employeur au titre des embauches en zone de revitalisation rurale (ZRR)
 values:
-  2019-01-01:
+  2009-01-01:
     value: 1.5
 metadata:
   short_label: Plafond de rémunération de l'exonération intégrale
@@ -8,7 +8,7 @@ metadata:
   label_en: Remuneration ceiling for full exemption
   unit: smic
   reference:
-    2019-01-01:
+    2009-01-01:
     - title: Article 6 du décret n° 97-127 du 12 février 1997
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037456942
     - title: BOSS.gouv.fr

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/plafond_exoneration_integrale_part_remuneration.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/plafond_exoneration_integrale_part_remuneration.yaml
@@ -1,0 +1,15 @@
+description: Plafond de rémunération (en nombre de Smic) d'exonération intégrale de cotisations employeur au titre des embauches en zone de revitalisation rurale (ZRR)
+values:
+  2019-01-01:
+    value: 1.5
+metadata:
+  short_label: Plafond de rémunération de l'exonération intégrale
+  last_value_still_valid_on: "2024-08-12"
+  label_en: Remuneration ceiling for full exemption
+  unit: smic
+  reference:
+    2019-01-01:
+    - title: Article 6 du décret n° 97-127 du 12 février 1997
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037456942
+    - title: BOSS.gouv.fr
+      href: https://boss.gouv.fr/portail/accueil/exonerations/exonerations-zonees.html#titre-chapitre-1--exoneration-applicab-section-3--modalites-dapplicatio-b-calcul-du-montant-de-lexonerat

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/plafond_exoneration_integrale_part_remuneration.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/plafond_exoneration_integrale_part_remuneration.yaml
@@ -1,5 +1,9 @@
 description: Plafond de rémunération (en nombre de Smic) de l'exonération intégrale de cotisations employeur au titre des embauches en zone de revitalisation rurale (ZRR)
 values:
+  1997-01-01:
+    value: 1.5
+  2008-03-01:
+    value: 1.5
   2009-01-01:
     value: 1.5
 metadata:
@@ -8,8 +12,21 @@ metadata:
   label_en: Remuneration ceiling for full exemption
   unit: smic
   reference:
+    1997-01-01:
+    - title: Article L322-13, I., du Code du travail
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006648287/1996-11-15/
+    2008-03-01:
+    - title: Article L131-4-2 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006741069/2008-03-01
     2009-01-01:
     - title: Article 6 du décret n° 97-127 du 12 février 1997
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037456942
     - title: BOSS.gouv.fr
       href: https://boss.gouv.fr/portail/accueil/exonerations/exonerations-zonees.html#titre-chapitre-1--exoneration-applicab-section-3--modalites-dapplicatio-b-calcul-du-montant-de-lexonerat
+  notes:
+    1997-01-01: 
+    - title: Le plafond de la rémunération prise en compte est, depuis le début du dispositif en 1994, de "montant du salaire minimum de croissance majoré de 50 p. 100.".
+    2008-03-01: 
+    - title: À partir du 1er mars 2008 apparaît la dégressivité à compter de ce paramètre qui reste à 1,5 Smic mais qui est déplacé dans le Code de la sécurité sociale
+    2009-01-01: 
+    - title: À partir de 2009, les deux paramètres (celui-ci, plafond de l'exonération totale et le point d'annulation) sont déplacés dans l'article 6 du décret n° 97-127 du 12 février 1997. Décret qui est donc modifié.

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/plafond_part_remuneration.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/plafond_part_remuneration.yaml
@@ -1,6 +1,6 @@
 description: Plafond de rémunération (en nombre de Smic) de l'exonération de cotisations employeur au titre des embauches en zone de revitalisation rurale (ZRR)
 values:
-  2019-01-01:
+  2009-01-01:
     value: 2.4
 metadata:
   short_label: Plafond de rémunération de l'exonération (Point d'annulation)
@@ -8,7 +8,7 @@ metadata:
   label_en: Remuneration ceiling for exemption
   unit: smic
   reference:
-    2019-01-01:
+    2009-01-01:
     - title: Article 6 du décret n° 97-127 du 12 février 1997
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037456942
     - title: BOSS.gouv.fr

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/plafond_part_remuneration.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/plafond_part_remuneration.yaml
@@ -1,5 +1,7 @@
 description: Plafond de rémunération (en nombre de Smic) de l'exonération de cotisations employeur au titre des embauches en zone de revitalisation rurale (ZRR)
 values:
+  2008-03-01:
+    value: 2.4
   2009-01-01:
     value: 2.4
 metadata:
@@ -8,9 +10,16 @@ metadata:
   label_en: Remuneration ceiling for exemption
   unit: smic
   reference:
+    2008-03-01:
+    - title: Article L131-4-2 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006741069/2008-03-01
     2009-01-01:
     - title: Article 6 du décret n° 97-127 du 12 février 1997
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037456942
     - title: BOSS.gouv.fr
       href: https://boss.gouv.fr/portail/accueil/exonerations/exonerations-zonees.html#titre-chapitre-1--exoneration-applicab-section-3--modalites-dapplicatio-b-calcul-du-montant-de-lexonerat
-
+  notes:
+    2008-03-01: 
+    - title: Ce paramètre n'existait pas à moment de la création du dispositif en 1997. La dégressivité apparaît à partir du 1er mars 2008 apparaît la dégressivité dans le Code de la sécurité sociale
+    2009-01-01: 
+    - title: À partir de 2009, les deux paramètres (le plafond de l'exonération totale et, celui-ci, le point d'annulation) sont déplacés dans l'article 6 du décret n° 97-127 du 12 février 1997. Décret qui est donc modifié.

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/plafond_part_remuneration.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/exonerations_geographiques_cotis/zrr/plafond_part_remuneration.yaml
@@ -1,0 +1,16 @@
+description: Plafond de rémunération (en nombre de Smic) de l'exonération de cotisations employeur au titre des embauches en zone de revitalisation rurale (ZRR)
+values:
+  2019-01-01:
+    value: 2.4
+metadata:
+  short_label: Plafond de rémunération de l'exonération (Point d'annulation)
+  last_value_still_valid_on: "2024-08-12"
+  label_en: Remuneration ceiling for exemption
+  unit: smic
+  reference:
+    2019-01-01:
+    - title: Article 6 du décret n° 97-127 du 12 février 1997
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037456942
+    - title: BOSS.gouv.fr
+      href: https://boss.gouv.fr/portail/accueil/exonerations/exonerations-zonees.html#titre-chapitre-1--exoneration-applicab-section-3--modalites-dapplicatio-b-calcul-du-montant-de-lexonerat
+

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/jei/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/jei/index.yaml
@@ -2,7 +2,7 @@ description: Exonération de cotisations employeur pour les jeunes entreprises i
 metadata:
   label_en: Exonération cotisations jeunes entreprises innovantes (JEI)
   reference:
-    2018-01-01:
+    2011-01-01:
     - title: Article 131 de la loi n° 2003-1311 du 30 décembre 2003 de finances pour 2004 (1).
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037075129
     - title: BOSS.gouv.fr

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/jei/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/jei/index.yaml
@@ -1,0 +1,11 @@
+description: Exonération de cotisations employeur pour les jeunes entreprises innovantes (JEI)
+metadata:
+  label_en: Exonération cotisations jeunes entreprises innovantes (JEI)
+  reference:
+    2018-01-01:
+    - title: Article 131 de la loi n° 2003-1311 du 30 décembre 2003 de finances pour 2004 (1).
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037075129
+    - title: BOSS.gouv.fr
+      href: https://boss.gouv.fr/portail/accueil/exonerations/jeunes-entreprises-innovantes.html
+documentation: |-
+    Les entreprises ayant le statut de "jeunes entreprises innovantes" (JEI) bénéficient, sous conditions, d'exonérations fiscales et sociales spécifiques pour une durée déterminée. L'exonération s'applique selon une double limite : la part de la rémunération concernée + un montant maximal par an d'exonération par établissement employeur.

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/jei/index.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/jei/index.yaml
@@ -8,4 +8,4 @@ metadata:
     - title: BOSS.gouv.fr
       href: https://boss.gouv.fr/portail/accueil/exonerations/jeunes-entreprises-innovantes.html
 documentation: |-
-    Les entreprises ayant le statut de "jeunes entreprises innovantes" (JEI) bénéficient, sous conditions, d'exonérations fiscales et sociales spécifiques pour une durée déterminée. L'exonération s'applique selon une double limite : la part de la rémunération concernée + un montant maximal par an d'exonération par établissement employeur.
+    Les entreprises ayant le statut de "jeunes entreprises innovantes" (JEI) bénéficient, sous conditions, d'exonérations fiscales et sociales spécifiques pour une durée déterminée. L'exonération s'applique selon une double limite : la part de la rémunération concernée (paramètre disponible dans OpenFisca) + un montant maximal par an d'exonération par établissement employeur (ce paramètre n'est pas disponible dans OpenFisca).

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/jei/plafond_part_remuneration.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/jei/plafond_part_remuneration.yaml
@@ -1,0 +1,17 @@
+description: Plafond de la part de rémunération des salariés (en nombre de Smic) concernée par l'exonération de cotisation employeur pour les jeunes entreprises innovantes (JEI)
+values:
+  2011-01-01:
+    value: 4.5
+metadata:
+  short_label: Plafond de la rémunération concernée par l'exonération
+  last_value_still_valid_on: "2024-08-12"
+  label_en: Maximum remuneration covered by the JEI exemption
+  unit: Smic
+  reference:
+    2011-01-01:
+    - title: Article 131, I. de la loi n° 2003-1311 du 30 décembre 2003 de finances pour 2004 (1)
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036501673
+    - titre: Article 175 de la loi n° 2010-1657 du 29 décembre 2010 de finances pour 2011 (Introduit ce plafond)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000023315782
+  official_journal_date:
+    2011-01-01: "2010-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/jei/plafond_part_remuneration.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/jei/plafond_part_remuneration.yaml
@@ -10,7 +10,7 @@ metadata:
   reference:
     2011-01-01:
     - title: Article 131, I. de la loi n° 2003-1311 du 30 décembre 2003 de finances pour 2004 (1)
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036501673
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037075129/
     - titre: Article 175 de la loi n° 2010-1657 du 29 décembre 2010 de finances pour 2011 (Introduit ce plafond)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000023315782
   official_journal_date:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '168.0.12',
+    version = '168.0.13',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal. | Amélioration technique.
* Périodes concernées : à partir du 01/01/2011.
* Zones impactées : 
      * Modification formules dans `prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/exonerations.py`.
      * Modification formules dans `prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/travail_fonction_publique.py`
      * Création d'un nouveau dossier de paramètre dans `prelevements_sociaux/contributions_sociales/csg/activite` pour l'`indemnite_compensatrice_fonctionnaires`
      * Création d'un nouveau dossier de paramètre dans `prelevements_sociaux/reductions_cotisations_sociales` pour les `exonerations_geographiques_cotis` et `jei`
      
* Détails : Retire une partie des paramètres en dur de l'indémnité compensatrice CSG, de l'exonération JEI, et des exonération zonnées ZRR et ZRD

- - - -

Ces changements modifient l'API publique d'OpenFisca France et ajoutent une fonctionnalité : la possibilité de modifier des paramètres actuellement en dur dans les formules.