### PR TITLE
supprime condition inutile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 169.15.7 [2418](https://github.com/openfisca/openfisca-france/pull/2418)
+
+* Amélioration technique.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/model/prestations/aides_logement.py`.
+* Détails :
+  - Supprime une condition de non cumul des aides au logement qui est redondante par rapport aux conditions dans les variables en amont
+
 ### 169.14.6 [2416](https://github.com/openfisca/openfisca-france/pull/2416)
 
 * Changement mineur.

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -30,7 +30,7 @@ class aide_logement(Variable):
         als = famille('als', period)
         alf = famille('alf', period)
 
-        return max_(max_(apl, als), alf)
+        return apl + als + alf
 
 
 class apl(Variable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.14.6"
+version = "169.14.7"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
Merci de contribuer à OpenFisca ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)

* Amélioration technique.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/prestations/aides_logement.py`.
* Détails :
  - Supprime une condition de non cumul des aides au logement qui est redondante par rapport aux conditions dans les variables en amont

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.
