### PR TITLE
Ajoute référence 2024 article codifié impôt sur le revenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 168.0.15 [2348](https://github.com/openfisca/openfisca-france/pull/2349)
+
+* Évolution du système socio-fiscal changement mineur.
+* Périodes concernées :  01/01/2023.
+* Zones impactées : `openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml`.
+* Détails : Ajoute référence 2024 article codifié impôt sur le revenu
+  
 ## 168.0.14 [2348](https://github.com/openfisca/openfisca-france/pull/2348)
 
 * Changement mineur : Modification d'un label

--- a/openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml
+++ b/openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml
@@ -1439,7 +1439,9 @@ metadata:
     - title: LOI n° 2022-1726, art. 2 du 30/12/2022 (LF pour 2023)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046845640
     2023-01-01:
-      title: Loi 2023-1322, art. 2 du 29/12/2023 (LF pour 2024)
+    - title: Article 197, I.1. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2024-01-01/
+    - title: Loi 2023-1322, art. 2 du 29/12/2023 (LF pour 2024)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
   official_journal_date:
     1946-01-01: "1949-01-01"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '168.0.14',
+    version = '168.0.15',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Évolution du système socio-fiscal changement mineur.
* Périodes concernées :  01/01/2023.
* Zones impactées : `openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml`.
* Détails : Ajoute référence 2024 article codifié impôt sur le revenu