### PR TITLE
Impôt sur le revenu : ajoute le paramètre couple manquant pour l'abattement d'assurance-vie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 169.4.1 [2377](https://github.com/openfisca/openfisca-france/pull/2377)
+### 169.4.0 [2377](https://github.com/openfisca/openfisca-france/pull/2377)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées :  à partir de 1978.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+### 169.4.1 [2377](https://github.com/openfisca/openfisca-france/pull/2377)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées :  à partir de 1978.
+* Zones impactées : 
+     * `impot_revenu/credits_impot.py`
+     * `impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py`
+     * `impot_revenu/ir.py`
+     * `impot_revenu/calcul_impot_revenu/plaf_qf/quotient_familial/couple_ou_pers_a_charge/index.yaml`
+     * `impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles`
+* Détails :
+  - Crée un nouveau paramètre spécifique pour l'abattement des couples pour produit d'assurance vie dans le calcul des revenus imposables à l'IR
+  - Modifie les formules en conséquence (qui utilisaient l'abattement pour célibataire en le multipliant par 2)
+
+
 ### 169.3.1 [2374](https://github.com/openfisca/openfisca-france/pull/2374)
 
 * Correction d'un crash.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1916,9 +1916,9 @@ class prlire(Variable):
         f2dh = foyer_fiscal('f2dh', period)
         f2ch = foyer_fiscal('f2ch', period)
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm.produits_assurances_vies_assimiles
+        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
-        abattement = P.abattement_couple if maries_ou_pacses else P.abattement_celib
+        abattement = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         plaf_resid = max_(abattement - f2ch, 0)
         return P.impot_revenu.credits_impots.prlire.taux * min_(f2dh, plaf_resid)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1916,9 +1916,11 @@ class prlire(Variable):
         f2dh = foyer_fiscal('f2dh', period)
         f2ch = foyer_fiscal('f2ch', period)
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
-        P = parameters(period)
+        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm.produits_assurances_vies_assimiles
 
-        plaf_resid = max_(P.impot_revenu.calcul_revenus_imposables.rvcm.produits_assurances_vies_assimiles.abattement * (1 + maries_ou_pacses) - f2ch, 0)
+        abattement = P.abattement_couple if maries_ou_pacses else P.abattement_celib
+
+        plaf_resid = max_(abattement - f2ch, 0)
         return P.impot_revenu.credits_impots.prlire.taux * min_(f2dh, plaf_resid)
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1924,7 +1924,7 @@ class prlire(Variable):
         abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         plaf_resid = max_(abattement_assurance_vie - f2ch, 0)
-        return P.impot_revenu.credits_impots.prlire.taux * min_(f2dh, plaf_resid)
+        return parameters(period).impot_revenu.credits_impots.prlire.taux * min_(f2dh, plaf_resid)
 
 
 class quaenv(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1919,9 +1919,9 @@ class prlire(Variable):
         celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
         veuf = foyer_fiscal('veuf', period)
         jeune_veuf = foyer_fiscal('jeune_veuf', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_assurance_vie = parameters_rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + parameters_rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         plaf_resid = max_(abattement_assurance_vie - f2ch, 0)
         return parameters(period).impot_revenu.credits_impots.prlire.taux * min_(f2dh, plaf_resid)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1921,9 +1921,9 @@ class prlire(Variable):
         jeune_veuf = foyer_fiscal('jeune_veuf', period)
         P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
-        abattement = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
-        plaf_resid = max_(abattement - f2ch, 0)
+        plaf_resid = max_(abattement_assurance_vie - f2ch, 0)
         return P.impot_revenu.credits_impots.prlire.taux * min_(f2dh, plaf_resid)
 
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -1916,6 +1916,9 @@ class prlire(Variable):
         f2dh = foyer_fiscal('f2dh', period)
         f2ch = foyer_fiscal('f2ch', period)
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        veuf = foyer_fiscal('veuf', period)
+        jeune_veuf = foyer_fiscal('jeune_veuf', period)
         P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
         abattement = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -703,9 +703,9 @@ class revenu_categoriel_capital(Variable):
         f2go = foyer_fiscal('f2go', period)
         f2gr = foyer_fiscal('f2gr', period)
         f2tr = foyer_fiscal('f2tr', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_assurance_vie = parameters_rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + parameters_rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         f2dc_bis = f2dc
         f2tr_bis = f2tr
@@ -718,19 +718,19 @@ class revenu_categoriel_capital(Variable):
         F1 = f2ca / den * f2dc_bis  # f12
         # Revenus de capitaux mobiliers nets de frais, ouvrant droit à abattement
         # partie négative (à déduire des autres revenus nets de frais d'abattements
-        g12a = -min_(f2dc_bis * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement) - F1, 0)
+        g12a = -min_(f2dc_bis * (1 - parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement) - F1, 0)
         # partie positive
-        g12b = max_(f2dc_bis * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement) - F1, 0)
-        rev = g12b + f2gr + f2fu * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement)
+        g12b = max_(f2dc_bis * (1 - parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement) - F1, 0)
+        rev = g12b + f2gr + f2fu * (1 - parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement)
 
         # Abattements, limité au revenu
-        h12 = P.revenus_capitaux_mobiliers_dividendes.abattement_forfaitaire * (1 + maries_ou_pacses)
+        h12 = parameters_rvcm.revenus_capitaux_mobiliers_dividendes.abattement_forfaitaire * (1 + maries_ou_pacses)
         TOT2 = max_(0, rev - h12)
         # i121= -min_(0,rev - h12)
 
         # Part des frais s'imputant sur les revenus déclarés ligne TS
         F2 = f2ca - F1
-        TOT3 = (f2ts - F2) + f2go * P.majoration_revenus_reputes_distribues + f2tr_bis - g12a
+        TOT3 = (f2ts - F2) + f2go * parameters_rvcm.majoration_revenus_reputes_distribues + f2tr_bis - g12a
 
         DEF = deficit_rcm
         return max_(TOT1 + TOT2 + TOT3 - DEF, 0)
@@ -753,25 +753,25 @@ class revenu_categoriel_capital(Variable):
         f2go = foyer_fiscal('f2go', period)
         f2gr = foyer_fiscal('f2gr', period)
         f2tr = foyer_fiscal('f2tr', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_assurance_vie = parameters_rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + parameters_rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         part_frais_imputes_sur_f2dc = f2ca / max_(1, f2dc + f2ts) * f2dc
-        part_frais_restant_a_imputer = -min_(f2dc * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
+        part_frais_restant_a_imputer = -min_(f2dc * (1 - parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
 
-        dividendes_apres_abattements = max_(f2dc * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
+        dividendes_apres_abattements = max_(f2dc * (1 - parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
         revenus_assurance_vie_apres_abattements = f2ch - min_(f2ch, abattement_assurance_vie)
         rvcm_apres_abattements_proportionnels = (
             revenus_assurance_vie_apres_abattements
             + dividendes_apres_abattements
             + f2gr
-            + f2fu * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0))
+            + f2fu * (1 - parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0))
             )
-        rvcm_apres_abattements_proportionnels_et_fixes = max_(0, rvcm_apres_abattements_proportionnels - P.revenus_capitaux_mobiliers_dividendes.abattement_forfaitaire * (1 + maries_ou_pacses))
+        rvcm_apres_abattements_proportionnels_et_fixes = max_(0, rvcm_apres_abattements_proportionnels - parameters_rvcm.revenus_capitaux_mobiliers_dividendes.abattement_forfaitaire * (1 + maries_ou_pacses))
         autres_rvcm_sans_abattements = (
             f2ts - (f2ca - part_frais_imputes_sur_f2dc)
-            + f2go * P.majoration_revenus_reputes_distribues
+            + f2go * parameters_rvcm.majoration_revenus_reputes_distribues
             + f2tr - part_frais_restant_a_imputer
             )
 
@@ -793,16 +793,16 @@ class revenu_categoriel_capital(Variable):
         f2go = foyer_fiscal('f2go', period)
         f2tr = foyer_fiscal('f2tr', period)
         f2ts = foyer_fiscal('f2ts', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
         # Revenus après abatemment
-        abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_dividende = (f2fu + f2dc) * parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement
+        abattement_assurance_vie = parameters_rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + parameters_rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         rvcm_apres_abattement = (
             f2fu + f2dc - abattement_dividende
             + f2ch - min_(f2ch, abattement_assurance_vie)
-            + f2ts + f2tr + f2go * P.majoration_revenus_reputes_distribues
+            + f2ts + f2tr + f2go * parameters_rvcm.majoration_revenus_reputes_distribues
             )
 
         return max_(0, rvcm_apres_abattement - f2ca - deficit_rcm)
@@ -825,16 +825,16 @@ class revenu_categoriel_capital(Variable):
         f2ts = foyer_fiscal('f2ts', period)
         f2tt_2016 = foyer_fiscal('f2tt_2016', period)
         f2tu_2016 = foyer_fiscal('f2tu_2016', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
         # Revenus après abatemment
-        abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_dividende = (f2fu + f2dc) * parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement
+        abattement_assurance_vie = parameters_rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + parameters_rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         rvcm_apres_abattement = (
             f2fu + f2dc - abattement_dividende
             + f2ch - min_(f2ch, abattement_assurance_vie)
-            + f2ts + f2tr + max_(0, f2tt_2016 - f2tu_2016) + f2go * P.majoration_revenus_reputes_distribues
+            + f2ts + f2tr + max_(0, f2tt_2016 - f2tu_2016) + f2go * parameters_rvcm.majoration_revenus_reputes_distribues
             )
 
         return max_(0, rvcm_apres_abattement - f2ca - deficit_rcm)
@@ -864,15 +864,15 @@ class revenu_categoriel_capital(Variable):
         f2tr = foyer_fiscal('f2tr', period)
         f2ts = foyer_fiscal('f2ts', period)
         f2tt = foyer_fiscal('f2tt', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
         # Revenus après abatemment
-        abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_dividende = (f2fu + f2dc) * parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement
+        abattement_assurance_vie = parameters_rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + parameters_rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
         rvcm_apres_abattement = (
             f2fu + f2dc - abattement_dividende
             + f2ch - min_(f2ch, abattement_assurance_vie)
-            + f2ts + f2tr + f2tt + f2go * P.majoration_revenus_reputes_distribues
+            + f2ts + f2tr + f2tt + f2go * parameters_rvcm.majoration_revenus_reputes_distribues
             )
 
         return max_(0, rvcm_apres_abattement - f2ca - deficit_rcm)
@@ -891,7 +891,7 @@ class revenu_categoriel_capital(Variable):
         veuf = foyer_fiscal('veuf', period)
         jeune_veuf = foyer_fiscal('jeune_veuf', period)
         deficit_rcm = foyer_fiscal('deficit_rcm', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
         imposition_au_bareme = foyer_fiscal('f2op', period)
 
         # Revenus à prendre en compte dans les deux cas: pfu ou imposition au barème
@@ -911,13 +911,13 @@ class revenu_categoriel_capital(Variable):
         f2zz = foyer_fiscal('f2zz', period)
 
         # Revenus après abatemment
-        abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_dividende = (f2fu + f2dc) * parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement
+        abattement_assurance_vie = parameters_rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + parameters_rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
         abattement_residuel = max_(abattement_assurance_vie - f2ch, 0)
         abattement_residuel2 = max_(abattement_residuel - f2vv, 0)
 
         pre_result = where(imposition_au_bareme, f2zz + max_(f2vv - abattement_residuel, 0) + max_(f2ww - abattement_residuel2, 0) + f2fu + f2dc - abattement_dividende
-            + f2ts + f2tr + f2tt + f2go * P.majoration_revenus_reputes_distribues, 0)
+            + f2ts + f2tr + f2tt + f2go * parameters_rvcm.majoration_revenus_reputes_distribues, 0)
         rvcm_apres_abattement = (
             f2yy
             + f2ch - min_(f2ch, abattement_assurance_vie)
@@ -940,7 +940,7 @@ class revenu_categoriel_capital(Variable):
         veuf = foyer_fiscal('veuf', period)
         jeune_veuf = foyer_fiscal('jeune_veuf', period)
         deficit_rcm = foyer_fiscal('deficit_rcm', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
         imposition_au_bareme = foyer_fiscal('f2op', period)
 
         # Revenus à prendre en compte dans les deux cas: pfu ou imposition au barème
@@ -961,13 +961,13 @@ class revenu_categoriel_capital(Variable):
         f2tq = foyer_fiscal('f2tq', period)
 
         # Revenus après abatemment
-        abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_dividende = (f2fu + f2dc) * parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement
+        abattement_assurance_vie = parameters_rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + parameters_rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
         abattement_residuel = max_(abattement_assurance_vie - f2ch, 0)
         abattement_residuel2 = max_(abattement_residuel - f2vv, 0)
 
         pre_result = where(imposition_au_bareme, f2zz + max_(f2vv - abattement_residuel, 0) + max_(f2ww - abattement_residuel2, 0) + f2fu + f2dc - abattement_dividende
-            + f2ts + f2tr + f2tt + f2go * P.majoration_revenus_reputes_distribues + f2tq, 0)
+            + f2ts + f2tr + f2tt + f2go * parameters_rvcm.majoration_revenus_reputes_distribues + f2tq, 0)
         rvcm_apres_abattement = (
             f2yy
             + f2ch - min_(f2ch, abattement_assurance_vie)
@@ -990,7 +990,7 @@ class revenu_categoriel_capital(Variable):
         veuf = foyer_fiscal('veuf', period)
         jeune_veuf = foyer_fiscal('jeune_veuf', period)
         deficit_rcm = foyer_fiscal('deficit_rcm', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
         imposition_au_bareme = foyer_fiscal('f2op', period)
 
         # Revenus à prendre en compte dans les deux cas: pfu ou imposition au barème
@@ -1012,13 +1012,13 @@ class revenu_categoriel_capital(Variable):
         f2tz = foyer_fiscal('f2tz', period)
 
         # Revenus après abatemment
-        abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_dividende = (f2fu + f2dc) * parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement
+        abattement_assurance_vie = parameters_rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + parameters_rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
         abattement_residuel = max_(abattement_assurance_vie - f2ch, 0)
         abattement_residuel2 = max_(abattement_residuel - f2vv, 0)
 
         pre_result = where(imposition_au_bareme, f2zz + max_(f2vv - abattement_residuel, 0) + max_(f2ww - abattement_residuel2, 0) + f2fu + f2dc - abattement_dividende
-            + f2ts + f2tr + f2tt + f2go * P.majoration_revenus_reputes_distribues + f2tq + f2tz, 0)
+            + f2ts + f2tr + f2tt + f2go * parameters_rvcm.majoration_revenus_reputes_distribues + f2tq + f2tz, 0)
         rvcm_apres_abattement = (
             f2yy
             + f2ch - min_(f2ch, abattement_assurance_vie)
@@ -1043,7 +1043,7 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
         f2gr = foyer_fiscal('f2gr', period)
         f2fu = foyer_fiscal('f2fu', period)
         f2da = foyer_fiscal('f2da', period)  # noqa F841
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
         # Calcul de i121
         # Part des frais s'imputant sur les revenus déclarés case DC
@@ -1051,20 +1051,20 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
         F1 = f2ca / den * f2dc  # f12
         # Revenus de capitaux mobiliers nets de frais, ouvrant droit à abattement
         # partie positive
-        g12b = max_(f2dc * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - F1, 0)
-        rev = g12b + f2gr + f2fu * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0))
+        g12b = max_(f2dc * (1 - parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - F1, 0)
+        rev = g12b + f2gr + f2fu * (1 - parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0))
 
         # Abattements, limité au revenu
-        h12 = P.revenus_capitaux_mobiliers_dividendes.abattement_forfaitaire * (1 + maries_ou_pacses)
+        h12 = parameters_rvcm.revenus_capitaux_mobiliers_dividendes.abattement_forfaitaire * (1 + maries_ou_pacses)
         i121 = - min_(0, rev - h12)
-        return max_((P.revenus_capitaux_mobiliers_dividendes.taux_abattement) * (f2dc + f2fu) * (f2da == 0) - i121, 0)
+        return max_((parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement) * (f2dc + f2fu) * (f2da == 0) - i121, 0)
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         f2dc = foyer_fiscal('f2dc', period)
         f2fu = foyer_fiscal('f2fu', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
-        abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
+        abattement_dividende = (f2fu + f2dc) * parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement
 
         return abattement_dividende
 
@@ -1086,13 +1086,13 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
         f2ww = foyer_fiscal('f2ww', period)
         f2dc = foyer_fiscal('f2dc', period)
         f2fu = foyer_fiscal('f2fu', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_assurance_vie = parameters_rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + parameters_rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
         abattement_assu_vie = where(imposition_au_bareme, 0,
             (f2ch < abattement_assurance_vie) * max_(0, min_(f2vv + f2ww, abattement_assurance_vie - f2ch - f2dh))
             )
-        abattement_dividende = where(imposition_au_bareme, (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement, 0)
+        abattement_dividende = where(imposition_au_bareme, (f2fu + f2dc) * parameters_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement, 0)
 
         return - abattement_assu_vie + abattement_dividende
 
@@ -1881,9 +1881,9 @@ class tax_rvcm_forfaitaire(Variable):
         Taxation des revenus des valeurs et capitaux mobiliers
         '''
         f2fa = foyer_fiscal('f2fa', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
-        return f2fa * P.taux_forfaitaire
+        return f2fa * parameters_rvcm.taux_forfaitaire
 
 
 class taxation_plus_values_hors_bareme(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -700,9 +700,9 @@ class revenu_categoriel_capital(Variable):
         f2go = foyer_fiscal('f2go', period)
         f2gr = foyer_fiscal('f2gr', period)
         f2tr = foyer_fiscal('f2tr', period)
-        rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
-        abattement_assurance_vie = rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         f2dc_bis = f2dc
         f2tr_bis = f2tr
@@ -1059,13 +1059,13 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
         f2fu = foyer_fiscal('f2fu', period)
         P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
-        abattement = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
-        abattement_assurance_vie = where(imposition_au_bareme, 0,
-            (f2ch < abattement) * max_(0, min_(f2vv + f2ww, abattement - f2ch - f2dh))
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        abattement_assu_vie = where(imposition_au_bareme, 0,
+            (f2ch < abattement) * max_(0, min_(f2vv + f2ww, abattement_assurance_vie - f2ch - f2dh))
             )
         abattement_dividende = where(imposition_au_bareme, (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement, 0)
 
-        return - abattement_assurance_vie + abattement_dividende
+        return - abattement_assu_vie + abattement_dividende
 
 
 class revenu_categoriel_foncier(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1059,7 +1059,7 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         f2dc = foyer_fiscal('f2dc', period)
         f2fu = foyer_fiscal('f2fu', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.P
+        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -747,23 +747,25 @@ class revenu_categoriel_capital(Variable):
         f2go = foyer_fiscal('f2go', period)
         f2gr = foyer_fiscal('f2gr', period)
         f2tr = foyer_fiscal('f2tr', period)
-        parameter_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         part_frais_imputes_sur_f2dc = f2ca / max_(1, f2dc + f2ts) * f2dc
-        part_frais_restant_a_imputer = -min_(f2dc * (1 - parameter_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
+        part_frais_restant_a_imputer = -min_(f2dc * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
 
-        dividendes_apres_abattements = max_(f2dc * (1 - parameter_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
-        revenus_assurance_vie_apres_abattements = f2ch - min_(f2ch, parameter_rvcm.abattement_assurance_vie)
+        dividendes_apres_abattements = max_(f2dc * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
+        revenus_assurance_vie_apres_abattements = f2ch - min_(f2ch, abattement_assurance_vie)
         rvcm_apres_abattements_proportionnels = (
             revenus_assurance_vie_apres_abattements
             + dividendes_apres_abattements
             + f2gr
-            + f2fu * (1 - parameter_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0))
+            + f2fu * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0))
             )
-        rvcm_apres_abattements_proportionnels_et_fixes = max_(0, rvcm_apres_abattements_proportionnels - parameter_rvcm.revenus_capitaux_mobiliers_dividendes.abattement_forfaitaire * (1 + maries_ou_pacses))
+        rvcm_apres_abattements_proportionnels_et_fixes = max_(0, rvcm_apres_abattements_proportionnels - P.revenus_capitaux_mobiliers_dividendes.abattement_forfaitaire * (1 + maries_ou_pacses))
         autres_rvcm_sans_abattements = (
             f2ts - (f2ca - part_frais_imputes_sur_f2dc)
-            + f2go * parameter_rvcm.majoration_revenus_reputes_distribues
+            + f2go * P.majoration_revenus_reputes_distribues
             + f2tr - part_frais_restant_a_imputer
             )
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -852,6 +852,9 @@ class revenu_categoriel_capital(Variable):
               - Brochure pratique de l'IR 2017 sur revenus 2016 : https://www.impots.gouv.fr/portail/www2/fichiers/documentation/brochure/ir_2017/files/assets/common/downloads/publication.pdf
         '''
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        veuf = foyer_fiscal('veuf', period)
+        jeune_veuf = foyer_fiscal('jeune_veuf', period)
         deficit_rcm = foyer_fiscal('deficit_rcm', period)
         f2ca = foyer_fiscal('f2ca', period)
         f2ch = foyer_fiscal('f2ch', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -702,11 +702,13 @@ class revenu_categoriel_capital(Variable):
         f2tr = foyer_fiscal('f2tr', period)
         rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
+
         f2dc_bis = f2dc
         f2tr_bis = f2tr
         # # Calcul du revenu catégoriel
         # 1.2 Revenus des valeurs et capitaux mobiliers
-        b12 = min_(f2ch, rvcm.produits_assurances_vies_assimiles.abattement * (1 + maries_ou_pacses))
+        b12 = min_(f2ch, abattement_assurance_vie)
         TOT1 = f2ch - b12  # c12
         # Part des frais s'imputant sur les revenus déclarés case DC
         den = ((f2dc_bis + f2ts) != 0) * (f2dc_bis + f2ts) + ((f2dc_bis + f2ts) == 0)
@@ -751,7 +753,7 @@ class revenu_categoriel_capital(Variable):
         part_frais_restant_a_imputer = -min_(f2dc * (1 - parameter_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
 
         dividendes_apres_abattements = max_(f2dc * (1 - parameter_rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - part_frais_imputes_sur_f2dc, 0)
-        revenus_assurance_vie_apres_abattements = f2ch - min_(f2ch, parameter_rvcm.produits_assurances_vies_assimiles.abattement * (1 + maries_ou_pacses))
+        revenus_assurance_vie_apres_abattements = f2ch - min_(f2ch, parameter_rvcm.abattement_assurance_vie)
         rvcm_apres_abattements_proportionnels = (
             revenus_assurance_vie_apres_abattements
             + dividendes_apres_abattements
@@ -784,7 +786,7 @@ class revenu_categoriel_capital(Variable):
 
         # Revenus après abatemment
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement * (1 + maries_ou_pacses)
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
         rvcm_apres_abattement = (
             f2fu + f2dc - abattement_dividende
             + f2ch - min_(f2ch, abattement_assurance_vie)
@@ -812,7 +814,7 @@ class revenu_categoriel_capital(Variable):
 
         # Revenus après abatemment
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement * (1 + maries_ou_pacses)
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
         rvcm_apres_abattement = (
             f2fu + f2dc - abattement_dividende
             + f2ch - min_(f2ch, abattement_assurance_vie)
@@ -888,7 +890,7 @@ class revenu_categoriel_capital(Variable):
 
         # Revenus après abatemment
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement * (1 + maries_ou_pacses)
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
         abattement_residuel = max_(abattement_assurance_vie - f2ch, 0)
         abattement_residuel2 = max_(abattement_residuel - f2vv, 0)
         pre_result = where(imposition_au_bareme, f2zz + max_(f2vv - abattement_residuel, 0) + max_(f2ww - abattement_residuel2, 0) + f2fu + f2dc - abattement_dividende
@@ -934,7 +936,7 @@ class revenu_categoriel_capital(Variable):
 
         # Revenus après abatemment
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement * (1 + maries_ou_pacses)
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
         abattement_residuel = max_(abattement_assurance_vie - f2ch, 0)
         abattement_residuel2 = max_(abattement_residuel - f2vv, 0)
         pre_result = where(imposition_au_bareme, f2zz + max_(f2vv - abattement_residuel, 0) + max_(f2ww - abattement_residuel2, 0) + f2fu + f2dc - abattement_dividende
@@ -981,7 +983,7 @@ class revenu_categoriel_capital(Variable):
 
         # Revenus après abatemment
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement * (1 + maries_ou_pacses)
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
         abattement_residuel = max_(abattement_assurance_vie - f2ch, 0)
         abattement_residuel2 = max_(abattement_residuel - f2vv, 0)
         pre_result = where(imposition_au_bareme, f2zz + max_(f2vv - abattement_residuel, 0) + max_(f2ww - abattement_residuel2, 0) + f2fu + f2dc - abattement_dividende
@@ -1052,8 +1054,9 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
         f2fu = foyer_fiscal('f2fu', period)
         P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
+        abattement = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
         abattement_assurance_vie = where(imposition_au_bareme, 0,
-            (f2ch < P.produits_assurances_vies_assimiles.abattement * (1 + maries_ou_pacses)) * max_(0, min_(f2vv + f2ww, P.produits_assurances_vies_assimiles.abattement * (1 + maries_ou_pacses) - f2ch - f2dh))
+            (f2ch < abattement) * max_(0, min_(f2vv + f2ww, abattement - f2ch - f2dh))
             )
         abattement_dividende = where(imposition_au_bareme, (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement, 0)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -748,7 +748,7 @@ class revenu_categoriel_capital(Variable):
         f2gr = foyer_fiscal('f2gr', period)
         f2tr = foyer_fiscal('f2tr', period)
         P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
-        
+
         abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         part_frais_imputes_sur_f2dc = f2ca / max_(1, f2dc + f2ts) * f2dc

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -865,7 +865,7 @@ class revenu_categoriel_capital(Variable):
 
         # Revenus après abatemment
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement * (1 + maries_ou_pacses)
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
         rvcm_apres_abattement = (
             f2fu + f2dc - abattement_dividende
             + f2ch - min_(f2ch, abattement_assurance_vie)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -691,6 +691,9 @@ class revenu_categoriel_capital(Variable):
         Revenus des valeurs et capitaux mobiliers
         '''
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        veuf = foyer_fiscal('veuf', period)
+        jeune_veuf = foyer_fiscal('jeune_veuf', period)
         deficit_rcm = foyer_fiscal('deficit_rcm', period)
         f2ch = foyer_fiscal('f2ch', period)
         f2dc = foyer_fiscal('f2dc', period)
@@ -737,6 +740,9 @@ class revenu_categoriel_capital(Variable):
         Revenus des valeurs et capitaux mobiliers
         '''
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        veuf = foyer_fiscal('veuf', period)
+        jeune_veuf = foyer_fiscal('jeune_veuf', period)
         deficit_rcm = foyer_fiscal('deficit_rcm', period)
         f2ch = foyer_fiscal('f2ch', period)
         f2da = foyer_fiscal('f2da', period)
@@ -776,6 +782,9 @@ class revenu_categoriel_capital(Variable):
         Revenus des valeurs et capitaux mobiliers
         '''
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        veuf = foyer_fiscal('veuf', period)
+        jeune_veuf = foyer_fiscal('jeune_veuf', period)
         deficit_rcm = foyer_fiscal('deficit_rcm', period)
         f2ca = foyer_fiscal('f2ca', period)
         f2ch = foyer_fiscal('f2ch', period)
@@ -803,6 +812,9 @@ class revenu_categoriel_capital(Variable):
         Revenus des valeurs et capitaux mobiliers
         '''
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        veuf = foyer_fiscal('veuf', period)
+        jeune_veuf = foyer_fiscal('jeune_veuf', period)
         deficit_rcm = foyer_fiscal('deficit_rcm', period)
         f2ca = foyer_fiscal('f2ca', period)
         f2ch = foyer_fiscal('f2ch', period)
@@ -872,6 +884,9 @@ class revenu_categoriel_capital(Variable):
         Dans ce cas, ils ne sortent pas de la variable `revenu_categoriel_capital`.
         '''
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        veuf = foyer_fiscal('veuf', period)
+        jeune_veuf = foyer_fiscal('jeune_veuf', period)
         deficit_rcm = foyer_fiscal('deficit_rcm', period)
         P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
         imposition_au_bareme = foyer_fiscal('f2op', period)
@@ -918,6 +933,9 @@ class revenu_categoriel_capital(Variable):
             Source : Brochure pratique revenus 2019 page 123 et 340: https://www.impots.gouv.fr/www2/fichiers/documentation/brochure/ir_2020/accueil.htm
         '''
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        veuf = foyer_fiscal('veuf', period)
+        jeune_veuf = foyer_fiscal('jeune_veuf', period)
         deficit_rcm = foyer_fiscal('deficit_rcm', period)
         P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
         imposition_au_bareme = foyer_fiscal('f2op', period)
@@ -965,6 +983,9 @@ class revenu_categoriel_capital(Variable):
             Source : Brochure pratique revenus 2020 page 119, 132 et 364: https://www.impots.gouv.fr/www2/fichiers/documentation/brochure/ir_2021/accueil.htm
         '''
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        veuf = foyer_fiscal('veuf', period)
+        jeune_veuf = foyer_fiscal('jeune_veuf', period)
         deficit_rcm = foyer_fiscal('deficit_rcm', period)
         P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
         imposition_au_bareme = foyer_fiscal('f2op', period)
@@ -1052,6 +1073,9 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
               Si le foyer a choisi l'imposition au barème pour les revenus éligibles au pfu, les revenus de l'assurance-vie entrent dans le calcul du RFR via `revenus_categoriel` net d'abattement.
         '''
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        veuf = foyer_fiscal('veuf', period)
+        jeune_veuf = foyer_fiscal('jeune_veuf', period)
         imposition_au_bareme = foyer_fiscal('f2op', period)
         f2ch = foyer_fiscal('f2ch', period)
         f2dh = foyer_fiscal('f2dh', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1087,7 +1087,7 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
 
         abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
         abattement_assu_vie = where(imposition_au_bareme, 0,
-            (f2ch < abattement) * max_(0, min_(f2vv + f2ww, abattement_assurance_vie - f2ch - f2dh))
+            (f2ch < abattement_assurance_vie) * max_(0, min_(f2vv + f2ww, abattement_assurance_vie - f2ch - f2dh))
             )
         abattement_dividende = where(imposition_au_bareme, (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement, 0)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -718,19 +718,19 @@ class revenu_categoriel_capital(Variable):
         F1 = f2ca / den * f2dc_bis  # f12
         # Revenus de capitaux mobiliers nets de frais, ouvrant droit à abattement
         # partie négative (à déduire des autres revenus nets de frais d'abattements
-        g12a = -min_(f2dc_bis * (1 - rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement) - F1, 0)
+        g12a = -min_(f2dc_bis * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement) - F1, 0)
         # partie positive
-        g12b = max_(f2dc_bis * (1 - rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement) - F1, 0)
-        rev = g12b + f2gr + f2fu * (1 - rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement)
+        g12b = max_(f2dc_bis * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement) - F1, 0)
+        rev = g12b + f2gr + f2fu * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement)
 
         # Abattements, limité au revenu
-        h12 = rvcm.revenus_capitaux_mobiliers_dividendes.abattement_forfaitaire * (1 + maries_ou_pacses)
+        h12 = P.revenus_capitaux_mobiliers_dividendes.abattement_forfaitaire * (1 + maries_ou_pacses)
         TOT2 = max_(0, rev - h12)
         # i121= -min_(0,rev - h12)
 
         # Part des frais s'imputant sur les revenus déclarés ligne TS
         F2 = f2ca - F1
-        TOT3 = (f2ts - F2) + f2go * rvcm.majoration_revenus_reputes_distribues + f2tr_bis - g12a
+        TOT3 = (f2ts - F2) + f2go * P.majoration_revenus_reputes_distribues + f2tr_bis - g12a
 
         DEF = deficit_rcm
         return max_(TOT1 + TOT2 + TOT3 - DEF, 0)
@@ -1040,7 +1040,7 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
         f2gr = foyer_fiscal('f2gr', period)
         f2fu = foyer_fiscal('f2fu', period)
         f2da = foyer_fiscal('f2da', period)  # noqa F841
-        rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
         # Calcul de i121
         # Part des frais s'imputant sur les revenus déclarés case DC
@@ -1048,18 +1048,18 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
         F1 = f2ca / den * f2dc  # f12
         # Revenus de capitaux mobiliers nets de frais, ouvrant droit à abattement
         # partie positive
-        g12b = max_(f2dc * (1 - rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - F1, 0)
-        rev = g12b + f2gr + f2fu * (1 - rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0))
+        g12b = max_(f2dc * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0)) - F1, 0)
+        rev = g12b + f2gr + f2fu * (1 - P.revenus_capitaux_mobiliers_dividendes.taux_abattement * (f2da == 0))
 
         # Abattements, limité au revenu
-        h12 = rvcm.revenus_capitaux_mobiliers_dividendes.abattement_forfaitaire * (1 + maries_ou_pacses)
+        h12 = P.revenus_capitaux_mobiliers_dividendes.abattement_forfaitaire * (1 + maries_ou_pacses)
         i121 = - min_(0, rev - h12)
-        return max_((rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement) * (f2dc + f2fu) * (f2da == 0) - i121, 0)
+        return max_((P.revenus_capitaux_mobiliers_dividendes.taux_abattement) * (f2dc + f2fu) * (f2da == 0) - i121, 0)
 
     def formula_2013_01_01(foyer_fiscal, period, parameters):
         f2dc = foyer_fiscal('f2dc', period)
         f2fu = foyer_fiscal('f2fu', period)
-        P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        P = parameters(period).impot_revenu.calcul_revenus_imposables.P
 
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -702,7 +702,7 @@ class revenu_categoriel_capital(Variable):
         f2tr = foyer_fiscal('f2tr', period)
         rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
+        abattement_assurance_vie = rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         f2dc_bis = f2dc
         f2tr_bis = f2tr
@@ -786,7 +786,8 @@ class revenu_categoriel_capital(Variable):
 
         # Revenus après abatemment
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+
         rvcm_apres_abattement = (
             f2fu + f2dc - abattement_dividende
             + f2ch - min_(f2ch, abattement_assurance_vie)
@@ -814,7 +815,8 @@ class revenu_categoriel_capital(Variable):
 
         # Revenus après abatemment
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+
         rvcm_apres_abattement = (
             f2fu + f2dc - abattement_dividende
             + f2ch - min_(f2ch, abattement_assurance_vie)
@@ -890,9 +892,10 @@ class revenu_categoriel_capital(Variable):
 
         # Revenus après abatemment
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
         abattement_residuel = max_(abattement_assurance_vie - f2ch, 0)
         abattement_residuel2 = max_(abattement_residuel - f2vv, 0)
+
         pre_result = where(imposition_au_bareme, f2zz + max_(f2vv - abattement_residuel, 0) + max_(f2ww - abattement_residuel2, 0) + f2fu + f2dc - abattement_dividende
             + f2ts + f2tr + f2tt + f2go * P.majoration_revenus_reputes_distribues, 0)
         rvcm_apres_abattement = (
@@ -936,9 +939,10 @@ class revenu_categoriel_capital(Variable):
 
         # Revenus après abatemment
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
         abattement_residuel = max_(abattement_assurance_vie - f2ch, 0)
         abattement_residuel2 = max_(abattement_residuel - f2vv, 0)
+
         pre_result = where(imposition_au_bareme, f2zz + max_(f2vv - abattement_residuel, 0) + max_(f2ww - abattement_residuel2, 0) + f2fu + f2dc - abattement_dividende
             + f2ts + f2tr + f2tt + f2go * P.majoration_revenus_reputes_distribues + f2tq, 0)
         rvcm_apres_abattement = (
@@ -983,9 +987,10 @@ class revenu_categoriel_capital(Variable):
 
         # Revenus après abatemment
         abattement_dividende = (f2fu + f2dc) * P.revenus_capitaux_mobiliers_dividendes.taux_abattement
-        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
+        abattement_assurance_vie = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
         abattement_residuel = max_(abattement_assurance_vie - f2ch, 0)
         abattement_residuel2 = max_(abattement_residuel - f2vv, 0)
+
         pre_result = where(imposition_au_bareme, f2zz + max_(f2vv - abattement_residuel, 0) + max_(f2ww - abattement_residuel2, 0) + f2fu + f2dc - abattement_dividende
             + f2ts + f2tr + f2tt + f2go * P.majoration_revenus_reputes_distribues + f2tq + f2tz, 0)
         rvcm_apres_abattement = (
@@ -1054,7 +1059,7 @@ class rfr_rvcm_abattements_a_reintegrer(Variable):
         f2fu = foyer_fiscal('f2fu', period)
         P = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
 
-        abattement = P.produits_assurances_vies_assimiles.abattement_couple if maries_ou_pacses else P.produits_assurances_vies_assimiles.abattement_celib
+        abattement = P.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
         abattement_assurance_vie = where(imposition_au_bareme, 0,
             (f2ch < abattement) * max_(0, min_(f2vv + f2ww, abattement - f2ch - f2dh))
             )

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -267,8 +267,8 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
     def formula_2018_01_01(foyer_fiscal, period, parameters):
         P1_taux = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018.taux_prelevement_forfaitaire_rev_capital_eligibles_pfu_interets_dividendes_etc
         P1_taux_reduit_av = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018.taux_prelevement_produits_assurance_vie_non_eligibles_prelevement_forfaitaire_unique
-        P2 = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm.produits_assurances_vies_assimiles
-        abattement_assurance_vie = P2.abattement_couple if maries_ou_pacses else P2.abattement_celib
+        P2 = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        abattement_assurance_vie = P2.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P2.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         imposition_au_bareme = foyer_fiscal('f2op', period)
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -270,10 +270,10 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
         veuf = foyer_fiscal('veuf', period)
         jeune_veuf = foyer_fiscal('jeune_veuf', period)
 
-        P1_taux = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018.taux_prelevement_forfaitaire_rev_capital_eligibles_pfu_interets_dividendes_etc
-        P1_taux_reduit_av = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018.taux_prelevement_produits_assurance_vie_non_eligibles_prelevement_forfaitaire_unique
-        P2 = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
-        abattement_assurance_vie = P2.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P2.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
+        parameters_taux = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018.taux_prelevement_forfaitaire_rev_capital_eligibles_pfu_interets_dividendes_etc
+        parameters_taux_reduit_av = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018.taux_prelevement_produits_assurance_vie_non_eligibles_prelevement_forfaitaire_unique
+        parameters_rvcm = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        abattement_assurance_vie = parameters_rvcm.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + parameters_rvcm.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         imposition_au_bareme = foyer_fiscal('f2op', period)
         f2ch = foyer_fiscal('f2ch', period)
@@ -284,10 +284,10 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
         abattement_residuel = max_(abattement_assurance_vie - f2ch, 0)
         abattement_residuel2 = max_(abattement_residuel - f2vv, 0)
         pfu_ir_sur_assurance_vie = where(imposition_au_bareme, 0,
-            (f2zz * P1_taux)
-            + (max_(f2vv - abattement_residuel, 0) * P1_taux_reduit_av)
+            (f2zz * parameters_taux)
+            + (max_(f2vv - abattement_residuel, 0) * parameters_taux_reduit_av)
             # Ce calcul avec le taux réduit ne semble pas prendre en compte le montant maximal des versements qui est de 150 000 euros et semble disponible dans ce paramètre : seuil_primes_applique_eligibilite_produits_assurance_vie_prelevement_forfaitaire_unique
-            + (max_(f2ww - abattement_residuel2, 0) * P1_taux)
+            + (max_(f2ww - abattement_residuel2, 0) * parameters_taux)
             )
 
         return -pfu_ir_sur_assurance_vie

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -271,7 +271,6 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
         abattement_assurance_vie = P2.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P2.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
         imposition_au_bareme = foyer_fiscal('f2op', period)
-        maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
         f2ch = foyer_fiscal('f2ch', period)
         f2zz = foyer_fiscal('f2zz', period)
         f2vv = foyer_fiscal('f2vv', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -265,15 +265,16 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
     definition_period = YEAR
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
+        maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        veuf = foyer_fiscal('veuf', period)
+        jeune_veuf = foyer_fiscal('jeune_veuf', period)
+
         P1_taux = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018.taux_prelevement_forfaitaire_rev_capital_eligibles_pfu_interets_dividendes_etc
         P1_taux_reduit_av = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018.taux_prelevement_produits_assurance_vie_non_eligibles_prelevement_forfaitaire_unique
         P2 = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
         abattement_assurance_vie = P2.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P2.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
-        maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
-        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
-        veuf = foyer_fiscal('veuf', period)
-        jeune_veuf = foyer_fiscal('jeune_veuf', period)
         imposition_au_bareme = foyer_fiscal('f2op', period)
         f2ch = foyer_fiscal('f2ch', period)
         f2zz = foyer_fiscal('f2zz', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -270,6 +270,10 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
         P2 = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
         abattement_assurance_vie = P2.produits_assurances_vies_assimiles.abattement_couple * maries_ou_pacses + P2.produits_assurances_vies_assimiles.abattement_celib * (celibataire_ou_divorce | veuf | jeune_veuf)
 
+        maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+        celibataire_ou_divorce = foyer_fiscal('celibataire_ou_divorce', period)
+        veuf = foyer_fiscal('veuf', period)
+        jeune_veuf = foyer_fiscal('jeune_veuf', period)
         imposition_au_bareme = foyer_fiscal('f2op', period)
         f2ch = foyer_fiscal('f2ch', period)
         f2zz = foyer_fiscal('f2zz', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -267,7 +267,8 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
     def formula_2018_01_01(foyer_fiscal, period, parameters):
         P1_taux = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018.taux_prelevement_forfaitaire_rev_capital_eligibles_pfu_interets_dividendes_etc
         P1_taux_reduit_av = parameters(period).taxation_capital.prelevement_forfaitaire.partir_2018.taux_prelevement_produits_assurance_vie_non_eligibles_prelevement_forfaitaire_unique
-        P2 = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm
+        P2 = parameters(period).impot_revenu.calcul_revenus_imposables.rvcm.produits_assurances_vies_assimiles
+        abattement_assurance_vie = P2.abattement_couple if maries_ou_pacses else P2.abattement_celib
 
         imposition_au_bareme = foyer_fiscal('f2op', period)
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
@@ -276,7 +277,7 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
         f2vv = foyer_fiscal('f2vv', period)
         f2ww = foyer_fiscal('f2ww', period)
 
-        abattement_residuel = max_(P2.produits_assurances_vies_assimiles.abattement * (1 + maries_ou_pacses) - f2ch, 0)
+        abattement_residuel = max_(abattement_assurance_vie - f2ch, 0)
         abattement_residuel2 = max_(abattement_residuel - f2vv, 0)
         pfu_ir_sur_assurance_vie = where(imposition_au_bareme, 0,
             (f2zz * P1_taux)

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/quotient_familial/couple_ou_pers_a_charge/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/quotient_familial/couple_ou_pers_a_charge/index.yaml
@@ -1,7 +1,7 @@
-description: Parts supplémentaires de quotient familial pour certaines situations de foyers fiscaux en couple ou avec personne à charge
+description: Cas spécifiques concernant les contribuables en couple ou avec personne à charge, donnant lieu à des parts supplémentaires de quotient familial (IR)
 metadata:
   documentation_start: true
-  short_label: Parts supplémentaires personne en couple ou avec personne à charge
+  short_label: Cas spécifiques concernant les contribuables en couple ou avec personne à charge
   order:
   - isol
   - inv1

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/quotient_familial/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/quotient_familial/index.yaml
@@ -3,10 +3,6 @@ metadata:
   documentation_start: true
   short_label: Quotient familial et parts supplémentaires
   order:
-  - conj
-  - enf1
-  - enf2
-  - enf3_et_sup
-  - isol
-  - veuf
+  - cas_general
   - sans_pers_a_charge
+  - couple_ou_pers_a_charge

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/quotient_familial/sans_pers_a_charge/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/quotient_familial/sans_pers_a_charge/index.yaml
@@ -1,5 +1,7 @@
-description: Parts supplémentaires personnes sans personne à charge
+description: Cas spécifiques concernant les contribuables célibataires, divorcés ou veuf, sans personne à charge, donnant lieu à des parts supplémentaires de quotient familial (IR)
 metadata:
+  documentation_start: true
+  short_label: Cas spécifiques concernant les contribuables seuls et sans personne à charge
   order:
   - not31a
   - not31b

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_celib.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_celib.yaml
@@ -7,7 +7,7 @@ values:
   2001-01-01:
     value: 4600
 metadata:
-  short_label: Abattement annuel, pour les contribuables célibataires, veufs ou divorcés, pour les produits d'assurance vie (contrat > 8 ans)
+  short_label: Contribuables célibataires, veufs ou divorcés
   last_value_still_valid_on: "2024-10-21"
   ipp_csv_id: abt_av
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_celib.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_celib.yaml
@@ -1,0 +1,31 @@
+description: Abattement annuel, pour les contribuables célibataires, veufs ou divorcés, applicable au montant imposable des produits de bons ou contrats d'une durée au moins égale à 8 ans (ou 6 ans pour ceux souscrits avant le 1er janvier 1990)
+values:
+  1978-01-01:
+    value: null
+  1997-01-01:
+    value: 30000
+  2001-01-01:
+    value: 4600
+metadata:
+  short_label: Abattement annuel, pour les contribuables célibataires, veufs ou divorcés, pour les produits d'assurance vie (contrat > 8 ans)
+  last_value_still_valid_on: "2024-10-21"
+  ipp_csv_id: abt_av
+  unit: currency_next_year
+  reference:
+    1997-01-01:
+      title: Loi 97-1269 du 30/12/1997 (LF pour 1998)
+      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000569621
+    2001-01-01:
+    - title: Article 125-0 A, I. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038836732
+    - title: Loi 2001-1275 du 28/12/2001 (LF pour 2002)
+      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000592233
+  official_journal_date:
+    1997-01-01: "1997-12-31"
+    2001-01-01: "2001-12-29"
+  notes:
+    1997-01-01:
+    - title: "Abattement forfaitaire sur dividendes: art. 158-5 du CGI (à doubler pour les couples)"
+documentation: |-
+  Abattement sur assurance-vie : l'abattement est multiplié par deux pour les couples.
+  Cet abattement concerne les contrats d'une durée d'au moins six ans, pour les contratssouscrits entre le 01/01/1983 et le 31/12/1989, et d'au moins huits ans pour les contrats souscrits depuis le 01/01/1990. voir l'art. 125-0 A du CGI.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_couple.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_couple.yaml
@@ -7,7 +7,7 @@ values:
   2001-01-01:
     value: 9200
 metadata:
-  short_label: Abattement annuel, pour les contribuables mariés ou pacsés, pour les produits d'assurance vie (contrat > 8 ans)
+  short_label: Contribuables mariés ou pacsés
   last_value_still_valid_on: "2024-10-21"
   ipp_csv_id: abt_av
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_couple.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_couple.yaml
@@ -1,13 +1,13 @@
-description: Abattement annuel applicable au montant imposable des produits de bons ou contrats d'une durée au moins égale à 8 ans (ou 6 ans pour ceux souscrits avant le 1er janvier 1990) - multiplié par deux pour les couples à imposition commune
+description: Abattement annuel, pour les contribuables mariés ou pacsés, applicable au montant imposable des produits de bons ou contrats d'une durée au moins égale à 8 ans (ou 6 ans pour ceux souscrits avant le 1er janvier 1990)
 values:
   1978-01-01:
     value: null
   1997-01-01:
-    value: 30000
+    value: 60000
   2001-01-01:
-    value: 4600
+    value: 9200
 metadata:
-  short_label: Abattement annuel pour les produits d'assurance vie (contrat > 8 ans) - doublé pour les couples imposés en commun
+  short_label: Abattement annuel, pour les contribuables mariés ou pacsés, pour les produits d'assurance vie (contrat > 8 ans)
   last_value_still_valid_on: "2024-10-21"
   ipp_csv_id: abt_av
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/index.yaml
@@ -1,4 +1,6 @@
-description: Produits des assurances-vies et assimilés
+description: Abattement annuel applicable au montant imposable des produits de bons ou contrats d'une durée au moins égale à 8 ans (ou 6 ans pour ceux souscrits avant le 1er janvier 1990)
 metadata:
+  short_label: Abattement pour les produits d'assurance vie (contrat > 8 ans)
   order:
-  - abattement
+  - abattement_celib
+  - abattement_couple

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/revenus_capitaux_mobiliers_dividendes/abattement_forfaitaire.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/revenus_capitaux_mobiliers_dividendes/abattement_forfaitaire.yaml
@@ -17,7 +17,7 @@ values:
   2013-01-01:
     value: null
 metadata:
-  short_label: Abattement forfaitaire maximal
+  short_label: Montant maximal de l'abattement
   ipp_csv_id: abt_rcm
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/revenus_capitaux_mobiliers_dividendes/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/revenus_capitaux_mobiliers_dividendes/index.yaml
@@ -1,5 +1,6 @@
-description: Revenus de capitaux mobiliers (dividendes)
+description: Abattement annuel applicable au montant imposable des revenus de capitaux mobiliers (dividendes), uniquement en cas de choix d'imposition au barème de l'impôt sur le revenu
 metadata:
+  short_label: Abattement pour les revenus de capitaux mobiliers, en cas de choix d'imposition au barème de l'impôt sur le revenu
   order:
   - taux_abattement
   - abattement_forfaitaire

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/revenus_capitaux_mobiliers_dividendes/taux_abattement.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/revenus_capitaux_mobiliers_dividendes/taux_abattement.yaml
@@ -16,7 +16,7 @@ metadata:
       title: Loi 80-30 du 18/01/1980 (LF pour 1980)
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000705191
     2006-01-01:
-    - title: Article 158, II-A, du Code général des impôts 
+    - title: Article 158, 3.2° du Code général des impôts 
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043662629
     - title: Loi 2005-1719 du 30/12/2005 (LF pour 2006) - Art. 76
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000634802

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/revenus_capitaux_mobiliers_dividendes/taux_abattement.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/revenus_capitaux_mobiliers_dividendes/taux_abattement.yaml
@@ -7,7 +7,7 @@ values:
   2006-01-01:
     value: 0.4
 metadata:
-  short_label: Taux de l'abattement (si choix d'imposition au barème)
+  short_label: Taux de l'abattement
   last_value_still_valid_on: "2024-10-21"
   ipp_csv_id: tx_abt_rcm
   unit: /1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.3.1"
+version = "169.4.1"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.4.1"
+version = "169.4.0"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées :  à partir de 1978.
* Zones impactées : 
     * `impot_revenu/credits_impot.py`
     * `impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py`
     * `impot_revenu/ir.py`
     * `impot_revenu/calcul_impot_revenu/plaf_qf/quotient_familial/couple_ou_pers_a_charge/index.yaml`
     * `impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles`
* Détails :
  - Crée un nouveau paramètre spécifique pour l'abattement des couples pour produit d'assurance vie dans le calcul des revenus imposables à l'IR
  - Modifie les formules en conséquence (qui utilisaient l'abattement pour célibataire en le multipliant par 2)