### PR TITLE
Simplifie la formule de l'impôt sur le revenu restant à payer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 169.11.0 [2397](https://github.com/openfisca/openfisca-france/pull/2397)
+
+* Changement mineur. 
+* Périodes concernées : toutes
+* Zones impactées : 
+  - `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`
+* Détails :
+  - La formule de calcul de l'impôt restant à payer contient des termes à zéro qui peuvent être supprimés sans modifier le résultat (simplification de la formule)
+
+
 ## 169.10.0 [2396](https://github.com/openfisca/openfisca-france/pull/2396)
 
 * Évolution du système socio-fiscal. 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2329,16 +2329,15 @@ class impot_revenu_restant_a_payer(Variable):
         impots_totaux_avant_imputations = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
 
         return (
-            (impots_totaux_avant_imputations > parameters_recouvrement.min_avant_credits_impots) *
-            (((pre_result <= 0) + (pre_result >= parameters_recouvrement.min_apres_credits_impots)) *
-             (- result)
-             )
-            +
-            (impots_totaux_avant_imputations <= parameters_recouvrement.min_avant_credits_impots) *
-            ((pre_result < 0) *
-             (-result)
-             )
-            )
+            (impots_totaux_avant_imputations > parameters_recouvrement.min_avant_credits_impots) * (
+                ((pre_result <= 0) + (pre_result >= parameters_recouvrement.min_apres_credits_impots))
+                * (- result)
+                )
+            + (impots_totaux_avant_imputations <= parameters_recouvrement.min_avant_credits_impots) * (
+                (pre_result < 0)
+                * (-result)
+                )
+        )
 
 
 class foyer_impose(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2329,16 +2329,16 @@ class impot_revenu_restant_a_payer(Variable):
         impots_totaux_avant_imputations = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
 
         return (
-            (impots_totaux_avant_imputations > parameters_recouvrement.min_avant_credits_impots) * 
+            (impots_totaux_avant_imputations > parameters_recouvrement.min_avant_credits_impots) *
             (((pre_result <= 0) + (pre_result >= parameters_recouvrement.min_apres_credits_impots)) *
              (- result)
-            )
-            + 
-            (impots_totaux_avant_imputations <= parameters_recouvrement.min_avant_credits_impots) * 
+             )
+            +
+            (impots_totaux_avant_imputations <= parameters_recouvrement.min_avant_credits_impots) *
             ((pre_result < 0) *
              (-result)
+             )
             )
-        )
 
 
 class foyer_impose(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2337,7 +2337,7 @@ class impot_revenu_restant_a_payer(Variable):
                 (pre_result < 0)
                 * (-result)
                 )
-        )
+                )
 
 
 class foyer_impose(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2329,22 +2329,16 @@ class impot_revenu_restant_a_payer(Variable):
         impots_totaux_avant_imputations = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
 
         return (
-            (impots_totaux_avant_imputations > parameters_recouvrement.min_avant_credits_impots) * (
-                (pre_result < parameters_recouvrement.min_apres_credits_impots)
-                * (result > 0)
-                * result
-                * 0
-                + ((pre_result <= 0) + (pre_result >= parameters_recouvrement.min_apres_credits_impots))
-                * (- result)
-                )
-            + (impots_totaux_avant_imputations <= parameters_recouvrement.min_avant_credits_impots) * (
-                (pre_result < 0)
-                * (-result)
-                + (pre_result >= 0)
-                * 0
-                * result
-                )
+            (impots_totaux_avant_imputations > parameters_recouvrement.min_avant_credits_impots) * 
+            (((pre_result <= 0) + (pre_result >= parameters_recouvrement.min_apres_credits_impots)) *
+             (- result)
             )
+            + 
+            (impots_totaux_avant_imputations <= parameters_recouvrement.min_avant_credits_impots) * 
+            ((pre_result < 0) *
+             (-result)
+            )
+        )
 
 
 class foyer_impose(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2337,7 +2337,7 @@ class impot_revenu_restant_a_payer(Variable):
                 (pre_result < 0)
                 * (-result)
                 )
-                )
+            )
 
 
 class foyer_impose(Variable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.10.0"
+version = "169.11.0"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`.
* Détails :
  - La formule de calcul de l'impôt restant à payer contient des termes à zéro qui peuvent être supprimés sans modifier le résultat (simplification de la formule)

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -
