### PR TITLE
Ajoute un calculate_output à crds_af

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 169.16.4 [2439](https://github.com/openfisca/openfisca-france/pull/2439)
+
+* Changement mineur.
+* Périodes concernées : toutes
+* Zones impactées :
+  - `openfisca_france/model/prestations/prestations_familiales/af.py`
+* Détails :
+  - Ajoute un calculate_output à crds_af
+
 ### 169.16.3 [2434](https://github.com/openfisca/openfisca-france/pull/2434)
 
 * Changement mineur.

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -429,6 +429,7 @@ def depassement_helper(famille, period, parameters, nb_enf_tot):
 
 
 class crds_af(Variable):
+    calculate_output = calculate_output_add
     value_type = float
     entity = Famille
     label = 'CRDS sur les allocations familiales'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.16.3"
+version = "169.16.4"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes
* Zones impactées : `openfisca_france/model/prestations/prestations_familiales/af.py`.
* Détails :
  - Ajoute un calculate_output à crds_af

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.
