### PR TITLE
MAJ `last_value_still_valid_on` pour les taxation_societes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,12 @@
 ### 169.14.10 [2426](https://github.com/openfisca/openfisca-france/pull/2426)
 
 * Changement mineur.
-* Périodes concernées : aucune.
+* Périodes concernées : à partir du 01/01/2025.
 * Zones impactées : 
   - `openfisca_france/parameters/taxation_societes/impot_societe/seuil_superieur_benefices_taux_reduit.yaml`
   - `openfisca_france/parameters/taxation_societes/impot_societe/seuil_superieur_benefices_taux_reduit.yaml`
 * Détails :
   - Mise à jour des `last_value_still_valid_on`, sur les paramètres qui où elle était périmée et dont la valeur a pu être vérifiée avec un bon niveau de fiabilité.
-
 
 ### 169.14.9 [2424](https://github.com/openfisca/openfisca-france/pull/2424)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 169.14.10 [2426](https://github.com/openfisca/openfisca-france/pull/2426)
+
+* Changement mineur.
+* Périodes concernées : aucune.
+* Zones impactées : 
+  - `openfisca_france/parameters/taxation_societes/impot_societe/seuil_superieur_benefices_taux_reduit.yaml`
+  - `openfisca_france/parameters/taxation_societes/impot_societe/seuil_superieur_benefices_taux_reduit.yaml`
+* Détails :
+  - Mise à jour des `last_value_still_valid_on`, sur les paramètres qui où elle était périmée et dont la valeur a pu être vérifiée avec un bon niveau de fiabilité.
+
+
 ### 169.14.9 [2424](https://github.com/openfisca/openfisca-france/pull/2424)
 
 * Amélioration technique.

--- a/openfisca_france/parameters/taxation_societes/impot_societe/seuil_superieur_benefices_taux_reduit.yaml
+++ b/openfisca_france/parameters/taxation_societes/impot_societe/seuil_superieur_benefices_taux_reduit.yaml
@@ -7,7 +7,7 @@ values:
   2022-01-01:
     value: 42500
 metadata:
-  last_value_still_valid_on: "2023-01-05"
+  last_value_still_valid_on: "2025-01-31"
   unit: currency
   reference:
     2001-01-01:

--- a/openfisca_france/parameters/taxation_societes/impot_societe/taux_normal.yaml
+++ b/openfisca_france/parameters/taxation_societes/impot_societe/taux_normal.yaml
@@ -23,7 +23,7 @@ values:
   2022-01-01:
     value: 0.25
 metadata:
-  last_value_still_valid_on: "2023-01-05"
+  last_value_still_valid_on: "2025-01-31"
   unit: /1
   reference:
     1977-12-31:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.14.9"
+version = "169.14.10"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2024.
* Zones impactées :
* openfisca_france/parameters/taxation_societes/impot_societe/seuil_superieur_benefices_taux_reduit.yaml
* openfisca_france/parameters/taxation_societes/impot_societe/seuil_superieur_benefices_taux_reduit.yaml
* Détails :
  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Mise à jour de paramètre.

- - - -

Méthodologie :
1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
1. Vérifie la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
1. Met à jour la `last_value_still_valid_on` à la date du jour.
1. Crée un tableau récapitulatif pour faciliter la revue.

Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

- - - -

Quelques conseils à prendre en compte :

- [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [X] Documentez votre contribution avec des références législatives.
- [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`setup.py`](https://github.com/openfisca/openfisca-france/blob/master/setup.py).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme n'ayant pas changés depuis la date indiquée dans `last_value_still_valid_on`.

Aide à la revue :

* taxation_societes.impot_societe.seuil_superieur_benefices_taux_reduit
   - Description : Seuil supérieur de bénéfices sur lesquels le taux réduit d'IS est applicable (si CAHT < plafond CA)
   - 42500.0
   - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046868562)
   - Extrait : _[...] lieu à douze mois, le taux de l'impôt applicable au bénéfice imposable est fixé, dans la limite de 42 500 € de bénéfice imposable par période de douze mois, à 25 % pour les exercices ouverts en 2001 [...]_
   - Reponse du LLM : _La valeur de 'Taux normal taxation_societes.impot_societe.taux_normal' est indiquée dans le texte comme suit : "Le taux normal de l'impôt est fixé à 25 %."  En convertissant ce pourcentage en une valeur décimale, on obtient :  0,25  La réponse est donc :  {     "valeur": 0.25 }_

* taxation_societes.impot_societe.seuil_superieur_benefices_taux_reduit
   - Description : Seuil supérieur de bénéfices sur lesquels le taux réduit d'IS est applicable (si CAHT < plafond CA)
   - 42500.0
   - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046868562)
   - Extrait : _[...] lieu à douze mois, le taux de l'impôt applicable au bénéfice imposable est fixé, dans la limite de 42 500 € de bénéfice imposable par période de douze mois, à 25 % pour les exercices ouverts en 2001 [...]_
   - Reponse du LLM : _Okay, let's tackle this problem step by step. The user is asking for the value of 'Seuil supérieur de bénéfices sur lesquels le taux réduit d'IS est applicable (si CAHT < plafond CA)' which translates to the upper threshold of profits on which the reduced corporate tax rate applies, given that the company's turnover (CAHT) is below a certain ceiling. The previous value was 42,500.0, and they want to know the current value from the provided legal text.  First, I need to find where in the text such a threshold might be mentioned. The user mentioned that percentages should be converted to decimal form, but here it's about a monetary threshold. Looking at the text, especially sections discussing tax rates and applicable conditions.  Scrolling through the text, under paragraph b of section I, there's a mention: "le taux de l'impôt applicable au bénéfice imposable est fixé, dans la limite de 42 500 € de bénéfice imposable par période de douze mois, à 25 % pour les exercices ouverts en 2001 et à 15 % pour les exercices ouverts à compter du 1er janvier 2002." Here, the limit is 42,500 euros of taxable profit for a 12-month period. This seems to be the threshold for applying the reduced tax rate (15%) for companies with a turnover not exceeding 10 million euros.  The previous value was 42,500.0, and the current text also states 42 500 €. The number is written with a space as the thousand separator, which in the required format should be 42500.0. The text doesn't mention any changes to this value in more recent parts, so it appears the threshold remains the same. There's no indication of a different value elsewhere in the text. Therefore, the current value is still 42500.0.   ```json {     "valeur": 42500.0 } ```_