### PR TITLE
Simplification de la formule de l'impôt sur le revenu

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Install package
         shell: pwsh
         run: mamba install --channel ./conda-bld --channel openfisca openfisca-france
+      - name: DEBUG
+        shell: pwsh
+        run: python -V
       - name: Test openfisca-france conda package
         shell: pwsh
         run: openfisca test tests/formulas/irpp.yaml

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -77,12 +77,6 @@ jobs:
       - name: Install package
         shell: pwsh
         run: mamba install --channel ./conda-bld --channel openfisca openfisca-france
-      - name: Test python version and pkg_resources
-        shell: pwsh
-        run: |
-          python -V
-          which python
-          python -c "import pkg_resources"
       - name: Test openfisca-france conda package
         shell: pwsh
         run: openfisca test tests/formulas/irpp.yaml

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -79,7 +79,11 @@ jobs:
         run: mamba install --channel ./conda-bld --channel openfisca openfisca-france
       - name: DEBUG
         shell: pwsh
-        run: python -V
+        run: |
+          python -V
+          which python
+          python -c "import openfisca_france; print(openfisca_france.__version__)"
+          python -c "import pkg_resources"
       - name: Test openfisca-france conda package
         shell: pwsh
         run: openfisca test tests/formulas/irpp.yaml

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -77,12 +77,11 @@ jobs:
       - name: Install package
         shell: pwsh
         run: mamba install --channel ./conda-bld --channel openfisca openfisca-france
-      - name: DEBUG
+      - name: Test python version and pkg_resources
         shell: pwsh
         run: |
           python -V
           which python
-          python -c "import openfisca_france; print(openfisca_france.__version__)"
           python -c "import pkg_resources"
       - name: Test openfisca-france conda package
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
-<<<<<<< HEAD
+### 169.14.0 [2401](https://github.com/openfisca/openfisca-france/pull/2401)
+
+* Amélioration technique et métier de la formule de l'impôt sur le revenu restant à payer
+* Périodes concernées : toutes.
+* Zones impactées : 
+ - `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`.
+ - `openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py`.
+ - `tests/calculateur_impots/yaml/pv_pfu.yaml`.
+ - `tests/calculateur_impots/yaml/rvcm.yaml`.
+ - `tests/formulas/irpp_prets_participatifs.yaml`.
+ - `tests/formulas/revenu_disponible.yaml`.
+ - `tests/formulas/taxation_capital.yaml`.
+ - `tests/impot_revenu/pfu_bareme.yaml`.
+* Détails :
+  - Améliore la lisibilité de la formule de l'impôt sur le revenu
+  - Objectif : séparer de la formule `impot_revenu_restant_a_payer` les complexités inhérentes au seuils de mise en recouvrement de l'iR (61 euros et 12 euros). Par conséquent cette formule est simplifiée sous la forme de `impot_revenu_restant_a_payer` = `impôts divers` - `correction seuils recouvrement`. Deux formules sont créées en complément : la première permettant de faire la somme des divers impôts, la seconde prenant en compte les conditions d'application des seuils de mise en recouvrement pour calculer si il y a un montant à déduire pour rapporter l'impôt à 0 euros si les seuils sont dépassés.
+
 ### 169.13.2 [2409](https://github.com/openfisca/openfisca-france/pull/2409)
 
 - Évolution du système socio-fiscal.
@@ -9,8 +25,6 @@
 - Détails :
   - Ajoute les revalorisations du 1e janvier 2025
 
-=======
->>>>>>> 6b32e77dd (bump)
 ### 169.13.1 [2405](https://github.com/openfisca/openfisca-france/pull/2405)
 
 - Évolution du système socio-fiscal. Changement mineur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+<<<<<<< HEAD
 ### 169.13.2 [2409](https://github.com/openfisca/openfisca-france/pull/2409)
 
 - Évolution du système socio-fiscal.
@@ -8,6 +9,8 @@
 - Détails :
   - Ajoute les revalorisations du 1e janvier 2025
 
+=======
+>>>>>>> 6b32e77dd (bump)
 ### 169.13.1 [2405](https://github.com/openfisca/openfisca-france/pull/2405)
 
 - Évolution du système socio-fiscal. Changement mineur.
@@ -17,19 +20,6 @@
   - Fait passer date de réforme PPA à octobre 2018, date où les salaires concernés par les nouveaux calculs de PA débutent (c'est explicite dans le décret associé).
 
 ## 169.13.0 [2399](https://github.com/openfisca/openfisca-france/pull/2399)
-=======
-### 169.14.0 [2401](https://github.com/openfisca/openfisca-france/pull/2401)
-
-- Amélioration technique et métier de la formule de l'impôt sur le revenu restant à payer.
-- Périodes concernées : toutes.
-- Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`.
-- Détails :
-  - Améliore la lisibilité de la formule de l'impôt sur le revenu.
-  - Objectif : séparer de la formule impot_revenu_restant_a_payer les complexités inhérentes au seuils de mise en recouvrement de l'IR (61 euros et 12 euros). Par conséquent cette formule est simplifiée sous la forme de impot_revenu_restant_a_payer = impôts divers - correction seuils recouvrement. Deux formules sont créées en complément : la première permettant de faire la somme des divers impôts, la seconde prenant en compte les conditions d'application des seuils de mise en recouvrement pour calculer si il y a un montant à déduire pour rapporter l'impôt à 0 euros si les seuils sont dépassés.
-
-
-### 169.13.0 [2399](https://github.com/openfisca/openfisca-france/pull/2399)
->>>>>>> a6b2baab2 (modifie changelog)
 
 - Évolution du système socio-fiscal.
 - Périodes concernées : à partir du 01/10/2024.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
  - `tests/impot_revenu/pfu_bareme.yaml`.
 * Détails :
   - Améliore la lisibilité de la formule de l'impôt sur le revenu
-  - Objectif : séparer de la formule `impot_revenu_restant_a_payer` les complexités inhérentes au seuils de mise en recouvrement de l'iR (61 euros et 12 euros). Par conséquent cette formule est simplifiée sous la forme de `impot_revenu_restant_a_payer` = `impôts divers` - `correction seuils recouvrement`. Deux formules sont créées en complément : la première permettant de faire la somme des divers impôts, la seconde prenant en compte les conditions d'application des seuils de mise en recouvrement pour calculer si il y a un montant à déduire pour rapporter l'impôt à 0 euros si les seuils sont dépassés.
+  - Objectif : séparer de la formule `impot_revenu_restant_a_payer` les complexités inhérentes au seuils de mise en recouvrement de l'IR (61 euros et 12 euros). Par conséquent cette formule est simplifiée sous la forme de `impot_revenu_restant_a_payer` = `impôts divers` - `correction seuils recouvrement`. Deux formules sont créées en complément : la première permettant de faire la somme des divers impôts, la seconde prenant en compte les conditions d'application des seuils de mise en recouvrement pour calculer si il y a un montant à déduire pour rapporter l'impôt à 0 euros si les seuils sont dépassés.
 
 ### 169.13.2 [2409](https://github.com/openfisca/openfisca-france/pull/2409)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@
   - Fait passer date de réforme PPA à octobre 2018, date où les salaires concernés par les nouveaux calculs de PA débutent (c'est explicite dans le décret associé).
 
 ## 169.13.0 [2399](https://github.com/openfisca/openfisca-france/pull/2399)
+=======
+### 169.14.0 [2401](https://github.com/openfisca/openfisca-france/pull/2401)
+
+- Amélioration technique et métier de la formule de l'impôt sur le revenu restant à payer.
+- Périodes concernées : toutes.
+- Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`.
+- Détails :
+  - Améliore la lisibilité de la formule de l'impôt sur le revenu.
+  - Objectif : séparer de la formule impot_revenu_restant_a_payer les complexités inhérentes au seuils de mise en recouvrement de l'IR (61 euros et 12 euros). Par conséquent cette formule est simplifiée sous la forme de impot_revenu_restant_a_payer = impôts divers - correction seuils recouvrement. Deux formules sont créées en complément : la première permettant de faire la somme des divers impôts, la seconde prenant en compte les conditions d'application des seuils de mise en recouvrement pour calculer si il y a un montant à déduire pour rapporter l'impôt à 0 euros si les seuils sont dépassés.
+
+
+### 169.13.0 [2399](https://github.com/openfisca/openfisca-france/pull/2399)
+>>>>>>> a6b2baab2 (modifie changelog)
 
 - Évolution du système socio-fiscal.
 - Périodes concernées : à partir du 01/10/2024.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2324,17 +2324,17 @@ class impot_revenu_restant_a_payer(Variable):
         prelevement_forfaitaire_liberatoire = foyer_fiscal('prelevement_forfaitaire_liberatoire', period)
 
         parameters_recouvrement = parameters(period).impot_revenu.calcul_impot_revenu.recouvrement
-        seuil_avant = parameters_recouvrement.min_avant_credits_impots
-        seuil_apres = parameters_recouvrement.min_apres_credits_impots
+        seuil_avant_imputation = parameters_recouvrement.min_avant_credits_impots
+        seuil_apres_imputation = parameters_recouvrement.min_apres_credits_impots
 
-        pre_result = iai - credits_impot - acomptes_ir + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
-        result = iai - credits_impot - acomptes_ir + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir
-        impots_totaux_avant_imputations = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
+        impots_avant_imputations = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
+        impots_apres_imputations = impots_avant_imputations - credits_impot - acomptes_ir 
+        impots_nets = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - credits_impot - acomptes_ir 
+        
+        condition_1 = (impots_avant_imputations > seuil_avant_imputation) * ((impots_apres_imputations <= 0) + (impots_apres_imputations >= seuil_apres_imputation))
+        condition_2 = (impots_avant_imputations <= seuil_avant_imputation) * (impots_apres_imputations < 0)
 
-        condition_1 = (impots_totaux_avant_imputations > seuil_avant) * ((pre_result <= 0) + (pre_result >= seuil_apres))
-        condition_2 = (impots_totaux_avant_imputations <= seuil_avant) * (pre_result < 0)
-
-        return (condition_1 + condition_2) * (-result)
+        return (condition_1 + condition_2) * (-impots_nets)
 
 
 class foyer_impose(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2311,8 +2311,8 @@ class montant_correction_ir_seuils_recouvrement(Variable):
         credits_impot = foyer_fiscal('credits_impot', period)
         acomptes_ir = foyer_fiscal('acomptes_ir', period)
         cehr = foyer_fiscal('contribution_exceptionnelle_hauts_revenus', period)
-        pfu = - foyer_fiscal('prelevement_forfaitaire_unique_ir', period)
-        pfl = - foyer_fiscal('prelevement_forfaitaire_liberatoire', period)
+        pfu = foyer_fiscal('prelevement_forfaitaire_unique_ir', period)
+        pfl = foyer_fiscal('prelevement_forfaitaire_liberatoire', period)
         '''
         Le prélèvement forfaitaire libératoire a déjà été payé il ne doit donc pas être compté dans l'impôt restant à payer.
         En revanche, il compte dans le calcul du seuil de recouvrement.
@@ -2322,8 +2322,8 @@ class montant_correction_ir_seuils_recouvrement(Variable):
         seuil_avant_imputations = parameters_recouvrement.min_avant_credits_impots
         seuil_apres_imputations = parameters_recouvrement.min_apres_credits_impots
 
-        impots_totaux_avant_imputations = iai + cehr + pfu + pfl
-        impots_totaux_apres_imputations = iai + cehr + pfu + pfl - credits_impot - acomptes_ir
+        impots_totaux_avant_imputations = iai + cehr - pfu - pfl
+        impots_totaux_apres_imputations = iai + cehr - pfu - pfl - credits_impot - acomptes_ir
 
         condition_1 = (impots_totaux_avant_imputations > seuil_avant_imputations) * ((impots_totaux_apres_imputations > 0) * (impots_totaux_apres_imputations < seuil_apres_imputations))
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2359,7 +2359,7 @@ class impot_revenu_restant_a_payer(Variable):
         correction_seuils_recouvrement = foyer_fiscal('montant_correction_ir_seuils_recouvrement', period)
         impots_nets = -(iai + cehr - pfu - credits_impot - acomptes_ir)
 
-        return  (impots_nets - correction_seuils_recouvrement)
+        return (impots_nets - correction_seuils_recouvrement)
 
 
 class foyer_impose(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2324,15 +2324,15 @@ class impot_revenu_restant_a_payer(Variable):
         pfl = foyer_fiscal('prelevement_forfaitaire_liberatoire', period)
 
         parameters_recouvrement = parameters(period).impot_revenu.calcul_impot_revenu.recouvrement
-        seuil_avant_imputation = parameters_recouvrement.min_avant_credits_impots
-        seuil_apres_imputation = parameters_recouvrement.min_apres_credits_impots
+        seuil_avant_imputations = parameters_recouvrement.min_avant_credits_impots
+        seuil_apres_imputations = parameters_recouvrement.min_apres_credits_impots
 
         impots_avant_imputations = iai + cehr - pfu - pfl
         impots_apres_imputations = impots_avant_imputations - credits_impot - acomptes_ir
         impots_nets = iai + cehr - pfu - credits_impot - acomptes_ir
 
         condition_1 = (impots_apres_imputations < 0)
-        condition_2 = (impots_avant_imputations > seuil_avant_imputation) * (impots_apres_imputations >= seuil_apres_imputation)
+        condition_2 = (impots_avant_imputations > seuil_avant_imputations) * (impots_apres_imputations >= seuil_apres_imputations)
 
         return (condition_1 + condition_2) * (-impots_nets)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2345,14 +2345,9 @@ class correction_ir_seuils_recouvrement(Variable):
         seuil_avant_imputations = parameters_recouvrement.min_avant_credits_impots
         seuil_apres_imputations = parameters_recouvrement.min_apres_credits_impots
 
-<<<<<<< HEAD
-        impots_totaux_avant_imputations = iai + cehr - pfu - pfl
-        impots_totaux_apres_imputations = iai + cehr - pfu - pfl - credits_impot - acomptes_ir
-<<<<<<< HEAD
-=======
+
         impots_totaux_avant_imputations = iai + cehr + pfu - pfl
         impots_totaux_apres_imputations = iai + cehr + pfu - pfl - credits_impot - acomptes_ir
->>>>>>> 0e0d7b571 (change le signe du pfu)
 
         condition_1 = (impots_totaux_avant_imputations > seuil_avant_imputations) * ((impots_totaux_apres_imputations <= 0) + (impots_totaux_apres_imputations >= seuil_apres_imputations))
         condition_2 = (impots_totaux_avant_imputations <= seuil_avant_imputations) * (impots_totaux_apres_imputations < 0)
@@ -2374,14 +2369,6 @@ class impot_revenu_restant_a_payer(Variable):
         correction_seuils_recouvrement = foyer_fiscal('correction_ir_seuils_recouvrement', period)
 
         return (impots_avant_seuils_recouvrement - correction_seuils_recouvrement)
-=======
-        impots_nets = iai + cehr - pfu - credits_impot - acomptes_ir
-
-        condition_1 = (impots_totaux_avant_imputations > seuil_avant_imputations) * ((impots_totaux_apres_imputations <= 0) + (impots_totaux_apres_imputations >= seuil_apres_imputations))
-        condition_2 = (impots_totaux_avant_imputations <= seuil_avant_imputations) * (impots_totaux_apres_imputations < 0)
-
-        return (condition_1 + condition_2) * (-impots_nets)
->>>>>>> b212ca7c1 (revient sur la précédente version des conditions)
 
 
 class foyer_impose(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2324,23 +2324,17 @@ class impot_revenu_restant_a_payer(Variable):
         prelevement_forfaitaire_liberatoire = foyer_fiscal('prelevement_forfaitaire_liberatoire', period)
 
         parameters_recouvrement = parameters(period).impot_revenu.calcul_impot_revenu.recouvrement
-        seuil_avant_credits_impots = parameters_recouvrement.min_avant_credits_impots
-        seuil_apres_credits_impots = parameters_recouvrement.min_apres_credits_impots
+        seuil_avant = parameters_recouvrement.min_avant_credits_impots
+        seuil_apres = parameters_recouvrement.min_apres_credits_impots
 
         pre_result = iai - credits_impot - acomptes_ir + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
         result = iai - credits_impot - acomptes_ir + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir
         impots_totaux_avant_imputations = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
 
-        return (
-            (impots_totaux_avant_imputations > seuil_avant_credits_impots) * (
-                ((pre_result <= 0) + (pre_result >= seuil_apres_credits_impots))
-                * (- result)
-                )
-            + (impots_totaux_avant_imputations <= seuil_avant_credits_impots) * (
-                (pre_result < 0)
-                * (-result)
-                )
-            )
+        condition_1 = (impots_totaux_avant_imputations > seuil_avant) * ((pre_result <= 0) + (pre_result >= seuil_apres))
+        condition_2 = (impots_totaux_avant_imputations <= seuil_avant) * (pre_result < 0)
+
+        return (condition_1 + condition_2) * (-result)
 
 
 class foyer_impose(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2322,18 +2322,21 @@ class impot_revenu_restant_a_payer(Variable):
         contribution_exceptionnelle_hauts_revenus = foyer_fiscal('contribution_exceptionnelle_hauts_revenus', period)
         prelevement_forfaitaire_unique_ir = foyer_fiscal('prelevement_forfaitaire_unique_ir', period)
         prelevement_forfaitaire_liberatoire = foyer_fiscal('prelevement_forfaitaire_liberatoire', period)
+
         parameters_recouvrement = parameters(period).impot_revenu.calcul_impot_revenu.recouvrement
+        seuil_avant_credits_impots = parameters_recouvrement.min_avant_credits_impots
+        seuil_apres_credits_impots = parameters_recouvrement.min_apres_credits_impots
 
         pre_result = iai - credits_impot - acomptes_ir + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
         result = iai - credits_impot - acomptes_ir + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir
         impots_totaux_avant_imputations = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
 
         return (
-            (impots_totaux_avant_imputations > parameters_recouvrement.min_avant_credits_impots) * (
-                ((pre_result <= 0) + (pre_result >= parameters_recouvrement.min_apres_credits_impots))
+            (impots_totaux_avant_imputations > seuil_avant_credits_impots) * (
+                ((pre_result <= 0) + (pre_result >= seuil_apres_credits_impots))
                 * (- result)
                 )
-            + (impots_totaux_avant_imputations <= parameters_recouvrement.min_avant_credits_impots) * (
+            + (impots_totaux_avant_imputations <= seuil_avant_credits_impots) * (
                 (pre_result < 0)
                 * (-result)
                 )

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2356,8 +2356,10 @@ class impot_revenu_restant_a_payer(Variable):
         acomptes_ir = foyer_fiscal('acomptes_ir', period)
         cehr = foyer_fiscal('contribution_exceptionnelle_hauts_revenus', period)
         pfu = foyer_fiscal('prelevement_forfaitaire_unique_ir', period)
-        correction_seuils_recouvrement = foyer_fiscal('montant_correction_ir_seuils_recouvrement', period)
+
         impots_nets = -(iai + cehr - pfu - credits_impot - acomptes_ir)
+
+        correction_seuils_recouvrement = foyer_fiscal('montant_correction_ir_seuils_recouvrement', period)
 
         return (impots_nets - correction_seuils_recouvrement)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2347,6 +2347,7 @@ class correction_ir_seuils_recouvrement(Variable):
 
         impots_totaux_avant_imputations = iai + cehr - pfu - pfl
         impots_totaux_apres_imputations = iai + cehr - pfu - pfl - credits_impot - acomptes_ir
+<<<<<<< HEAD
 
         condition_1 = (impots_totaux_avant_imputations > seuil_avant_imputations) * ((impots_totaux_apres_imputations <= 0) + (impots_totaux_apres_imputations >= seuil_apres_imputations))
         condition_2 = (impots_totaux_avant_imputations <= seuil_avant_imputations) * (impots_totaux_apres_imputations < 0)
@@ -2368,6 +2369,14 @@ class impot_revenu_restant_a_payer(Variable):
         correction_seuils_recouvrement = foyer_fiscal('correction_ir_seuils_recouvrement', period)
 
         return (impots_avant_seuils_recouvrement - correction_seuils_recouvrement)
+=======
+        impots_nets = iai + cehr - pfu - credits_impot - acomptes_ir
+
+        condition_1 = (impots_totaux_avant_imputations > seuil_avant_imputations) * ((impots_totaux_apres_imputations <= 0) + (impots_totaux_apres_imputations >= seuil_apres_imputations))
+        condition_2 = (impots_totaux_avant_imputations <= seuil_avant_imputations) * (impots_totaux_apres_imputations < 0)
+        
+        return (condition_1 + condition_2) * (-impots_nets)
+>>>>>>> b212ca7c1 (revient sur la précédente version des conditions)
 
 
 class foyer_impose(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2324,14 +2324,14 @@ class montant_correction_ir_seuils_recouvrement(Variable):
 
         impots_totaux_avant_imputations = iai + cehr - pfu - pfl
         impots_totaux_apres_imputations = iai + cehr - pfu - pfl - credits_impot - acomptes_ir
+        montant_correction = iai + cehr - pfu - credits_impot - acomptes_ir
 
         condition_1 = (impots_totaux_avant_imputations > seuil_avant_imputations) * ((impots_totaux_apres_imputations <= 0) + (impots_totaux_apres_imputations >= seuil_apres_imputations))
-
         condition_2 = (impots_totaux_avant_imputations <= seuil_avant_imputations) * (impots_totaux_apres_imputations < 0)
 
-        condition_correction = ~(condition_1 + condition_2)
+        condition_correction = (1 - (condition_1 + condition_2))
 
-        return condition_correction * (iai + cehr + pfu - credits_impot - acomptes_ir)
+        return condition_correction * montant_correction
 
 
 class impot_revenu_restant_a_payer(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2348,10 +2348,10 @@ class correction_ir_seuils_recouvrement(Variable):
         impots_totaux_avant_imputations = iai + cehr + pfu - pfl
         impots_totaux_apres_imputations = iai + cehr + pfu - pfl - credits_impot - acomptes_ir
 
-        condition_1 = (impots_totaux_avant_imputations > seuil_avant_imputations) * ((impots_totaux_apres_imputations <= 0) + (impots_totaux_apres_imputations >= seuil_apres_imputations))
-        condition_2 = (impots_totaux_avant_imputations <= seuil_avant_imputations) * (impots_totaux_apres_imputations < 0)
+        condition_1 = (impots_totaux_avant_imputations <= seuil_avant_imputations) * (impots_totaux_apres_imputations > 0)
+        condition_2 = (impots_totaux_avant_imputations > seuil_avant_imputations) * (impots_totaux_apres_imputations > 0) * (impots_totaux_apres_imputations <= seuil_apres_imputations)
 
-        condition_correction_seuils_mise_recouvrement = ~(condition_1 | condition_2)
+        condition_correction_seuils_mise_recouvrement = (condition_1 | condition_2)
 
         return condition_correction_seuils_mise_recouvrement * impots_avant_seuils_mise_recouvrement
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2319,17 +2319,17 @@ class impot_revenu_restant_a_payer(Variable):
         iai = foyer_fiscal('iai', period)
         credits_impot = foyer_fiscal('credits_impot', period)
         acomptes_ir = foyer_fiscal('acomptes_ir', period)
-        contribution_exceptionnelle_hauts_revenus = foyer_fiscal('contribution_exceptionnelle_hauts_revenus', period)
-        prelevement_forfaitaire_unique_ir = foyer_fiscal('prelevement_forfaitaire_unique_ir', period)
-        prelevement_forfaitaire_liberatoire = foyer_fiscal('prelevement_forfaitaire_liberatoire', period)
+        cehr = foyer_fiscal('contribution_exceptionnelle_hauts_revenus', period)
+        pfu = foyer_fiscal('prelevement_forfaitaire_unique_ir', period)
+        pfl = foyer_fiscal('prelevement_forfaitaire_liberatoire', period)
 
         parameters_recouvrement = parameters(period).impot_revenu.calcul_impot_revenu.recouvrement
         seuil_avant_imputation = parameters_recouvrement.min_avant_credits_impots
         seuil_apres_imputation = parameters_recouvrement.min_apres_credits_impots
 
-        impots_avant_imputations = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
+        impots_avant_imputations = iai + cehr - pfu - pfl
         impots_apres_imputations = impots_avant_imputations - credits_impot - acomptes_ir
-        impots_nets = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - credits_impot - acomptes_ir
+        impots_nets = iai + cehr - pfu - credits_impot - acomptes_ir
 
         condition_1 = (impots_apres_imputations < 0)
         condition_2 = (impots_avant_imputations > seuil_avant_imputation) * (impots_apres_imputations >= seuil_apres_imputation)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2325,11 +2325,11 @@ class montant_correction_ir_seuils_recouvrement(Variable):
         impots_totaux_avant_imputations = iai + cehr - pfu - pfl
         impots_totaux_apres_imputations = iai + cehr - pfu - pfl - credits_impot - acomptes_ir
 
-        condition_1 = (impots_totaux_avant_imputations > seuil_avant_imputations) * ((impots_totaux_apres_imputations > 0) * (impots_totaux_apres_imputations < seuil_apres_imputations))
+        condition_1 = (impots_totaux_avant_imputations > seuil_avant_imputations) * ((impots_totaux_apres_imputations <= 0) + (impots_totaux_apres_imputations >= seuil_apres_imputations))
 
-        condition_2 = (impots_totaux_avant_imputations <= seuil_avant_imputations) * (impots_totaux_apres_imputations >= 0)
+        condition_2 = (impots_totaux_avant_imputations <= seuil_avant_imputations) * (impots_totaux_apres_imputations < 0)
 
-        condition_correction = (condition_1 + condition_2)
+        condition_correction = ~(condition_1 + condition_2)
 
         return condition_correction * (iai + cehr + pfu - credits_impot - acomptes_ir)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2298,6 +2298,7 @@ class contribution_exceptionnelle_hauts_revenus(Variable):
         return bareme.calc(rfr / nb_adult) * nb_adult
         # TODO: Gérer le II.-1 du lissage interannuel ? (problème de non recours)
 
+
 class montant_correction_ir_seuils_recouvrement(Variable):
     value_type = float
     entity = FoyerFiscal

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2319,7 +2319,7 @@ class impot_revenu_avant_seuils_mise_recouvrement(Variable):
         cehr = foyer_fiscal('contribution_exceptionnelle_hauts_revenus', period)
         pfu = foyer_fiscal('prelevement_forfaitaire_unique_ir', period)
 
-        return -(iai + cehr - pfu - credits_impot - acomptes_ir)
+        return -(iai + cehr + pfu - credits_impot - acomptes_ir)
 
 
 class correction_ir_seuils_recouvrement(Variable):
@@ -2345,9 +2345,14 @@ class correction_ir_seuils_recouvrement(Variable):
         seuil_avant_imputations = parameters_recouvrement.min_avant_credits_impots
         seuil_apres_imputations = parameters_recouvrement.min_apres_credits_impots
 
+<<<<<<< HEAD
         impots_totaux_avant_imputations = iai + cehr - pfu - pfl
         impots_totaux_apres_imputations = iai + cehr - pfu - pfl - credits_impot - acomptes_ir
 <<<<<<< HEAD
+=======
+        impots_totaux_avant_imputations = iai + cehr + pfu - pfl
+        impots_totaux_apres_imputations = iai + cehr + pfu - pfl - credits_impot - acomptes_ir
+>>>>>>> 0e0d7b571 (change le signe du pfu)
 
         condition_1 = (impots_totaux_avant_imputations > seuil_avant_imputations) * ((impots_totaux_apres_imputations <= 0) + (impots_totaux_apres_imputations >= seuil_apres_imputations))
         condition_2 = (impots_totaux_avant_imputations <= seuil_avant_imputations) * (impots_totaux_apres_imputations < 0)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2328,7 +2328,7 @@ class impot_revenu_restant_a_payer(Variable):
         seuil_apres_imputation = parameters_recouvrement.min_apres_credits_impots
 
         impots_avant_imputations = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
-        impots_apres_imputations = impots_avant_imputations - credits_impot - acomptes_ir 
+        impots_apres_imputations = impots_avant_imputations - credits_impot - acomptes_ir
         impots_nets = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - credits_impot - acomptes_ir
 
         condition_1 = (impots_apres_imputations < 0)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2302,7 +2302,7 @@ class contribution_exceptionnelle_hauts_revenus(Variable):
 class impot_revenu_avant_seuils_mise_recouvrement(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = "Impôt sur le revenu des personnes physiques restant à payer, après prise en compte des éventuels acomptes et avant application des seuils de mise en recouvrement"
+    label = 'Impôt sur le revenu des personnes physiques restant à payer, après prise en compte des éventuels acomptes et avant application des seuils de mise en recouvrement'
     reference = 'https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041464766'
     definition_period = YEAR
 
@@ -2325,7 +2325,7 @@ class impot_revenu_avant_seuils_mise_recouvrement(Variable):
 class correction_ir_seuils_recouvrement(Variable):
     value_type = float
     entity = FoyerFiscal
-    label = "Montant de la correction de l'impôt sur le revenu par application des seuils de mise en recouvrement"
+    label = 'Montant de la correction de l´impôt sur le revenu par application des seuils de mise en recouvrement'
     reference = 'https://bofip.impots.gouv.fr/bofip/2496-PGP.html/identifiant%3DBOI-IR-LIQ-20-20-40-20180704#Franchise_pour_les_impositi_14'
     definition_period = YEAR
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2374,7 +2374,7 @@ class impot_revenu_restant_a_payer(Variable):
 
         condition_1 = (impots_totaux_avant_imputations > seuil_avant_imputations) * ((impots_totaux_apres_imputations <= 0) + (impots_totaux_apres_imputations >= seuil_apres_imputations))
         condition_2 = (impots_totaux_avant_imputations <= seuil_avant_imputations) * (impots_totaux_apres_imputations < 0)
-        
+
         return (condition_1 + condition_2) * (-impots_nets)
 >>>>>>> b212ca7c1 (revient sur la précédente version des conditions)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2329,10 +2329,10 @@ class impot_revenu_restant_a_payer(Variable):
 
         impots_avant_imputations = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - prelevement_forfaitaire_liberatoire
         impots_apres_imputations = impots_avant_imputations - credits_impot - acomptes_ir 
-        impots_nets = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - credits_impot - acomptes_ir 
-        
-        condition_1 = (impots_avant_imputations > seuil_avant_imputation) * ((impots_apres_imputations <= 0) + (impots_apres_imputations >= seuil_apres_imputation))
-        condition_2 = (impots_avant_imputations <= seuil_avant_imputation) * (impots_apres_imputations < 0)
+        impots_nets = iai + contribution_exceptionnelle_hauts_revenus - prelevement_forfaitaire_unique_ir - credits_impot - acomptes_ir
+
+        condition_1 = (impots_apres_imputations < 0)
+        condition_2 = (impots_avant_imputations > seuil_avant_imputation) * (impots_apres_imputations >= seuil_apres_imputation)
 
         return (condition_1 + condition_2) * (-impots_nets)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2345,7 +2345,6 @@ class correction_ir_seuils_recouvrement(Variable):
         seuil_avant_imputations = parameters_recouvrement.min_avant_credits_impots
         seuil_apres_imputations = parameters_recouvrement.min_apres_credits_impots
 
-
         impots_totaux_avant_imputations = iai + cehr + pfu - pfl
         impots_totaux_apres_imputations = iai + cehr + pfu - pfl - credits_impot - acomptes_ir
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2324,7 +2324,7 @@ class montant_correction_ir_seuils_recouvrement(Variable):
 
         impots_totaux_avant_imputations = iai + cehr - pfu - pfl
         impots_totaux_apres_imputations = iai + cehr - pfu - pfl - credits_impot - acomptes_ir
-        montant_correction = iai + cehr - pfu - credits_impot - acomptes_ir
+        montant_correction = -(iai + cehr - pfu - credits_impot - acomptes_ir)
 
         condition_1 = (impots_totaux_avant_imputations > seuil_avant_imputations) * ((impots_totaux_apres_imputations <= 0) + (impots_totaux_apres_imputations >= seuil_apres_imputations))
         condition_2 = (impots_totaux_avant_imputations <= seuil_avant_imputations) * (impots_totaux_apres_imputations < 0)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2338,7 +2338,7 @@ class minimum_recouvrement_ir(Variable):
         # Appliquer les conditions :
         # Si condition_1 ou condition_2 est vraie, minimum_recouvrement_ir = 0 - pas d'annulation de l'impôt
         # Si condition_3 est vraie, minimum_recouvrement_ir = impot_revenu_restant_a_payer - annulation de l'impôt
-        return condition_1 * 0 + condition_2 * 0 + condition_3 * impot_revenu_restant_a_payer
+        return condition_1 * 0 + condition_2 * 0 + condition_3 * (iai + cehr + pfu - credits_impot - acomptes_ir)
 
 
 class impot_revenu_restant_a_payer(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2357,8 +2357,9 @@ class impot_revenu_restant_a_payer(Variable):
         cehr = foyer_fiscal('contribution_exceptionnelle_hauts_revenus', period)
         pfu = foyer_fiscal('prelevement_forfaitaire_unique_ir', period)
         correction_seuils_recouvrement = foyer_fiscal('montant_correction_ir_seuils_recouvrement', period)
+        impots_nets = -(iai + cehr - pfu - credits_impot - acomptes_ir)
 
-        return (iai + cehr - pfu - credits_impot - acomptes_ir) - correction_seuils_recouvrement
+        return  (impots_nets - correction_seuils_recouvrement)
 
 
 class foyer_impose(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py
@@ -255,7 +255,7 @@ class prelevement_forfaitaire_unique_ir_hors_assurance_vie(Variable):
             + plus_values_prelevement_forfaitaire_unique_ir
             )
 
-        return -assiette_pfu_hors_assurance_vie * P.taux_prelevement_forfaitaire_rev_capital_eligibles_pfu_interets_dividendes_etc
+        return assiette_pfu_hors_assurance_vie * P.taux_prelevement_forfaitaire_rev_capital_eligibles_pfu_interets_dividendes_etc
 
 
 class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
@@ -290,7 +290,7 @@ class prelevement_forfaitaire_unique_ir_sur_assurance_vie(Variable):
             + (max_(f2ww - abattement_residuel2, 0) * parameters_taux)
             )
 
-        return -pfu_ir_sur_assurance_vie
+        return pfu_ir_sur_assurance_vie
 
 
 class prelevement_forfaitaire_unique_ir(Variable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,14 @@
 [project]
 name = "OpenFisca-France"
+<<<<<<< HEAD
 version = "169.13.2"
+=======
+<<<<<<< HEAD
+version = "169.13.1"
+=======
+version = "169.14.0"
+>>>>>>> fb8897c83 (bump)
+>>>>>>> 7c0d16df9 (bump)
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,6 @@
 [project]
 name = "OpenFisca-France"
-<<<<<<< HEAD
-<<<<<<< HEAD
-version = "169.13.2"
-=======
-<<<<<<< HEAD
-version = "169.13.1"
-=======
 version = "169.14.0"
->>>>>>> fb8897c83 (bump)
->>>>>>> 7c0d16df9 (bump)
-=======
-version = "169.13.1"
->>>>>>> 6b32e77dd (bump)
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "OpenFisca-France"
 <<<<<<< HEAD
+<<<<<<< HEAD
 version = "169.13.2"
 =======
 <<<<<<< HEAD
@@ -9,6 +10,9 @@ version = "169.13.1"
 version = "169.14.0"
 >>>>>>> fb8897c83 (bump)
 >>>>>>> 7c0d16df9 (bump)
+=======
+version = "169.13.1"
+>>>>>>> 6b32e77dd (bump)
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/calculateur_impots/yaml/pv_pfu.yaml
+++ b/tests/calculateur_impots/yaml/pv_pfu.yaml
@@ -19,7 +19,7 @@
     menage:
       personne_de_reference: ind0
   output:
-    prelevement_forfaitaire_unique_ir: -6400.0
+    prelevement_forfaitaire_unique_ir: 6400.0
     nbptr: 1.0
     rfr: 50000.0
     impot_revenu_restant_a_payer: -6400
@@ -46,7 +46,7 @@
     menage:
       personne_de_reference: ind0
   output:
-    prelevement_forfaitaire_unique_ir: -5120.0
+    prelevement_forfaitaire_unique_ir: 5120.0
     nbptr: 1.0
     rfr: 60000.0
     impot_revenu_restant_a_payer: -15120.0

--- a/tests/calculateur_impots/yaml/rvcm.yaml
+++ b/tests/calculateur_impots/yaml/rvcm.yaml
@@ -76,7 +76,7 @@
     menage:
       personne_de_reference: ind0
   output:
-    prelevement_forfaitaire_unique_ir: -10368.0
+    prelevement_forfaitaire_unique_ir: 10368.0
     nbptr: 1.0
     ppe: 0.0
     rfr: 81000.0

--- a/tests/calculateur_impots/yaml/rvcm.yaml
+++ b/tests/calculateur_impots/yaml/rvcm.yaml
@@ -118,7 +118,7 @@
     menage:
       personne_de_reference: ind0
   output:
-    prelevement_forfaitaire_unique_ir: -4298.0 # 1000 * 0.128 + 30000 * 0.075 + 15000 * 0.128
+    prelevement_forfaitaire_unique_ir: 4298.0 # 1000 * 0.128 + 30000 * 0.075 + 15000 * 0.128
     #prelevement_forfaitaire_liberatoire: -345.0
     ir_brut: 1461.0
     impot_revenu_restant_a_payer: -5659.0

--- a/tests/formulas/irpp_prets_participatifs.yaml
+++ b/tests/formulas/irpp_prets_participatifs.yaml
@@ -27,5 +27,5 @@
     f2tt: 100000
   output:
     impot_revenu_restant_a_payer: -0.128*100000
-    prelevement_forfaitaire_unique_ir: -0.128*100000
+    prelevement_forfaitaire_unique_ir: 0.128*100000
     impots_directs: -0.128*100000

--- a/tests/formulas/revenu_disponible.yaml
+++ b/tests/formulas/revenu_disponible.yaml
@@ -246,7 +246,7 @@
   output:
     prelevements_sociaux_revenus_capital: -774000 # -4500000*(0.045+0.02+0.003+0.005+0.099)
     revenus_nets_du_capital: 4500000 - 774000
-    prelevement_forfaitaire_unique_ir_sur_assurance_vie: -209305.0 # ((150000 - 4600)  * 0.075 + 800000 * 0.128 + 750000 * 0.128)
+    prelevement_forfaitaire_unique_ir_sur_assurance_vie: 209305.0 # ((150000 - 4600)  * 0.075 + 800000 * 0.128 + 750000 * 0.128)
     impots_directs: -376805  # Simulation dgfip
     revenu_disponible: 4500000 - 774000 - 376805
 
@@ -264,7 +264,7 @@
   output:
     prelevements_sociaux_revenus_capital: -41280
     revenus_nets_du_capital: (270000 - 30000) - 41280 # car les revenus associés à 3SA et 3SB ne sont pas dans les revenus courants : voir docstring de plus_values_base_large
-    prelevement_forfaitaire_unique_ir_hors_assurance_vie: -28160 #-(220000*0.128) 3VD est un gain taxé forfaitairement au taux de 18% et non au PFU
+    prelevement_forfaitaire_unique_ir_hors_assurance_vie: 28160 #-(220000*0.128) 3VD est un gain taxé forfaitairement au taux de 18% et non au PFU
     taxation_plus_values_hors_bareme: 9000 #50000 * 0.18
     impots_directs: -28160 - 9000
     revenu_disponible: (270000 - 30000) - 41280 - 28160 - 9000 # car les revenus associés à 3SA et 3SB ne sont pas dans les revenus courants : voir docstring de plus_values_base_large

--- a/tests/formulas/taxation_capital.yaml
+++ b/tests/formulas/taxation_capital.yaml
@@ -15,6 +15,6 @@
       2022: 155000
   output:
     # Prélèv. forfaitaire unique (PFU) hors prélèvements sociaux 155000 - 12,8% = 19 840 €
-    prelevement_forfaitaire_unique_ir_sur_assurance_vie: 155_000 * (- 0.128)
+    prelevement_forfaitaire_unique_ir_sur_assurance_vie: 155_000 * (0.128)
     # revenu_disponible = 155 000€ - "flat tax" de 30% (PFU 12.8% + revenus_nets_du_capital 17.2%)
     revenu_disponible: 155_000 * (1 - (0.092 + 0.005 + 0.075 + 0.128))

--- a/tests/impot_revenu/pfu_bareme.yaml
+++ b/tests/impot_revenu/pfu_bareme.yaml
@@ -77,7 +77,7 @@
       ind0:
         statut_marital: celibataire
   output:
-    prelevement_forfaitaire_unique_ir: -25600  # (700000 - 500000)*0.128
+    prelevement_forfaitaire_unique_ir: 25600  # (700000 - 500000)*0.128
     rfr: 700000
     impot_revenu_restant_a_payer: -41100  # pfu + cehr
 
@@ -121,7 +121,7 @@
       ind0:
         statut_marital: celibataire
   output:
-    prelevement_forfaitaire_unique_ir: -37120
+    prelevement_forfaitaire_unique_ir: 37120
     impot_revenu_restant_a_payer: -41320  # pfu + cehr
     rfr: 390000
 
@@ -146,7 +146,7 @@
       ind0:
         statut_marital: celibataire
   output:
-    prelevement_forfaitaire_unique_ir: -2560  # pfu des actifs numériques f3an qui ne peuvent pas être imposé au barème
+    prelevement_forfaitaire_unique_ir: 2560  # pfu des actifs numériques f3an qui ne peuvent pas être imposé au barème
     rfr: 390000
     impot_revenu_restant_a_payer: -94395  # pfu des an + taxation au barème des revenus éligibles au pfu
 
@@ -167,7 +167,7 @@
         statut_marital: celibataire
   output:
     rfr: 80000
-    prelevement_forfaitaire_unique_ir: -10240  # 80000*0.128
+    prelevement_forfaitaire_unique_ir: 10240  # 80000*0.128
     impot_revenu_restant_a_payer: -10240  # pfu
 
 - name: option_imposition_bareme_capital_2019
@@ -207,7 +207,7 @@
       ind0:
         statut_marital: celibataire
   output:
-    prelevement_forfaitaire_unique_ir: -10560  # (10000*1.25 (2go majoré dans tous les cas, pfu ou barème, à partir de 2020) + 70000)*0.128
+    prelevement_forfaitaire_unique_ir: 10560  # (10000*1.25 (2go majoré dans tous les cas, pfu ou barème, à partir de 2020) + 70000)*0.128
     impot_revenu_restant_a_payer: -10560  # pfu
     rfr: 82500
 

--- a/tests/impot_revenu/pfu_bareme.yaml
+++ b/tests/impot_revenu/pfu_bareme.yaml
@@ -97,7 +97,7 @@
         statut_marital: celibataire
   output:
     prelevement_forfaitaire_unique_ir: 0  # option bareme
-    impot_revenu_restant_a_payer: -85337
+    impot_revenu_restant_a_payer: 85337
     rfr: 700000
 
 - name: option_prelevement_forfaitaire_unique_abattements_plus_values_2019

--- a/tests/impot_revenu/pfu_bareme.yaml
+++ b/tests/impot_revenu/pfu_bareme.yaml
@@ -26,7 +26,7 @@
       ind0:
         statut_marital: celibataire
   output:
-    prelevement_forfaitaire_unique_ir: -25070  # 190 000 * 0.128 (pfu) + 10 000 (f2vv) * 0.075 (taux réduit)
+    prelevement_forfaitaire_unique_ir: 25070  # 190 000 * 0.128 (pfu) + 10 000 (f2vv) * 0.075 (taux réduit)
     impot_revenu_restant_a_payer: -25070  # Tous les revenus sont éligibles au pfu sauf 2ch mais qui bénéficie d'un abattement de 4600 euros ce qui donne un revenu imposable net à 400 euros donc pas imposable
     rfr: 180400
 

--- a/tests/impot_revenu/pfu_bareme.yaml
+++ b/tests/impot_revenu/pfu_bareme.yaml
@@ -26,8 +26,8 @@
       ind0:
         statut_marital: celibataire
   output:
-    prelevement_forfaitaire_unique_ir: -25070  # 190 000 * 0.128 (pfu) + 10 000 (f2vv) * 0.075 (taux réduit)
-    impot_revenu_restant_a_payer: -25070  # Tous les revenus sont éligibles au pfu sauf 2ch mais qui bénéficie d'un abattement de 4600 euros ce qui donne un revenu imposable net à 400 euros donc pas imposable
+    prelevement_forfaitaire_unique_ir: 25070  # 190 000 * 0.128 (pfu) + 10 000 (f2vv) * 0.075 (taux réduit)
+    impot_revenu_restant_a_payer: 25070  # Tous les revenus sont éligibles au pfu sauf 2ch mais qui bénéficie d'un abattement de 4600 euros ce qui donne un revenu imposable net à 400 euros donc pas imposable
     rfr: 180400
 
 - name: option_imposition_bareme

--- a/tests/impot_revenu/pfu_bareme.yaml
+++ b/tests/impot_revenu/pfu_bareme.yaml
@@ -26,8 +26,8 @@
       ind0:
         statut_marital: celibataire
   output:
-    prelevement_forfaitaire_unique_ir: 25070  # 190 000 * 0.128 (pfu) + 10 000 (f2vv) * 0.075 (taux réduit)
-    impot_revenu_restant_a_payer: 25070  # Tous les revenus sont éligibles au pfu sauf 2ch mais qui bénéficie d'un abattement de 4600 euros ce qui donne un revenu imposable net à 400 euros donc pas imposable
+    prelevement_forfaitaire_unique_ir: -25070  # 190 000 * 0.128 (pfu) + 10 000 (f2vv) * 0.075 (taux réduit)
+    impot_revenu_restant_a_payer: -25070  # Tous les revenus sont éligibles au pfu sauf 2ch mais qui bénéficie d'un abattement de 4600 euros ce qui donne un revenu imposable net à 400 euros donc pas imposable
     rfr: 180400
 
 - name: option_imposition_bareme

--- a/tests/impot_revenu/pfu_bareme.yaml
+++ b/tests/impot_revenu/pfu_bareme.yaml
@@ -97,7 +97,7 @@
         statut_marital: celibataire
   output:
     prelevement_forfaitaire_unique_ir: 0  # option bareme
-    impot_revenu_restant_a_payer: 85337
+    impot_revenu_restant_a_payer: -85337
     rfr: 700000
 
 - name: option_prelevement_forfaitaire_unique_abattements_plus_values_2019


### PR DESCRIPTION
* Amélioration technique et métier de la formule de l'impôt sur le revenu restant à payer
* Périodes concernées : toutes.
* Zones impactées : 
 - `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`.
 - `openfisca_france/model/prelevements_obligatoires/impot_revenu/prelevements_forfaitaires/ir_prelevement_forfaitaire_unique.py`.
 - `tests/calculateur_impots/yaml/pv_pfu.yaml`.
 - `tests/calculateur_impots/yaml/rvcm.yaml`.
 - `tests/formulas/irpp_prets_participatifs.yaml`.
 - `tests/formulas/revenu_disponible.yaml`.
 - `tests/formulas/taxation_capital.yaml`.
 - `tests/impot_revenu/pfu_bareme.yaml`.
* Détails :
  - Améliore la lisibilité de la formule de l'impôt sur le revenu
  - Objectif : séparer de la formule `impot_revenu_restant_a_payer` les complexités inhérentes au seuils de mise en recouvrement de l'iR (61 euros et 12 euros). Par conséquent cette formule est simplifiée sous la forme de `impot_revenu_restant_a_payer` = `impôts divers` - `correction seuils recouvrement`. Deux formules sont créées en complément : la première permettant de faire la somme des divers impôts, la seconde prenant en compte les conditions d'application des seuils de mise en recouvrement pour calculer si il y a un montant à déduire pour rapporter l'impôt à 0 euros si les seuils sont dépassés.
- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.