### PR TITLE
met à jour smic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 169.1.2 [2379](https://github.com/openfisca/openfisca-france/pull/2379)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/11/2024.
+* Zones impactées : `openfisca_france/parameters/marche_travail/salaire_minimum/smic`.
+* Détails :
+  - Met à jour les montants du smic horaire et mensuel à partir de novembre 2024
+
 ### 169.1.1 [2329](https://github.com/openfisca/openfisca-france/pull/2329)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml
@@ -242,6 +242,8 @@ values:
     value: 11.52
   2024-01-01:
     value: 11.65
+  2024-11-01:
+    value: 11.88
 metadata:
   short_label: Smic horaire brut
   last_value_still_valid_on: "2024-01-03"
@@ -546,6 +548,9 @@ metadata:
     2024-01-01:
       title: Décret du 20/12/2023
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048604684
+    2024-11-01:
+      title: Décret n° 2024-951 23/10/2024
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050392683
   official_journal_date:
     1970-01-01: "1970-01-04"
     1970-03-01: "1970-03-01"
@@ -664,6 +669,7 @@ metadata:
     2023-01-01: "2022-12-23"
     2023-05-01: "2023-04-27"
     2024-01-01: "2023-12-21"
+    2024-11-01: "2024-10-24"
   notes:
     1971-01-01:
     - title: Abattement pour les jeunes de moins de 17 ans (-20%) et de moins de 18 ans (-10%). Décret 71-101 du 02/02/1971 pour la plasturgie

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml
@@ -242,6 +242,8 @@ values:
     value: 1747.2
   2024-01-01:
     value: 1766.92
+  2024-11-01:
+    value: 1801.80 
 metadata:
   short_label: Smic brut mensuel
   last_value_still_valid_on: "2024-01-03"
@@ -546,6 +548,9 @@ metadata:
     2024-01-01:
       title: Décret du 20/12/2023
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048604684
+    2024-11-01:
+      title: Décret n° 2024-951 23/10/2024
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050392683
   official_journal_date:
     1970-01-01: "1970-01-04"
     1970-03-01: "1970-03-01"
@@ -664,6 +669,7 @@ metadata:
     2023-01-01: "2022-12-23"
     2023-05-01: "2023-04-27"
     2024-01-01: "2023-12-21"
+    2024-11-01: "2024-10-24"
   notes:
     1971-01-01:
     - title: Abattement pour les jeunes de moins de 17 ans (-20%) et de moins de 18 ans (-10%). Décret 71-101 du 02/02/1971 pour la plasturgie

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.1.1"
+version = "169.1.2"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/11/2024.
* Zones impactées : `openfisca_france/parameters/marche_travail/salaire_minimum/smic`.
* Détails :
  - Met à jour les montants du smic horaire et mensuel à partir de novembre 2024

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.
