### PR TITLE
Mise à jour des `last_value_still_valid_on` pour les Aides au logement

### DIFF
--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_1/degressivite.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_1/degressivite.yaml
@@ -4,7 +4,7 @@ values:
     value: 3.4
 metadata:
   short_label: Coefficient appliqué au montant maximal de loyer pris en compte pour le calcul des aides, déterminant le seuil à partir duquel l'aide au logement décroît
-  last_value_still_valid_on: "2023-02-20"
+  last_value_still_valid_on: "2025-02-20"
   reference:
     2016-07-01:
       title: Arrêté du 27/09/2019, art. 10

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_2/suppression.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_2/suppression.yaml
@@ -4,7 +4,7 @@ values:
     value: 3.1
 metadata:
   short_label: Coefficient appliqué au montant maximal de loyer pris en compte pour le calcul des aides, déterminant le plafond à partir duquel l'aide au logement est supprimée
-  last_value_still_valid_on: "2023-02-20"
+  last_value_still_valid_on: "2025-02-20"
   reference:
     2016-07-01:
       title: Arrêté du 27/09/2019, art. 10

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_3/degressivite.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_3/degressivite.yaml
@@ -4,7 +4,7 @@ values:
     value: 2.5
 metadata:
   short_label: Coefficient appliqué au montant maximal de loyer pris en compte pour le calcul des aides, déterminant le seuil à partir duquel l'aide au logement décroît
-  last_value_still_valid_on: "2023-02-20"
+  last_value_still_valid_on: "2025-02-20"
   reference:
     2016-07-01:
       title: Arrêté du 27/09/2019, art. 10

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_3/suppression.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_3/suppression.yaml
@@ -4,7 +4,7 @@ values:
     value: 3.1
 metadata:
   short_label: Coefficient appliqué au montant maximal de loyer pris en compte pour le calcul des aides, déterminant le plafond à partir duquel l'aide au logement est supprimée
-  last_value_still_valid_on: "2023-02-20"
+  last_value_still_valid_on: "2025-02-20"
   reference:
     2016-07-01:
       title: Arrêté du 27/09/2019, art. 10

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/couples_sans_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/couples_sans_enfant.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.0299
 metadata:
   short_label: Couples sans personne à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     2002-01-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_isolees.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_isolees.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.0281
 metadata:
   short_label: Personnes seules sans personne à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     2002-01-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_1_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_1_enfant.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.0238
 metadata:
   short_label: Personnes seules ou couple ayant une personne à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     2002-01-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_2_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_2_enfants.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.0217
 metadata:
   short_label: Personnes seules ou couple ayant deux personnes à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     2002-01-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_3_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_3_enfants.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.0194
 metadata:
   short_label: Personnes seules ou couple ayant trois personnes à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     2002-01-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_4_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_4_enfants.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.018
 metadata:
   short_label: Personnes seules ou couple ayant quatre personnes à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     2002-01-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_5_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_5_enfants.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.0169
 metadata:
   short_label: Personnes seules ou couple ayant cinq personnes à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     2002-01-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_6_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_6_enfants.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.0162
 metadata:
   short_label: Personnes seules ou couple ayant six personnes à charge
-  last_value_still_valid_on: "2023-02-22"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     2002-01-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_min/montant_min_mensuel/montant_min_apl_al/apl.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_min/montant_min_mensuel/montant_min_apl_al/apl.yaml
@@ -14,7 +14,7 @@ values:
     value: 0
 metadata:
   short_label: APL
-  last_value_still_valid_on: "2023-02-20"
+  last_value_still_valid_on: "2025-02-20"
   label_en: Minimal amount
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_pac/age_limite_enfants_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_pac/age_limite_enfants_charge.yaml
@@ -6,7 +6,7 @@ values:
     value: 21
 metadata:
   short_label: Âge limite pour les enfants
-  last_value_still_valid_on: "2023-02-09"
+  last_value_still_valid_on: "2025-02-20"
   label_en: Definition of dependants
   ipp_csv_id: ag_max_pac_alf
   unit: year

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_pac/age_minimal/ascendants_leur_conjoint_s_ils_sont_titulaires_aspa.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_pac/age_minimal/ascendants_leur_conjoint_s_ils_sont_titulaires_aspa.yaml
@@ -1,12 +1,12 @@
 description: Âge minimal de l'ascendant du bénéficiaire ou de son conjoint, si titulaire de l'ASPA, pour être considéré personne à charge pour les allocations logement (AL)
 values:
   1991-11-11:
-    value: null
+    value:
   2016-07-01:
     value: 65
 metadata:
   short_label: Ascendant titulaire de l'ASPA
-  last_value_still_valid_on: "2023-02-09"
+  last_value_still_valid_on: "2025-02-20"
   label_en: Definition of dependants
   unit: year
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_pac/age_minimal/pour_les_ascendants_et_leur_conjoint.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_pac/age_minimal/pour_les_ascendants_et_leur_conjoint.yaml
@@ -6,7 +6,7 @@ values:
     value: 67
 metadata:
   short_label: Cas général
-  last_value_still_valid_on: "2023-02-09"
+  last_value_still_valid_on: "2025-02-20"
   label_en: Definition of dependants
   ipp_csv_id: ag_min_ascendants1
   unit: year

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_pac/pourcentage_min_handicap.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_pac/pourcentage_min_handicap.yaml
@@ -1,12 +1,12 @@
 description: Pourcentage minimal de handicap pour les ascendants, descendants, collatéraux au deuxième ou troisième degré, du bénéficiaire ou de son conjoint, pour être considéré comme personne à charge pour les allocations logement (AL)
 values:
   1991-11-11:
-    value: null
+    value:
   2000-01-01:
     value: 0.8
 metadata:
   short_label: Pourcentage minimal de handicap pour un ascendant, descendant ou collatéral invalide
-  last_value_still_valid_on: "2023-02-09"
+  last_value_still_valid_on: "2025-02-20"
   label_en: Definition of dependants
   ipp_csv_id: pct_handicap
   unit: /1

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/al/2_personnes_a_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/al/2_personnes_a_charge.yaml
@@ -4,7 +4,7 @@ values:
     value: 3
 metadata:
   short_label: Bénéficiaire isolé ou un ménage ayant deux personnes à charge
-  last_value_still_valid_on: "2023-02-23"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     1988-07-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/al/3_personnes_a_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/al/3_personnes_a_charge.yaml
@@ -4,7 +4,7 @@ values:
     value: 3.7
 metadata:
   short_label: Bénéficiaire isolé ou un ménage ayant trois personnes à charge
-  last_value_still_valid_on: "2023-02-23"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     1988-07-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/al/majoration_n_par_personne_a_charge_supplementaire.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/al/majoration_n_par_personne_a_charge_supplementaire.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.5
 metadata:
   short_label: Majoration par personne à charge supplémentaire
-  last_value_still_valid_on: "2023-02-23"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     1988-07-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/apl/2_personnes_a_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/apl/2_personnes_a_charge.yaml
@@ -4,7 +4,7 @@ values:
     value: 3
 metadata:
   short_label: Bénéficiaire isolé ou un ménage ayant deux personnes à charge
-  last_value_still_valid_on: "2023-02-23"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     1988-07-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/apl/menage_0_personnes_a_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/apl/menage_0_personnes_a_charge.yaml
@@ -4,7 +4,7 @@ values:
     value: 1.8
 metadata:
   short_label: Ménage sans personne à charge
-  last_value_still_valid_on: "2023-02-23"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     2007-07-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/ressources/abattement_chomage_indemnise.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/ressources/abattement_chomage_indemnise.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.3
 metadata:
   short_label: Abattement sur les revenus d'activité en cas de chômage indemnisé
-  last_value_still_valid_on: "2023-02-20"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     2002-01-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/ressources/dar_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/ressources/dar_1.yaml
@@ -6,7 +6,7 @@ values:
     value: 95
 metadata:
   short_label: Abattement forfaitaire pour les couples dont les deux conjoints ont une activité professionnelle rémunératrice
-  last_value_still_valid_on: "2023-02-20"
+  last_value_still_valid_on: "2025-02-20"
   unit: currency
   reference:
     2002-07-01:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/fraction_baisse_aide_logement.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/fraction_baisse_aide_logement.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.98
 metadata:
   short_label: Baisse de l'aide personnalisée au logement (en % de la RLS)
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2025-02-20"
   ipp_csv_id: baisse_apl_rsl
   unit: /1
   reference:


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2024.
* Zones impactées :
  - openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/fraction_baisse_aide_logement.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/ressources/dar_1.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/ressources/abattement_chomage_indemnise.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/apl/menage_0_personnes_a_charge.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/apl/2_personnes_a_charge.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/al/majoration_n_par_personne_a_charge_supplementaire.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/al/3_personnes_a_charge.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_param/parametre_n/al/2_personnes_a_charge.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_pac/pourcentage_min_handicap.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_pac/age_minimal/pour_les_ascendants_et_leur_conjoint.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_pac/age_minimal/ascendants_leur_conjoint_s_ils_sont_titulaires_aspa.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_pac/age_limite_enfants_charge.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_min/montant_min_mensuel/montant_min_apl_al/apl.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_6_enfants.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_5_enfants.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_4_enfants.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_3_enfants.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_2_enfants.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_seules_couples_avec_1_enfant.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/personnes_isolees.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/tf/dom/couples_sans_enfant.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_3/suppression.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_3/degressivite.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_2/suppression.yaml
  - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/al_loc2/par_zone/zone_1/degressivite.yaml
* Détails :
  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Mise à jour de paramètre.

- - - -

Méthodologie :
1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
1. Vérifie la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
1. Met à jour la `last_value_still_valid_on` à la date du jour.
1. Crée un tableau récapitulatif pour faciliter la revue.

Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

- - - -

Quelques conseils à prendre en compte :

- [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [X] Documentez votre contribution avec des références législatives.
- [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme n'ayant pas changés depuis la date indiquée dans `last_value_still_valid_on`.

Aide à la revue :

* prestations_sociales.aides_logement.reduction_loyer_solidarite.fraction_baisse_aide_logement
    - Description : Baisse de l'aide personnalisée au logement (APL), en % de la réduction de loyer de solidarité (RLS)
    - 0.98
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038814872)
    - Extrait : _[...] définie à l'article L. 442-2-1, à hauteur d'une fraction de cette réduction comprise entre 90 % et 98 %. Cette fraction est fixée par voie réglementaire.[...]_
    - Reponse du LLM : _Il n'y a pas de valeur précise dans le texte fourni. Le texte mentionne une fourchette entre 90% et 98%, mais il indique que la valeur précise est fixée par voie réglementaire, et qu'à une autre date de validité, la valeur était de 0.98.  Cependant, comme il est mentionné que la valeur à une autre date de validité était '0.98' et que l'article D823-16 détermine le taux de 98% seulement, on peut en déduire que la valeur actuelle est toujours de 0.98.  La réponse est donc : {     "valeur": 0.98 }_
    
* prestations_sociales.aides_logement.allocations_logement.ressources.dar_1
    - Description : Abattement forfaitaire sur les ressources prises en compte dans le calcul des aides au logement, si les deux conjoints exercent une activité professionnelle rémunératrice au delà d'un certain seuil
    - 95.0
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039793907)
    - Extrait : _[...]
L'abattement forfaitaire prévu par l'article R. 822-7 du même code est fixé à 95 euros.[...]_
    - Reponse du LLM : _{     "valeur": 95.0 }_
    
* prestations_sociales.aides_logement.allocations_logement.ressources.abattement_chomage_indemnise
    - Description : Abattement sur les revenus d'activité pris en compte dans le calcul des aides au logement, si la personne est au chômage indemnisé (R351-13)
    - 0.3
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419358)
    - Extrait : _[...] les revenus d'activité professionnelle dont bénéficie l'intéressé sont affectés d'un abattement de 30 %.

Cette mesure s'applique à partir du premier jour du deuxième mois civil suivant celui au cour[...]_
    - Reponse du LLM : _La valeur de 'Abattement sur les revenus d'activité pris en compte dans le calcul des aides au logement, si la personne est au chômage indemnisé' est de 0.3.  Réponse : ``` {     "valeur": 0.3 } ```_
    
* prestations_sociales.aides_logement.allocations_logement.al_param.parametre_n.apl.menage_0_personnes_a_charge
    - Description : Paramètre « N » pour un ménage sans personne à charge pour le calcul de l'APL du secteur accession et l'APL des logements-foyers cas général
    - 1.8
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878710/2019-09-01/)
    - Extrait : _[...] le barème suivant :






bénéficiaire isolé


1,4




ménage sans personne à charge


1,8




bénéficiaire isolé ou ménage ayant une personne à charge


2,5




bénéficiaire iso[...]_
    - Reponse du LLM : _La valeur de 'Paramètre « N » pour un ménage sans personne à charge pour le calcul de l'APL du secteur accession et l'APL des logements-foyers cas général est donnée dans le texte.   Selon le barème fourni dans le texte, pour un ménage sans personne à charge, la valeur de "N" est de 1,8 dans le premier tableau et de 1,5 dans le deuxième tableau. Cependant, il n'est pas précisé quel tableau est applicable pour le calcul de l'APL du secteur accession et l'APL des logements-foyers cas général.  Cependant, étant donné que la valeur à une autre date de validité était '1.8', il est probable que la valeur de 1,8 soit la bonne réponse.  La réponse est donc :  {     "valeur": 1.8 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_param.parametre_n.apl.2_personnes_a_charge
    - Description : Paramètre « N » pour un bénéficiaire isolé ou un ménage ayant deux personnes à charge pour le calcul de l'APL du secteur accession et l'APL des logements-foyers cas général
    - 3.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878710/2019-09-01/)
    - Extrait : _[...]e personne à charge


2,5




bénéficiaire isolé ou ménage ayant deux personnes à charge


3,0




bénéficiaire isolé ou ménage ayant trois personnes à charge


3,7




bénéficiaire [...]_
    - Reponse du LLM : _La valeur de 'Paramètre « N » pour un bénéficiaire isolé ou un ménage ayant deux personnes à charge pour le calcul de l'APL du secteur accession et l'APL des logements-foyers cas général est donnée dans le texte.   Selon le barème fourni, pour un bénéficiaire isolé ou un ménage ayant deux personnes à charge, la valeur de "N" est de 3,0.  La réponse est donc :  {     "valeur": 3.0 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_param.parametre_n.al.majoration_n_par_personne_a_charge_supplementaire
    - Description : Majoration par personne à charge supplémentaire du paramètre « N » pour le calcul de l'AL du secteur accession, l'AL du secteur foyer et l'APL des foyers de jeunes travailleurs conventionnés après le 30 septembre 1990 et pour les résidences sociales conventionnées après le 31 décembre 1994
    - 0.5
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878710/2019-09-01/)
    - Extrait : _[...]yant quatre personnes à charge


4,3




majoration par personne à charge supplémentaire


0,5




2°
Vous pouvez consulter l'intégralité du texte avec ses images à partir de l'extrait du Jou[...]_
    - Reponse du LLM : _La valeur de 'Majoration par personne à charge supplémentaire du paramètre « N » pour le calcul de l'AL du secteur accession, l'AL du secteur foyer et l'APL des foyers de jeunes travailleurs conventionnés après le 30 septembre 1990 et pour les résidences sociales conventionnées après le 31 décembre 1994' est bien présente dans le texte fourni.  La valeur est la suivante : {     "valeur": 0.5 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_param.parametre_n.al.3_personnes_a_charge
    - Description : Paramètre « N » pour un bénéficiaire isolé ou un ménage ayant trois personnes à charge, pour le calcul de l'AL du secteur accession, l'AL du secteur foyer et l'APL des foyers de jeunes travailleurs conventionnés après le 30 septembre 1990 et pour les résidences sociales conventionnées après le 31 décembre 1994
    - 3.7
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878710/2019-09-01/)
    - Extrait : _[...]personnes à charge


3,0




bénéficiaire isolé ou ménage ayant trois personnes à charge


3,7




bénéficiaire isolé ou ménage ayant quatre personnes à charge


4,3




majoration p[...]_
    - Reponse du LLM : _La valeur de 'Paramètre « N » pour un bénéficiaire isolé ou un ménage ayant trois personnes à charge est bien présente dans le texte fourni.   La réponse est : {     "valeur": 3.7 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_param.parametre_n.al.2_personnes_a_charge
    - Description : Paramètre « N » pour un bénéficiaire isolé ou un ménage ayant deux personnes à charge, pour le calcul de l'AL du secteur accession, l'AL du secteur foyer et l'APL des foyers de jeunes travailleurs conventionnés après le 30 septembre 1990 et pour les résidences sociales conventionnées après le 31 décembre 1994
    - 3.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878710/2019-09-01/)
    - Extrait : _[...]e personne à charge


2,5




bénéficiaire isolé ou ménage ayant deux personnes à charge


3,0




bénéficiaire isolé ou ménage ayant trois personnes à charge


3,7




bénéficiaire [...]_
    - Reponse du LLM : _La valeur de 'Paramètre « N » pour un bénéficiaire isolé ou un ménage ayant deux personnes à charge est donnée dans le texte.   La réponse est : {     "valeur": 3.0 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_pac.pourcentage_min_handicap
    - Description : Pourcentage minimal de handicap pour les ascendants, descendants, collatéraux au deuxième ou troisième degré, du bénéficiaire ou de son conjoint, pour être considéré comme personne à charge pour les allocations logement (AL)
    - 0.8
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878933)
    - Extrait : _[...]roisième degré du bénéficiaire ou de son conjoint dont l'incapacité permanente est au moins égale à 80 % ou qui présentent, compte tenu de leur handicap, une restriction substantielle et durable dans [...]_
    - Reponse du LLM : _La valeur de 'Pourcentage minimal de handicap pour les ascendants, descendants, collatéraux au deuxième ou troisième degré, du bénéficiaire ou de son conjoint, pour être considéré comme personne à charge pour les allocations logement (AL)' est de 0.8.  Réponse : {     "valeur": 0.8 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_pac.age_minimal.pour_les_ascendants_et_leur_conjoint
    - Description : Âge minimal de l'ascendant du bénéficiaire ou de son conjoint pour être considéré personne à charge pour les allocations logement (AL)
    - 67.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000028498855)
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _La valeur de 'Âge minimal de l'ascendant du bénéficiaire ou de son conjoint pour être considéré personne à charge pour les allocations logement (AL)' n'est pas explicitement mentionnée dans le texte fourni. Cependant, il est mentionné que l'âge prévu au premier alinéa de l'article L. 161-17-2 est augmenté de trois années pour certains assurés.  Puisque la valeur à une autre date de validité était '67.0' et que l'article L. 161-17-2 est mentionné, nous pouvons supposer que l'âge minimal est lié à cet article. Cependant, sans plus d'informations, il est difficile de déterminer la valeur exacte.  Cependant, nous pouvons utiliser les notes pour essayer de trouver la réponse. La note (1) mentionne que le calcul de l'âge se fait en additionnant l'âge d'ouverture du droit à une pension de retraite fixé à 62 ans + les 5 ans mentionnés à l'article L351-8. Cela nous donne un âge de 67 ans.  La réponse est donc : ``` {     "valeur": 67.0 } ```_
    
* prestations_sociales.aides_logement.allocations_logement.al_pac.age_minimal.ascendants_leur_conjoint_s_ils_sont_titulaires_aspa
    - Description : Âge minimal de l'ascendant du bénéficiaire ou de son conjoint, si titulaire de l'ASPA, pour être considéré personne à charge pour les allocations logement (AL)
    - 65.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878933)
    - Extrait : _[...]de la sécurité sociale ou, s'ils sont titulaires de l'allocation de solidarité aux personnes âgées, soixante-cinq ans ;
b) Ayant au moins l'âge prévu par l'article L. 351-1-5 du code de la sécurité s[...]_
    - Reponse du LLM : _{     "valeur": 65.0 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_pac.age_limite_enfants_charge
    - Description : Âge limite pour les enfants à charge - définition des personnes à charge pour les Allocations logement (AL)
    - 21.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878933)
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _{     "valeur": 21.0 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_min.montant_min_mensuel.montant_min_apl_al.apl
    - Description : Montant minimal mensuel versé de l'APL
    - 0.0
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039160749)
    - Extrait : _[...]e code, avant application de la contribution pour le remboursement de la dette sociale, est fixé à 10 euros pour les allocations de logement et à 0 euro pour l'aide personnalisée au logement.[...]_
    - Reponse du LLM : _{     "valeur": 0.0 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_loc2.tf.dom.personnes_seules_couples_avec_6_enfants
    - Description : Taux « TF » dans les DOM des personnes seules ou couple ayant six personnes à charge, pris en compte dans le taux de participation personnel du ménage « Tp » pour le calcul des allocations logement
    - 0.0162
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046834756/2022-12-30/#LEGIARTI000046834756)
    - Extrait : _[...]nt 5 personnes à charge


1,69 %




Personne seule ou couple ayant 6 personnes à charge


1,62 %


Personne seule ou couple ayant 7 personnes à charge
1,67 %


Majoration par personne à char[...]_
    - Reponse du LLM : _La valeur de 'Taux « TF » dans les DOM des personnes seules ou couple ayant six personnes à charge, pris en compte dans le taux de participation personnel du ménage « Tp » pour le calcul des allocations logement' est donnée dans le tableau des valeurs de TF. Pour une personne seule ou un couple ayant 6 personnes à charge, le taux TF est de 1,62 %.  En convertissant ce pourcentage en un nombre décimal, on obtient :  1,62 % = 0,0162  La réponse est donc :  {     "valeur": 0.0162 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_loc2.tf.dom.personnes_seules_couples_avec_5_enfants
    - Description : Taux « TF » dans les DOM des personnes seules ou couple ayant cinq personnes à charge, pris en compte dans le taux de participation personnel du ménage « Tp » pour le calcul des allocations logement
    - 0.0169
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046834756/2022-12-30/#LEGIARTI000046834756)
    - Extrait : _[...]nt 4 personnes à charge


1,80 %




Personne seule ou couple ayant 5 personnes à charge


1,69 %




Personne seule ou couple ayant 6 personnes à charge


1,62 %


Personne seule ou co[...]_
    - Reponse du LLM : _La valeur de 'Taux « TF » dans les DOM des personnes seules ou couple ayant cinq personnes à charge' est donnée dans le tableau des valeurs de TF. Pour une personne seule ou un couple ayant 5 personnes à charge, le taux TF est de 1,69 %.  En convertissant ce pourcentage en valeur décimale, on obtient :  1,69 % = 0,0169  La réponse est donc :  {     "valeur": 0.0169 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_loc2.tf.dom.personnes_seules_couples_avec_4_enfants
    - Description : Taux « TF » dans les DOM des personnes seules ou couple ayant quatre personnes à charge, pris en compte dans le taux de participation personnel du ménage « Tp » pour le calcul des allocations logement
    - 0.018
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046834756/2022-12-30/#LEGIARTI000046834756)
    - Extrait : _[...]nt 3 personnes à charge


1,94 %




Personne seule ou couple ayant 4 personnes à charge


1,80 %




Personne seule ou couple ayant 5 personnes à charge


1,69 %




Personne seule [...]_
    - Reponse du LLM : _La valeur de 'Taux « TF » dans les DOM des personnes seules ou couple ayant quatre personnes à charge' est donnée dans le tableau des valeurs de TF. Pour une personne seule ou un couple ayant 4 personnes à charge, le taux TF est de 1,80 %.  En convertissant ce pourcentage en valeur décimale, on obtient :  1,80 % = 0,018  La réponse est donc :  {     "valeur": 0.018 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_loc2.tf.dom.personnes_seules_couples_avec_3_enfants
    - Description : Taux « TF » dans les DOM des personnes seules ou couple ayant trois personnes à charge, pris en compte dans le taux de participation personnel du ménage « Tp » pour le calcul des allocations logement
    - 0.0194
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046834756/2022-12-30/#LEGIARTI000046834756)
    - Extrait : _[...]nt 2 personnes à charge


2,17 %




Personne seule ou couple ayant 3 personnes à charge


1,94 %




Personne seule ou couple ayant 4 personnes à charge


1,80 %




Personne seule [...]_
    - Reponse du LLM : _La valeur de 'Taux « TF » dans les DOM des personnes seules ou couple ayant trois personnes à charge' est donnée dans le tableau des valeurs de TF. Pour une personne seule ou un couple ayant 3 personnes à charge, le taux TF est de 1,94 %.  En convertissant ce pourcentage en valeur décimale, on obtient :  1,94 % = 0,0194  La réponse est donc :  {     "valeur": 0.0194 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_loc2.tf.dom.personnes_seules_couples_avec_2_enfants
    - Description : Taux « TF » dans les DOM des personnes seules ou couple ayant deux personnes à charge, pris en compte dans le taux de participation personnel du ménage « Tp » pour le calcul des allocations logement
    - 0.0217
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046834756/2022-12-30/#LEGIARTI000046834756)
    - Extrait : _[...]ant 1 personne à charge


2,38 %




Personne seule ou couple ayant 2 personnes à charge


2,17 %




Personne seule ou couple ayant 3 personnes à charge


1,94 %




Personne seule [...]_
    - Reponse du LLM : _La valeur de 'Taux « TF » dans les DOM des personnes seules ou couple ayant deux personnes à charge' est indiquée dans le tableau des valeurs de TF. Pour une personne seule ou un couple ayant 2 personnes à charge, le taux TF est de 2,17 %.  En convertissant ce pourcentage en valeur décimale, on obtient :  2,17 % = 0,0217  La réponse est donc :  {     "valeur": 0.0217 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_loc2.tf.dom.personnes_seules_couples_avec_1_enfant
    - Description : Taux « TF » dans les DOM des personnes seules ou couple ayant une personne à charge, pris en compte dans le taux de participation personnel du ménage « Tp » pour le calcul des allocations logement
    - 0.0238
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046834756/2022-12-30/#LEGIARTI000046834756)
    - Extrait : _[...]


Couple sans enfant


2,99 %




Personne seule ou couple ayant 1 personne à charge


2,38 %




Personne seule ou couple ayant 2 personnes à charge


2,17 %




Personne seule [...]_
    - Reponse du LLM : _La valeur de 'Taux « TF » dans les DOM des personnes seules ou couple ayant une personne à charge' est donnée dans le tableau des valeurs de TF. Pour une personne seule ou un couple ayant 1 personne à charge, le taux TF est de 2,38 %.  En convertissant ce pourcentage en valeur décimale, on obtient :  2,38 % = 0,0238  Cependant, la question demande la valeur actuelle, et non la valeur à une autre date de validité. La valeur actuelle est donnée dans le texte et est de 2,38 % pour une personne seule ou un couple ayant 1 personne à charge.  La réponse est donc :  {     "valeur": 0.0238 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_loc2.tf.dom.personnes_isolees
    - Description : Taux « TF » dans les DOM pour les personnes seules sans personne à charge, pris en compte dans le taux de participation personnel du ménage « Tp » pour le calcul des allocations logement
    - 0.0281
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046834756/2022-12-30/#LEGIARTI000046834756)
    - Extrait : _[...]es par les valeurs suivantes :





VALEURS DE TF




Bénéficiaires


TF




Isolé


2,81 %




Couple sans enfant


2,99 %




Personne seule ou couple ayant 1 personne à char[...]_
    - Reponse du LLM : _La valeur de 'Taux « TF » dans les DOM pour les personnes seules sans personne à charge' est indiquée dans le tableau "VALEURS DE TF" sous la rubrique "Bénéficiaires" avec la désignation "Isolé" et la valeur "2,81 %".  Pour répondre à la question, il faut convertir cette valeur en un nombre décimal en divisant par 100, ce qui donne 0,0281.  La réponse est donc :  {     "valeur": 0.0281 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_loc2.tf.dom.couples_sans_enfant
    - Description : Taux « TF » dans les DOM pour les couples sans personne à charge, pris en compte dans le taux de participation personnel du ménage « Tp » pour le calcul des allocations logement
    - 0.0299
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046834756/2022-12-30/#LEGIARTI000046834756)
    - Extrait : _[...] VALEURS DE TF




Bénéficiaires


TF




Isolé


2,81 %




Couple sans enfant


2,99 %




Personne seule ou couple ayant 1 personne à charge


2,38 %




Personne seule o[...]_
    - Reponse du LLM : _La valeur de 'Taux « TF » dans les DOM pour les couples sans personne à charge' est indiquée dans le tableau des valeurs de TF. Pour un couple sans enfant, la valeur de TF est de 2,99 %.  En convertissant cette valeur en notation mathématique, on obtient :  2,99 % = 0,0299  La réponse est donc :  {     "valeur": 0.0299 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_loc2.par_zone.zone_3.suppression
    - Description : Coefficient de suppression, en zone 3, appliqué au montant maximal de loyer pris en compte pour le calcul des aides, pour déterminer le plafond à partir duquel l'aide au logement est supprimée
    - 3.1
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039160745)
    - Extrait : _[...] comme suit :





ZONE

PREMIER PLAFOND DE LOYER

SECOND PLAFOND DE LOYER



I

3,4

4



II

2,5

3,1



III

2,5

3,1



[...]_
    - Reponse du LLM : _Pour déterminer la valeur de 'Coefficient de suppression, en zone 3, appliqué au montant maximal de loyer pris en compte pour le calcul des aides, pour déterminer le plafond à partir duquel l'aide au logement est supprimée', il faut regarder le tableau fourni dans le texte. La zone 3 correspond à la ligne où est écrit "III" dans le tableau.  Selon le tableau, le second plafond de loyer pour la zone III est de 3,1. Cependant, il est important de noter que le texte ne parle explicitement que de "premier plafond de loyer" et "second plafond de loyer" sans mentionner directement un "coefficient de suppression". Mais étant donné que la valeur à une autre date de validité était '3.1' et que le second plafond de loyer pour la zone III est également de 3,1, on peut en déduire que la valeur recherchée est bien 3,1.  La réponse est donc :  {     "valeur": 3.1 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_loc2.par_zone.zone_3.degressivite
    - Description : Coefficient de dégressivité, en zone 3, appliqué au montant maximal de loyer pris en compte pour le calcul des aides, pour déterminer le seuil à partir duquel l'aide au logement décroît
    - 2.5
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039160745)
    - Extrait : _[...]bleau comme suit :





ZONE

PREMIER PLAFOND DE LOYER

SECOND PLAFOND DE LOYER



I

3,4

4



II

2,5

3,1



III

2,5

3,1



[...]_
    - Reponse du LLM : _Il semble que le texte fourni ne contienne pas directement la valeur de 'Coefficient de dégressivité, en zone 3, appliqué au montant maximal de loyer pris en compte pour le calcul des aides, pour déterminer le seuil à partir duquel l'aide au logement décroît'. Cependant, on peut voir que la zone III (qui correspond à la zone 3) a des coefficients pour les premier et second plafonds de loyer, mais il n'est pas explicitement indiqué que ces coefficients sont ceux de dégressivité pour l'aide au logement.  Cependant, étant donné que la valeur à une autre date de validité était '2.5' et que le tableau fourni montre que le coefficient pour le premier plafond de loyer en zone III est bien 2.5, on pourrait considérer que cette valeur pourrait être liée à la dégressivité, même si le texte ne le spécifie pas clairement.  Donc, en l'absence d'information directe et en considérant la valeur précédente et les informations disponibles, la réponse pourrait être :  {     "valeur": 2.5 }  Mais il est important de noter que cette réponse est basée sur une interprétation et non sur une information directe du texte fourni. Si l'on devait être strict sur la présence de l'information dans le texte, la réponse devrait être :  {     "valeur": null }_
    
* prestations_sociales.aides_logement.allocations_logement.al_loc2.par_zone.zone_2.suppression
    - Description : Coefficient de suppression, en zone 2, appliqué au montant maximal de loyer pris en compte pour le calcul des aides, pour déterminer le plafond à partir duquel l'aide au logement est supprimée
    - 3.1
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039160745)
    - Extrait : _[...] comme suit :





ZONE

PREMIER PLAFOND DE LOYER

SECOND PLAFOND DE LOYER



I

3,4

4



II

2,5

3,1



III

2,5

3,1



[...]_
    - Reponse du LLM : _La valeur de 'Coefficient de suppression, en zone 2, appliqué au montant maximal de loyer pris en compte pour le calcul des aides, pour déterminer le plafond à partir duquel l'aide au logement est supprimée' est donnée dans le tableau sous le nom de 'SECOND PLAFOND DE LOYER' pour la zone II.  La valeur est donc 3.1.  La réponse est : {     "valeur": 3.1 }_
    
* prestations_sociales.aides_logement.allocations_logement.al_loc2.par_zone.zone_1.degressivite
    - Description : Coefficient de dégressivité, en zone 1, appliqué au montant maximal de loyer pris en compte pour le calcul des aides, pour déterminer le seuil à partir duquel l'aide au logement décroît
    - 3.4
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039160745)
    - Extrait : _[...]is selon le tableau comme suit :





ZONE

PREMIER PLAFOND DE LOYER

SECOND PLAFOND DE LOYER



I

3,4

4



II

2,5

3,1



III

2,5

3,1



[...]_
    - Reponse du LLM : _La valeur de 'Coefficient de dégressivité, en zone 1, appliqué au montant maximal de loyer pris en compte pour le calcul des aides, pour déterminer le seuil à partir duquel l'aide au logement décroît' est la même que celle du premier plafond de loyer pour la zone I, qui est de 3,4.  La réponse est donc : {     "valeur": 3.4 }_
    