### PR TITLE
MAJ `last_value_still_valid_on` de l'IR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 169.16.15 [2428](https://github.com/openfisca/openfisca-france/pull/2428)
+
+* Changement mineur.
+    * Périodes concernées : 2025.
+    * Zones impactées :
+      - openfisca_france/parameters/impot_revenu/*
+    * Détails :
+    - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+
 ### 169.16.14 [2452](https://github.com/openfisca/openfisca-france/pull/2452)
 
 * Changement mineur.

--- a/openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml
+++ b/openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml
@@ -1453,7 +1453,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
     2024-01-01:
     - title: Article 197, I.1. du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2025-01-01/
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2025-02-16/
     - title: Loi 2025-127, art. 2 du 14/02/2025 de finances (LF pour 2025)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051168019
   official_journal_date:

--- a/openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml
+++ b/openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml
@@ -1452,10 +1452,10 @@ metadata:
     - title: Loi 2023-1322, art. 2 du 29/12/2023 (LF pour 2024)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
     2024-01-01:
-    - title: Loi 2025-127, art. 2 du 14/02/2025 de finances (LF pour 2025)
-      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051168019
     - title: Article 197, I.1. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2025-01-01/
+    - title: Loi 2025-127, art. 2 du 14/02/2025 de finances (LF pour 2025)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051168019
   official_journal_date:
     1946-01-01: "1949-01-01"
     1959-01-01: "1959-12-31"
@@ -1522,7 +1522,7 @@ metadata:
     2020-01-01: 2020-12-30; 2019-12-29
     2022-01-01: "2022-12-31"
     2023-01-01: "2023-12-30"
-    2024-01-01: "2024-02-15"
+    2024-01-01: "2025-02-15"
   notes:
     1947-01-01:
     - title: Coexistence IGR et impôts cédulaires (voir notes 1 à 4). Ces barèmes concernent l'IGR jusqu'en 1948. En 1948, un « prélèvement exceptionnel de lutte contre l'inflation » sur les revenus 1946 est instauré dans le cadre du « plan Mayer » (intégré dans le barème); les contribuables ayant le choix d'échapper à cette majoration du barème s'ils souscrivent à un « emprunt obligatoire » rémunéré à 3 % sur 10 ans.

--- a/openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml
+++ b/openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml
@@ -131,6 +131,8 @@ brackets:
       value: 10777
     2023-01-01:
       value: 11294
+    2024-01-01:
+      value: 11497
   rate:
     1945-01-01:
       value: 0.12
@@ -283,6 +285,8 @@ brackets:
       value: 27478
     2023-01-01:
       value: 28797
+    2024-01-01:
+      value: 29315
   rate:
     1945-01-01:
       value: 0.3
@@ -437,6 +441,8 @@ brackets:
       value: 78570
     2023-01-01:
       value: 82341
+    2024-01-01:
+      value: 83823
   rate:
     1945-01-01:
       value: 0.45
@@ -593,6 +599,8 @@ brackets:
       value: 168994
     2023-01-01:
       value: 177106
+    2024-01-01:
+      value: 180294
   rate:
     1945-01-01:
       value: 0.6
@@ -1224,7 +1232,7 @@ brackets:
       value: null
 metadata:
   short_label: Barème de l'impôt sur le revenu
-  last_value_still_valid_on: "2023-01-05"
+  last_value_still_valid_on: "2025-02-17"
   label_en: Thresholds and marginal tax rates
   reference:
     1945-01-01:
@@ -1443,6 +1451,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2024-01-01/
     - title: Loi 2023-1322, art. 2 du 29/12/2023 (LF pour 2024)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
+    2024-01-01:
+    - title: Loi 2025-127, art. 2 du 14/02/2025 de finances (LF pour 2025)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051168019
+    - title: Article 197, I.1. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2025-01-01/
   official_journal_date:
     1946-01-01: "1949-01-01"
     1959-01-01: "1959-12-31"
@@ -1509,6 +1522,7 @@ metadata:
     2020-01-01: 2020-12-30; 2019-12-29
     2022-01-01: "2022-12-31"
     2023-01-01: "2023-12-30"
+    2024-01-01: "2024-02-15"
   notes:
     1947-01-01:
     - title: Coexistence IGR et impôts cédulaires (voir notes 1 à 4). Ces barèmes concernent l'IGR jusqu'en 1948. En 1948, un « prélèvement exceptionnel de lutte contre l'inflation » sur les revenus 1946 est instauré dans le cadre du « plan Mayer » (intégré dans le barème); les contribuables ayant le choix d'échapper à cette majoration du barème s'ils souscrivent à un « emprunt obligatoire » rémunéré à 3 % sur 10 ans.
@@ -1532,6 +1546,8 @@ metadata:
     - title: Intégration de l'abattement de 20 % au barème de l'impôt sur le revenu et diminution du nombre de tranches de 7 à 5.
     2020-01-01:
     - title: La modification du taux est codifiée par la LF 2019 (le A. du IV. de l'art. 2 précise que l'application se fait au titre des revenus perçus ou réalisés en 2020). Les seuils d'entrée des troisièmes et quatrièmes tranches sont abaissés en compensation de la baisse du taux d'imposition dans la deuxième tranche, afin que la baisse d'impôt profite en priorité aux contribuables des deux premières tranches.
+    2025-01-01:
+    - title: Suite à la censure du gouvernement Barnier, la loi de finance a été publiée le 15 février 2025 avec effet rétro-actif au 1er janvier 2025.
   rate_unit: /1
   threshold_unit: currency_next_year
 documentation: |-

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/abat_dom/guadeloupe_martinique_reunion/plaf.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/abat_dom/guadeloupe_martinique_reunion/plaf.yaml
@@ -6,7 +6,7 @@ values:
     value: 2450
 metadata:
   short_label: Plafond max (Guadeloupe, Martinique, Réunion)
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2025-02-04"
   unit: currency_next_year
   reference:
     2001-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/abat_dom/guyane_mayotte/plaf.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/abat_dom/guyane_mayotte/plaf.yaml
@@ -6,7 +6,7 @@ values:
     value: 4050
 metadata:
   short_label: Plafond max (Guyane, Mayotte)
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2025-02-04"
   unit: currency_next_year
   reference:
     2001-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/decote/seuil_celib.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/decote/seuil_celib.yaml
@@ -100,9 +100,11 @@ values:
     value: 833
   2023-01-01:
     value: 873
+  2024-01-01:
+    value: 889
 metadata:
   short_label: Plafond pour les contribuables célibataires, divorcés ou veufs
-  last_value_still_valid_on: "2025-02-04"
+  last_value_still_valid_on: "2025-02-18"
   ipp_csv_id: param_decote
   unit: currency_next_year
   reference:
@@ -228,14 +230,19 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042907517/2022-01-01
     2022-01-01:
     - title: Article 197, I.4.a) du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2023-01-01/
     - title: Article 2, c) de la Loi n° 2022-1726 du 30/12/2022 (LF pour 2023)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046845640
     2023-01-01:
     - title: Article 197, I.4.a) du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2024-01-01/
     - title: Loi 2023-1322, art. 2 du 29/12/2023 (LF pour 2024)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
+    2024-01-01:
+    - title: Article 197, I.4.a) du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2025-01-01/
+    - title: Loi 2025-127, art. 2 du 14/02/2025 de finances (LF pour 2025)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051168019
   official_journal_date:
     1986-01-01: "1986-12-31"
     1987-01-01: "1987-12-31"
@@ -272,6 +279,7 @@ metadata:
     2021-01-01: "2021-12-31"
     2022-01-01: "2022-12-31"
     2023-01-01: "2023-12-30"
+    2024-01-01: "2025-02-15"
   notes:
     1986-01-01:
     - title: La décote s'applique uniquement aux contribuables ayant 1 ou 1,5 part avant 1986, c'est généralisé à tous après 1986. Demi-part généralisée à tous les enfants après le 3ème (loi 30/12/1986).

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/decote/seuil_celib.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/decote/seuil_celib.yaml
@@ -102,7 +102,7 @@ values:
     value: 873
 metadata:
   short_label: Plafond pour les contribuables célibataires, divorcés ou veufs
-  last_value_still_valid_on: "2024-01-03"
+  last_value_still_valid_on: "2025-02-04"
   ipp_csv_id: param_decote
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/decote/seuil_couple.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/decote/seuil_couple.yaml
@@ -38,9 +38,11 @@ values:
     value: 1378
   2023-01-01:
     value: 1444
+  2024-01-01:
+    value: 1470
 metadata:
   short_label: Plafond pour les contribuables en couple à imposition commune
-  last_value_still_valid_on: "2025-02-04"
+  last_value_still_valid_on: "2025-02-18"
   ipp_csv_id: param_decote_b
   unit: currency_next_year
   reference:
@@ -74,14 +76,19 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042907517/2022-01-01
     2022-01-01:
     - title: Article 197, I.4. a) du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2023-01-01/
     - title: Article 2, c) de la Loi n° 2022-1726 du 30/12/2022 (LF pour 2023)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046845640
     2023-01-01:
     - title: Article 197, I.4. a) du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2024-01-01/
     - title: Loi 2023-1322, art. 2 du 29/12/2023 (LF pour 2024)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
+    2024-01-01:
+    - title: Article 197, I.4. a) du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2025-01-01/
+    - title: Loi 2025-127, art. 2 du 14/02/2025 de finances (LF pour 2025)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051168019
   official_journal_date:
     2014-01-01: "2014-12-30"
     2015-01-01: "2015-12-30"
@@ -92,6 +99,7 @@ metadata:
     2021-01-01: "2021-12-31"
     2022-01-01: "2022-12-31"
     2023-01-01: "2023-12-30"
+    2024-01-01: "2025-02-15"
   notes:
     2014-01-01:
     - title: La formule de calcul de la décote change

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/decote/seuil_couple.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/decote/seuil_couple.yaml
@@ -40,7 +40,7 @@ values:
     value: 1444
 metadata:
   short_label: Plafond pour les contribuables en couple à imposition commune
-  last_value_still_valid_on: "2024-01-03"
+  last_value_still_valid_on: "2025-02-04"
   ipp_csv_id: param_decote_b
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/decote/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/decote/taux.yaml
@@ -10,7 +10,7 @@ values:
     value: 0.4525
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "2023-01-05"
+  last_value_still_valid_on: "2025-02-04"
   unit: /1
   reference:
     2001-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/celib.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/celib.yaml
@@ -50,7 +50,7 @@ values:
     value: 1050
 metadata:
   short_label: Personnes seules ayant eu des enfants
-  last_value_still_valid_on: "2024-01-03"
+  last_value_still_valid_on: "2025-02-04"
   label_en: Family quotient ceiling and "decote"
   ipp_csv_id: plaf_qf_persseule
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/celib.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/celib.yaml
@@ -48,9 +48,11 @@ values:
     value: 1002
   2023-01-01:
     value: 1050
+  2024-01-01:
+    value: 1069
 metadata:
   short_label: Personnes seules ayant eu des enfants
-  last_value_still_valid_on: "2025-02-04"
+  last_value_still_valid_on: "2025-02-18"
   label_en: Family quotient ceiling and "decote"
   ipp_csv_id: plaf_qf_persseule
   unit: currency_next_year
@@ -148,6 +150,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759
     - title: Loi 2023-1322, art. 2 du 29/12/2023 (LF pour 2024)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
+    2024-01-01:
+    - title: Article 197, I.2.§3 du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2025-01-01/
+    - title: Loi 2025-127, art. 2 du 14/02/2025 de finances (LF pour 2025)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051168019
   official_journal_date:
     1997-01-01: "1997-12-31"
     1999-01-01: "1999-12-31"
@@ -172,6 +179,7 @@ metadata:
     2021-01-01: "2021-12-31"
     2022-01-01: "2022-12-31"
     2023-01-01: "2023-12-30"
+    2024-01-01: "2025-02-15"
   notes:
     1997-01-01:
     - title: Création de la catégorie "personne seule" (art. 2 de la loi de finances pour 1998)

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/celib_enf.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/celib_enf.yaml
@@ -74,7 +74,7 @@ values:
     value: 4149
 metadata:
   short_label: Part pour le 1er enfant des parents isolés
-  last_value_still_valid_on: "2024-01-03"
+  last_value_still_valid_on: "2025-02-04"
   label_en: Family quotient ceiling and "decote"
   ipp_csv_id: plaf_qf_parentisole
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/celib_enf.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/celib_enf.yaml
@@ -72,9 +72,11 @@ values:
     value: 3959
   2023-01-01:
     value: 4149
+  2024-01-01:
+    value: 4224
 metadata:
   short_label: Part pour le 1er enfant des parents isolés
-  last_value_still_valid_on: "2025-02-04"
+  last_value_still_valid_on: "2025-02-18"
   label_en: Family quotient ceiling and "decote"
   ipp_csv_id: plaf_qf_parentisole
   unit: currency_next_year
@@ -201,14 +203,19 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042907517/2022-01-01
     2022-01-01:
     - title: Article 197, I.2.§2 du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2023-01-01/
     - title: Article 2, b) de la Loi n° 2022-1726 du 30/12/2022 (LF pour 2023)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046845640
     2023-01-01:
     - title: Article 197, I.2.§2 du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2024-01-01/
     - title: Loi 2023-1322, art. 2 du 29/12/2023 (LF pour 2024)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
+    2024-01-01:
+    - title: Article 197, I.2.§2 du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2025-01-01/
+    - title: Loi 2025-127, art. 2 du 14/02/2025 de finances (LF pour 2025)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051168019
   official_journal_date:
     1986-01-01: "1986-12-31"
     1987-01-01: "1987-12-31"
@@ -245,6 +252,7 @@ metadata:
     2021-01-01: "2021-12-31"
     2022-01-01: "2022-12-31"
     2023-01-01: "2023-12-30"
+    2024-01-01: "2025-02-15"
   notes:
     1986-01-01:
     - title: La décote s'applique uniquement aux contribuables ayant 1 ou 1,5 part avant 1986, c'est généralisé à tous après 1986. Demi-part généralisée à tous les enfants après le 3ème (loi 30/12/1986).

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/general.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/general.yaml
@@ -86,9 +86,11 @@ values:
     value: 1678
   2023-01-01:
     value: 1759
+  2024-01-01:
+    value: 1791
 metadata:
   short_label: Plafond par demi-part (cas général)
-  last_value_still_valid_on: "2025-02-04"
+  last_value_still_valid_on: "2025-02-17"
   label_en: Family quotient ceiling and "decote"
   ipp_csv_id: plaf_qf
   unit: currency_next_year
@@ -242,9 +244,14 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046845640
     2023-01-01:
     - title: Article 197, I.2.§1 du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2023-01-01/
     - title: Loi 2023-1322, art. 2 du 29/12/2023 (LF pour 2024)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
+    2024-01-01:
+    - title: Article 197, I.2. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2025-01-01/
+    - title: Loi 2025-127, art. 2 du 14/02/2025 de finances (LF pour 2025)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051168019
   official_journal_date:
     1981-01-01: "1981-12-31"
     1982-01-01: "1982-12-30"
@@ -288,6 +295,7 @@ metadata:
     2021-01-01: "2021-12-31"
     2022-01-01: "2022-12-31"
     2023-01-01: "2023-12-30"
+    2024-01-01: "2024-02-15"
   notes:
     1986-01-01:
     - title: La décote s'applique uniquement aux contribuables ayant 1 ou 1,5 part avant 1986, c'est généralisé à tous après 1986. Demi-part généralisée à tous les enfants après le 3ème (loi 30/12/1986).

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/general.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/general.yaml
@@ -88,7 +88,7 @@ values:
     value: 1759
 metadata:
   short_label: Plafond par demi-part (cas général)
-  last_value_still_valid_on: "2024-01-03"
+  last_value_still_valid_on: "2025-02-04"
   label_en: Family quotient ceiling and "decote"
   ipp_csv_id: plaf_qf
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/reduc_postplafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/reduc_postplafond.yaml
@@ -48,7 +48,7 @@ values:
     value: 1753
 metadata:
   short_label: Réduction supplémentaire (invalides, etc.)
-  last_value_still_valid_on: "2023-01-05"
+  last_value_still_valid_on: "2025-02-04"
   label_en: Family quotient ceiling and "decote"
   ipp_csv_id: plaf_qf_inv
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/reduc_postplafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/reduc_postplafond.yaml
@@ -46,9 +46,11 @@ values:
     value: 1673
   2023-01-01:
     value: 1753
+  2024-01-01:
+    value: 1785
 metadata:
   short_label: Réduction supplémentaire (invalides, etc.)
-  last_value_still_valid_on: "2025-02-04"
+  last_value_still_valid_on: "2025-02-18"
   label_en: Family quotient ceiling and "decote"
   ipp_csv_id: plaf_qf_inv
   unit: currency_next_year
@@ -134,14 +136,19 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042907517/2022-01-01
     2022-01-01:
     - title: Article 197, I.2.§4 du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2023-01-01/
     - title: Article 2, b) de la Loi n° 2022-1726 du 30/12/2022 (LF pour 2023)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046845640
     2023-01-01:
     - title: Article 197, I.2.§4 du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2024-01-01/
     - title: Loi 2023-1322, art. 2 du 29/12/2023 (LF pour 2024)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
+    2024-01-01:
+    - title: Article 197, I.2.§4 du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2025-01-01/
+    - title: Loi 2025-127, art. 2 du 14/02/2025 de finances (LF pour 2025)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051168019
   official_journal_date:
     1998-01-01: "1998-12-31"
     2001-01-01: "2001-12-29"
@@ -165,6 +172,7 @@ metadata:
     2021-01-01: "2021-12-31"
     2022-01-01: "2022-12-31"
     2023-01-01: "2023-12-30"
+    2024-01-01: "2025-02-15"
   notes:
     1998-01-01:
     - title: Création de la catégorie "invalidité" (art. 3 de la loi de finances pour 1999)

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/reduc_postplafond_veuf.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/reduc_postplafond_veuf.yaml
@@ -26,9 +26,11 @@ values:
     value: 1868
   2023-01-01:
     value: 1958
+  2024-01-01:
+    value: 1993
 metadata:
   short_label: Réduction supplémentaire (veufs avec enfants à charge)
-  last_value_still_valid_on: "2025-02-04"
+  last_value_still_valid_on: "2025-02-17"
   label_en: Family quotient ceiling and "decote"
   ipp_csv_id: plaf_qf_persseule
   unit: currency_next_year
@@ -74,14 +76,19 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042907517/2022-01-01
     2022-01-01:
     - title: Article 197, I.2.§5 du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2023-01-01/
     - title: Article 2, b) de la Loi n° 2022-1726 du 30/12/2022 (LF pour 2023)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046845640
     2023-01-01:
     - title: Article 197, I.2.§5 du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2024-01-01/
     - title: Loi 2023-1322, art. 2 du 29/12/2023 (LF pour 2024)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
+    2024-01-01:
+    - title: Article 197, I.2.§5 du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860759/2025-01-01/
+    - title: Loi 2025-127, art. 2 du 14/02/2025 de finances (LF pour 2025)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051168019
   official_journal_date:
     2012-01-01: "2012-12-29"
     2013-01-01: "2013-12-30"
@@ -95,6 +102,7 @@ metadata:
     2021-01-01: "2021-12-31"
     2022-01-01: "2022-12-31"
     2023-01-01: "2023-12-30"
+    2024-01-01: "2025-02-15"
   notes:
     2012-01-01:
     - title: Création de la réduction d'impôt complémentaire pour veuf avec un ou plusieurs enfants à charge. Cette réduction ne s'applique qu'aux veufs concernés par le plafonnement du quotient familial.

--- a/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/reduc_postplafond_veuf.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_impot_revenu/plaf_qf/plafond_avantages_procures_par_demi_part/reduc_postplafond_veuf.yaml
@@ -28,7 +28,7 @@ values:
     value: 1958
 metadata:
   short_label: Réduction supplémentaire (veufs avec enfants à charge)
-  last_value_still_valid_on: "2024-01-03"
+  last_value_still_valid_on: "2025-02-04"
   label_en: Family quotient ceiling and "decote"
   ipp_csv_id: plaf_qf_persseule
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/depenses_investissement_forestier/travaux/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/depenses_investissement_forestier/travaux/plafond.yaml
@@ -4,7 +4,7 @@ values:
     value: 6250
 metadata:
   short_label: Plafond de dépenses
-  last_value_still_valid_on: "2023-01-09"
+  last_value_still_valid_on: "2025-02-04"
   unit: currency_next_year
   reference:
     2009-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/outremer_investissement/doment/propre_entreprise/majoration.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/outremer_investissement/doment/propre_entreprise/majoration.yaml
@@ -4,12 +4,11 @@ values:
     value: 2.5
 metadata:
   short_label: Coefficient de majoration du plafond de réductions
-  last_value_still_valid_on: "2022-10-11"
+  last_value_still_valid_on: "2025-02-04"
   reference:
     2009-01-01:
     - title: Loi 2008-1425 du 27/12/2008 - art. 87 (V) (créé Art. 199 undecies D)
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000020000207/2008-12-29/
     - title: Art. 199 undecies D, II. du CGI
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000020034322/
-documentation: "Dans le Code général des impôts, le coefficient de majoration du plafond n'est pas exprimé en pourcentage, c'est pourquoi il n'a pas d''unit'"
-    
+documentation: "Dans le Code général des impôts, le coefficient de majoration du plafond n'est pas exprimé en pourcentage, c'est pourquoi il n'a pas d''unit'. Le texte mentionné est `deux fois et demie la limite mentionnée`"

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/outremer_investissement/plaf_bis.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/outremer_investissement/plaf_bis.yaml
@@ -10,7 +10,7 @@ values:
     value: 0.11
 metadata:
   short_label: Plafond (% revenu imposable)
-  last_value_still_valid_on: "2023-07-04"
+  last_value_still_valid_on: "2025-02-04"
   unit: /1
   reference:
     2003-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/enfant_marie.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/enfant_marie.yaml
@@ -94,9 +94,11 @@ values:
     value: 6368
   2023-01-01:
     value: 6674
+  2024-01-01:
+    value: 6794
 metadata:
   short_label: Abattement pour enfant marié/pacsé et enfant non marié chargé de famille (case N)
-  last_value_still_valid_on: "2025-02-04"
+  last_value_still_valid_on: "2025-02-18"
   label_en: Tax allowance for net taxable income
   ipp_csv_id: abt_enfmaries
   unit: currency_next_year
@@ -189,14 +191,19 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041464076/2022-01-01/
     2022-01-01:
     - title: Article 196 B du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860788
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860788/2023-01-01/
     - title: Article 2 de la loi n° 2022-1726 du 30/12/2022 (LF pour 2023)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046845640
     2023-01-01:
     - title: Article 196 B du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860788
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860788/2024-01-01/
     - title: Article 2 de la loi n° 2023-1322 du 29/12/2023 (LF pour 2024)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
+    2024-01-01:
+    - title: Article 196 B du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860788/2025-01-01/
+    - title: Loi 2025-127, art. 2 du 14/02/2025 de finances (LF pour 2025)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051168019
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"
@@ -235,6 +242,7 @@ metadata:
     2021-01-01: 2021-12-31; 2021-06-11
     2022-01-01: "2022-12-31"
     2023-01-01: "2022-12-30"
+    2024-01-01: "2025-02-15"
   notes:
     2001-01-01:
     - title: Voir aussi Loi 2001-1276 du 28/12/2001 - art. 51 (LFR pour 2001)

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/enfant_marie.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/enfant_marie.yaml
@@ -96,7 +96,7 @@ values:
     value: 6674
 metadata:
   short_label: Abattement pour enfant marié/pacsé et enfant non marié chargé de famille (case N)
-  last_value_still_valid_on: "2023-07-05"
+  last_value_still_valid_on: "2025-02-04"
   label_en: Tax allowance for net taxable income
   ipp_csv_id: abt_enfmaries
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/taux_jgt_2006.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/taux_jgt_2006.yaml
@@ -6,7 +6,7 @@ values:
     value: 1.25
 metadata:
   short_label: "Cas spécifique - Coefficient de réévaluation des pensions alimentaires d'une décision de justice avant le 01.01.2006"
-  last_value_still_valid_on: "2023-10-17"
+  last_value_still_valid_on: "2025-02-04"
   unit: /1
   reference:
     2006-01-01:
@@ -17,3 +17,4 @@ metadata:
     - title: BOI 5 B-10-07 n°47 du 29/03/2007
   official_journal_date:
     2006-01-01: "2006-12-27"
+documentation: "Le texte mentionne `est multiplié par un coefficient de 1,25`"

--- a/openfisca_france/parameters/impot_revenu/credits_impots/aide_a_domicile/plafond/plafond_additionnel.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/aide_a_domicile/plafond/plafond_additionnel.yaml
@@ -4,7 +4,7 @@ values:
     value: 1500
 metadata:
   short_label: Majoration du plafond des dépenses (/pers de 65ans ou enfant)
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-02-24"
   label_en: Tax credits for personal care assistant employment
   ipp_csv_id: plafond_credit_aide_majoration
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond.yaml
@@ -4,7 +4,7 @@ values:
     value: 12000
 metadata:
   short_label: Plafond des dépenses, avant majorations
-  last_value_still_valid_on: "2024-11-14"
+  last_value_still_valid_on: "2025-02-24"
   ipp_csv_id: plafsaldomicile
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond_1ere_annee.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond_1ere_annee.yaml
@@ -4,7 +4,7 @@ values:
     value: 15000
 metadata:
   short_label: Plafond des dépenses, avant majorations, la première année
-  last_value_still_valid_on: "2024-11-14"
+  last_value_still_valid_on: "2025-02-24"
   unit: currency_next_year
   reference:
     2008-01-01:

--- a/openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond_invalides.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond_invalides.yaml
@@ -4,7 +4,7 @@ values:
     value: 20000
 metadata:
   short_label: Plafond des dépenses, avant majorations, pour les contribuables invalides ou ayant à charge une personne invalide
-  last_value_still_valid_on: "2024-11-14"
+  last_value_still_valid_on: "2025-02-24"
   ipp_csv_id: plafsaldominvalide
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond_maximum.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond_maximum.yaml
@@ -4,7 +4,7 @@ values:
     value: 15000
 metadata:
   short_label: Plafond des dépenses, après majorations
-  last_value_still_valid_on: "2024-11-14"
+  last_value_still_valid_on: "2025-02-24"
   ipp_csv_id: superplafsaldom
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond_maximum_1ere_annee.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond_maximum_1ere_annee.yaml
@@ -4,7 +4,7 @@ values:
     value: 18000
 metadata:
   short_label: Plafond des dépenses, après majorations, la première année
-  last_value_still_valid_on: "2024-11-14"
+  last_value_still_valid_on: "2025-02-24"
   unit: currency_next_year
   reference:
     2008-01-01:

--- a/openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/taux.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.5
 metadata:
   short_label: Taux du crédit d'impôt
-  last_value_still_valid_on: "2024-11-14"
+  last_value_still_valid_on: "2025-02-24"
   ipp_csv_id: txsaldomicile
   unit: /1
   reference:

--- a/openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/plafond/plafond_commun/celib.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/plafond/plafond_commun/celib.yaml
@@ -3,6 +3,7 @@ values:
   2005-01-01:
     value: 5000
 metadata:
+  last_value_still_valid_on: "2025-02-24"
   short_label: Célibataires
   ipp_csv_id: plaf_aide_pers_celib
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/plafond/plafond_commun/couple.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/plafond/plafond_commun/couple.yaml
@@ -3,6 +3,7 @@ values:
   2005-01-01:
     value: 10000
 metadata:
+  last_value_still_valid_on: "2025-02-24"
   short_label: Déclarations communes
   ipp_csv_id: plaf_aide_pers_couple
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/plafond/plafond_commun/maj_pac.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/plafond/plafond_commun/maj_pac.yaml
@@ -3,6 +3,7 @@ values:
   2006-01-01:
     value: 400
 metadata:
+  last_value_still_valid_on: "2025-02-24"
   short_label: Majoration par personne à charge
   ipp_csv_id: plaf_aide_pers_pac
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/plafond/plafond_risque_techno_apres_2015.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/plafond/plafond_risque_techno_apres_2015.yaml
@@ -3,6 +3,7 @@ values:
   2015-01-01:
     value: 20000
 metadata:
+  last_value_still_valid_on: "2025-02-24"
   short_label: Plafond de dépenses de travaux de prévention des risques technologiques et diagnostic préalable (à compter de l'imposition des revenus 2015)
   ipp_csv_id: plaf_risques_techno_post_2015
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/taux/taux_equ_pers_agees_hand.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/taux/taux_equ_pers_agees_hand.yaml
@@ -3,6 +3,7 @@ values:
   2005-01-01:
     value: 0.25
 metadata:
+  last_value_still_valid_on: "2025-02-24"
   short_label: Equipements conçus pour les personnes âgées ou handicapées (case 7WJ)
   ipp_csv_id: tx_equ_pers_agees_hand
   unit: /1

--- a/openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/taux/taux_risques_techno.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/taux/taux_risques_techno.yaml
@@ -5,6 +5,7 @@ values:
   2013-01-01:
     value: 0.4
 metadata:
+  last_value_still_valid_on: "2025-02-24"
   short_label: Travaux de prévention des risques technologiques et diagnostic préalable (case 7WL)
   ipp_csv_id: tx_risques_techno
   unit: /1

--- a/openfisca_france/parameters/impot_revenu/credits_impots/gardenf/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/gardenf/plafond.yaml
@@ -20,7 +20,7 @@ values:
     value: 3500
 metadata:
   short_label: Plafond de dépenses par enfant à charge
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-02-24"
   label_en: Child care costs
   ipp_csv_id: plafgardenf
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/credits_impots/gardenf/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/gardenf/taux.yaml
@@ -7,6 +7,7 @@ values:
   2006-01-01:
     value: 0.5
 metadata:
+  last_value_still_valid_on: "2025-02-24"
   short_label: Taux du crédit d'impôt
   label_en: Child care costs
   ipp_csv_id: txgardenf

--- a/openfisca_france/parameters/impot_revenu/credits_impots/interets_emprunt_habitation_principale/cas_base/taux_applique_premiere_annuite_remboursement.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/interets_emprunt_habitation_principale/cas_base/taux_applique_premiere_annuite_remboursement.yaml
@@ -3,6 +3,7 @@ values:
   2007-01-01:
     value: 0.4
 metadata:
+  last_value_still_valid_on: "2025-02-24"
   short_label: Taux 1ère année
   unit: /1
   reference:

--- a/openfisca_france/parameters/impot_revenu/credits_impots/interets_emprunt_habitation_principale/majoration_plafond_par_enfant_charge.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/interets_emprunt_habitation_principale/majoration_plafond_par_enfant_charge.yaml
@@ -3,6 +3,7 @@ values:
   2007-01-01:
     value: 500
 metadata:
+  last_value_still_valid_on: "2025-02-24"
   short_label: Majoration par enfant à charge
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/credits_impots/interets_emprunt_habitation_principale/plafond_base.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/interets_emprunt_habitation_principale/plafond_base.yaml
@@ -3,6 +3,7 @@ values:
   2007-01-01:
     value: 3750
 metadata:
+  last_value_still_valid_on: "2025-02-24"
   short_label: Plafond
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/credits_impots/plaf_nich/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/plaf_nich/plafond.yaml
@@ -10,7 +10,7 @@ values:
     value: 10000
 metadata:
   short_label: Plafond
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-02-24"
   ipp_csv_id: plaf_nich
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/credits_impots/plaf_nich/plafonnement_des_niches/majoration_om.yaml
+++ b/openfisca_france/parameters/impot_revenu/credits_impots/plaf_nich/plafonnement_des_niches/majoration_om.yaml
@@ -4,7 +4,7 @@ values:
     value: 8000
 metadata:
   short_label: Majoration du plafond s’agissant des réductions d'impôt outre-mer et SOFICA
-  last_value_still_valid_on: "2023-10-17"
+  last_value_still_valid_on: "2025-02-24"
   ipp_csv_id: majo_nich
   unit: currency_next_year
   reference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.16.14"
+version = "169.16.15"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
    * Périodes concernées : 2025.
    * Zones impactées :
      - openfisca_france/parameters/impot_revenu/credits_impots/aide_a_domicile/plafond/plafond_additionnel.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond_1ere_annee.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond_invalides.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond_maximum.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/plafond_maximum_1ere_annee.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/emploi_salarie_domicile/taux.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/plafond/plafond_commun/celib.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/plafond/plafond_commun/couple.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/plafond/plafond_risque_techno_apres_2015.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/taux/taux_equ_pers_agees_hand.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/interets_emprunt_habitation_principale/cas_base/taux_applique_premiere_annuite_remboursement.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/interets_emprunt_habitation_principale/majoration_plafond_par_enfant_charge.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/plaf_nich/plafond.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/plaf_nich/plafonnement_des_niches/majoration_om.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/plaf_nich/plafonnement_des_niches/majoration_om.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/plafond/plafond_commun/maj_pac.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/equ_hab_princ_aide_personnes/taux/taux_risques_techno.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/gardenf/plafond.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/gardenf/taux.yaml
  - openfisca_france/parameters/impot_revenu/credits_impots/interets_emprunt_habitation_principale/plafond_base.yaml
    * Détails :
    - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.

    - - - -

    Ces changements (effacez les lignes ne correspondant pas à votre cas) :

    - Mise à jour de paramètre.

    - - - -

    Méthodologie :
    1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
    1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
    1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
    1. Vérifie la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
    1. Met à jour la `last_value_still_valid_on` à la date du jour.
    1. Crée un tableau récapitulatif pour faciliter la revue.

    Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

    - - - -

    Quelques conseils à prendre en compte :

    - [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
    - [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
    - [X] Documentez votre contribution avec des références législatives.
    - [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
    - [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
    - [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
    - [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
    
    Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme n'ayant pas changés depuis la date indiquée dans `last_value_still_valid_on`.

    Aide à la revue :
    
* impot_revenu.credits_impots.aide_a_domicile.plafond.plafond_additionnel
    - Description : Majoration, par personne de 65 ans ou enfant membre du foyer fiscal, du plafond des dépenses retenues dans le calcul du crédit d'impôt pour l'aide à domicile
    - 1500.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046861251/2023-10-17) de type CODE
    - Extrait : _[...]vu par le deuxième alinéa de l'article L. 541-1 du même code.
La limite de 12 000 € est majorée de 1 500 € par enfant à charge au sens des articles 196 et 196 B et au titre de chacun des membres du f[...]_
    - Reponse du LLM : _La valeur de 'Majoration, par personne de 65 ans ou enfant membre du foyer fiscal, du plafond des dépenses retenues dans le calcul du crédit d'impôt pour l'aide à domicile' est de 1500 €.  La réponse est donc : ``` {     "valeur": 1500.0 } ```_
    
* impot_revenu.credits_impots.emploi_salarie_domicile.plafond
    - Description : Plafond des dépenses, avant majorations, prises en compte pour le calcul du crédit d'impôt sur le revenu (IR) pour emploi d'un salarié à domicile
    - 12000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046861251) de type CODE
    - Extrait : _[...]épenses mentionnées au 1 sont retenues, pour leur montant effectivement supporté, dans la limite de 12 000 €, sous réserve des plafonds prévus à l'article D. 7233-5 du code du travail dans sa rédactio[...]_
    - Reponse du LLM : _La valeur de 'Plafond des dépenses, avant majorations, prises en compte pour le calcul du crédit d'impôt sur le revenu (IR) pour emploi d'un salarié à domicile' est indiquée dans le texte comme étant de 12 000 €.  La réponse est donc :  ``` {     "valeur": 12000.0 } ```_
    
* impot_revenu.credits_impots.emploi_salarie_domicile.plafond_1ere_annee
    - Description : Plafond des dépenses, la première année, avant majorations pour enfants à charge et personne de plus de 65 ans, prises en compte pour le calcul du crédit d'impôt sur le revenu (IR) pour emploi d'un salarié à domicile
    - 15000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046861251) de type CODE
    - Extrait : _[...]de du travail dans sa rédaction en vigueur au 1er janvier 2021.
La limite de 12 000 € est portée à 15 000 € pour la première année d'imposition pour laquelle le contribuable bénéficie des disposition[...]_
    - Reponse du LLM : _La valeur de 'Plafond des dépenses, la première année, avant majorations pour enfants à charge et personne de plus de 65 ans, prises en compte pour le calcul du crédit d'impôt sur le revenu (IR) pour emploi d'un salarié à domicile' est de 15000.0.  Réponse : ``` {     "valeur": 15000.0 } ```_
    
* impot_revenu.credits_impots.emploi_salarie_domicile.plafond_invalides
    - Description : Plafond des dépenses, avant majorations, prises en compte pour le calcul du crédit d'impôt sur le revenu (IR) pour emploi d'un salarié à domicile, pour les contribuables invalides en incapacité d'exercer une profession et dans l'obligation d'avoir assistance d'une tierce personne, pour les contribuables ayant à charge une personne invalide dans les mêmes conditions ou un enfant bénéficiaire du complément d'allocation d'éducation de l'enfant handicapé
    - 20000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046861251) de type CODE
    - Extrait : _[...]buable bénéficie des dispositions du présent article au titre du a du 1.
Cette limite est portée à 20 000 € pour les contribuables mentionnés au 3° de l'article L. 341-4 du code de la sécurité social[...]_
    - Reponse du LLM : _La valeur de 'Plafond des dépenses, avant majorations, prises en compte pour le calcul du crédit d'impôt sur le revenu (IR) pour emploi d'un salarié à domicile, pour les contribuables invalides en incapacité d'exercer une profession et dans l'obligation d'avoir assistance d'une tierce personne, pour les contribuables ayant à charge une personne invalide dans les mêmes conditions ou un enfant bénéficiaire du complément d'allocation d'éducation de l'enfant handicapé' est de 20000.  Réponse : ``` {     "valeur": 20000.0 } ```_
    
* impot_revenu.credits_impots.emploi_salarie_domicile.plafond_maximum
    - Description : Plafond des dépenses, après majorations pour enfants à charge et personne de plus de 65 ans, prises en compte pour le calcul du crédit d'impôt sur le revenu (IR) pour emploi d'un salarié à domicile
    - 15000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046861251) de type CODE
    - Extrait : _[...]de du travail dans sa rédaction en vigueur au 1er janvier 2021.
La limite de 12 000 € est portée à 15 000 € pour la première année d'imposition pour laquelle le contribuable bénéficie des disposition[...]_
    - Reponse du LLM : _La valeur de 'Plafond des dépenses, après majorations pour enfants à charge et personne de plus de 65 ans, prises en compte pour le calcul du crédit d'impôt sur le revenu (IR) pour emploi d'un salarié à domicile' n'est pas explicitement indiquée dans le texte fourni. Cependant, le texte mentionne des plafonds pour les dépenses :  - Un plafond de 12 000 € pour les dépenses mentionnées au 1, sous réserve des plafonds prévus à l'article D. 7233-5 du code du travail. - Un plafond de 15 000 € pour la première année d'imposition pour laquelle le contribuable bénéficie des dispositions du présent article au titre du a du 1. - Un plafond de 20 000 € pour les contribuables mentionnés au 3° de l'article L. 341-4 du code de la sécurité sociale, ainsi que pour les contribuables ayant à leur charge une personne, vivant sous leur toit, mentionnée au même 3°, ou un enfant donnant droit au complément d'allocation d'éducation de l'enfant handicapé prévu par le deuxième alinéa de l'article L. 541-1 du même code. - La limite de 12 000 € est majorée de 1 500 € par enfant à charge et par personne de plus de 65 ans, avec un maximum de 15 000 €, ou 18 000 € lorsque les dispositions du deuxième alinéa sont applicables.  Puisque la valeur à une autre date de validité était '15000.0', il est possible que cette valeur soit toujours applicable, mais cela n'est pas explicitement indiqué dans le texte fourni.  La réponse est donc : ``` {     "valeur": 15000.0 } ```_
    
* impot_revenu.credits_impots.emploi_salarie_domicile.plafond_maximum_1ere_annee
    - Description : Plafond des dépenses, la première année, après majorations pour enfants à charge et personne de plus de 65 ans, prises en compte pour le calcul du crédit d'impôt sur le revenu (IR) pour emploi d'un salarié à domicile
    - 18000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046861251) de type CODE
    - Extrait : _[...] l'objet des majorations prévues au présent alinéa et le montant total des dépenses ne peut excéder 18 000 €.
4. Le crédit d'impôt est égal à 50 % des dépenses mentionnées au 3 au titre des services [...]_
    - Reponse du LLM : _La valeur de 'Plafond des dépenses, la première année, après majorations pour enfants à charge et personne de plus de 65 ans, prises en compte pour le calcul du crédit d'impôt sur le revenu (IR) pour emploi d'un salarié à domicile' est de 15000.0. Cependant, cette valeur peut être majorée de 1500 € par enfant à charge et par personne de plus de 65 ans, avec un plafond de 18000 €.  La réponse est donc : ``` {     "valeur": 18000.0 } ```_
    
* impot_revenu.credits_impots.emploi_salarie_domicile.taux
    - Description : Taux du crédit d'impôt sur le revenu (IR) pour emploi d'un salarié à domicile
    - 0.5
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046861251) de type CODE
    - Extrait : _[...] par le deuxième alinéa de l'article L. 541-1 du même code.
La limite de 12 000 € est majorée de 1 500 € par enfant à charge au sens des articles 196 et 196 B et au titre de chacun des membres du foy[...]_
    - Reponse du LLM : _La valeur de 'Taux du crédit d'impôt sur le revenu (IR) pour emploi d'un salarié à domicile' est indiquée dans le paragraphe 4 du texte fourni. Il est mentionné que "Le crédit d'impôt est égal à 50 % des dépenses mentionnées au 3 au titre des services définis aux articles L. 7231-1 et D. 7231-1 du code du travail fournis dans les conditions prévues au 2, supportées par le contribuable au titre de l'emploi d'un salarié ou en cas de recours à une association, une entreprise ou un organisme, mentionné aux b ou c du 1."  Ainsi, le taux du crédit d'impôt est de 50%, ce qui équivaut à 0,5 en notation mathématique.  La réponse est donc :  ``` {     "valeur": 0.5 } ```_
    
* impot_revenu.credits_impots.equ_hab_princ_aide_personnes.plafond.plafond_commun.celib
    - Description : Célibataires
    - 5000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049641733/2024-06-02) de type CODE
    - Extrait : _[...]de cinq années consécutives comprises entre le 1er janvier 2005 et le 31 décembre 2025, la somme de 5 000 € pour une personne célibataire, veuve ou divorcée et de 10 000 € pour un couple marié soumis [...]_
    - Reponse du LLM : _La valeur de 'Célibataires - impot_revenu.credits_impots.equ_hab_princ_aide_personnes.plafond.plafond_commun.celib - nan' est indiquée dans le paragraphe 4 du texte :  "4. Pour un même logement, le montant des dépenses mentionnées au 1 ouvrant droit au crédit d'impôt ne peut excéder, au titre d'une période de cinq années consécutives comprises entre le 1er janvier 2005 et le 31 décembre 2025, la somme de 5 000 € pour une personne célibataire, veuve ou divorcée et de 10 000 € pour un couple marié soumis à imposition commune."  La réponse est donc :  {     "valeur": 5000.0 }_
    
* impot_revenu.credits_impots.equ_hab_princ_aide_personnes.plafond.plafond_commun.couple
    - Description : Déclarations communes
    - 10000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049641733/2024-06-02) de type CODE
    - Extrait : _[...] et le 31 décembre 2025, la somme de 5 000 € pour une personne célibataire, veuve ou divorcée et de 10 000 € pour un couple marié soumis à imposition commune. Cette somme est majorée de 400 € par pers[...]_
    - Reponse du LLM : _La valeur de 'Déclarations communes - impot_revenu.credits_impots.equ_hab_princ_aide_personnes.plafond.plafond_commun.couple - nan' est de 10000.0.  Cependant, il est important de noter que cette valeur est mentionnée comme étant valable pour une autre date de validité. Le texte fourni ne contient pas d'information spécifique sur la valeur actuelle pour un couple.  Mais on peut trouver une information qui pourrait être utile : "4. Pour un même logement, le montant des dépenses mentionnées au 1 ouvrant droit au crédit d'impôt ne peut excéder, au titre d'une période de cinq années consécutives comprises entre le 1er janvier 2005 et le 31 décembre 2025, la somme de 5 000 € pour une personne célibataire, veuve ou divorcée et de 10 000 € pour un couple marié soumis à imposition commune."  La réponse est donc : ``` {     "valeur": 10000.0 } ```_
    
* impot_revenu.credits_impots.equ_hab_princ_aide_personnes.plafond.plafond_risque_techno_apres_2015
    - Description : Plafond de dépenses de travaux de prévention des risques technologiques et diagnostic préalable (à compter de l'imposition des revenus 2015)
    - 20000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049641733/2024-06-02) de type CODE
    - Extrait : _[...]s au I des articles L. 515-16-2 et L. 515-19 du code de l'environnement ne peut excéder la somme de 20 000 €. Lorsque plusieurs contribuables détiennent la propriété du même logement, cette somme est [...]_
    - Reponse du LLM : _La valeur de 'Plafond de dépenses de travaux de prévention des risques technologiques et diagnostic préalable (à compter de l'imposition des revenus 2015)' est indiquée dans le paragraphe 4 bis du texte fourni. Elle est égale à 20 000 €.  La réponse est donc :  ``` {     "valeur": 20000.0 } ```_
    
* impot_revenu.credits_impots.equ_hab_princ_aide_personnes.taux.taux_equ_pers_agees_hand
    - Description : Taux du crédit d'impôt pour les dépenses d'installation ou de remplacement d'équipements spécialement conçus pour les personnes âgées ou handicapées
    - 0.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049641733/2024-06-02) de type CODE
    - Extrait : _[...] équipements mentionnés au a doivent être :
1° Payés entre le 1er janvier 2005 et le 31 décembre 2025 dans le cadre de travaux réalisés dans un logement achevé ;
2° Intégrés à un logement acquis neu[...]_
    - Reponse du LLM : _La valeur de 'Taux du crédit d'impôt pour les dépenses d'installation ou de remplacement d'équipements spécialement conçus pour les personnes âgées ou handicapées' est indiquée dans le texte à la section 5, a : "25 % du montant des dépenses mentionnées au 1".  La valeur est donc de 0.25.  Réponse : ``` {     "valeur": 0.25 } ```_
    
* impot_revenu.credits_impots.interets_emprunt_habitation_principale.cas_base.taux_applique_premiere_annuite_remboursement
    - Description : Taux appliqué à la première annuité de remboursement pour le crédit d'impôt sur les intérêts d'emprunt pour l'habitation principale
    - 0.4
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000017923830/2024-11-12/) de type CODE
    - Extrait : _[...] % du montant des intérêts mentionnés au III, dans la limite mentionnée au IV.
Ce taux est porté à 40 % pour les intérêts payés au titre de la première annuité de remboursement.
Toutefois, pour les [...]_
    - Reponse du LLM : _La valeur de 'Taux appliqué à la première annuité de remboursement pour le crédit d'impôt sur les intérêts d'emprunt pour l'habitation principale' est de 0.4.   Cependant, il est important de noter que cette valeur peut varier en fonction des conditions spécifiques, telles que la date d'acquisition ou de construction du logement, ainsi que les caractéristiques énergétiques du logement.  Voici la réponse au format JSON :  ``` {     "valeur": 0.4 } ```_
    
* impot_revenu.credits_impots.interets_emprunt_habitation_principale.majoration_plafond_par_enfant_charge
    - Description : Majoration du plafond par enfant à charge du crédit d'impôt sur les intérêts d'emprunt pour l'habitation principale
    - 500.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000017923830/2024-11-12/) de type CODE
    - Extrait : _[...]ue année d'imposition, la somme de 3 750 € pour une personne célibataire, veuve ou divorcée et de 7 500 € pour un couple soumis à imposition commune. Cette somme est majorée chaque année de 500 € par [...]_
    - Reponse du LLM : _La valeur de 'Majoration du plafond par enfant à charge du crédit d'impôt sur les intérêts d'emprunt pour l'habitation principale' est indiquée dans le texte comme suit : "La somme de 500 € est divisée par deux lorsqu'il s'agit d'un enfant réputé à charge égale de l'un et l'autre de ses parents."  Cependant, la question demande la valeur de la majoration par enfant à charge, qui est de 500 € par personne à charge, mais divisée par deux pour un enfant réputé à charge égale de l'un et l'autre de ses parents. La valeur demandée est donc la majoration pour un enfant à charge, qui est de 500 €.  La réponse est donc :  ``` {     "valeur": 500.0 } ```_
    
* impot_revenu.credits_impots.plaf_nich.plafond
    - Description : Plafond des niches
    - 10000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860048/2023-10-17) de type CODE
    - Extrait : _[...]article 199 novovicies, ne peut pas procurer une réduction de l'impôt dû supérieure à un montant de 10 000 €.
Le total des avantages mentionnés au premier alinéa du présent 1, retenu dans la limite de[...]_
    - Reponse du LLM : _La valeur de 'Plafond des niches - impot_revenu.credits_impots.plaf_nich.plafond - Art. 200-0 A du CGI' est de 10000.0. Cependant, il est également mentionné que le total des avantages mentionnés au premier alinéa du présent 1, retenu dans la limite de 10 000 €, majoré du montant de ceux mentionnés aux articles 199 undecies A, 199 undecies B, 199 undecies C et 199 unvicies et au XII de l'article 199 novovicies, ne peut pas procurer une réduction de l'impôt dû supérieure à la somme d'un montant de 18 000 €.  La réponse est donc : ``` {     "valeur": 10000.0 } ``` Cependant, il est important de noter que le plafond total des niches est de 18 000 €, mais cela concerne le total des avantages fiscaux mentionnés au premier alinéa du présent 1, majoré du montant de ceux mentionnés aux articles 199 undecies A, 199 undecies B, 199 undecies C et 199 unvicies et au XII de l'article 199 novovicies.   Si on cherche à répondre à la question en considérant le plafond total des niches, la réponse serait : ``` {     "valeur": 18000.0 } ```_
    
* impot_revenu.credits_impots.plaf_nich.plafonnement_des_niches.majoration_om
    - Description : Majoration du plafonnement des avantages fiscaux (« niches fiscales ») s'agissant des réductions d'impôt outre-mer et SOFICA
    - 8000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860048/2023-10-17) de type CODE
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _La valeur de 'Majoration du plafonnement des avantages fiscaux (« niches fiscales ») s'agissant des réductions d'impôt outre-mer et SOFICA' n'est pas explicitement mentionnée dans le texte fourni. Cependant, on peut déduire que la majoration est incluse dans le montant de 18 000 € mentionné dans le deuxième alinéa du paragraphe 1, qui représente la somme du plafonnement de base (10 000 €) et de la majoration pour les avantages fiscaux spécifiques.  Pour calculer la majoration, on soustrait le plafonnement de base du montant total :  Majoration = 18 000 € - 10 000 € = 8 000 €  La réponse est donc :  {     "valeur": 8000.0 }_
    
* impot_revenu.credits_impots.plaf_nich.plafonnement_des_niches.majoration_om
    - Description : Majoration du plafonnement des avantages fiscaux (« niches fiscales ») s'agissant des réductions d'impôt outre-mer et SOFICA
    - 8000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860048/2023-10-17) de type CODE
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _La valeur de 'Majoration du plafonnement des avantages fiscaux (« niches fiscales ») s'agissant des réductions d'impôt outre-mer et SOFICA' n'est pas explicitement mentionnée dans le texte fourni. Cependant, on peut déduire que la majoration est incluse dans le montant de 18 000 € mentionné dans le deuxième alinéa du paragraphe 1, qui représente la somme du plafonnement de base (10 000 €) et de la majoration pour les avantages fiscaux spécifiques.  Pour calculer la majoration, on soustrait le plafonnement de base du montant total :  Majoration = Montant total - Plafonnement de base = 18 000 € - 10 000 € = 8 000 €  La valeur de 'Majoration du plafonnement des avantages fiscaux (« niches fiscales ») s'agissant des réductions d'impôt outre-mer et SOFICA' est donc :  {     "valeur": 8000.0 }_
    
* impot_revenu.credits_impots.equ_hab_princ_aide_personnes.plafond.plafond_commun.maj_pac
    - Description : Majoration par personne à charge
    - 400.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049641733/2024-06-02) de type CODE
    - Extrait : _[...]ivorcée et de 10 000 € pour un couple marié soumis à imposition commune. Cette somme est majorée de 400 € par personne à charge au sens des articles 196 à 196 B. La somme de 400 € est divisée par deux[...]_
    - Reponse du LLM : _Bon, je dois extraire la valeur de 'Majoration par personne à charge - impot_revenu.credits_impots.equ_hab_princ_aide_personnes.plafond.plafond_commun.maj_pac' à partir du texte fourni.   Je commence par lire attentivement le texte pour identifier la section pertinente. Le texte parle principalement de crédits d'impôt pour des dépenses liées à l'adaptation des logements.   Je cherche des termes comme "majoration", "personne à charge", "plafond", etc. En parcourant le document, je tombe sur le paragraphe 4 du point 1.   Là, il est mentionné : "La somme de 400 € par personne à charge au sens des articles 196 à 196 B. La somme de 400 € est divisée par deux lorsqu'il s'agit d'un enfant réputé à charge égale de l'un et l'autre de ses parents."   Cela semble correspondre à la majoration par personne à charge. La valeur est de 400 €, ce qui se convertit en 400.0 dans le format numérique.   Je vérifie s'il y a d'autres mentions de majoration, mais rien d'autre ne semble correspondre. Ainsi, la valeur est bien 400.0.   ```json {     "valeur": 400.0 } ```_
    
* impot_revenu.credits_impots.equ_hab_princ_aide_personnes.taux.taux_risques_techno
    - Description : Taux du crédit d'impôt pour les dépenses de prévention des risques technologiques
    - 0.4
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049641733/2024-06-02) de type CODE
    - Extrait : _[...]ivorcée et de 10 000 € pour un couple marié soumis à imposition commune. Cette somme est majorée de 400 € par personne à charge au sens des articles 196 à 196 B. La somme de 400 € est divisée par deux[...]_
    - Reponse du LLM : _Bon, je dois extraire la valeur du 'Taux du crédit d'impôt pour les dépenses de prévention des risques technologiques' à partir du texte fourni. Le texte est en français et semble être un article de loi ou un règlement fiscal.  Je commence par lire attentivement le texte pour identifier la section pertinente. Je cherche des termes comme 'crédit d'impôt', 'risques technologiques', 'taux', etc.  Je remarque une section numérotée 5 qui parle du crédit d'impôt. En regardant les sous-sections, la 5 bis mentionne spécifiquement les dépenses de prévention des risques technologiques.   Dans le point 5 bis, il est écrit : "40 % du montant des dépenses mentionnées au 1 bis." Cela indique que le taux est de 40%, ce qui se traduit par 0.4 en décimal.  Je vérifie si ce taux est bien associé aux dépenses de prévention des risques technologiques. Oui, le 1 bis parle de diagnostics et de travaux prescrits pour la prévention des risques technologiques, et le crédit d'impôt est de 40% pour ces dépenses.  Aucune autre mention n'est trouvée qui modifierait ce taux, donc je conclus que la valeur est 0.4.   ```json {     "valeur": 0.4 } ```_
    
* impot_revenu.credits_impots.gardenf.plafond
    - Description : Plafond des dépenses effectivement supportées pour la garde des enfants âgés de moins de six ans qu'ils ont à leur charge pour le calcul du crédit d’impôt
    - 3500.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046861318/2023-01-01/) de type CODE
    - Extrait : _[...] de six ans qu'ils ont à leur charge. Ces dépenses sont retenues dans la limite d'un plafond fixé à 3 500 € par enfant à charge et à la moitié de ce montant lorsque l'enfant est réputé à charge égale [...]_
    - Reponse du LLM : _Bon, je dois extraire la valeur du plafond des dépenses pour la garde des enfants âgés de moins de six ans à partir du texte fourni. Le texte mentionne que le plafond est fixé à 3 500 € par enfant à charge. De plus, si l'enfant est en résidence alternée, le plafond est divisé par deux, donc 1 750 €.   La question précise que la valeur à une autre date était 3500.0, ce qui correspond exactement au montant indiqué dans le texte. Aucune autre information n'est nécessaire ici, donc je peux directement utiliser cette valeur.   ```json {     "valeur": 3500.0 } ```_
    
* impot_revenu.credits_impots.gardenf.taux
    - Description : Taux du crédit d'impôt pour frais de garde d'enfants à charge âgés de moins de six ans
    - 0.5
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046861318/2023-01-01/) de type CODE
    - Extrait : _[...]buables domiciliés en France au sens de l'article 4 B peuvent bénéficier d'un crédit d'impôt égal à 50 % des dépenses effectivement supportées pour la garde des enfants âgés de moins de six ans qu'ils[...]_
    - Reponse du LLM : _Bon, je dois extraire le taux du crédit d'impôt pour les frais de garde d'enfants à charge âgés de moins de six ans à partir du texte fourni. Le texte mentionne que les contribuables peuvent bénéficier d'un crédit d'impôt égal à 50 % des dépenses.   Je me souviens que dans les instructions, il faut convertir les pourcentages en décimal. Donc 50% devient 0.5. De plus, la réponse doit être au format JSON avec la clé "valeur".   Je vérifie que le texte ne contient pas d'autres informations qui pourraient influencer ce taux, comme des barèmes ou des seuils, mais ici c'est un taux unique.   Ainsi, le taux est bien 0.5, et je dois le structurer correctement en JSON.   ```json {     "valeur": 0.5 } ```_
    
* impot_revenu.credits_impots.interets_emprunt_habitation_principale.plafond_base
    - Description : Plafond de base du crédit d'impôt sur les intérêts d'emprunt pour l'habitation principale
    - 3750.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000017923830/2024-11-12/) de type CODE
    - Extrait : _[...]ouvrant droit au crédit d'impôt ne peut excéder, au titre de chaque année d'imposition, la somme de 3 750 € pour une personne célibataire, veuve ou divorcée et de 7 500 € pour un couple soumis à impos[...]_
    - Reponse du LLM : _Bon, je dois extraire la valeur du 'Plafond de base du crédit d'impôt sur les intérêts d'emprunt pour l'habitation principale' à partir du texte fourni.   Je commence par lire le texte attentivement. La section IV semble traiter des plafonds.   Au paragraphe IV, je vois mentionné : "Le montant des intérêts mentionnés au III ouvrant droit au crédit d'impôt ne peut excéder, au titre de chaque année d'imposition, la somme de 3 750 € pour une personne célibataire, veuve ou divorcée et de 7 500 € pour un couple soumis à imposition commune."   Cela semble correspondre au plafond de base. La valeur est donc 3750.   Je vérifie s'il y a d'autres mentions, mais le reste concerne des majorations ou des cas particuliers. Aucune autre valeur de base n'est indiquée.   Donc, la valeur à extraire est 3750.0.   ```json {     "valeur": 3750.0 } ```_