### PR TITLE
Fix CI `test-conda` qui ne fonctionnait plus

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -73,6 +73,7 @@ jobs:
           miniforge-version: latest
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           use-mamba: true
+          channels: conda-forge,defaults
       - name: Install package
         shell: pwsh
         run: mamba install --channel ./conda-bld --channel openfisca openfisca-france
@@ -204,7 +205,7 @@ jobs:
 
   test-on-windows:
     runs-on: windows-latest
-    # TO REVERT if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
+    if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
     needs: [ build-and-test-conda ]
     steps:
       # Checkout needed to get github.sha
@@ -215,6 +216,7 @@ jobs:
           miniforge-version: latest
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           use-mamba: true
+          channels: conda-forge,defaults
       - name: Restore build
         uses: actions/cache@v4
         with:
@@ -302,8 +304,7 @@ jobs:
 
   publish-to-conda:
     runs-on: windows-latest
-    # TO REVERT needs: [ deploy, test-on-windows ]
-    needs: [ test-on-windows ]
+    needs: [ deploy, test-on-windows ]
     steps:
       - uses: actions/checkout@v4
       - name: Restore build
@@ -319,6 +320,7 @@ jobs:
           miniforge-version: latest
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           use-mamba: true
+          channels: conda-forge,defaults
       - name: Install package
         shell: pwsh
         run: mamba install --channel ./conda-bld --channel openfisca openfisca-france

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -86,7 +86,11 @@ jobs:
         # `bash -l {0}` démarre un login shell avec les variables d'environnement
         # voir  https://github.com/conda-incubator/setup-miniconda/issues/128
         shell: bash -l {0}
-        run: mamba install --channel file:///${RUNNER_TEMP//\\//}/conda-bld --channel openfisca openfisca-france
+        run: |
+          echo "${RUNNER_TEMP}"
+          echo "${RUNNER_TEMP//\\//}"
+          echo "conda install --channel file:///${RUNNER_TEMP//\\//}/conda-bld --channel openfisca openfisca-france"
+          mamba install --channel file:///${RUNNER_TEMP//\\//}/conda-bld --channel openfisca openfisca-france
       - name: Test conda package
         shell: bash -l {0}
         run: openfisca test tests/formulas/irpp.yaml

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,7 +43,7 @@ jobs:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}-${{ matrix.os }}-${{ matrix.openfisca-dependencies }}
 
-  build-conda:
+  build-and-test-conda:
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -51,24 +51,18 @@ jobs:
       - name: Cache build
         uses: actions/cache@v4
         with:
-          path: ${{ runner.temp }}\conda-bld
+          path: ./conda-bld
           key: build-conda-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}
+          enableCrossOsArchive: true
       - name: set version
         run: |
           python3 .github/pyproject_version.py --replace True
       - name: Build conda package
         uses: prefix-dev/rattler-build-action@v0.2.16
         with:
-          build-args: --channel openfisca --channel conda-forge --output-dir ${{ runner.temp }}\conda-bld
+          build-args: --channel openfisca --channel conda-forge --output-dir ./conda-bld
           recipe-path: .conda/recipe.yaml
           upload-artifact: false
-
-  test-conda:
-    runs-on: windows-latest
-    needs: [ build-conda ]
-    steps:
-      # Checkout needed to get github.sha
-      - uses: actions/checkout@v4
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -76,24 +70,14 @@ jobs:
           miniforge-version: latest
           python-version: 3.9.12
           use-mamba: true
-      - name: Restore build
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}\conda-bld
-          key: build-conda-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}
-          fail-on-cache-miss: true
       - name: Install package
-        # `bash -l {0}` démarre un login shell avec les variables d'environnement
-        # voir  https://github.com/conda-incubator/setup-miniconda/issues/128
-        shell: bash -l {0}
-        run: |
-          echo "${RUNNER_TEMP}"
-          echo "${RUNNER_TEMP//\\//}"
-          echo "conda install --channel file:///${RUNNER_TEMP//\\//}/conda-bld --channel openfisca openfisca-france"
-          mamba install --channel file:///${RUNNER_TEMP//\\//}/conda-bld --channel openfisca openfisca-france
-      - name: Test conda package
-        shell: bash -l {0}
+        shell: pwsh
+        run: mamba install --channel ./conda-bld --channel openfisca openfisca-france
+      - name: Test openfisca-france conda package
+        shell: pwsh
         run: openfisca test tests/formulas/irpp.yaml
+
+      
 
   lint-files:
     runs-on: ubuntu-20.04
@@ -217,8 +201,8 @@ jobs:
 
   test-on-windows:
     runs-on: windows-latest
-    if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
-    needs: [ test-conda ]
+    # TO REVERT if: github.ref == 'refs/heads/master' # Only triggered for the `master` branch
+    needs: [ build-and-test-conda ]
     steps:
       # Checkout needed to get github.sha
       - uses: actions/checkout@v4
@@ -231,16 +215,17 @@ jobs:
       - name: Restore build
         uses: actions/cache@v4
         with:
-          path: ${{ runner.temp }}\conda-bld
+          path: ./conda-bld
           key: build-conda-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}
           fail-on-cache-miss: true
+          enableCrossOsArchive: true
       - name: Test max path length
         run: "python3 openfisca_france/scripts/check_path_length.py"
       - name: Install package
-        shell: bash -l {0}
-        run: mamba install --channel file:///${RUNNER_TEMP//\\//}/conda-bld --channel openfisca openfisca-france
+        shell: pwsh
+        run: mamba install --channel ./conda-bld --channel openfisca openfisca-france
       - name: Test conda package
-        shell: bash -l {0}
+        shell: pwsh
         run: openfisca test tests/formulas/irpp.yaml
 
   check-version-and-changelog:
@@ -314,15 +299,17 @@ jobs:
 
   publish-to-conda:
     runs-on: windows-latest
-    needs: [ deploy, test-on-windows ]
+    # TO REVERT needs: [ deploy, test-on-windows ]
+    needs: [ test-on-windows ]
     steps:
       - uses: actions/checkout@v4
       - name: Restore build
         uses: actions/cache@v4
         with:
-          path: ${{ runner.temp }}\conda-bld
+          path: ./conda-bld
           key: build-conda-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}
           fail-on-cache-miss: true
+          enableCrossOsArchive: true
       - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: openfisca
@@ -330,13 +317,13 @@ jobs:
           python-version: 3.10.6
           use-mamba: true
       - name: Install package
-        shell: bash -l {0}
-        run: mamba install --channel file:///${RUNNER_TEMP//\\//}/conda-bld --channel openfisca openfisca-france
+        shell: pwsh
+        run: mamba install --channel ./conda-bld --channel openfisca openfisca-france
       - name: Test conda package
-        shell: bash -l {0}
+        shell: pwsh
         run: openfisca test tests/formulas/irpp.yaml
       - name: Conda upload already built package
-        shell: bash -l {0}
+        shell: pwsh
         run: |
           conda install --yes anaconda-client
-          anaconda -t ${{ secrets.ANACONDA_TOKEN }} upload --user openfisca ${{ runner.temp }}\conda-bld\noarch\openfisca-france-*
+          anaconda -t ${{ secrets.ANACONDA_TOKEN }} upload --user openfisca ./conda-bld\noarch\openfisca-france-*

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [opened, reopened]
 
+env:
+  DEFAULT_PYTHON_VERSION: '3.10.6'
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -68,7 +71,7 @@ jobs:
         with:
           activate-environment: openfisca
           miniforge-version: latest
-          python-version: 3.9.12
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           use-mamba: true
       - name: Install package
         shell: pwsh
@@ -92,7 +95,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - name: Cache build
         id: restore-build
         uses: actions/cache@v4
@@ -139,7 +142,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - name: Test max path length
         run: make check-path-length
 
@@ -160,7 +163,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - name: Cache build
         id: restore-build
         uses: actions/cache@v4
@@ -189,7 +192,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - name: Cache build
         id: restore-build
         uses: actions/cache@v4
@@ -210,7 +213,7 @@ jobs:
         with:
           activate-environment: openfisca
           miniforge-version: latest
-          python-version: 3.10.6
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           use-mamba: true
       - name: Restore build
         uses: actions/cache@v4
@@ -238,7 +241,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - name: Check version number has been properly updated
         run: "${GITHUB_WORKSPACE}/.github/is-version-number-acceptable.sh"
 
@@ -258,7 +261,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - id: stop-early
         run: if "${GITHUB_WORKSPACE}/.github/has-functional-changes.sh" ; then echo "::set-output name=status::success" ; fi
 
@@ -279,7 +282,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9.9
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
       - name: Cache build
         id: restore-build
         uses: actions/cache@v4
@@ -314,7 +317,7 @@ jobs:
         with:
           activate-environment: openfisca
           miniforge-version: latest
-          python-version: 3.10.6
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           use-mamba: true
       - name: Install package
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Périodes concernées : aucune.
 - Zones impactées : `.github/workflows/workflow.yml`.
 - Détails :
-  - Contournement d'une erreur qui empêchait la CI Conda de fonctionner.
+  - Contourne une erreur de commande inconnue sur le job `test-conda` de l'intégration continue
+  - Réunit en `build-and-test-conda` les jobs de CI `build-conda` et `test-conda`
 
 ### 169.3.2 [2382](https://github.com/openfisca/openfisca-france/pull/2382)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 169.3.3 [2381](https://github.com/openfisca/openfisca-france/pull/2381)
+
+- Changement mineur.
+- Périodes concernées : aucune.
+- Zones impactées : `.github/workflows/workflow.yml`.
+- Détails :
+  - Contournement d'une erreur qui empêchait la CI Conda de fonctionner.
+
 ### 169.3.2 [2382](https://github.com/openfisca/openfisca-france/pull/2382)
 
 - Changement mineur.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.3.2"
+version = "169.3.3"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Amélioration technique.
* Périodes concernées : toutes.
* Zones impactées : `.github/workflows/workflow.yml`.
* Détails :
  - Contournement d'une erreur qui empêchait la CI Conda de fonctionner.

- - - -
_edit @sandcha_ : 
Corrige [test-conda](https://github.com/openfisca/openfisca-france/actions/runs/11680517825/job/32523881244?pr=2377) détecté sur https://github.com/openfisca/openfisca-france/pull/2377 (alors que l'erreur n'est pas survenue sur la branche `master` 🤔) ; la première lettre 'c' semble avoir été supprimée : 

```shell
> Install package
Run mamba install --channel file:///${RUNNER_TEMP//\\//}/conda-bld --channel openfisca openfisca-france
  mamba install --channel file:///${RUNNER_TEMP//\\//}/conda-bld --channel openfisca openfisca-france
  shell: C:\Program Files\Git\bin\bash.EXE -l {0}
  env:
    INPUT_RUN_POST: true
    CONDA: C:\Users\runneradmin\miniconda3
'onda-bld' is not recognized as an internal or external command,
operable program or batch file.
Error: Process completed with exit code 1.
```

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (CI).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

