### PR TITLE
IR 2025 sur les revenus 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,31 +10,6 @@
 * Détails :
   - Mise à jour des montants de la déduction forfaitaire pour frais professionnels sur les revenus 2024.
 
-### 169.17.0 [2451](https://github.com/openfisca/openfisca-france/pull/2451)
-
-### 169.17.1 [2449](https://github.com/openfisca/openfisca-france/pull/2449)
-
-* Changement mineur.
-* Périodes concernées : 2025.
-* Zones impactées :
-  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/*`
-* Détails :
-  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
-
-## 169.17.0 [2451](https://github.com/openfisca/openfisca-france/pull/2451)
-
-* Changement mineur.
-* Périodes concernées : 2024.
-* Zones impactées :
-  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/*`
-  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_fl/taux_forfait_logement/*`
-  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/api/api_cond/age_pac.yaml`
-  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/*`
-  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/covid19/indemnite_ap/plafond_smic.yaml`
-* Détails :
-  - Mise à jour des last_value_still_valid_on, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
-  - Ajout de l'appel d'un paramètre dans une variable
-
 ## 169.18.0 [2444](https://github.com/openfisca/openfisca-france/pull/2444)
 
 * Évolution du système socio-fiscal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 169.18.1 [2445](https://github.com/openfisca/openfisca-france/pull/2445)
+
+* Changement mineur.
+* Périodes concernées : à partir du 01/01/2024.
+* Zones impactées :
+  - `parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/*`
+  - `parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/*`
+* Détails :
+  - Mise à jour des montants de la déduction forfaitaire pour frais professionnels sur les revenus 2024.
+
 ## 169.18.0 [2444](https://github.com/openfisca/openfisca-france/pull/2444)
 
 * Évolution du système socio-fiscal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@
 * Détails :
   - Mise à jour des montants de la déduction forfaitaire pour frais professionnels sur les revenus 2024.
 
+### 169.17.0 [2451](https://github.com/openfisca/openfisca-france/pull/2451)
+
+* Changement mineur.
+* Périodes concernées : 2024.
+* Zones impactées :
+  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/*`
+  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_fl/taux_forfait_logement/*`
+  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/api/api_cond/age_pac.yaml`
+  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/*`
+  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/covid19/indemnite_ap/plafond_smic.yaml`
+* Détails :
+  - Mise à jour des last_value_still_valid_on, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.
+  - Ajout de l'appel d'un paramètre dans une variable
+
 ## 169.18.0 [2444](https://github.com/openfisca/openfisca-france/pull/2444)
 
 * Évolution du système socio-fiscal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@
   - Mise à jour des montants de la déduction forfaitaire pour frais professionnels sur les revenus 2024.
 
 ### 169.17.0 [2451](https://github.com/openfisca/openfisca-france/pull/2451)
+### 169.17.1 [2449](https://github.com/openfisca/openfisca-france/pull/2449)
+
+* Changement mineur.
+* Périodes concernées : 2025.
+* Zones impactées :
+  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/*`
+* Détails :
+  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+
+## 169.17.0 [2451](https://github.com/openfisca/openfisca-france/pull/2451)
 
 * Changement mineur.
 * Périodes concernées : 2024.
@@ -21,7 +31,7 @@
   - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/cs/cmu/*`
   - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/autre_solidarite/covid19/indemnite_ap/plafond_smic.yaml`
 * Détails :
-  - Mise à jour des last_value_still_valid_on, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.
+  - Mise à jour des last_value_still_valid_on, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
   - Ajout de l'appel d'un paramètre dans une variable
 
 ## 169.18.0 [2444](https://github.com/openfisca/openfisca-france/pull/2444)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Mise à jour des montants de la déduction forfaitaire pour frais professionnels sur les revenus 2024.
 
 ### 169.17.0 [2451](https://github.com/openfisca/openfisca-france/pull/2451)
+
 ### 169.17.1 [2449](https://github.com/openfisca/openfisca-france/pull/2449)
 
 * Changement mineur.

--- a/openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml
+++ b/openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml
@@ -1232,7 +1232,7 @@ brackets:
       value: null
 metadata:
   short_label: Barème de l'impôt sur le revenu
-  last_value_still_valid_on: "2025-02-17"
+  last_value_still_valid_on: "2024-02-18"
   label_en: Thresholds and marginal tax rates
   reference:
     1945-01-01:

--- a/openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml
+++ b/openfisca_france/parameters/impot_revenu/bareme_ir_depuis_1945/bareme.yaml
@@ -1232,7 +1232,7 @@ brackets:
       value: null
 metadata:
   short_label: Barème de l'impôt sur le revenu
-  last_value_still_valid_on: "2024-02-18"
+  last_value_still_valid_on: "2025-02-18"
   label_en: Thresholds and marginal tax rates
   reference:
     1945-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
@@ -221,6 +221,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000049629765
     - title: Article 158, 5.a. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042909707/
+    2024-01-01:
+    - title: Article 158, 5.a. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042909707/
   official_journal_date:
     1977-01-01: "1977-12-31"
     1978-01-01: "1978-12-30"
@@ -287,6 +290,8 @@ metadata:
     - title: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
     2021-01-01:
     - title: Les limites sont révisées chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. En 2021, l'augmentation était de 1,4 %.
+    2024-01-01:
+    - title: Les limites sont révisées chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. En 2024, l'augmentation était de 1,8 %.
 documentation: |-
   Notes : Chaque année, il est révisé selon les mêmes modalités que la limite supérieure de la première tranche du barème de l'impôt sur le revenu.
   Ref : Article 158-5-a. du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622551

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
@@ -92,6 +92,8 @@ values:
     value: 4123
   2023-01-01:
     value: 4321
+  2024-01-01:
+    value: 4399
 metadata:
   short_label: Montant maximum de l'abattement, pour le foyer fiscal
   last_value_still_valid_on: "2025-02-25"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
@@ -150,6 +150,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000049629765
     - title: Article 158, 5.a. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042909707/
+    2024-01-01:
+    - title: Article 158, 5.a. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042909707/
   official_journal_date:
     1978-01-01: "1978-12-30"
     1992-01-01: "1992-12-31"
@@ -197,6 +200,8 @@ metadata:
     - title: Revalorisation de (10 084 / 10 064) suivant l'évolution de la limite supérieure de la première tranche du barème de l'impôt sur le revenu
     2021-01-01:
     - title: Les limites sont révisées chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. En 2021, l'augmentation était de 1,4 %.
+    2024-01-01:
+    - title: Les limites sont révisées chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. En 2024, l'augmentation était de 1,8 %.
 documentation: |-
   Notes : Chaque année, il est révisé selon les mêmes modalités que la limite supérieure de la première tranche du barème de l'impôt sur le revenu.
   Ref : Article 158-5-a. du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622551

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
@@ -58,6 +58,8 @@ values:
     value: 422
   2023-01-01:
     value: 442
+  2024-01-01:
+    value: 450
 metadata:
   short_label: Montant minimum de l'abattement, par pensionné
   last_value_still_valid_on: "2025-02-25"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
@@ -214,6 +214,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000049629765
     - title: Article 83, 3. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000032701943
+    2024-01-01:
+    - title: Article 83, 3. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000032701943
   official_journal_date:
     1979-01-01: "1980-01-19"
     1980-01-01: "1980-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
@@ -94,6 +94,8 @@ values:
     value: 13522
   2023-01-01:
     value: 14171
+  2024-01-01:
+    value: 14426
 metadata:
   short_label: Montant maximum de la déduction
   last_value_still_valid_on: "2025-02-25"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
@@ -280,8 +280,11 @@ metadata:
     - title: Suppression de la déduction minimale majorée pour les demandeurs d'emploi depuis plus d'un an.
     2021-01-01:
     - title: Les limites sont révisées chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. En 2021, l'augmentation était de 1,4 %.
+    2024-01-01:
+    - title: Les limites sont révisées chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. En 2024, l'augmentation était de 1,8 %.
 documentation: |-
   Ref: Article 83-3 du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622408
   Relevé dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu.
-  Il n'y a pas de plafond à la déduction entre 1952 et 1978.Entre 1934 et 1942, la déduction de 10 % est aussi plafonnée à 20 000 FRF (colonne J).
+  Le décret est publié à la fin du mois de mai. Pour que les simulateurs soient à jour, nous mettons à jour le paramètre avant la publication du décret.
+  Il n'y a pas de plafond à la déduction entre 1952 et 1978. Entre 1934 et 1942, la déduction de 10 % est aussi plafonnée à 20 000 FRF (colonne J).
   > Voir Annexe C-3 dans Thomas Piketty, Les hauts revenus en France au XXe siècle (Grasset, 2001)

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
@@ -215,6 +215,9 @@ metadata:
     - title: Suppression de la déduction minimale majorée pour les demandeurs d'emploi depuis plus d'un an.
     2021-01-01:
     - title: Les limites sont révisées chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. En 2021, l'augmentation était de 1,4 %.
+    2024-01-01:
+    - title: Les limites sont révisées chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. En 2024, l'augmentation était de 1,8 %.
 documentation: |-
   Ref: Article 83-3 du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622408
+  Le décret est publié à la fin du mois de mai. Pour que les simulateurs soient à jour, nous mettons à jour le paramètre avant la publication du décret.
   Relevé dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
@@ -163,6 +163,9 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000049629765
     - title: Article 83, 3. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000032701943
+    2024-01-01:
+    - title: Article 83, 3. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000032701943
   official_journal_date:
     1977-01-01: "1977-12-31"
     1978-01-01: "1978-12-30"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
@@ -66,6 +66,8 @@ values:
     value: 472
   2023-01-01:
     value: 495
+  2024-01-01:
+    value: 504
 metadata:
   short_label: Montant minimum de la déduction
   last_value_still_valid_on: "2025-02-25"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.18.0"
+version = "169.18.1"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : à partir du 01/01/2024.
* Zones impactées : `openfisca_france/parameters/impot_revenu/`.
* Détails :
  - Mise à jour des barèmes et seuils pour le calcul de l'IR 2025 sur les revenus 2024.

- - - -

Ces changements :
- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus


## Commentaire

Comme chaque année, je sais que ma PR ne sera pas acceptée car il n'y a pas encore de publication au journal officiel, mais les éléments utilisés se basent sur le site du gouvernement : <https://www.economie.gouv.fr/particuliers/tranches-imposition-impot-revenu#>
Personnellement, je ne peux pas me permettre de faire un calcul de l'IR faux pendant 8 mois. 
