### PR TITLE
Fix calcul allegements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 168.1.1 [2351](https://github.com/openfisca/openfisca-france/pull/2351)
+
+* Correction d'un crash
+* Périodes concernées : à partir du 01/01/2024
+* Zones impactées : `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py`
+* Détails :
+  - Correction du calcul introduit de la version 168.1.0 : la variable `coefficient_de_proratisation` ne doit pas être appelé en décembre 2023 mais au moment du calcul
+  - Cette modification a entraîné des modifications de calcul car la variable `coefficient_de_proratisation` ne peut être calculée que pour un mois 
+
 ## 168.1.0 [2350](https://github.com/openfisca/openfisca-france/pull/2350)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -342,8 +342,6 @@ def compute_allegement_general(individu, period, parameters):
         Exonération générale de cotisations patronales
         https://www.service-public.fr/professionnels-entreprises/vosdroits/F24542
     '''
-    # Be careful ! Period is several months
-    first_month = period.first_month
 
     assiette = individu('assiette_allegement', period)
     smic_proratise = individu('smic_proratise', period)

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -451,8 +451,13 @@ def compute_allegement_cotisation_allocations_familiales_base(individu, period, 
     if period.start.year < 2024:
         plafond_reduction = law.plafond_smic * smic_proratise
     else:
-        smic_proratise_2O23_12_31 = individu('smic_proratise', '2023-12', options = [ADD])
-        plafond_reduction = max_(law.plafond_smic_courant * smic_proratise, law.plafond_smic_2023_12_31 * smic_proratise_2O23_12_31)
+        coefficient_proratisation = individu('coefficient_proratisation', period)
+        parameters_smic_2023_12 = parameters('2023-12').marche_travail.salaire_minimum.smic
+        smic_horaire_brut_2023_12 = parameters_smic_2023_12.smic_b_horaire
+        nbh_travail_2023_12 = parameters_smic_2023_12.nb_heures_travail_mensuel
+
+        smic_proratise_2O23_12 = coefficient_proratisation * smic_horaire_brut_2023_12 * nbh_travail_2023_12
+        plafond_reduction = max_(law.plafond_smic_courant * smic_proratise, law.plafond_smic_2023_12_31 * smic_proratise_2O23_12)
 
     # Montant de l'allegment
     return (assiette < plafond_reduction) * taux_reduction * assiette
@@ -505,8 +510,12 @@ def compute_allegement_cotisation_maladie_base(individu, period, parameters):
     if period.start.year < 2024:
         plafond_allegement_mmid = allegement_mmid.plafond * smic_proratise
     else:
-        smic_proratise_2O23_12_31 = individu('smic_proratise', '2023-12', options = [ADD])
-        plafond_allegement_mmid = max_(allegement_mmid.plafond_smic_courant * smic_proratise, allegement_mmid.plafond_smic_2023_12_31 * smic_proratise_2O23_12_31)
+        coefficient_proratisation = individu('coefficient_proratisation', period)
+        parameters_smic_2023_12 = parameters('2023-12').marche_travail.salaire_minimum.smic
+        smic_horaire_brut_2023_12 = parameters_smic_2023_12.smic_b_horaire
+        nbh_travail_2023_12 = parameters_smic_2023_12.nb_heures_travail_mensuel
+        smic_proratise_2O23_12 = coefficient_proratisation * smic_horaire_brut_2023_12 * nbh_travail_2023_12
+        plafond_allegement_mmid = max_(allegement_mmid.plafond_smic_courant * smic_proratise, allegement_mmid.plafond_smic_2023_12_31 * smic_proratise_2O23_12)
 
     sous_plafond = assiette_allegement <= plafond_allegement_mmid
     return sous_plafond * allegement_mmid.taux * assiette_allegement

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -510,7 +510,7 @@ def compute_allegement_cotisation_maladie_base(individu, period, parameters):
     if period.start.year < 2024:
         plafond_allegement_mmid = allegement_mmid.plafond * smic_proratise
     else:
-        coefficient_proratisation = individu('coefficient_proratisation', period)
+        coefficient_proratisation = individu('coefficient_proratisation', period, options = [ADD])
         parameters_smic_2023_12 = parameters('2023-12').marche_travail.salaire_minimum.smic
         smic_horaire_brut_2023_12 = parameters_smic_2023_12.smic_b_horaire
         nbh_travail_2023_12 = parameters_smic_2023_12.nb_heures_travail_mensuel

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py
@@ -553,7 +553,7 @@ def compute_allegement_annuel(individu, period, parameters, variable_name, compu
         return sum(
             compute_function(individu, sub_period, parameters)
             for sub_period in period.this_year.get_subperiods(MONTH)
-        )
+            )
 
 
 def compute_allegement_anticipe(individu, period, parameters, variable_name, compute_function):
@@ -566,7 +566,7 @@ def compute_allegement_anticipe(individu, period, parameters, variable_name, com
         return sum(
             compute_function(individu, sub_period, parameters)
             for sub_period in period.this_year.get_subperiods(MONTH)
-        ) - cumul
+            ) - cumul
 
 
 def compute_allegement_progressif(individu, period, parameters, variable_name, compute_function):
@@ -580,7 +580,7 @@ def compute_allegement_progressif(individu, period, parameters, variable_name, c
         return sum(
             compute_function(individu, sub_period, parameters)
             for sub_period in up_to_this_month.get_subperiods(MONTH)
-        ) - cumul
+            ) - cumul
 
 
 def taux_exo_cice(assiette_allegement, smic_proratise, cice):

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/alleg_gen/mmid/plafond_smic_2023_12_31.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/alleg_gen/mmid/plafond_smic_2023_12_31.yaml
@@ -3,7 +3,7 @@ values:
   2024-01-01:
     value: 2.5
 metadata:
-  short_label: 1ère possibilité de plafond de rémunération des salariés | Retenue si > 2ème possibilité
+  short_label: 1ère possibilité de plafond de rémunération des salariés (retenue si le montant est supérieur à la 2ème possibilité)
   last_value_still_valid_on: "2024-09-13"
   label_en: SSCs for sickness, maternity, disability and death benefits
   unit: smic_2023_12_31

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/alleg_gen/mmid/plafond_smic_courant.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/alleg_gen/mmid/plafond_smic_courant.yaml
@@ -4,7 +4,7 @@ values:
   2024-01-01:
     value: 2
 metadata:
-  short_label: 2ème possibilité de plafond de rémunération des salariés | Retenue si > 1ère possibilité
+  short_label: 2ème possibilité de plafond de rémunération des salariés (retenue si le montant est supérieur à la 1ère possibilité)
   last_value_still_valid_on: "2024-09-13"
   label_en: SSCs for sickness, maternity, disability and death benefits
   unit: smic_annuel

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_cotisation_allocations_familiales/plafond_smic_2023_12_31.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_cotisation_allocations_familiales/plafond_smic_2023_12_31.yaml
@@ -3,7 +3,7 @@ values:
   2024-01-01:
     value: 3.5
 metadata:
-  short_label: 1ère possibilité de plafond de rémunération des salariés | Retenue si > 2ème possibilité
+  short_label: 1ère possibilité de plafond de rémunération des salariés (retenue si le montant est supérieur à la 2ème possibilité)
   last_value_still_valid_on: "2024-09-13"
   label_en: Reduction in SSCs for family benefits
   ipp_csv_id: pss_red_fam

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_cotisation_allocations_familiales/plafond_smic_courant.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_cotisation_allocations_familiales/plafond_smic_courant.yaml
@@ -3,7 +3,7 @@ values:
   2024-01-01:
     value: 2
 metadata:
-  short_label: 2ème possibilité de plafond de rémunération des salariés | Retenue si > 1ère possibilité
+  short_label: 2ème possibilité de plafond de rémunération des salariés (retenue si le montant est supérieur à la 1ère possibilité)
   last_value_still_valid_on: "2024-09-13"
   label_en: Reduction in SSCs for family benefits
   ipp_csv_id: pss_red_fam

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / 'README.md').read_text()
 
 setup(
     name = 'OpenFisca-France',
-    version = '168.1.0',
+    version = '168.1.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/tests/formulas/allegement_cotisation_allocations_familiales.yaml
+++ b/tests/formulas/allegement_cotisation_allocations_familiales.yaml
@@ -70,3 +70,18 @@
     effectif_entreprise: 1
   output:
     allegement_cotisation_allocations_familiales: 0
+
+- period: 2024-01
+  name: Sous le plafond de 2024
+  description: A partir de janvier 2024 le montant du smic pour le plafond est figé à décembre 2023
+  relative_error_margin: 0.001
+  input:
+    salaire_de_base: 6007.53 #1766.92*3.4
+    # allegement mode necessary when requesting on a 1 month salary :
+    allegement_cotisation_allocations_familiales_mode_recouvrement: anticipe
+    allegement_general_mode_recouvrement: anticipe
+    contrat_de_travail_debut: 2023-01-01
+    contrat_de_travail_fin: 2024-12-31
+    effectif_entreprise: 1
+  output:
+    allegement_cotisation_allocations_familiales: 108.14

--- a/tests/formulas/allegement_cotisation_maladie.yaml
+++ b/tests/formulas/allegement_cotisation_maladie.yaml
@@ -23,7 +23,7 @@
       2021-09: 0
       2021-10: 0
       2021-11: 0
-      2021-12: 93.27 * 9  # 0.06 * 1554.58 * 9 mois de salaire
+      2021-12: 93.27 * 9  # 0.06 * 1554.58 * 9 mois de   salaire
 
 - name: Taux complet de cotisation maladie recouvrée progressivement pour rémunération > 2.5xSmic
   period: 2021-03

--- a/tests/formulas/allegement_cotisation_maladie.yaml
+++ b/tests/formulas/allegement_cotisation_maladie.yaml
@@ -70,3 +70,18 @@
     effectif_entreprise: 1
   output:
     allegement_cotisation_maladie: 0
+
+- period: 2024-01
+  name: En dessous du plafond de 2024
+  description: A partir de janvier 2024 le montant du smic pour le plafond est figé à décembre 2023
+  relative_error_margin: 0.001
+  input:
+    salaire_de_base: 4240.61 #1766.92*2.4
+    # allegement mode necessary when requesting on a 1 month salary :
+    allegement_cotisation_maladie_mode_recouvrement: anticipe
+    allegement_general_mode_recouvrement: anticipe
+    contrat_de_travail_debut: 2023-01-01
+    contrat_de_travail_fin: 2024-12-31
+    effectif_entreprise: 1
+  output:
+    allegement_cotisation_maladie: 254.44


### PR DESCRIPTION
* Correction d'un crash
* Périodes concernées : à partir du 01/01/2024
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/cotisations_sociales/allegements.py`
* Détails :
  - Correction du calcul introduit de la version 168.1.0 : la variable `coefficient_de_proratisation` ne doit pas être appelée en décembre 2023 mais au moment du calcul
  - Cette modification a entraîné des modifications de calcul car la variable `coefficient_de_proratisation` ne peut être calculée que pour un mois 

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.
