### PR TITLE
Simplifie la formule de l'impôt sur le revenu net suite à l'abrogation de la "réfaction foyers modestes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 169.14.6 [2416](https://github.com/openfisca/openfisca-france/pull/2416)
+
+* Changement mineur.
+* Périodes concernées : à partir du 01/01/2020.
+* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`.
+* Détails :
+  - Enlève de la formule de l'IR net la réfaction foyers modestes (reduction_ss_condition_revenus) à partir de son abrogation en 2020
+
 ### 169.14.5 [2415](https://github.com/openfisca/openfisca-france/pull/2415)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1723,6 +1723,15 @@ class ip_net(Variable):
         reduction_ss_condition_revenus = foyer_fiscal('reduction_ss_condition_revenus', period)
 
         return around(max_(0, ir_plaf_qf - decote - reduction_ss_condition_revenus))
+    
+    def formula_2020_01_01(foyer_fiscal, period, parameters):
+        '''
+        Impôt net avant réductions suite à l'abrogation de la "réfaction foyers modestes"
+        '''
+        ir_plaf_qf = foyer_fiscal('ir_plaf_qf', period)
+        decote_gain_fiscal = foyer_fiscal('decote_gain_fiscal', period)        
+
+        return around(0, ir_plaf_qf - decote_gain_fiscal)
 
 
 class iaidrdi(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1723,13 +1723,13 @@ class ip_net(Variable):
         reduction_ss_condition_revenus = foyer_fiscal('reduction_ss_condition_revenus', period)
 
         return around(max_(0, ir_plaf_qf - decote - reduction_ss_condition_revenus))
-    
+
     def formula_2020_01_01(foyer_fiscal, period, parameters):
         '''
         Impôt net avant réductions suite à l'abrogation de la "réfaction foyers modestes"
         '''
         ir_plaf_qf = foyer_fiscal('ir_plaf_qf', period)
-        decote_gain_fiscal = foyer_fiscal('decote_gain_fiscal', period)        
+        decote_gain_fiscal = foyer_fiscal('decote_gain_fiscal', period)
 
         return around(0, ir_plaf_qf - decote_gain_fiscal)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -1731,7 +1731,7 @@ class ip_net(Variable):
         ir_plaf_qf = foyer_fiscal('ir_plaf_qf', period)
         decote_gain_fiscal = foyer_fiscal('decote_gain_fiscal', period)
 
-        return around(0, ir_plaf_qf - decote_gain_fiscal)
+        return around(ir_plaf_qf - decote_gain_fiscal)
 
 
 class iaidrdi(Variable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.14.5"
+version = "169.14.6"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/2020.
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`.
* Détails :
  - Enlève de la formule de l'IR net la réfaction foyers modestes (reduction_ss_condition_revenus) à partir de son abrogation en 2020