### PR TITLE
Met fin à la réduction d'impôt sur la réhabilitation de résidences de tourisme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 169.7.1 [2394](https://github.com/openfisca/openfisca-france/pull/2394)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 31/12/2023.
+* Zones impactées : 
+    * `model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py`
+* Détails :
+  - Met fin à la réduction d'impôt sur la réhabilitation de résidences de tourisme, abrogée en 2023 ([Article 199 decies G bis](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000033781921/))
+
+
 ### 169.7.0 [2390](https://github.com/openfisca/openfisca-france/pull/2390)
 
 * Évolution intermédiaire du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py
@@ -3562,7 +3562,7 @@ class rehab(Variable):
     value_type = float
     entity = FoyerFiscal
     label = "Réduction d'impôt pour travaux de réhabilitation des résidences de tourisme"
-    reference = 'https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000033781921&cidTexte=LEGITEXT000006069577&categorieLien=id&dateTexte=20170101'
+    reference = 'https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000033781921/'
     definition_period = YEAR
     end = '2023-12-31'
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py
@@ -3564,6 +3564,7 @@ class rehab(Variable):
     label = "Réduction d'impôt pour travaux de réhabilitation des résidences de tourisme"
     reference = 'https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000033781921&cidTexte=LEGITEXT000006069577&categorieLien=id&dateTexte=20170101'
     definition_period = YEAR
+    end = '2023-12-31'
 
     def formula_2017_01_01(foyer_fiscal, period, parameters):
         '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.7.0"
+version = "169.7.1"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 31/12/2023.
* Zones impactées : `model/prelevements_obligatoires/impot_revenu/reductions_impot_plafonnees.py`.
* Détails :
  - Met fin à la réduction d'impôt sur la réhabilitation de résidences de tourisme, abrogée en 2023 ([Article 199 decies G bis](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000033781921/))

- - - -

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).

- - - -