### PR TITLE
Corrige le format des metadata de bspce

### DIFF
--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/pv/bspce/taux_moins_3_ans.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/pv/bspce/taux_moins_3_ans.yaml
@@ -6,8 +6,9 @@ values:
     value: 0.3
 metadata:
   short_label: Taux d'imposition pour une activité exercée dans la société depuis moins de 3 ans (case 3SK)
-  1998-01-01:
-    - title: Article 163 bis G du Code général des impôts
+  reference:
+    1998-01-01:
+      title: Article 163 bis G du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031011397
   last_value_still_valid_on: "2024-11-07"
   ipp_csv_id: tx_bspce_moins


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes
* Zones impactées : `openfisca_france/parameters/impot_revenu/calcul_impot_revenu/pv/bspce/taux_moins_3_ans.yaml`.
* Détails :
  - Corrige le format pour une date dans les metadata de bspce
