### PR TITLE
Revalorisation janvier suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 169.14.3 [2412](https://github.com/openfisca/openfisca-france/pull/2412)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2025
+* Zones impactées : 
+  - `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/ressources`.
+  - `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0`
+  - `openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils`
+* Détails :
+  - Mets à jour les paramètres qui ont évolué au premier janvier 2025
+
 ### 169.14.2 [2411](https://github.com/openfisca/openfisca-france/pull/2411)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/demi_part_suppl_rfr1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/demi_part_suppl_rfr1.yaml
@@ -22,9 +22,11 @@ values:
     value: 3101
   2024-01-01:
     value: 3265
+  2025-01-01:
+    value: 3422
 metadata:
   short_label: Majoration du seuil par demi-part de quotient familial supplémentaire
-  last_value_still_valid_on: "2024-07-24"
+  last_value_still_valid_on: "2025-01-08"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red1_demip
   unit: currency
@@ -71,6 +73,11 @@ metadata:
     2024-01-01:
       title: Lettre ministérielle D23-022880 du 23/11/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_23112023.pdf
+    2025-01-01:
+    - title: Article L136-8 du Code de la sécurité sociale (seuils avant revalorisation)
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546
+    - title: Lettre ministérielle D-24-019252 du 4/12/2024
+      href: https://legislation.lassuranceretraite.fr/Pdf/instruction_ministerielle_04122024.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/seuil_rfr1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr1/seuil_rfr1.yaml
@@ -22,9 +22,11 @@ values:
     value: 11614
   2024-01-01:
     value: 12230
+  2025-01-01:
+    value: 12817
 metadata:
   short_label: Seuil de RFR pour la première part de quotient familial
-  last_value_still_valid_on: "2024-07-24"
+  last_value_still_valid_on: "2025-01-08"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red1
   unit: currency
@@ -73,6 +75,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546
     - title: Lettre ministérielle D23-022880 du 23/11/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_23112023.pdf
+    2025-01-01:
+    - title: Article L136-8 du Code de la sécurité sociale (seuils avant revalorisation)
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546
+    - title: Lettre ministérielle D-24-019252 du 4/12/2024
+      href: https://legislation.lassuranceretraite.fr/Pdf/instruction_ministerielle_04122024.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/demi_part_suppl_rfr2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/demi_part_suppl_rfr2.yaml
@@ -22,9 +22,11 @@ values:
     value: 4054
   2024-01-01:
     value: 4269
+  2025-01-01:
+    value: 4474
 metadata:
   short_label: Majoration du seuil par demi-part de quotient familial supplémentaire
-  last_value_still_valid_on: "2024-07-24"
+  last_value_still_valid_on: "2025-01-08"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red2_demip
   unit: currency
@@ -71,6 +73,11 @@ metadata:
     2024-01-01:
       title: Lettre ministérielle D23-022880 du 23/11/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_23112023.pdf
+    2025-01-01:
+    - title: Article L136-8 du Code de la sécurité sociale (seuils avant revalorisation)
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546
+    - title: Lettre ministérielle D-24-019252 du 4/12/2024
+      href: https://legislation.lassuranceretraite.fr/Pdf/instruction_ministerielle_04122024.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/seuil_rfr2.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr2/seuil_rfr2.yaml
@@ -22,9 +22,11 @@ values:
     value: 15183
   2024-01-01:
     value: 15988
+  2025-01-01:
+    value: 16755
 metadata:
   short_label: Seuil de RFR pour la première part de quotient familial
-  last_value_still_valid_on: "2024-07-24"
+  last_value_still_valid_on: "2025-01-08"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red2
   unit: currency
@@ -73,6 +75,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546
     - title: Lettre ministérielle D23-022880 du 23/11/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_23112023.pdf
+    2025-01-01:
+    - title: Article L136-8 du Code de la sécurité sociale (seuils avant revalorisation)
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546
+    - title: Lettre ministérielle D-24-019252 du 4/12/2024
+      href: https://legislation.lassuranceretraite.fr/Pdf/instruction_ministerielle_04122024.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2015-01-01: "2014-12-30"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/demi_part_suppl_rfr3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/demi_part_suppl_rfr3.yaml
@@ -14,9 +14,11 @@ values:
     value: 6290
   2024-01-01:
     value: 6623
+  2025-01-01:
+    value: 6941
 metadata:
   short_label: Majoration du seuil par demi-part de quotient familial supplémentaire
-  last_value_still_valid_on: "2024-07-24"
+  last_value_still_valid_on: "2025-01-08"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red3_demip
   unit: currency
@@ -46,6 +48,11 @@ metadata:
     2024-01-01:
       title: Lettre ministérielle D23-022880 du 23/11/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_23112023.pdf
+    2025-01-01:
+    - title: Article L136-8 du Code de la sécurité sociale (seuils avant revalorisation)
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546
+    - title: Lettre ministérielle D-24-019252 du 4/12/2024
+      href: https://legislation.lassuranceretraite.fr/Pdf/instruction_ministerielle_04122024.pdf
   official_journal_date:
     2018-01-01: "2017-12-31"
     2019-01-01: "2018-12-26"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/seuil_rfr3.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils/seuil_rfr3/seuil_rfr3.yaml
@@ -14,9 +14,11 @@ values:
     value: 23564
   2024-01-01:
     value: 24813
+  2025-01-01:
+    value: 26004
 metadata:
   short_label: Seuil de RFR pour la première part de quotient familial
-  last_value_still_valid_on: "2024-07-24"
+  last_value_still_valid_on: "2025-01-08"
   label_en: CSG - rates on retirement incomes
   ipp_csv_id: seuil_csg_pens_red3
   unit: currency
@@ -49,6 +51,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546
     - title: Lettre ministérielle D23-022880 du 23/11/2023
       href: https://legislation.lassuranceretraite.fr/Pdf/lettre_ministerielle_23112023.pdf
+    2025-01-01:
+    - title: Article L136-8 du Code de la sécurité sociale (seuils avant revalorisation)
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546
+    - title: Lettre ministérielle D-24-019252 du 4/12/2024
+      href: https://legislation.lassuranceretraite.fr/Pdf/instruction_ministerielle_04122024.pdf
   official_journal_date:
     1991-02-01: "1990-12-30"
     2019-01-01: "2018-12-26"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux1pac.yaml
@@ -14,9 +14,11 @@ values:
     value: 8456
   2024-01-01:
     value: 8862
+  2025-01-01:
+    value: 8947
 metadata:
   short_label: Personne seule ou couple ayant une personne à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-01-08"
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   ipp_csv_id: r0_1pac
   unit: currency
@@ -44,6 +46,13 @@ metadata:
     2024-01-01:
       title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
+    2025-01-01:
+    - title: Arrêté du 30/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050873291
+    - title: Arrêté du 27/09/2019, art. 15
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329
+    - title: Article D823-17 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"
@@ -51,6 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
+    2025-01-01: "2024-31-12"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux1pac.yaml
@@ -60,7 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
-    2025-01-01: "2024-31-12"
+    2025-01-01: "2024-12-31"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux2pac.yaml
@@ -14,9 +14,11 @@ values:
     value: 8646
   2024-01-01:
     value: 9061
+  2025-01-01:
+    value: 9148
 metadata:
   short_label: Personne seule ou couple ayant deux personnes à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-01-08"
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   ipp_csv_id: r0_2pac
   unit: currency
@@ -44,6 +46,13 @@ metadata:
     2024-01-01:
       title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
+    2025-01-01:
+    - title: Arrêté du 30/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050873291
+    - title: Arrêté du 27/09/2019, art. 15
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329
+    - title: Article D823-17 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"
@@ -51,6 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
+    2025-01-01: "2024-31-12"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux2pac.yaml
@@ -60,7 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
-    2025-01-01: "2024-31-12"
+    2025-01-01: "2024-12-31"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux3pac.yaml
@@ -14,9 +14,11 @@ values:
     value: 8977
   2024-01-01:
     value: 9408
+  2025-01-01:
+    value: 9498
 metadata:
   short_label: Personne seule ou couple ayant trois personnes à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-01-08"
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   ipp_csv_id: r0_3pac
   unit: currency
@@ -44,6 +46,13 @@ metadata:
     2024-01-01:
       title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
+    2025-01-01:
+    - title: Arrêté du 30/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050873291
+    - title: Arrêté du 27/09/2019, art. 15
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329
+    - title: Article D823-17 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"
@@ -51,6 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
+    2025-01-01: "2024-31-12"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux3pac.yaml
@@ -60,7 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
-    2025-01-01: "2024-31-12"
+    2025-01-01: "2024-12-31"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux4pac.yaml
@@ -14,9 +14,11 @@ values:
     value: 9311
   2024-01-01:
     value: 9758
+  2025-01-01:
+    value: 9851
 metadata:
   short_label: Personne seule ou couple ayant quatre personnes à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-01-08"
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   ipp_csv_id: r0_4pac
   unit: currency
@@ -44,6 +46,13 @@ metadata:
     2024-01-01:
       title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
+    2025-01-01:
+    - title: Arrêté du 30/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050873291
+    - title: Arrêté du 27/09/2019, art. 15
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329
+    - title: Article D823-17 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"
@@ -51,6 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
+    2025-01-01: "2024-31-12"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux4pac.yaml
@@ -60,7 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
-    2025-01-01: "2024-31-12"
+    2025-01-01: "2024-12-31"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux5pac.yaml
@@ -14,9 +14,11 @@ values:
     value: 9642
   2024-01-01:
     value: 10105
+  2025-01-01:
+    value: 10202
 metadata:
   short_label: Personne seule ou couple ayant cinq personnes à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-01-08"
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   ipp_csv_id: r0_5pac
   unit: currency
@@ -44,6 +46,13 @@ metadata:
     2024-01-01:
       title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
+    2025-01-01:
+    - title: Arrêté du 30/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050873291
+    - title: Arrêté du 27/09/2019, art. 15
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329
+    - title: Article D823-17 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"
@@ -51,6 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
+    2025-01-01: "2024-31-12"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux5pac.yaml
@@ -60,7 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
-    2025-01-01: "2024-31-12"
+    2025-01-01: "2024-12-31"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux6pac.yaml
@@ -14,9 +14,11 @@ values:
     value: 9975
   2024-01-01:
     value: 10454
+  2025-01-01:
+    value: 10554
 metadata:
   short_label: Personne seule ou couple ayant six personnes à charge ou plus
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-01-08"
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   ipp_csv_id: r0_6pac
   unit: currency
@@ -44,6 +46,13 @@ metadata:
     2024-01-01:
       title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
+    2025-01-01:
+    - title: Arrêté du 30/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050873291
+    - title: Arrêté du 27/09/2019, art. 15
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329
+    - title: Article D823-17 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"
@@ -51,6 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
+    2025-01-01: "2024-31-12"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux6pac.yaml
@@ -60,7 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
-    2025-01-01: "2024-31-12"
+    2025-01-01: "2024-12-31"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_couple.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_couple.yaml
@@ -60,7 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
-    2025-01-01: "2024-31-12"
+    2025-01-01: "2024-12-31"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_couple.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_couple.yaml
@@ -14,9 +14,11 @@ values:
     value: 7090
   2024-01-01:
     value: 7430
+  2025-01-01:
+    value: 7501
 metadata:
   short_label: Couple sans personne à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-01-08"
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   ipp_csv_id: r0_couple
   unit: currency
@@ -44,6 +46,13 @@ metadata:
     2024-01-01:
       title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
+    2025-01-01:
+    - title: Arrêté du 30/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050873291
+    - title: Arrêté du 27/09/2019, art. 15
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329
+    - title: Article D823-17 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"
@@ -51,6 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
+    2025-01-01: "2024-31-12"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_pac_supp.yaml
@@ -60,7 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
-    2025-01-01: "2024-31-12"
+    2025-01-01: "2024-12-31"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_pac_supp.yaml
@@ -14,9 +14,11 @@ values:
     value: 328
   2024-01-01:
     value: 343
+  2025-01-01:
+    value: 346
 metadata:
   short_label: Par personne à charge supplémentaire
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-01-08"
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   ipp_csv_id: r0_majoration_par_pac
   unit: currency
@@ -44,6 +46,13 @@ metadata:
     2024-01-01:
       title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
+    2025-01-01:
+    - title: Arrêté du 30/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050873291
+    - title: Arrêté du 27/09/2019, art. 15
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329
+    - title: Article D823-17 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"
@@ -51,6 +60,7 @@ metadata:
     2020-01-01: "2020-01-04"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
+    2025-01-01: "2024-31-12"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_seul.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_seul.yaml
@@ -57,7 +57,7 @@ metadata:
     2019-01-01: "2018-12-29"
     2020-01-01: "2020-01-04"
     2024-01-01: "2023-12-21"
-    2025-01-01: "2024-31-12"
+    2025-01-01: "2024-12-31"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_seul.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0/taux_seul.yaml
@@ -14,9 +14,11 @@ values:
     value: 4949
   2024-01-01:
     value: 5186
+  2025-01-01:
+    value: 5235
 metadata:
   short_label: Personne seule sans personne à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-01-08"
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   ipp_csv_id: r0_seul
   unit: currency
@@ -42,12 +44,20 @@ metadata:
     2024-01-01:
       title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
+    2025-01-01:
+    - title: Arrêté du 30/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050873291
+    - title: Arrêté du 27/09/2019, art. 15
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329
+    - title: Article D823-17 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
   official_journal_date:
     2015-01-01: "2014-12-31"
     2016-01-01: "2016-01-22"
     2019-01-01: "2018-12-29"
     2020-01-01: "2020-01-04"
     2024-01-01: "2023-12-21"
+    2025-01-01: "2024-31-12"
 documentation: |-
   Notes :
   (1) Les abattements appliqués aux traitements et salaires mentionnés dans le code général des impôts s'appliquent à R1-R2.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/ressources/dar_11.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/ressources/dar_11.yaml
@@ -22,9 +22,11 @@ values:
     value: 6200
   2024-01-01:
     value: 6400
+  2025-01-01:
+    value: 6600
 metadata:
   short_label: Forfait de ressources pour les étudiants en logement-foyer
-  last_value_still_valid_on: "2023-02-20"
+  last_value_still_valid_on: "2025-01-08"
   unit: currency
   reference:
     2003-01-01:
@@ -42,6 +44,13 @@ metadata:
     2024-01-01:
       title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
+    2025-01-01:
+    - title: Arrêté du 30/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050873291
+    - title: Arrêté du 27 septembre 2019, article 6 (montant non revalorisé)
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046126949/2022-08-01
+    - title: Article R822-20 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419188
   official_journal_date:
     2024-01-01: "2023-12-21"
 documentation: Plancher de ressources (avant 2021) puis forfait de ressources (depuis 2021) pour les étudiants dans un logement foyer (avant oct 2019, R.351-7-2 du CCH et art. 8 de l'arrêté du 30 juin 1979 ; oct 2019 - dec 2020, art. 6 de l'arrêté du 27 sept 2019 et art. R822-21 du CCH ; depuis janv 2021, même arrêté et art. R822-20 du CCH

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/ressources/dar_4.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/ressources/dar_4.yaml
@@ -24,9 +24,11 @@ values:
     value: 8100
   2024-01-01:
     value: 8400
+  2025-01-01:
+    value: 8600
 metadata:
   short_label: Forfait de ressources pour les étudiants en location
-  last_value_still_valid_on: "2023-02-20"
+  last_value_still_valid_on: "2025-01-08"
   unit: currency
   reference:
     2002-07-01:
@@ -52,6 +54,13 @@ metadata:
     2024-01-01:
       title: Arrêté du 15/12/2023 relatif au calcul des aides personnelles au logement pour l'année 2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048621292
+    2025-01-01:
+    - title: Arrêté du 30/12/2024, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050873291
+    - title: Arrêté du 27 septembre 2019, article 6 (montant non revalorisé)
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046126949/2022-08-01
+    - title: Article R822-20 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419188
   official_journal_date:
     2024-01-01: "2023-12-21"
 documentation: Plancher de ressources (avant 2021) puis forfait de ressources (depuis 2021) pour les étudiants (avant oct 2019, R.351-7-2 du CCH et art. 1 quater de l'arrêté du 3 juillet 1978 ; oct 2019 - dec 2020, art. 6 de l'arrêté du 27 sept 2019 et art. R822-21 du CCH ; depuis janv 2021, même arrêté et art. R822-20 du CCH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.14.2"
+version = "169.14.3"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
Merci de contribuer à OpenFisca ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)

* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2025
* Zones impactées : 
  - `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/ressources`.
  - `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param_r0/r0`
  - `openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/seuils`
* Détails :
  - Mets à jour les paramètres qui ont évolué au premier janvier 2025

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.