### PR TITLE
Paramètre réduction souscription capital PME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 169.7.0 [2390](https://github.com/openfisca/openfisca-france/pull/2390)
+
+* Évolution intermédiaire du système socio-fiscal.
+* Périodes concernées : toutes
+* Zones impactées : 
+    * `model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py`,
+    * `parameters/impot_revenu/calcul_reductions_impots/souscriptions`,
+* Détails : Réorganisation du dossier concernant la réduction Madelin des versements pour souscription au capital des PME.
+  - Ajoute label et références
+  - Utilise dans les formules les derniers paramètres plus génériques
+
+
 ### 169.6.1 [2392](https://github.com/openfisca/openfisca-france/pull/2392)
 
 * Changement mineur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,32 @@
 * Zones impactées : 
     * `model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py`,
     * `parameters/impot_revenu/calcul_reductions_impots/souscriptions`,
-* Détails : Réorganisation du dossier concernant la réduction Madelin des versements pour souscription au capital des PME.
+    * `model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py`,
+    * `parameters/impot_revenu/calcul_impot_revenu/pv/bspce/taux_moins_3_ans.yaml`,
+* Détails :  Réorganisation du dossier concernant la réduction Madelin IR-PME des versements pour souscription au capital des PME.
   - Ajoute label et références
   - Utilise dans les formules les derniers paramètres plus génériques
+  - Met à jour la variable de la case 7CQ qui change d'objet à partir de 2012
+
+
+### 169.6.1 [2392](https://github.com/openfisca/openfisca-france/pull/2392)
+
+* Changement mineur.
+* Périodes concernées : toutes
+* Zones impactées : 
+- `parameters/impot_revenu/calcul_impot_revenu/pv/bspce/index.yaml`
+- `parameters/impot_revenu/calcul_impot_revenu/pv/bspce/taux_moins_3_ans.yaml`
+- `parameters/impot_revenu/calcul_reductions_impots/divers/rehabilitation_residences_touristiques/plafond.yaml`
+- `parameters/impot_revenu/calcul_reductions_impots/divers/rehabilitation_residences_touristiques/taux.yaml`
+- `parameters/impot_revenu/calcul_reductions_impots/divers/restauration_patrimoine_bati/taux_22.yaml`
+- `parameters/impot_revenu/calcul_reductions_impots/dons/dons_aux_partis_politiques/plafond_seul.yaml`
+- `parameters/impot_revenu/calcul_reductions_impots/dons/dons_cultuels/index.yaml`
+- `parameters/impot_revenu/calcul_reductions_impots/dons/taux_reduction.yaml`
+- `parameters/impot_revenu/calcul_revenus_imposables/abat_rni/index.yaml`
+
+* Détails :
+- Corrige les erreurs apparues sur le Control Center suite à la PR réductions-impôts
+- Petites modifications : modifications les noms mentionnés dans l'order des index, change la documentation, corrige les values mal renseignées, corrige les short_label mal renseignés
 
 
 ### 169.6.1 [2392](https://github.com/openfisca/openfisca-france/pull/2392)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py
@@ -1509,7 +1509,7 @@ class cappme(Variable):
 
         P = parameters(period).impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital
 
-        plafond_TPE = P.seuil_tpe * (maries_ou_pacses + 1)
+        plafond_TPE = P.seuil * (maries_ou_pacses + 1)
 
         # Réduction investissement TPE (souscription à partir de 2012) : imputation du plus ancien au plus récent,
         # dans l'ordre PME/ESUS > SFS
@@ -1529,7 +1529,7 @@ class cappme(Variable):
 
         return (
             reports_plaf_general
-            + P.taux18 * (base_report_pme_2017_TPE
+            + P.taux * (base_report_pme_2017_TPE
                 + base_report_pme_2018_TPE
                 + base_report_pme_2019_TPE
                 + base_pme_2020_avant0908
@@ -1567,7 +1567,7 @@ class cappme_esus_sfs(Variable):
 
         P = parameters(period).impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital
 
-        plafond_TPE = P.seuil_tpe * (maries_ou_pacses + 1)
+        plafond_TPE = P.seuil * (maries_ou_pacses + 1)
 
         # Réduction investissement TPE (souscription à partir de 2012) : imputation du plus ancien au plus récent,
         # dans l'ordre PME/ESUS > SFS

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py
@@ -1028,7 +1028,7 @@ class cappme(Variable):
         f7cl = foyer_fiscal('f7cl', period)
         f7cm = foyer_fiscal('f7cm', period)
         f7cn = foyer_fiscal('f7cn', period)
-        f7cq = foyer_fiscal('f7cq', period)
+        f7cq = foyer_fiscal('f7cq_2012', period)
         f7cu = foyer_fiscal('f7cu', period)
         P = parameters(period).impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital
 
@@ -1047,15 +1047,15 @@ class cappme(Variable):
         f7cl = foyer_fiscal('f7cl', period)
         f7cm = foyer_fiscal('f7cm', period)
         f7cn = foyer_fiscal('f7cn', period)
-        f7cq = foyer_fiscal('f7cq', period)
+        f7cq = foyer_fiscal('f7cq_2012', period)
         f7cu = foyer_fiscal('f7cu', period)
         P = parameters(period).impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital
 
         # TODO: gérer les changements de situation familiale
         base = f7cl + f7cm + f7cn
         seuil1 = P.seuil * (maries_ou_pacses + 1)
-        seuil2 = max_(0, P.seuil_tpe * (maries_ou_pacses + 1) - min_(base, seuil1) - min_(f7cq, seuil1) - min_(f7cu, seuil1))
-        seuil3 = min_(P.seuil_tpe * (maries_ou_pacses + 1) - min_(base, seuil1) - min_(f7cq, seuil1), seuil1)
+        seuil2 = max_(0, P.seuil * (maries_ou_pacses + 1) - min_(base, seuil1) - min_(f7cq, seuil1) - min_(f7cu, seuil1))
+        seuil3 = min_(P.seuil * (maries_ou_pacses + 1) - min_(base, seuil1) - min_(f7cq, seuil1), seuil1)
 
         return (
             P.taux25 * min_(base, seuil1)
@@ -1080,8 +1080,8 @@ class cappme(Variable):
 
         base = f7cl + f7cm
         seuil1 = P.seuil * (maries_ou_pacses + 1)
-        seuil2 = max_(0, P.seuil_tpe * (maries_ou_pacses + 1) - min_(base, seuil1) - min_(f7cn, seuil1) - min_(f7cu, seuil1))
-        seuil3 = min_(P.seuil_tpe * (maries_ou_pacses + 1) - min_(base, seuil1) - min_(f7cq, seuil1), seuil1)
+        seuil2 = max_(0, P.seuil * (maries_ou_pacses + 1) - min_(base, seuil1) - min_(f7cn, seuil1) - min_(f7cu, seuil1))
+        seuil3 = min_(P.seuil * (maries_ou_pacses + 1) - min_(base, seuil1) - min_(f7cq, seuil1), seuil1)
 
         return (
             P.taux25 * min_(base, seuil1)
@@ -1106,27 +1106,26 @@ class cappme(Variable):
         report_cappme_2013_plaf_general = foyer_fiscal('f7cy', period)
         P = parameters(period).impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital
 
-        seuil1 = P.seuil * (maries_ou_pacses + 1)
-        seuil2 = P.seuil_tpe * (maries_ou_pacses + 1)
+        seuil = P.seuil * (maries_ou_pacses + 1)
 
         # Réduction investissement PME : imputation du plus ancien au plus récent
-        base_report_cappme_2010_PME = min_(f7cl, seuil1)
-        base_report_cappme_2011_PME = max_(0, min_(f7cm, seuil1) - base_report_cappme_2010_PME)
-        base_report_cappme_2012_PME = max_(0, min_(f7cn, seuil1 - base_report_cappme_2010_PME - base_report_cappme_2011_PME))
-        base_report_cappme_2013_PME = max_(0, min_(f7cc, seuil1 - base_report_cappme_2010_PME - base_report_cappme_2011_PME - base_report_cappme_2012_PME))
-        base_cappme_2014_PME = max_(0, min_(f7cu, seuil1 - base_report_cappme_2010_PME - base_report_cappme_2011_PME - base_report_cappme_2012_PME - base_report_cappme_2013_PME))
+        base_report_cappme_2010_PME = min_(f7cl, seuil)
+        base_report_cappme_2011_PME = max_(0, min_(f7cm, seuil) - base_report_cappme_2010_PME)
+        base_report_cappme_2012_PME = max_(0, min_(f7cn, seuil - base_report_cappme_2010_PME - base_report_cappme_2011_PME))
+        base_report_cappme_2013_PME = max_(0, min_(f7cc, seuil - base_report_cappme_2010_PME - base_report_cappme_2011_PME - base_report_cappme_2012_PME))
+        base_cappme_2014_PME = max_(0, min_(f7cu, seuil - base_report_cappme_2010_PME - base_report_cappme_2011_PME - base_report_cappme_2012_PME - base_report_cappme_2013_PME))
 
         # Réduction investissement TPE : imputation du plus ancien au plus récent
-        base_report_cappme_2012_TPE = min_(f7cq, seuil2)
-        base_report_cappme_2013_TPE = max_(0, min_(f7cr, seuil2 - base_report_cappme_2012_TPE))
-        base_cappme_2014_TPE = max_(0, min_(f7cf, seuil2 - base_report_cappme_2012_TPE - base_report_cappme_2013_TPE))
+        base_report_cappme_2012_TPE = min_(f7cq, seuil)
+        base_report_cappme_2013_TPE = max_(0, min_(f7cr, seuil - base_report_cappme_2012_TPE))
+        base_cappme_2014_TPE = max_(0, min_(f7cf, seuil - base_report_cappme_2012_TPE - base_report_cappme_2013_TPE))
 
-        seuil3 = seuil2 - min_(seuil2, base_report_cappme_2010_PME)
+        seuil3 = seuil - min_(seuil, base_report_cappme_2010_PME)
         seuil4 = seuil3 - min_(seuil3, base_report_cappme_2010_PME + base_report_cappme_2011_PME)
 
         return (
             report_cappme_2013_plaf_general
-            + min_(seuil2, base_report_cappme_2010_PME) * P.taux25
+            + min_(seuil, base_report_cappme_2010_PME) * P.taux25
             + min_(seuil3, base_report_cappme_2011_PME) * P.taux22
             + min_(
                 seuil4,
@@ -1158,31 +1157,30 @@ class cappme(Variable):
         f7dy = foyer_fiscal('f7dy', period)
         P = parameters(period).impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital
 
-        seuil1 = P.seuil * (maries_ou_pacses + 1)
-        seuil2 = P.seuil_tpe * (maries_ou_pacses + 1)
+        seuil = P.seuil * (maries_ou_pacses + 1)
 
         # Réduction investissement PME : imputation du plus ancien au plus récent
-        base_report_cappme_2011_PME = min_(f7cl, seuil1)
-        base_report_cappme_2012_PME = max_(0, min_(f7cm, seuil1) - base_report_cappme_2011_PME)
-        base_report_cappme_2013_PME = max_(0, min_(f7cn, seuil1 - base_report_cappme_2011_PME - base_report_cappme_2012_PME))
-        base_report_cappme_2014_PME = max_(0, min_(f7cc, seuil1 - base_report_cappme_2011_PME - base_report_cappme_2012_PME - base_report_cappme_2013_PME))
-        base_cappme_2015_PME = max_(0, min_(f7cu, seuil1 - base_report_cappme_2011_PME - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME))
+        base_report_cappme_2011_PME = min_(f7cl, seuil)
+        base_report_cappme_2012_PME = max_(0, min_(f7cm, seuil) - base_report_cappme_2011_PME)
+        base_report_cappme_2013_PME = max_(0, min_(f7cn, seuil - base_report_cappme_2011_PME - base_report_cappme_2012_PME))
+        base_report_cappme_2014_PME = max_(0, min_(f7cc, seuil - base_report_cappme_2011_PME - base_report_cappme_2012_PME - base_report_cappme_2013_PME))
+        base_cappme_2015_PME = max_(0, min_(f7cu, seuil - base_report_cappme_2011_PME - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME))
 
         # Réduction investissement TPE : imputation du plus ancien au plus récent
-        base_report_cappme_2012_TPE = min_(f7cq, seuil2)
-        base_report_cappme_2013_TPE = max_(0, min_(f7cr, seuil2 - base_report_cappme_2012_TPE))
-        base_report_cappme_2014_TPE = max_(0, min_(f7cv, seuil2 - base_report_cappme_2012_TPE - base_report_cappme_2013_TPE))
-        base_cappme_2015_TPE = max_(0, min_(f7cf, seuil2 - base_report_cappme_2012_TPE - base_report_cappme_2013_TPE - base_report_cappme_2014_TPE))
+        base_report_cappme_2012_TPE = min_(f7cq, seuil)
+        base_report_cappme_2013_TPE = max_(0, min_(f7cr, seuil - base_report_cappme_2012_TPE))
+        base_report_cappme_2014_TPE = max_(0, min_(f7cv, seuil - base_report_cappme_2012_TPE - base_report_cappme_2013_TPE))
+        base_cappme_2015_TPE = max_(0, min_(f7cf, seuil - base_report_cappme_2012_TPE - base_report_cappme_2013_TPE - base_report_cappme_2014_TPE))
 
         report_cappme_2013_plaf_general = f7cy
         report_cappme_2014_plaf_general = f7dy
 
-        seuil3 = seuil2 - min_(seuil2, base_report_cappme_2011_PME)
+        seuil3 = seuil - min_(seuil, base_report_cappme_2011_PME)
 
         return (
             report_cappme_2013_plaf_general
             + report_cappme_2014_plaf_general
-            + P.taux22 * min_(seuil2, base_report_cappme_2011_PME)
+            + P.taux22 * min_(seuil, base_report_cappme_2011_PME)
             + P.taux18 * min_(
                 seuil3,
                 base_report_cappme_2012_PME
@@ -1222,22 +1220,21 @@ class cappme(Variable):
 
         P = parameters(period).impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital
 
-        seuil1 = P.seuil * (maries_ou_pacses + 1)
-        seuil2 = P.seuil_tpe * (maries_ou_pacses + 1)
+        seuil = P.seuil * (maries_ou_pacses + 1)
 
         # Réduction investissement PME : imputation du plus ancien au plus récent
-        base_report_cappme_2012_PME = min_(f7cl, seuil1)
-        base_report_cappme_2013_PME = max_(0, min_(f7cm, seuil1 - base_report_cappme_2012_PME))
-        base_report_cappme_2014_PME = max_(0, min_(f7cn, seuil1 - base_report_cappme_2012_PME - base_report_cappme_2013_PME))
-        base_report_cappme_2015_PME = max_(0, min_(f7cc, seuil1 - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME))
-        base_cappme_2016_PME = max_(0, min_(f7cu, seuil1 - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME))
+        base_report_cappme_2012_PME = min_(f7cl, seuil)
+        base_report_cappme_2013_PME = max_(0, min_(f7cm, seuil - base_report_cappme_2012_PME))
+        base_report_cappme_2014_PME = max_(0, min_(f7cn, seuil - base_report_cappme_2012_PME - base_report_cappme_2013_PME))
+        base_report_cappme_2015_PME = max_(0, min_(f7cc, seuil - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME))
+        base_cappme_2016_PME = max_(0, min_(f7cu, seuil - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME))
 
         # Réduction investissement TPE : imputation du plus ancien au plus récent
-        base_report_cappme_2012_TPE = min_(f7cq, seuil2 - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME)
-        base_report_cappme_2013_TPE = max_(0, min_(f7cr, seuil2 - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2012_TPE))
-        base_report_cappme_2014_TPE = max_(0, min_(f7cv, seuil2 - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2012_TPE - base_report_cappme_2013_TPE))
-        base_report_cappme_2015_TPE = max_(0, min_(f7cx, seuil2 - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2012_TPE - base_report_cappme_2013_TPE - base_report_cappme_2014_TPE))
-        base_cappme_2016_TPE = max_(0, min_(f7cf, seuil2 - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2012_TPE - base_report_cappme_2013_TPE - base_report_cappme_2014_TPE - base_report_cappme_2015_TPE))
+        base_report_cappme_2012_TPE = min_(f7cq, seuil - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME)
+        base_report_cappme_2013_TPE = max_(0, min_(f7cr, seuil - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2012_TPE))
+        base_report_cappme_2014_TPE = max_(0, min_(f7cv, seuil - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2012_TPE - base_report_cappme_2013_TPE))
+        base_report_cappme_2015_TPE = max_(0, min_(f7cx, seuil - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2012_TPE - base_report_cappme_2013_TPE - base_report_cappme_2014_TPE))
+        base_cappme_2016_TPE = max_(0, min_(f7cf, seuil - base_report_cappme_2012_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2012_TPE - base_report_cappme_2013_TPE - base_report_cappme_2014_TPE - base_report_cappme_2015_TPE))
 
         reports_plaf_general = f7cy + f7dy + f7ey
 
@@ -1281,23 +1278,22 @@ class cappme(Variable):
 
         P = parameters(period).impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital
 
-        plafond_PME = P.seuil * (maries_ou_pacses + 1)
-        plafond_TPE = P.seuil_tpe * (maries_ou_pacses + 1)
+        plafond = P.seuil * (maries_ou_pacses + 1)
 
         # Réduction investissement PME (souscription avant 2012) : imputation du plus ancien au plus récent
-        base_report_cappme_2013_PME = min_(f7cl, plafond_PME)
-        base_report_cappme_2014_PME = max_(0, min_(f7cm, plafond_PME - base_report_cappme_2013_PME))
-        base_report_cappme_2015_PME = max_(0, min_(f7cn, plafond_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME))
-        base_report_cappme_2016_PME = max_(0, min_(f7cc, plafond_PME - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME))
+        base_report_cappme_2013_PME = min_(f7cl, plafond)
+        base_report_cappme_2014_PME = max_(0, min_(f7cm, plafond - base_report_cappme_2013_PME))
+        base_report_cappme_2015_PME = max_(0, min_(f7cn, plafond - base_report_cappme_2013_PME - base_report_cappme_2014_PME))
+        base_report_cappme_2016_PME = max_(0, min_(f7cc, plafond - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME))
 
         # Réduction investissement TPE (souscription à partir de 2012) : imputation du plus ancien au plus récent
-        base_report_cappme_2013_TPE = min_(f7cq, plafond_TPE)
-        base_report_cappme_2014_TPE = max_(0, min_(f7cr, plafond_TPE - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2013_TPE))
-        base_report_cappme_2015_TPE = max_(0, min_(f7cv, plafond_TPE - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2013_TPE - base_report_cappme_2014_TPE))
-        base_report_cappme_2016_TPE = max_(0, min_(f7cx, plafond_TPE - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2013_TPE - base_report_cappme_2014_TPE - base_report_cappme_2015_TPE))
+        base_report_cappme_2013_TPE = min_(f7cq, plafond)
+        base_report_cappme_2014_TPE = max_(0, min_(f7cr, plafond - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2013_TPE))
+        base_report_cappme_2015_TPE = max_(0, min_(f7cv, plafond - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2013_TPE - base_report_cappme_2014_TPE))
+        base_report_cappme_2016_TPE = max_(0, min_(f7cx, plafond - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2013_TPE - base_report_cappme_2014_TPE - base_report_cappme_2015_TPE))
 
         # Réduction investissements de l'année courante
-        base_cappme_2017 = max_(0, min_(f7cf, plafond_TPE - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2013_TPE - base_report_cappme_2014_TPE - base_report_cappme_2015_TPE - base_report_cappme_2016_TPE))
+        base_cappme_2017 = max_(0, min_(f7cf, plafond - base_report_cappme_2013_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2013_TPE - base_report_cappme_2014_TPE - base_report_cappme_2015_TPE - base_report_cappme_2016_TPE))
 
         reports_plaf_general = f7cy + f7dy + f7ey + f7fy
 
@@ -1340,22 +1336,21 @@ class cappme(Variable):
 
         P = parameters(period).impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital
 
-        plafond_PME = P.seuil * (maries_ou_pacses + 1)
-        plafond_TPE = P.seuil_tpe * (maries_ou_pacses + 1)
+        plafond = P.seuil * (maries_ou_pacses + 1)
 
         # Réduction investissement PME (souscription avant 2012) : imputation du plus ancien au plus récent
-        base_report_cappme_2014_PME = min_(f7cl, plafond_PME)
-        base_report_cappme_2015_PME = max_(0, min_(f7cm, plafond_PME - base_report_cappme_2014_PME))
-        base_report_cappme_2016_PME = max_(0, min_(f7cn, plafond_PME - base_report_cappme_2014_PME - base_report_cappme_2015_PME))
+        base_report_cappme_2014_PME = min_(f7cl, plafond)
+        base_report_cappme_2015_PME = max_(0, min_(f7cm, plafond - base_report_cappme_2014_PME))
+        base_report_cappme_2016_PME = max_(0, min_(f7cn, plafond - base_report_cappme_2014_PME - base_report_cappme_2015_PME))
 
         # Réduction investissement TPE (souscription à partir de 2012) : imputation du plus ancien au plus récent
-        base_report_cappme_2014_TPE = min_(f7cq, plafond_TPE - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME)
-        base_report_cappme_2015_TPE = max_(0, min_(f7cr, plafond_TPE - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2014_TPE))
-        base_report_cappme_2016_TPE = max_(0, min_(f7cv, plafond_TPE - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2014_TPE - base_report_cappme_2015_TPE))
-        base_report_cappme_2017_TPE = max_(0, min_(f7cx, plafond_TPE - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2014_TPE - base_report_cappme_2015_TPE - base_report_cappme_2016_TPE))
+        base_report_cappme_2014_TPE = min_(f7cq, plafond - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME)
+        base_report_cappme_2015_TPE = max_(0, min_(f7cr, plafond - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2014_TPE))
+        base_report_cappme_2016_TPE = max_(0, min_(f7cv, plafond - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2014_TPE - base_report_cappme_2015_TPE))
+        base_report_cappme_2017_TPE = max_(0, min_(f7cx, plafond - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2014_TPE - base_report_cappme_2015_TPE - base_report_cappme_2016_TPE))
 
         # Réduction investissements de l'année courante
-        base_cappme_2018 = max_(0, min_(f7cf, plafond_TPE - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2014_TPE - base_report_cappme_2015_TPE - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE))
+        base_cappme_2018 = max_(0, min_(f7cf, plafond - base_report_cappme_2014_PME - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2014_TPE - base_report_cappme_2015_TPE - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE))
 
         reports_plaf_general = f7cy + f7dy + f7ey + f7fy + f7gy
 
@@ -1396,21 +1391,20 @@ class cappme(Variable):
 
         P = parameters(period).impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital
 
-        plafond_PME = P.seuil * (maries_ou_pacses + 1)
-        plafond_TPE = P.seuil_tpe * (maries_ou_pacses + 1)
+        plafond = P.seuil * (maries_ou_pacses + 1)
 
         # Réduction investissement PME (souscription avant 2012) : imputation du plus ancien au plus récent
-        base_report_cappme_2015_PME = min_(f7cl, plafond_PME)
-        base_report_cappme_2016_PME = max_(0, min_(f7cm, plafond_PME - base_report_cappme_2015_PME))
+        base_report_cappme_2015_PME = min_(f7cl, plafond)
+        base_report_cappme_2016_PME = max_(0, min_(f7cm, plafond - base_report_cappme_2015_PME))
 
         # Réduction investissement TPE (souscription à partir de 2012) : imputation du plus ancien au plus récent
-        base_report_cappme_2015_TPE = min_(f7cq, plafond_TPE - base_report_cappme_2015_PME - base_report_cappme_2016_PME)
-        base_report_cappme_2016_TPE = max_(0, min_(f7cr, plafond_TPE - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2015_TPE))
-        base_report_cappme_2017_TPE = max_(0, min_(f7cv, plafond_TPE - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2015_TPE - base_report_cappme_2016_TPE))
-        base_report_cappme_2018_TPE = max_(0, min_(f7cx, plafond_TPE - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2015_TPE - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE))
+        base_report_cappme_2015_TPE = min_(f7cq, plafond - base_report_cappme_2015_PME - base_report_cappme_2016_PME)
+        base_report_cappme_2016_TPE = max_(0, min_(f7cr, plafond - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2015_TPE))
+        base_report_cappme_2017_TPE = max_(0, min_(f7cv, plafond - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2015_TPE - base_report_cappme_2016_TPE))
+        base_report_cappme_2018_TPE = max_(0, min_(f7cx, plafond - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2015_TPE - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE))
 
         # Réduction investissements de l'année courante
-        base_cappme_2019 = max_(0, min_(f7cf, plafond_TPE - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2015_TPE - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE - base_report_cappme_2018_TPE))
+        base_cappme_2019 = max_(0, min_(f7cf, plafond - base_report_cappme_2015_PME - base_report_cappme_2016_PME - base_report_cappme_2015_TPE - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE - base_report_cappme_2018_TPE))
 
         reports_plaf_general = f7cy + f7dy + f7ey + f7fy + f7gy
 
@@ -1451,24 +1445,23 @@ class cappme(Variable):
 
         P = parameters(period).impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital
 
-        plafond_PME = P.seuil * (maries_ou_pacses + 1)
-        plafond_TPE = P.seuil_tpe * (maries_ou_pacses + 1)
+        plafond = P.seuil * (maries_ou_pacses + 1)
 
         # Réduction investissement PME (souscription avant 2012) : imputation du plus ancien au plus récent
-        base_report_cappme_2016_PME = min_(f7cl, plafond_PME)
+        base_report_cappme_2016_PME = min_(f7cl, plafond)
 
         # Réduction investissement TPE (souscription à partir de 2012) : imputation du plus ancien au plus récent,
         # en prenant en compte les versement avant 2012 qui seront pris en compte pour le seuil
-        base_report_cappme_2016_TPE = min_(f7cq, plafond_TPE - base_report_cappme_2016_PME)
-        base_report_cappme_2017_TPE = max_(0, min_(f7cr, plafond_TPE - base_report_cappme_2016_PME - base_report_cappme_2016_TPE))
-        base_report_cappme_2018_TPE = max_(0, min_(f7cv, plafond_TPE - base_report_cappme_2016_PME - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE))
-        base_report_cappme_2019_TPE = max_(0, min_(f7cx, plafond_TPE - base_report_cappme_2016_PME - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE - base_report_cappme_2018_TPE))
+        base_report_cappme_2016_TPE = min_(f7cq, plafond - base_report_cappme_2016_PME)
+        base_report_cappme_2017_TPE = max_(0, min_(f7cr, plafond - base_report_cappme_2016_PME - base_report_cappme_2016_TPE))
+        base_report_cappme_2018_TPE = max_(0, min_(f7cv, plafond - base_report_cappme_2016_PME - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE))
+        base_report_cappme_2019_TPE = max_(0, min_(f7cx, plafond - base_report_cappme_2016_PME - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE - base_report_cappme_2018_TPE))
 
         # Réduction investissements de l'année courante
         # on applique les investissements en commençant avec les plus anciennes
-        base_cappme_2020_avant0908 = max_(0, min_(f7cf, plafond_TPE - base_report_cappme_2016_PME - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE - base_report_cappme_2018_TPE - base_report_cappme_2019_TPE))
-        base_cappme_2020_apres0908 = max_(0, min_(f7ch, plafond_TPE - base_report_cappme_2016_PME - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE - base_report_cappme_2018_TPE - base_report_cappme_2019_TPE - base_cappme_2020_avant0908))
-        base_sfs_2020 = max_(0, min_(f7gw, plafond_TPE - plafond_TPE - base_report_cappme_2016_PME - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE - base_report_cappme_2018_TPE - base_report_cappme_2019_TPE - base_cappme_2020_avant0908 - base_cappme_2020_apres0908))
+        base_cappme_2020_avant0908 = max_(0, min_(f7cf, plafond - base_report_cappme_2016_PME - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE - base_report_cappme_2018_TPE - base_report_cappme_2019_TPE))
+        base_cappme_2020_apres0908 = max_(0, min_(f7ch, plafond - base_report_cappme_2016_PME - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE - base_report_cappme_2018_TPE - base_report_cappme_2019_TPE - base_cappme_2020_avant0908))
+        base_sfs_2020 = max_(0, min_(f7gw, plafond - plafond - base_report_cappme_2016_PME - base_report_cappme_2016_TPE - base_report_cappme_2017_TPE - base_report_cappme_2018_TPE - base_report_cappme_2019_TPE - base_cappme_2020_avant0908 - base_cappme_2020_apres0908))
 
         reports_plaf_general = f7cy + f7dy + f7ey + f7fy + f7gy
 
@@ -1509,21 +1502,21 @@ class cappme(Variable):
 
         P = parameters(period).impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital
 
-        plafond_TPE = P.seuil * (maries_ou_pacses + 1)
+        plafond_PME = P.seuil * (maries_ou_pacses + 1)
 
         # Réduction investissement TPE (souscription à partir de 2012) : imputation du plus ancien au plus récent,
         # dans l'ordre PME/ESUS > SFS
-        base_report_pme_2017_TPE = min_(f7cq, plafond_TPE)
-        base_report_pme_2018_TPE = max_(0, min_(f7cr, plafond_TPE - base_report_pme_2017_TPE))
-        base_report_pme_2019_TPE = max_(0, min_(f7cv, plafond_TPE - base_report_pme_2017_TPE - base_report_pme_2018_TPE))
-        base_pme_2020_avant0908 = max_(0, min_(f7cx, plafond_TPE - base_report_pme_2017_TPE - base_report_pme_2018_TPE - base_report_pme_2019_TPE))
-        base_pme_2020_apres0908 = max_(0, min_(f7cs, plafond_TPE - base_report_pme_2017_TPE - base_report_pme_2018_TPE - base_report_pme_2019_TPE - base_pme_2020_avant0908))
-        base_sfs_2020 = max_(0, min_(f7bs, plafond_TPE - base_report_pme_2017_TPE - base_report_pme_2018_TPE - base_report_pme_2019_TPE - base_pme_2020_avant0908 - base_pme_2020_apres0908))
+        base_report_pme_2017_TPE = min_(f7cq, plafond_PME)
+        base_report_pme_2018_TPE = max_(0, min_(f7cr, plafond_PME - base_report_pme_2017_TPE))
+        base_report_pme_2019_TPE = max_(0, min_(f7cv, plafond_PME - base_report_pme_2017_TPE - base_report_pme_2018_TPE))
+        base_pme_2020_avant0908 = max_(0, min_(f7cx, plafond_PME - base_report_pme_2017_TPE - base_report_pme_2018_TPE - base_report_pme_2019_TPE))
+        base_pme_2020_apres0908 = max_(0, min_(f7cs, plafond_PME - base_report_pme_2017_TPE - base_report_pme_2018_TPE - base_report_pme_2019_TPE - base_pme_2020_avant0908))
+        base_sfs_2020 = max_(0, min_(f7bs, plafond_PME - base_report_pme_2017_TPE - base_report_pme_2018_TPE - base_report_pme_2019_TPE - base_pme_2020_avant0908 - base_pme_2020_apres0908))
 
         # Réduction investissements de l'année courante
         # on applique les investissements en commençant avec les plus anciennes
-        base_pme_esus_2021_avant0805 = max_(0, min_(f7cf, plafond_TPE - base_report_pme_2017_TPE - base_report_pme_2018_TPE - base_report_pme_2019_TPE - base_pme_2020_avant0908 - base_pme_2020_apres0908 - base_sfs_2020))
-        base_pme_2021_apres0805 = max_(0, min_(f7ch, plafond_TPE - base_report_pme_2017_TPE - base_report_pme_2018_TPE - base_report_pme_2019_TPE - base_pme_2020_avant0908 - base_pme_2020_apres0908 - base_sfs_2020 - base_pme_esus_2021_avant0805))
+        base_pme_esus_2021_avant0805 = max_(0, min_(f7cf, plafond_PME - base_report_pme_2017_TPE - base_report_pme_2018_TPE - base_report_pme_2019_TPE - base_pme_2020_avant0908 - base_pme_2020_apres0908 - base_sfs_2020))
+        base_pme_2021_apres0805 = max_(0, min_(f7ch, plafond_PME - base_report_pme_2017_TPE - base_report_pme_2018_TPE - base_report_pme_2019_TPE - base_pme_2020_avant0908 - base_pme_2020_apres0908 - base_sfs_2020 - base_pme_esus_2021_avant0805))
 
         reports_plaf_general = f7cy + f7dy + f7ey + f7fy + f7gy
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -5500,8 +5500,19 @@ class f7cc(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = "Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1"
+    label = "Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1, remplace la case 7CQ à partir des revenus 2013"
     # start_date = date(2013, 1, 1)
+    definition_period = YEAR
+
+
+class f7cq_2012(Variable):
+    cerfa_field = '7CQ'
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = "Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1"
+    # start_date = date(2011, 1, 1)
+    end = '2012-01-01'
     definition_period = YEAR
 
 
@@ -5510,8 +5521,9 @@ class f7cq(Variable):
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
-    label = "Souscriptions au capital des PME non cotées, report de versement de l'année de perception des revenus -1pour les start-up"
+    label = "Souscription au capital de petites entreprises en phase d'amorçage, de démarrage ou d'expansion"
     # start_date = date(2011, 1, 1)
+    end = '2021-12-31'
     definition_period = YEAR
 
 

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/index.yaml
@@ -1,7 +1,7 @@
-description: Souscription au capital des PME
+description: Réduction d'impôt sur le revenu (IR) sur les souscriptions au capital des PME
 metadata:
   documentation_start: true
-  short_label: Au capital des PME
+  short_label: Souscriptions au capital des PME
   label_en: Small Firms Capital Subscription (PME)
   order:
   - emprunts_contractes_reprise_pme

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/index.yaml
@@ -1,11 +1,13 @@
-description: Souscriptions au capital des PME
+description: Réduction d'impôt sur le revenu (IR) sur les souscriptions au capital des PME, dite « Réduction Madelin »
 metadata:
-  short_label: Souscription de PME
+  short_label: « Réduction Madelin »
   label_en: Small Firms Capital Subscription (PME)
   order:
-  - seuil_tpe
-  - seuil
   - taux
+  - taux25
+  - seuil
+  - seuil_tpe
   - taux18
   - taux22
-  - taux25
+  documentation: |
+    https://entreprendre.service-public.fr/vosdroits/F37091

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/index.yaml
@@ -1,6 +1,6 @@
-description: Réduction d'impôt sur le revenu (IR) sur les souscriptions au capital des PME, dite « Réduction Madelin »
+description: Réduction d'impôt sur le revenu (IR) sur les souscriptions au capital des PME, dite « Réduction Madelin IR-PME »
 metadata:
-  short_label: « Réduction Madelin »
+  short_label: « Réduction Madelin IR-PME »
   label_en: Small Firms Capital Subscription (PME)
   order:
   - taux

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil.yaml
@@ -1,4 +1,4 @@
-description: Seuil de la réduction d'impôt sur les souscriptions en numéraire au capital initial ou aux augmentations de capital de sociétés
+description: Plafond des versements, pour une personne célibataire, veuve, ou divorcé, ouvrant droit à la réduction d'impôt sur le revenu (IR) sur les souscriptions en numéraire au capital initial ou aux augmentations de capital de sociétés
 values:
   2001-01-01:
     value: 6000
@@ -7,7 +7,7 @@ values:
   2023-03-12:
     value: 50000
 metadata:
-  short_label: Seuil de souscription en numéraire au capital de sociétés
+  short_label: Plafond des versements pour célibataire, veuf ou divorcé
   last_value_still_valid_on: "2024-04-26"
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil.yaml
@@ -4,7 +4,7 @@ values:
     value: 6000
   2002-01-01:
     value: 20000
-  2023-03-12:
+  2012-01-01:
     value: 50000
 metadata:
   short_label: Plafond des versements pour célibataire, veuf ou divorcé
@@ -19,7 +19,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006303140/2003-08-31/
     - title: Article 199 terdecies-0 A, II, du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000021629212/2010-01-01/
-    2023-03-12:
+    2012-01-01:
       title: Article 199 terdecies-0 A, II, du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000021629212/2023-10-17/
 documentation: Seuil pour les contribuables célibataires, veufs ou divorcés. Il est doublé pour les contribuables mariés soumis à imposition commune.

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil_tpe.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil_tpe.yaml
@@ -12,4 +12,9 @@ metadata:
     2009-01-01:
       title: Article 199 terdecies-0 A, II bis, du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000021629212/2010-01-01/
-documentation: Seuil pour les contribuables célibataires, veufs ou divorcés. Il est doublé pour les contribuables mariés soumis à imposition commune.
+    2012-01-01:
+      title: Article 199 terdecies-0 A, II bis, du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000025074039/2012-01-01/
+documentation: |-
+  Seuil pour les contribuables célibataires, veufs ou divorcés. Il est doublé pour les contribuables mariés soumis à imposition commune.
+  A partir du 1er janvier 2012 l'article II bis de Article 199 terdecies-0 A est abrogé.

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil_tpe.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil_tpe.yaml
@@ -1,9 +1,10 @@
-description: Seuil de la réduction d'impôt sur les souscriptions en numéraire au capital initial ou aux augmentations de capital de sociétés
+description: Plafond des versements, pour une personne célibataire, veuve, ou divorcé, ouvrant droit à la réduction d'impôt sur le revenu (IR) sur les souscriptions en numéraire au capital initial ou aux augmentations de capital de Très Petites Entreprises
 values:
   2009-01-01:
     value: 50000
 metadata:
-  last_value_still_valid_on: "2024-04-26"
+  short_label: Plafond des versements pour célibataire, veuf ou divorcé, pour les TPE
+  last_value_still_valid_on: "2024-11-18"
   unit: currency_next_year
   reference:
     2009-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil_tpe.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil_tpe.yaml
@@ -2,6 +2,8 @@ description: Plafond des versements, pour une personne célibataire, veuve, ou d
 values:
   2009-01-01:
     value: 50000
+  2012-01-01:
+    value: null
 metadata:
   short_label: Plafond des versements pour célibataire, veuf ou divorcé, pour les TPE
   last_value_still_valid_on: "2024-11-18"

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux.yaml
@@ -1,4 +1,4 @@
-description: Taux
+description: Taux de la réduction d'impôt sur le revenu (IR) sur les versements  effectués au titre de souscriptions en numéraire au capital initial ou aux augmentations de capital de sociétés
 values:
   1994-01-01:
     value: 0.25
@@ -7,7 +7,8 @@ values:
   2012-01-01:
     value: 0.18
 metadata:
-  last_value_still_valid_on: "2023-02-03"
+  short_label: Taux de la réduction d'impôt
+  last_value_still_valid_on: "2024-11-18"
   unit: /1
   reference:
     1994-01-01:
@@ -17,7 +18,8 @@ metadata:
       title: Article 199 terdecies-0 A, I du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000025074039/2012-01-01/
     2012-01-01:
-    - title: Décret n° 2012-547 du 23/04/2012, Art. 1, F, 1º
-      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000025743489
     - title: Article 199 terdecies-0 A, I du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000026948386/2013-01-01/
+    - title: Décret n° 2012-547 du 23/04/2012, Art. 1, F, 1º
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000025743489
+

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux18.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux18.yaml
@@ -1,8 +1,9 @@
-description: Taux de la réduction d'impôt sur le revenu (IR) sur les versements  effectués au titre de souscriptions en numéraire au capital initial ou aux augmentations de capital de sociétés, dans sa version depuis 2012
+description: Taux de la réduction d'impôt sur le revenu (IR) sur les versements  effectués au titre de souscriptions en numéraire au capital initial ou aux augmentations de capital de sociétés, dans sa version depuis 2012 (case 7CI)
 values:
   2012-01-01:
     value: 0.18
 metadata:
+  short_label: Taux de la réduction d’impôt pour les versements PME et ESUS effectués du 01.01.2023 au 11.03.2023 (case 7CI)
   unit: /1
   reference:
     2012-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux18.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux18.yaml
@@ -1,4 +1,4 @@
-description: Taux 18%
+description: Taux de la réduction d'impôt sur le revenu (IR) sur les versements  effectués au titre de souscriptions en numéraire au capital initial ou aux augmentations de capital de sociétés, dans sa version depuis 2012
 values:
   2012-01-01:
     value: 0.18

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux22.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux22.yaml
@@ -1,4 +1,4 @@
-description: Taux 22%
+description: Taux de la réduction d'impôt sur le revenu (IR) sur les versements  effectués au titre de souscriptions en numéraire au capital initial ou aux augmentations de capital de sociétés, dans sa version entre 2011 et 2012
 values:
   2011-01-01:
     value: 0.22

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux25.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux25.yaml
@@ -1,8 +1,9 @@
-description: Taux 25%
+description: Taux de la réduction d'impôt sur le revenu (IR) sur versements de souscriptions au capital d'entreprises solidaires d'utilité publique (ESUS), entre le 28 juin 2024 et le 31 décembre 2025
 values:
   1994-01-01:
     value: 0.25
 metadata:
+  short_label: Taux de la réduction pour entreprises solidaires d'utilité publique (ESUS)
   unit: /1
   reference:
     1994-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux25.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux25.yaml
@@ -1,9 +1,9 @@
-description: Taux de la réduction d'impôt sur le revenu (IR) sur versements de souscriptions au capital d'entreprises solidaires d'utilité publique (ESUS), entre le 28 juin 2024 et le 31 décembre 2025
+description: Taux de la réduction d'impôt sur le revenu (IR) sur versements de souscriptions au capital d'entreprises solidaires d'utilité publique (ESUS), entre le 28 juin 2024 et le 31 décembre 2025 (case 7CH)
 values:
   1994-01-01:
     value: 0.25
 metadata:
-  short_label: Taux de la réduction pour entreprises solidaires d'utilité publique (ESUS)
+  short_label: Taux de la réduction pour les versements PME et ESUS effectués du 12.03.2023 au 31.12.2023 (case 7CH)
   unit: /1
   reference:
     1994-01-01:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.6.1"
+version = "169.7.0"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Évolution intermédiaire du système socio-fiscal.
* Périodes concernées : toutes
* Zones impactées : 
    * `model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py`,
    * `parameters/impot_revenu/calcul_reductions_impots/souscriptions`,
    * `model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py`,
    * `parameters/impot_revenu/calcul_impot_revenu/pv/bspce/taux_moins_3_ans.yaml`,
* Détails :  Réorganisation du dossier concernant la réduction Madelin IR-PME des versements pour souscription au capital des PME.
  - Ajoute label et références
  - Utilise dans les formules les derniers paramètres plus génériques
  - Met à jour la variable de la case 7CQ qui change d'objet à partir de 2012