### PR TITLE
Met à jour la last value des modulateurs allocations familiales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 169.16.3 [2434](https://github.com/openfisca/openfisca-france/pull/2434)
+
+* Changement mineur.
+* Périodes concernées : à partir du 10/02/2025.
+* Zones impactées :
+  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/modulation
+* Détails :
+  - Mise à jour des `last_value_still_valid_on` des modulateurs des allocations familiales
+
 ### 169.16.2 [2430](https://github.com/openfisca/openfisca-france/pull/2430)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/modulation/taux_tranche_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/modulation/taux_tranche_1.yaml
@@ -6,7 +6,7 @@ values:
     value: 1
 metadata:
   short_label: Taux Tranche 1
-  last_value_still_valid_on: "2022-09-27"
+  last_value_still_valid_on: "2025-02-10"
   label_en: "Family allowances (AF): General conditions and amount"
   unit: BMAF
   reference:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/modulation/taux_tranche_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/modulation/taux_tranche_2.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.5
 metadata:
   short_label: Taux Tranche 2
-  last_value_still_valid_on: "2022-09-27"
+  last_value_still_valid_on: "2025-02-10"
   label_en: "Family allowances (AF): General conditions and amount"
   ipp_csv_id: af_modulation_taux1
   unit: BMAF

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/modulation/taux_tranche_3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/modulation/taux_tranche_3.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.25
 metadata:
   short_label: Taux Tranche 3
-  last_value_still_valid_on: "2022-09-27"
+  last_value_still_valid_on: "2025-02-10"
   label_en: "Family allowances (AF): General conditions and amount"
   ipp_csv_id: af_modulation_taux2
   unit: BMAF

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/majoration_enfants/allocation_forfaitaire/taux.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/majoration_enfants/allocation_forfaitaire/taux.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.20234
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "2024-01-05"
+  last_value_still_valid_on: "2025-02-10"
   label_en: "Family allowances (AF): Extra allowances"
   ipp_csv_id: maj_forf_tx
   unit: BMAF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.16.2"
+version = "169.16.3"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 10/02/2025.
* Zones impactées : `openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/modulation`.
* Détails :
  - Met à jour la last value des modulateurs allocations familiales

- - - -

- Corrigent ou améliorent un calcul déjà existant.

- - - -