### PR TITLE
Met à jour les paramètres revalorisés le 1e janvier 2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 169.14.1 [2410](https://github.com/openfisca/openfisca-france/pull/2410)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées :  à partir du 01/01/2025.
+* Zones impactées : 
+  - `openfisca_france/parameters/prelevements_sociaux/pss`
+  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/ars/ars_plaf`
+  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_plaf/ne_adopte_apres_04_2018/taux_partiel`
+  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_plaf/ne_adopte_apres_04_2018/taux_plein`
+* Détails :
+  - Met à jour les paramètres revalorisés au premier janvier 2025
+
 ### 169.14.0 [2401](https://github.com/openfisca/openfisca-france/pull/2401)
 
 * Amélioration technique et métier de la formule de l'impôt sur le revenu restant à payer

--- a/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_annuel.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_annuel.yaml
@@ -172,9 +172,11 @@ values:
     value: 43992
   2024-01-01:
     value: 46368
+  2025-01-01:
+    value: 47100
 metadata:
   short_label: Annuel
-  last_value_still_valid_on: "2024-01-05"
+  last_value_still_valid_on: "2025-01-07"
   label_en: Social security yearly ceiling
   ipp_csv_id: pss_a
   unit: currency
@@ -390,6 +392,11 @@ metadata:
     2024-01-01:
       title: Arrêté du 19/12/2023
       href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000048708695#JORFARTI000048708695
+    2025-01-01:
+    - title: Arrêté du 19/12/2024
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050854392
+    - title: Site de l'URSSAF
+      href: https://www.urssaf.fr/portail/home/taux-et-baremes/plafonds.html
   official_journal_date:
     1938-07-01: "1938-06-15"
     1946-10-01: "1946-10-08"
@@ -469,6 +476,7 @@ metadata:
     2022-01-01: "2021-12-18"
     2023-01-01: "2022-12-16"
     2024-01-01: "2023-12-29"
+    2025-01-01: "2024-12-29"
   notes:
     1930-07-01:
     - title: Voir référence sur Gallica.bnf.fr

--- a/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_mensuel.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/pss/plafond_securite_sociale_mensuel.yaml
@@ -188,9 +188,11 @@ values:
     value: 3666
   2024-01-01:
     value: 3864
+  2025-01-01:
+    value: 3925
 metadata:
   short_label: Plafond mensuel
-  last_value_still_valid_on: "2024-01-05"
+  last_value_still_valid_on: "2025-01-07"
   label_en: Social security monthly ceiling
   ipp_csv_id: pss_m
   unit: currency
@@ -435,6 +437,9 @@ metadata:
     2024-01-01:
       title: Arrêté du 19/12/2023
       href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000048708695#JORFARTI000048708695
+    2025-01-01:
+      title: Arrêté du 19/12/2024
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050854392
   official_journal_date:
     1946-07-01: "1945-10-06"
     1946-10-01: "1946-10-08"
@@ -529,6 +534,7 @@ metadata:
     2022-01-01: "2021-12-18"
     2023-01-01: "2022-12-16"
     2024-01-01: "2023-12-29"
+    2025-01-01: "2024-12-29"
   notes:
     1930-07-01:
     - title: Voir référence sur Gallica.bnf.fr

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/ars/ars_plaf/plafond_ressources.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/ars/ars_plaf/plafond_ressources.yaml
@@ -58,9 +58,11 @@ values:
     value: 19827
   2024-01-01:
     value: 20878
+  2025-01-01:
+    value: 21880
 metadata:
   short_label: Base du plafond de ressources
-  last_value_still_valid_on: "2024-01-26"
+  last_value_still_valid_on: "2025-01-07"
   label_en: "Back-to-school allowance (ARS): Thresholds for means-testing"
   ipp_csv_id: plaf_ars_0enf
   unit: currency
@@ -140,6 +142,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037951022
     - title: Arrêté du 22/12/2023, art. 3
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048680633
+    2025-01-01:
+    - title: Article L543-1 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037951022
+    - title: Arrêté du 20/12/2024, art. 3
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050842452
   official_journal_date:
     1978-07-13: "1985-12-21"
     1997-07-01: "1997-05-27"
@@ -164,6 +171,7 @@ metadata:
     2022-01-01: "2021-12-28"
     2023-01-01: "2022-12-24"
     2024-01-01: "2023-12-28"
+    2024-01-01: "2024-12-27"
   notes:
     1978-07-13:
     - title: "Plafond: 2,130 fois le salaire minimum de croissance prévu à l'article L 141-4 du code du travail en vigueur au 01/07 de l'année de référence, majoré de 30% à partir du premier enfant, par enfant à charge"

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/ars/ars_plaf/plafond_ressources.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/ars/ars_plaf/plafond_ressources.yaml
@@ -171,7 +171,7 @@ metadata:
     2022-01-01: "2021-12-28"
     2023-01-01: "2022-12-24"
     2024-01-01: "2023-12-28"
-    2024-01-01: "2024-12-27"
+    2025-01-01: "2024-12-27"
   notes:
     1978-07-13:
     - title: "Plafond: 2,130 fois le salaire minimum de croissance prévu à l'article L 141-4 du code du travail en vigueur au 01/07 de l'année de référence, majoré de 30% à partir du premier enfant, par enfant à charge"

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_plaf/ne_adopte_apres_04_2018/taux_partiel/biactifs_parents_isoles.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_plaf/ne_adopte_apres_04_2018/taux_partiel/biactifs_parents_isoles.yaml
@@ -16,9 +16,11 @@ values:
     value: 10625
   2024-01-01:
     value: 11188
+  2025-01-01:
+    value: 11725
 metadata:
   short_label: Majoration pour couple avec deux revenus ou parent isolé
-  last_value_still_valid_on: "2024-01-26"
+  last_value_still_valid_on: "2025-01-07"
   label_en: Increase for couple with two incomes or single parent
   ipp_csv_id: maj_plaf_paje_bi_pn_pa_abpartiel_a_partir_20180401
   unit: currency
@@ -55,6 +57,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042685543
     - title: Arrêté du 22/12/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048680633
+    2025-01-01:
+    - title: Article L. 531-2 du code de la sécurité sociale, dernier alinéa
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042685543
+    - title: Arrêté du 20/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050842452
   official_journal_date:
     2004-01-01: "2004-01-01"
     2018-04-01: 2018-04-28; 2018-05-05; 2017-12-31
@@ -64,6 +71,7 @@ metadata:
     2022-01-01: "2021-12-28"
     2023-01-01: "2022-12-24"
     2024-01-01: "2023-12-28"
+    2025-01-01: "2024-12-27"
   notes:
     2004-01-01:
     - title: "Création de la PAJE. Mais entrée en vigueur progressive : de janvier 2004 à décembre 2006 inclus (cf. art. 60, VIII de la loi 2003-1199)"

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_plaf/ne_adopte_apres_04_2018/taux_partiel/plafond_ressources_0_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_plaf/ne_adopte_apres_04_2018/taux_partiel/plafond_ressources_0_enfant.yaml
@@ -16,9 +16,11 @@ values:
     value: 26432
   2024-01-01:
     value: 27833
+  2025-01-01:
+    value: 29169
 metadata:
   short_label: Base du plafond de ressources
-  last_value_still_valid_on: "2024-01-26"
+  last_value_still_valid_on: "2025-01-07"
   label_en: Resource ceiling base
   ipp_csv_id: plaf_paje_0enf_pn_pa_abpartiel_a_partir_20180401
   unit: currency
@@ -55,6 +57,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042685543
     - title: Arrêté du 22/12/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048680633
+    2025-01-01:
+    - title: Article L. 531-2 du code de la sécurité sociale, dernier alinéa
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042685543
+    - title : Arrêté du 20/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050842452
   official_journal_date:
     2004-01-01: "2004-01-01"
     2018-04-01: 2018-04-28; 2018-05-05; 2017-12-31
@@ -64,6 +71,7 @@ metadata:
     2022-01-01: "2021-12-28"
     2023-01-01: "2022-12-24"
     2024-01-01: "2023-12-28"
+    2025-01-01: "2024-12-27"
   notes:
     2004-01-01:
     - title: "Création de la PAJE. Mais entrée en vigueur progressive : de janvier 2004 à décembre 2006 inclus (cf. art. 60, VIII de la loi 2003-1199)"

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_plaf/ne_adopte_apres_04_2018/taux_plein/biactifs_parents_isoles.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_plaf/ne_adopte_apres_04_2018/taux_plein/biactifs_parents_isoles.yaml
@@ -16,9 +16,11 @@ values:
     value: 8892
   2024-01-01:
     value: 9363
+  2025-01-01:
+    value: 9812
 metadata:
   short_label: Majoration pour couple avec deux revenus ou parent isolé
-  last_value_still_valid_on: "2024-01-26"
+  last_value_still_valid_on: "2025-01-07"
   label_en: Increase for couple with two incomes or single parent
   ipp_csv_id: maj_plaf_paje_bi_abplein_a_partir_20180401
   unit: currency
@@ -55,6 +57,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036393143
     - title: Arrêté du 22/12/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048680633
+    2025-01-01:
+    - title: Article L. 531-3 du code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036393143
+    - title: Arrêté du 20/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050842452
   official_journal_date:
     2004-01-01: "2004-01-01"
     2018-04-01: 2018-04-28; 2018-05-05; 2017-12-31
@@ -64,6 +71,7 @@ metadata:
     2022-01-01: "2021-12-28"
     2023-01-01: "2022-12-24"
     2024-01-01: "2023-12-28"
+    2025-01-01: "2024-12-27"
   notes:
     2004-01-01:
     - title: "Création de la PAJE. Mais entrée en vigueur progressive : de janvier 2004 à décembre 2006 inclus (cf. art. 60, VIII de la loi 2003-1199)"

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_plaf/ne_adopte_apres_04_2018/taux_plein/plafond_ressources_0_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_plaf/ne_adopte_apres_04_2018/taux_plein/plafond_ressources_0_enfant.yaml
@@ -16,9 +16,11 @@ values:
     value: 22123
   2024-01-01:
     value: 23296
+  2025-01-01:
+    value: 24414
 metadata:
   short_label: Base du plafond de ressources
-  last_value_still_valid_on: "2024-01-26"
+  last_value_still_valid_on: "2025-01-07"
   label_en: Resource ceiling base
   ipp_csv_id: plaf_paje_0enf_abplein_a_partir_20180401
   unit: currency
@@ -55,6 +57,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036393143
     - title: Arrêté du 22/12/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048680633
+    2025-01-01:
+    - title: Article L. 531-3 du code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036393143
+    - title: Arrêté du 20/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050842452
   official_journal_date:
     2004-01-01: "2004-01-01"
     2018-04-01: 2018-04-28; 2018-05-05; 2017-12-31
@@ -64,6 +71,7 @@ metadata:
     2022-01-01: "2021-12-28"
     2023-01-01: "2022-12-24"
     2024-01-01: "2023-12-28"
+    2025-01-01: "2024-12-27"
   notes:
     2004-01-01:
     - title: "Création de la PAJE. Mais entrée en vigueur progressive : de janvier 2004 à décembre 2006 inclus (cf. art. 60, VIII de la loi 2003-1199)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.14.0"
+version = "169.14.1"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
Merci de contribuer à OpenFisca ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)

* Évolution du système socio-fiscal.
* Périodes concernées :  à partir du 01/01/2025.
* Zones impactées : 
  - `openfisca_france/parameters/prelevements_sociaux/pss`
  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/education_presence_parentale/ars/ars_plaf`
  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_plaf/ne_adopte_apres_04_2018/taux_partiel`
  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_plaf/ne_adopte_apres_04_2018/taux_plein`
* Détails :
  - Met à jour les paramètres revalorisés au premier janvier 2025

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.
