### PR TITLE
MAJ last_value_still_valid_on prestations familialles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 169.16.16 [2450](https://github.com/openfisca/openfisca-france/pull/2450)
+
+ * Changement mineur.
+    * Périodes concernées : 2025.
+    * Zones impactées :
+      - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/*
+    * Détails :
+    - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+
 ### 169.16.15 [2428](https://github.com/openfisca/openfisca-france/pull/2428)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age1.yaml
@@ -2,8 +2,6 @@ description: Âge mininimal de l'enfant ouvrant droit aux prestations familiales
 values:
   1985-12-22:
     value: 0
-  2021-01-01:
-    value: 6
 metadata:
   short_label: Âge minimal de l'enfant
   last_value_still_valid_on: "2025-02-20"
@@ -12,8 +10,3 @@ metadata:
     1985-12-22:
       title: Article L512-3 du Code de la sécurité sociale
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006743276/1985-12-21/
-    2021-01-01:
-    - title: Art. L512-3 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041979743/2021-01-01/
-    - title: LOI n°2020-692 du 8 juin 2020 - art. 5 (V)
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000041975976

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age1.yaml
@@ -2,11 +2,18 @@ description: Âge mininimal de l'enfant ouvrant droit aux prestations familiales
 values:
   1985-12-22:
     value: 0
+  2021-01-01:
+    value: 6
 metadata:
   short_label: Âge minimal de l'enfant
-  last_value_still_valid_on: "2023-01-27"
+  last_value_still_valid_on: "2025-02-20"
   unit: year
   reference:
     1985-12-22:
       title: Article L512-3 du Code de la sécurité sociale
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006743276/1985-12-21/
+    2021-01-01:
+    - title: Art. L512-3 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041979743/2021-01-01/
+    - title: LOI n°2020-692 du 8 juin 2020 - art. 5 (V)
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000041975976

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age2.yaml
@@ -9,7 +9,7 @@ values:
   2000-02-01:
     value: 20
 metadata:
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-02-27"
   unit: year
   reference:
     2000-02-01:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/facteur_garde_alternee.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/facteur_garde_alternee.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.5
 metadata:
   short_label: Facteur multiplicatif pour un enfant en cas de garde alternée
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-02-27"
   unit: currency
   reference:
     2007-05-01:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/modulation/taux_tranche_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/modulation/taux_tranche_2.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.5
 metadata:
   short_label: Taux Tranche 2
-  last_value_still_valid_on: "2025-02-10"
+  last_value_still_valid_on: "2025-02-27"
   label_en: "Family allowances (AF): General conditions and amount"
   ipp_csv_id: af_modulation_taux1
   unit: BMAF

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/modulation/taux_tranche_3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/modulation/taux_tranche_3.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.25
 metadata:
   short_label: Taux Tranche 3
-  last_value_still_valid_on: "2025-02-10"
+  last_value_still_valid_on: "2025-02-27"
   label_en: "Family allowances (AF): General conditions and amount"
   ipp_csv_id: af_modulation_taux2
   unit: BMAF

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/nb_enfants_min_pour_allocation.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/nb_enfants_min_pour_allocation.yaml
@@ -6,7 +6,7 @@ values:
     value: 2
 metadata:
   short_label: Nombre minimal d'enfants
-  last_value_still_valid_on: "2024-01-05"
+  last_value_still_valid_on: "2025-02-27"
   label_en: "Family allowances (AF): General conditions and amount"
   ipp_csv_id: af_nenf_agemin
   reference:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/taux/enf2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/taux/enf2.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.32
 metadata:
   short_label: Premier taux
-  last_value_still_valid_on: "2023-05-04"
+  last_value_still_valid_on: "2025-02-27"
   label_en: "Family allowances (AF): General conditions and amount"
   ipp_csv_id: af_t1_2enf
   unit: BMAF

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age1.yaml
@@ -6,7 +6,7 @@ values:
     value: 14
 metadata:
   short_label: Âge seuil de la majoration
-  last_value_still_valid_on: "2024-01-05"
+  last_value_still_valid_on: "2025-02-27"
   unit: year
   reference:
     2008-04-30:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/taux1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/taux1.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.16
 metadata:
   short_label: Taux de la majoration
-  last_value_still_valid_on: "2024-01-05"
+  last_value_still_valid_on: "2025-02-27"
   unit: BMAF
   reference:
     2008-05-01:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/majoration_enfants/allocation_forfaitaire/nb_enfants_min.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/majoration_enfants/allocation_forfaitaire/nb_enfants_min.yaml
@@ -2,8 +2,6 @@ description: Nombre d'enfants minimum pour toucher l'allocation forfaitaire de l
 values:
   2003-07-01:
     value: 3
-  2015-07-01:
-    value: 2
 metadata:
   short_label: Nombre d'enfants minimum
   last_value_still_valid_on: "2025-02-20"
@@ -20,10 +18,5 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006743288/2002-12-24
     - title: Article R512-2 du Code de la sécurité sociale
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006750602/2000-01-29/
-    2015-07-01:
-    - title: Art. L521-1 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029963006/2015-07-01/
-    - title: LOI n°2014-1554 du 22 décembre 2014 - art. 85
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000029953502
   official_journal_date:
     2003-07-01: 2002-12-24; 2003-06-28

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/majoration_enfants/allocation_forfaitaire/nb_enfants_min.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/majoration_enfants/allocation_forfaitaire/nb_enfants_min.yaml
@@ -2,9 +2,11 @@ description: Nombre d'enfants minimum pour toucher l'allocation forfaitaire de l
 values:
   2003-07-01:
     value: 3
+  2015-07-01:
+    value: 2
 metadata:
   short_label: Nombre d'enfants minimum
-  last_value_still_valid_on: "2024-01-05"
+  last_value_still_valid_on: "2025-02-20"
   label_en: "Family allowances (AF): minimum age"
   ipp_csv_id: maj_forf_age
   unit: year
@@ -18,5 +20,10 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006743288/2002-12-24
     - title: Article R512-2 du Code de la sécurité sociale
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006750602/2000-01-29/
+    2015-07-01:
+    - title: Art. L521-1 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029963006/2015-07-01/
+    - title: LOI n°2014-1554 du 22 décembre 2014 - art. 85
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000029953502
   official_journal_date:
     2003-07-01: 2002-12-24; 2003-06-28

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/majoration_enfants/allocation_forfaitaire/taux.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/majoration_enfants/allocation_forfaitaire/taux.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.20234
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "2025-02-10"
+  last_value_still_valid_on: "2025-02-27"
   label_en: "Family allowances (AF): Extra allowances"
   ipp_csv_id: maj_forf_tx
   unit: BMAF

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/allocations_familiales_un_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/allocations_familiales_un_enfant.yaml
@@ -2,8 +2,6 @@ description: Taux de majoration, en part de BMAF, des allocations familiales (AF
 values:
   1991-08-06:
     value: 0.0588
-  1998-12-30:
-    value: 0.0567
 metadata:
   short_label: Taux de la majoration pour un seul enfant à charge
   last_value_still_valid_on: "2025-02-20"
@@ -15,8 +13,5 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006775833&cidTexte=JORFTEXT000000571496
     - title: Article D755-5 2. du Code de la Sécurité sociale
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006738570/1991-08-06/
-    1998-12-30:
-      title: Art. D755-5 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006738575/1998-12-30/
   official_journal_date:
     1991-08-06: "1991-08-06"

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/allocations_familiales_un_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/allocations_familiales_un_enfant.yaml
@@ -2,9 +2,11 @@ description: Taux de majoration, en part de BMAF, des allocations familiales (AF
 values:
   1991-08-06:
     value: 0.0588
+  1998-12-30:
+    value: 0.0567
 metadata:
   short_label: Taux de la majoration pour un seul enfant à charge
-  last_value_still_valid_on: "2024-01-15"
+  last_value_still_valid_on: "2025-02-20"
   label_en: "Family allowances (AF): Extra allowances for oversea territories"
   unit: BMAF
   reference:
@@ -13,5 +15,8 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006775833&cidTexte=JORFTEXT000000571496
     - title: Article D755-5 2. du Code de la Sécurité sociale
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006738570/1991-08-06/
+    1998-12-30:
+      title: Art. D755-5 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006738575/1998-12-30/
   official_journal_date:
     1991-08-06: "1991-08-06"

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/majoration_premier_enfant/taux_tranche_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/majoration_premier_enfant/taux_tranche_1.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.0369
 metadata:
   short_label: Taux de la tranche 1
-  last_value_still_valid_on: "2023-02-02"
+  last_value_still_valid_on: "2025-02-27"
   label_en: "Family allowances (AF): Extra allowances for oversea territories"
   unit: BMAF
   reference:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/majoration_premier_enfant/taux_tranche_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/majoration_premier_enfant/taux_tranche_2.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.0567
 metadata:
   short_label: Taux de la tranche 2
-  last_value_still_valid_on: "2023-02-02"
+  last_value_still_valid_on: "2025-02-27"
   label_en: "Family allowances (AF): Extra allowances for oversea territories"
   unit: BMAF
   reference:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/tranches_age/age_debut_deuxieme_tranche.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/tranches_age/age_debut_deuxieme_tranche.yaml
@@ -6,7 +6,7 @@ values:
     value: 16
 metadata:
   short_label: Âge seuil de la tranche 2
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-02-27"
   label_en: "Family allowances (AF): Extra allowances for oversea territories"
   unit: year
   reference:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/tranches_age/age_debut_premiere_tranche.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/tranches_age/age_debut_premiere_tranche.yaml
@@ -6,7 +6,7 @@ values:
     value: 11
 metadata:
   short_label: Âge seuil de la tranche 1
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-02-27"
   label_en: "Family allowances (AF): Extra allowances for oversea territories"
   unit: year
   reference:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/age_max.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/age_max.yaml
@@ -10,7 +10,7 @@ values:
     value: 21
 metadata:
   short_label: Âge max enfants
-  last_value_still_valid_on: "2023-05-11"
+  last_value_still_valid_on: "2025-02-27"
   label_en: Max age children
   ipp_csv_id: cf_enf_agemax
   unit: year

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/age_min.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/age_min.yaml
@@ -10,7 +10,7 @@ values:
     value: 3
 metadata:
   short_label: Âge min enfants
-  last_value_still_valid_on: "2023-05-11"
+  last_value_still_valid_on: "2025-02-27"
   label_en: Min age children
   ipp_csv_id: cf_enf_agemin
   unit: year

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/complement_familial/taux_cf_base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/complement_familial/taux_cf_base.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.4165
 metadata:
   short_label: Taux de base
-  last_value_still_valid_on: "2023-05-11"
+  last_value_still_valid_on: "2025-02-27"
   label_en: "Family complement (CF): General conditions and amounts"
   ipp_csv_id: tx_cf
   unit: BMAF

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/complement_familial/taux_cf_majore.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/complement_familial/taux_cf_majore.yaml
@@ -14,7 +14,7 @@ values:
     value: 0.6248
 metadata:
   short_label: Taux majoré
-  last_value_still_valid_on: "2023-05-11"
+  last_value_still_valid_on: "2025-02-27"
   label_en: Increased rate
   ipp_csv_id: tx_cf_maj
   unit: BMAF

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/majoration/deux_premiers_enf.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/majoration/deux_premiers_enf.yaml
@@ -2,8 +2,6 @@ description: Majoration en % de la base du plafond de ressources, pour les deux 
 values:
   1986-01-01:
     value: 0.25
-  2022-10-29:
-    value: 0.5
 metadata:
   short_label: Pour les deux premiers enfants
   last_value_still_valid_on: "2025-02-20"
@@ -16,11 +14,6 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046499019
     - title: Décret 85-1353 du 17/12/1985, art. 1 (crée art.R522-2 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000866621
-    2022-10-29:
-    - title: Art. R522-2 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046499019/2022-10-29/
-    - title: Décret n°2022-1370 du 27 octobre 2022 - art. 1
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046497145
   official_journal_date:
     1986-01-01: "1985-12-21"
   notes:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/majoration/deux_premiers_enf.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/majoration/deux_premiers_enf.yaml
@@ -14,9 +14,7 @@ metadata:
     1986-01-01:
     - title: Article R522-2 du Code de la sécurité sociale
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046499019
-    - title: Article L522-2 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036393166
-    - title: Décret 85-1353 du 17/12/1985, art. 1 (crée art. L522-2 et R522-2 du CSS)
+    - title: Décret 85-1353 du 17/12/1985, art. 1 (crée art.R522-2 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000866621
     2022-10-29:
     - title: Art. R522-2 du Code de la sécurité sociale

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/majoration/deux_premiers_enf.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/majoration/deux_premiers_enf.yaml
@@ -2,9 +2,11 @@ description: Majoration en % de la base du plafond de ressources, pour les deux 
 values:
   1986-01-01:
     value: 0.25
+  2022-10-29:
+    value: 0.5
 metadata:
   short_label: Pour les deux premiers enfants
-  last_value_still_valid_on: "2023-01-27"
+  last_value_still_valid_on: "2025-02-20"
   label_en: Increase, per child, in % of the resource ceiling base, for the first two children
   ipp_csv_id: maj_plaf_cf_apje_adopt_enf1et2
   unit: /1
@@ -16,6 +18,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036393166
     - title: Décret 85-1353 du 17/12/1985, art. 1 (crée art. L522-2 et R522-2 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000866621
+    2022-10-29:
+    - title: Art. R522-2 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046499019/2022-10-29/
+    - title: Décret n°2022-1370 du 27 octobre 2022 - art. 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046497145
   official_journal_date:
     1986-01-01: "1985-12-21"
   notes:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/majoration/troisieme_enf_et_plus.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/majoration/troisieme_enf_et_plus.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.3
 metadata:
   short_label: À partir du 3ème enfant
-  last_value_still_valid_on: "2023-01-27"
+  last_value_still_valid_on: "2025-02-27"
   label_en: Increase, per child, in % of the resource ceiling, from the 3rd child
   ipp_csv_id: maj_plaf_cf_apje_adopt_enf3pl
   unit: /1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.16.15"
+version = "169.16.16"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
 * Changement mineur.
    * Périodes concernées : 2025.
    * Zones impactées :
      - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/age2.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/facteur_garde_alternee.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/nb_enfants_min_pour_allocation.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/taux/enf2.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/taux/enf3.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age1.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/majoration_enfants/allocation_forfaitaire/taux.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/allocations_familiales_un_enfant.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/majoration_premier_enfant/taux_tranche_1.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/tranches_age/age_debut_deuxieme_tranche.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/tranches_age/age_debut_premiere_tranche.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/age_max.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/age_min.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/complement_familial/taux_cf_majore.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/majoration/deux_premiers_enf.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/majoration/troisieme_enf_et_plus.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/majoration/troisieme_enf_et_plus.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_plaf/majoration/deux_premiers_enf.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/complement_familial/taux_cf_majore.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/complement_familial/taux_cf_base.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/age_min.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/age_max.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/majoration_premier_enfant/taux_tranche_1.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/taux1.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age1.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/taux/enf2.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_cm/nb_enfants_min_pour_allocation.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/taux1.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/majoration_premier_enfant/taux_tranche_2.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm/complement_familial/taux_cf_base.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/majoration_premier_enfant/taux_tranche_2.yaml
    * Détails :
    - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.

    - - - -

    Ces changements (effacez les lignes ne correspondant pas à votre cas) :

    - Mise à jour de paramètre.

    - - - -

    Méthodologie :
    1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
    1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
    1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
    1. Vérifie la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
    1. Met à jour la `last_value_still_valid_on` à la date du jour.
    1. Crée un tableau récapitulatif pour faciliter la revue.

    Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

    - - - -

    Quelques conseils à prendre en compte :

    - [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
    - [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
    - [X] Documentez votre contribution avec des références législatives.
    - [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
    - [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
    - [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
    - [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
    
    Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme n'ayant pas changés depuis la date indiquée dans `last_value_still_valid_on`.

    Aide à la revue :
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_cm.age2
    - Description : Âge maximal de l'enfant ouvrant droit aux prestations familiales (hors l'aide additionnelle de l'allocation forfaitaire)
    - 20.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006750602/2000-01-29) de type CODE
    - Extrait : _[...]Les enfants ouvrent droit aux prestations familiales jusqu'à l'âge de vingt ans sous réserve que leur rémunération n'excède pas le plafond fixé au deuxième alinéa du prés[...]_
    - Reponse du LLM : _{     "valeur": 20.0 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_cm.facteur_garde_alternee
    - Description : Facteur multiplicatif pour un enfant en cas de garde alternée
    - 0.5
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006750610) de type CODE
    - Extrait : _[...]nfants à charge dans les conditions suivantes :
1° Chaque enfant en résidence alternée compte pour 0,5 ;
2° Les autres enfants à charge comptent pour 1.
Le nombre total d'enfants, pour chaque foyer[...]_
    - Reponse du LLM : _La valeur de 'Facteur multiplicatif pour un enfant en cas de garde alternée' est indiquée dans le texte comme étant 0,5 pour chaque enfant en résidence alternée.  La réponse est donc : {     "valeur": 0.5 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_cm.nb_enfants_min_pour_allocation
    - Description : Nombre minimal d'enfants pour avoir droit à l'allocation
    - 2.0
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/id/LEGISCTA000006106589) de type CODE
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _{     "valeur": 2.0 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_cm.taux.enf2
    - Description : Premier taux, en part de BMAF, servant au calcul des allocations familiales (AF)
    - 0.32
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000030674064) de type CODE
    - Extrait : _[...]ons familiales sont fixés, en pourcentage de la base mensuelle prévue à l'article L. 551-1, à :
a) 32 % pour le deuxième enfant à charge ;
b) 41 % pour le troisième enfant à charge et chacun des sui[...]_
    - Reponse du LLM : _La valeur de 'Premier taux, en part de BMAF, servant au calcul des allocations familiales (AF)' pour le deuxième enfant à charge est donnée dans le texte à 3 endroits différents en fonction du montant de ressources du ménage ou de la personne.   Cependant, la valeur demandée est celle qui correspond à la première tranche, c'est-à-dire lorsque le ménage ou la personne a disposé d'un montant de ressources inférieur ou égal au plafond défini au I de l'article D. 521-3.  La valeur est donc de 32%, ce qui équivaut à 0.32 en notation mathématique.  La réponse est : ``` {     "valeur": 0.32 } ```_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_cm.taux.enf3
    - Description : Deuxième taux, en part de BMAF, servant au calcul des allocations familiales (AF)
    - 0.41
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000030680318/) de type CODE
    - Extrait : _[...] la base mensuelle prévue à l'article L. 551-1, à :
a) 32 % pour le deuxième enfant à charge ;
b) 41 % pour le troisième enfant à charge et chacun des suivants.
La majoration pour âge est fixée à 1[...]_
    - Reponse du LLM : _La valeur de 'Deuxième taux, en part de BMAF, servant au calcul des allocations familiales (AF) - prestations_sociales.prestations_familiales.prestations_generales.af.af_cm.taux.enf3' est donnée dans le texte à trois reprises, selon les tranches de ressources du ménage ou de la personne :  - Pour les ressources inférieures ou égales au plafond défini au I de l'article D. 521-3, le taux est de 32 % pour le deuxième enfant à charge, mais nous recherchons le taux pour le troisième enfant et les suivants, qui est de 41 %. - Pour les ressources supérieures au plafond défini au I de l'article D. 521-3 et inférieures ou égales au plafond défini au II du même article, le taux pour le troisième enfant et les suivants est de 20,5 %. - Pour les ressources supérieures au plafond défini au II de l'article D. 521-3, le taux pour le troisième enfant et les suivants est de 10,25 %.  Cependant, la question demande spécifiquement la valeur pour le troisième enfant (enf3), et il est mentionné que la valeur à une autre date de validité était '0.41'.   La valeur qui correspond à cette description est donc 0.41, qui est le taux pour le troisième enfant à charge et chacun des suivants lorsque le ménage ou la personne a disposé d'un montant de ressources inférieur ou égal au plafond défini au I de l'article D. 521-3.  La réponse est : {     "valeur": 0.41 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_maj.maj_age_deux_enfants.age1
    - Description : Âge seuil de la majoration pour âge des allocations familiales
    - 14.0
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000018731950/2022-02-28/) de type CODE
    - Extrait : _[...]1-3 à partir duquel les enfants ouvrent droit à la majoration des allocations familiales est fixé à 14 ans.
Le nombre minimum d'enfants à charge, mentionné au deuxième alinéa de l'article L. 521-3 ou[...]_
    - Reponse du LLM : _{     "valeur": 14.0 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_maj.majoration_enfants.allocation_forfaitaire.taux
    - Description : Taux de l'allocation forfaitaire de la majoration pour les enfants (en % de la BMAF) des allocations familiales (AF)
    - 0.20234
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000030680324/2015-07-01) de type CODE
    - Extrait : _[...]lafond défini au I de l'article D. 521-3, le montant mensuel de l'allocation forfaitaire est fixé à 20,234 % de la base mensuelle de calcul des allocations familiales par enfant ;
2° Lorsque le ménag[...]_
    - Reponse du LLM : _La valeur de 'Taux de l'allocation forfaitaire de la majoration pour les enfants (en % de la BMAF) des allocations familiales (AF)' n'est pas explicitement indiquée dans le texte fourni. Cependant, on peut trouver des informations sur les taux d'allocation forfaitaire pour les enfants en fonction des ressources du ménage ou de la personne.  Selon le texte, les taux d'allocation forfaitaire sont les suivants : - 20,234 % de la base mensuelle de calcul des allocations familiales par enfant lorsque le ménage ou la personne a disposé d'un montant de ressources inférieur ou égal au plafond défini au I de l'article D. 521-3. - 10,117 % de la base mensuelle de calcul des allocations familiales par enfant lorsque le ménage ou la personne a disposé d'un montant de ressources supérieur au plafond défini au I de l'article D. 521-3 et inférieur ou égal à celui défini au II du même article. - 5,059 % de la base mensuelle de calcul des allocations familiales par enfant lorsque le ménage ou la personne a disposé d'un montant de ressources supérieur au plafond défini au II de l'article D. 521-3.  Puisque la valeur à une autre date de validité était '0.20234', on peut supposer que cette valeur correspond au taux d'allocation forfaitaire pour les enfants lorsque le ménage ou la personne a disposé d'un montant de ressources inférieur ou égal au plafond défini au I de l'article D. 521-3.  La réponse est donc : ``` {     "valeur": 0.20234 } ``` Cependant, il est important de noter que cette valeur n'est pas explicitement indiquée dans le texte fourni pour la date de validité actuelle. Il est possible que les taux aient changé depuis la dernière date de validité.   Si l'on considère les taux indiqués dans le texte, on peut répondre : ``` {     "brackets": [         {"threshold": null, "rate": 0.20234},         {"threshold": null, "rate": 0.10117},         {"threshold": null, "rate": 0.05059},     ] } ``` Mais comme les threshold ne sont pas indiqués dans le texte, il est préférable de répondre : ``` {     "valeur": null } ```_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_maj_dom.allocations_familiales_un_enfant
    - Description : Taux de majoration, en part de BMAF, des allocations familiales (AF), pour un seul enfant à charge, dans les DOM
    - 0.0588
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006775833&cidTexte=JORFTEXT000000571496) de type CODE
    - Extrait : _[...]e taux servant au calcul des allocations familiales servies pour un seul enfant à charge est fixé à 5,88 p. 100 de la base mensuelle prévue à l'article L. 755-3.
La majoration des allocations familia[...]_
    - Reponse du LLM : _Pour trouver la valeur de 'Taux de majoration, en part de BMAF, des allocations familiales (AF), pour un seul enfant à charge, dans les DOM', nous devons analyser le texte fourni. Le texte mentionne les taux servant au calcul des allocations familiales et de la majoration, mais il ne spécifie pas explicitement la valeur pour les DOM (Départements d'Outre-Mer) pour un seul enfant à charge.  Cependant, le texte fourni dans la partie II mentionne les taux pour un seul enfant à charge, mais sans distinction géographique (DOM ou métropole). Il est important de noter que les taux mentionnés sont :  - 5,88 % pour un seul enfant à charge, - Une majoration à 3,69 % de la base mensuelle à partir de onze ans, - Une majoration à 5,67 % à partir de seize ans.  Puisque la question concerne spécifiquement les DOM et qu'il n'y a pas d'information spécifique dans le texte fourni qui différencie les taux pour les DOM, et considérant que la valeur à une autre date de validité était '0.0588', il semble qu'il y ait une correspondance avec le taux de 5,88 % mentionné pour un seul enfant à charge, qui pourrait être interprété comme le taux de majoration pour les allocations familiales dans les DOM, bien que cela ne soit pas explicitement indiqué.  La conversion de 5,88 % en notation mathématique est 0,0588.  Donc, la réponse, en considérant les informations disponibles et en faisant une correspondance approchante, serait :  ```json {     "valeur": 0.0588 } ```_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_maj_dom.majoration_premier_enfant.taux_tranche_1
    - Description : Taux de la tranche 1 de la majoration pour le premier enfant (en % de la BMAF) pour les DOM - Allocations Familiales (AF)
    - 0.0369
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006775833&cidTexte=JORFTEXT000000571496) de type CODE
    - Extrait : _[...]rticle L. 755-3.
La majoration des allocations familiales pour un seul enfant à charge est fixée à 3,69 p. 100 de la base mensuelle prévue à l'article L. 755-3 à partir de onze ans et à 5,67 p. 100 à[...]_
    - Reponse du LLM : _Pour déterminer la valeur de 'Taux de la tranche 1 de la majoration pour le premier enfant (en % de la BMAF) pour les DOM', nous devons analyser le texte fourni. Le texte mentionne les taux pour les allocations familiales et la majoration, mais il est important de comprendre que les pourcentages sont exprimés sous forme mathématique, donc une valeur de X% sera notée X/100.  Le texte indique que "La majoration des allocations familiales pour un seul enfant à charge est fixée à 3,69 p. 100 de la base mensuelle prévue à l'article L. 755-3 à partir de onze ans et à 5,67 p. 100 à partir de seize ans." Cela signifie que pour les enfants à partir de 11 ans, le taux de majoration est de 3,69%, et pour ceux à partir de 16 ans, il est de 5,67%.  Puisque la question concerne spécifiquement la "tranche 1 de la majoration pour le premier enfant", et qu'il n'y a pas de détails supplémentaires sur les tranches dans le texte fourni, nous allons considérer la valeur pour les enfants à partir de 11 ans comme la référence pour la "tranche 1", étant donné qu'il n'y a pas d'information sur d'autres tranches.  La valeur de 3,69% doit être convertie en notation mathématique, ce qui donne 0,0369.  La réponse est donc :  {     "valeur": 0.0369 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_maj_dom.tranches_age.age_debut_deuxieme_tranche
    - Description : Âge seuil de la tranche pour laquelle s'applique le taux 2 de la majoration premier enfant pour les DOM - allocations familiales (AF)
    - 16.0
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000209409&categorieLien=id) de type CODE
    - Extrait : _[...] de la base mensuelle prévue à l'article L. 755-3 à partir de onze ans et à 5,67 p. 100 à partir de seize ans.[...]_
    - Reponse du LLM : _Pour trouver la valeur de 'Âge seuil de la tranche pour laquelle s'applique le taux 2 de la majoration premier enfant pour les DOM', il faut analyser le texte donné. Le texte indique que la majoration des allocations familiales pour un seul enfant à charge est fixée à 3,69 p. 100 de la base mensuelle à partir de onze ans et à 5,67 p. 100 à partir de seize ans.  Cela signifie que le taux 2 de la majoration s'applique à partir de l'âge de seize ans. Par conséquent, la valeur de 'Âge seuil de la tranche pour laquelle s'applique le taux 2 de la majoration premier enfant pour les DOM' est 16.  La réponse est donc :  {     "valeur": 16.0 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_maj_dom.tranches_age.age_debut_premiere_tranche
    - Description : Âge seuil de la tranche pour laquelle s'applique le taux 1 de la majoration premier enfant pour les DOM - allocations familiales (AF)
    - 11.0
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000209409&categorieLien=id) de type CODE
    - Extrait : _[...]Les taux servant au calcul des allocations familiales et de la majoration prévue à l'article L. 755-11 sont identiques à ceux mentionnés à l'article D. 521-1.

II.-En application de l'article L. 755-[...]_
    - Reponse du LLM : _Pour trouver la valeur de 'Âge seuil de la tranche pour laquelle s'applique le taux 1 de la majoration premier enfant pour les DOM', il faut analyser le texte donné. Le texte mentionne que la majoration des allocations familiales pour un seul enfant à charge est fixée à 3,69 p. 100 de la base mensuelle à partir de onze ans et à 5,67 p. 100 à partir de seize ans.  La valeur que nous recherchons est l'âge seuil pour la première tranche de majoration, qui correspond au taux de 3,69 p. 100. Selon le texte, cette majoration s'applique à partir de onze ans.  La réponse est donc :  {     "valeur": 11.0 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_cm.age_max
    - Description : Âge maximal des enfants pris en compte pour le calcul du Complément familial (CF)
    - 21.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006750615) de type CODE
    - Extrait : _[...]ier alinéa de l'article R. 512-2, les enfants ouvrent droit au complément familial jusqu'à l'âge de vingt et un ans sous réserve que leur rémunération n'excède pas le plafond fixé au deuxième alinéa d[...]_
    - Reponse du LLM : _{     "valeur": 21.0 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_cm.age_min
    - Description : Âge minimal des enfants pris en compte pour le calcul du Complément familial (CF)
    - 3.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006750615) de type CODE
    - Extrait : _[...]ment familial prévu à l'article L. 522-1 le ménage ou la personne doit assumer la charge d'au moins trois enfants, âgés de trois ans et plus.
Par dérogation aux dispositions du premier alinéa de l'ar[...]_
    - Reponse du LLM : _{     "valeur": 3.0 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_cm.complement_familial.taux_cf_majore
    - Description : Taux majoré (en % de la BMAF) du complément familial (CF)
    - 0.6248
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038249420/2022-09-27/) de type CODE
    - Extrait : _[...]
Le taux du complément familial majoré est égal à 62,48 % de la base mensuelle de calcul des allocations familiales fixée en application de l'article [...]_
    - Reponse du LLM : _Pour déterminer la valeur de 'Taux majoré (en % de la BMAF) du complément familial (CF)', nous devons extraire l'information spécifique du texte fourni. Le texte indique que le taux du complément familial majoré est égal à 62,48 % de la base mensuelle de calcul des allocations familiales.  Étant donné que les pourcentages sont exprimés sous forme mathématique, nous devons convertir 62,48 % en une valeur décimale. Pour cela, nous divisons 62,48 par 100, ce qui nous donne 0,6248.  Cependant, la question demande la valeur sous forme de nombre, sans pourcentage, et avec un point comme séparateur des décimales. La valeur est donc directement 0,6248.  La réponse est donc :  {     "valeur": 0.6248 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_plaf.majoration.deux_premiers_enf
    - Description : Majoration en % de la base du plafond de ressources, pour les deux premiers enfants - complément familial (CF)
    - 0.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046499019) de type CODE
    - Extrait : _[...]ions prévues à l'article R. 532-1, ne doit pas dépasser un plafond annuel.
Ce plafond est majoré de 25 % par enfant à charge à partir du premier et de 30 % par enfant à charge à partir du troisième.
I[...]_
    - Reponse du LLM : _La valeur de 'Majoration en % de la base du plafond de ressources, pour les deux premiers enfants - complément familial (CF) - prestations_sociales.prestations_familiales.prestations_generales.cf.cf_plaf.majoration.deux_premiers_enf' est de 0.25.   En effet, le texte indique que le plafond est majoré de 25 % par enfant à charge à partir du premier.   La réponse est donc : {     "valeur": 0.25 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_plaf.majoration.troisieme_enf_et_plus
    - Description : Majoration en % de la base du plafond de ressources, pour chaque enfant, à partir du 3ème enfant - complément familial (CF)
    - 0.3
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046499019) de type CODE
    - Extrait : _[...]sser un plafond annuel.
Ce plafond est majoré de 25 % par enfant à charge à partir du premier et de 30 % par enfant à charge à partir du troisième.
Il est également majoré lorsque les deux membres du [...]_
    - Reponse du LLM : _La valeur de 'Majoration en % de la base du plafond de ressources, pour chaque enfant, à partir du 3ème enfant' est de 0.3, ce qui correspond à 30 %.  Réponse : ``` {     "valeur": 0.3 } ```_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_plaf.majoration.troisieme_enf_et_plus
    - Description : Majoration en % de la base du plafond de ressources, pour chaque enfant, à partir du 3ème enfant - complément familial (CF)
    - 0.3
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046499019) de type CODE
    - Extrait : _[...]sser un plafond annuel.
Ce plafond est majoré de 25 % par enfant à charge à partir du premier et de 30 % par enfant à charge à partir du troisième.
Il est également majoré lorsque les deux membres du [...]_
    - Reponse du LLM : _La valeur de 'Majoration en % de la base du plafond de ressources, pour chaque enfant, à partir du 3ème enfant' est de 0.3, ce qui correspond à 30 %.  Réponse : ``` {     "valeur": 0.3 } ```_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_plaf.majoration.deux_premiers_enf
    - Description : Majoration en % de la base du plafond de ressources, pour les deux premiers enfants - complément familial (CF)
    - 0.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046499019) de type CODE
    - Extrait : _[...]ions prévues à l'article R. 532-1, ne doit pas dépasser un plafond annuel.
Ce plafond est majoré de 25 % par enfant à charge à partir du premier et de 30 % par enfant à charge à partir du troisième.
I[...]_
    - Reponse du LLM : _La valeur de 'Majoration en % de la base du plafond de ressources, pour les deux premiers enfants - complément familial (CF) - prestations_sociales.prestations_familiales.prestations_generales.cf.cf_plaf.majoration.deux_premiers_enf' est de 0.25.   En effet, le texte indique que le plafond est majoré de 25 % par enfant à charge à partir du premier.   La réponse est donc : {     "valeur": 0.25 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_cm.complement_familial.taux_cf_majore
    - Description : Taux majoré (en % de la BMAF) du complément familial (CF)
    - 0.6248
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038249420/2022-09-27/) de type CODE
    - Extrait : _[...]
Le taux du complément familial majoré est égal à 62,48 % de la base mensuelle de calcul des allocations familiales fixée en application de l'article [...]_
    - Reponse du LLM : _Pour déterminer la valeur de 'Taux majoré (en % de la BMAF) du complément familial (CF)', nous devons extraire l'information spécifique du texte fourni. Le texte indique que le taux du complément familial majoré est égal à 62,48 % de la base mensuelle de calcul des allocations familiales.  Étant donné que les pourcentages sont exprimés sous forme mathématique, nous devons convertir 62,48 % en une valeur décimale. Pour cela, nous divisons 62,48 par 100, ce qui nous donne 0,6248.  Cependant, comme le texte ne fournit pas de nouvelle valeur pour la date de validité actuelle mais confirme la valeur existante, nous pouvons conclure que la valeur reste la même.  La réponse est donc :  {     "valeur": 0.6248 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_cm.complement_familial.taux_cf_base
    - Description : Taux de base (en % de la BMAF) du Complément familial (CF)
    - 0.4165
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006737116/) de type CODE
    - Extrait : _[...]Le montant du complément familial est fixé à 41,65 p. 100 de la base mensuelle de calcul des allocations familiales fixée en application de l'art[...]_
    - Reponse du LLM : _Pour déterminer la valeur de 'Taux de base (en % de la BMAF) du Complément familial (CF)', nous devons analyser le texte fourni. Le texte indique que le montant du complément familial est fixé à 41,65 pour cent de la base mensuelle de calcul des allocations familiales.  Étant donné que les pourcentages sont exprimés sous forme mathématique, nous devons convertir 41,65 pour cent en une valeur décimale. Pour ce faire, nous divisons 41,65 par 100.  La valeur de 'Taux de base (en % de la BMAF) du Complément familial (CF)' est donc :  41,65 / 100 = 0,4165  Cependant, comme indiqué dans les instructions, nous devons utiliser le point comme séparateur des décimales. La réponse est donc :  {     "valeur": 0.4165 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_cm.age_min
    - Description : Âge minimal des enfants pris en compte pour le calcul du Complément familial (CF)
    - 3.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006750615) de type CODE
    - Extrait : _[...]ment familial prévu à l'article L. 522-1 le ménage ou la personne doit assumer la charge d'au moins trois enfants, âgés de trois ans et plus.
Par dérogation aux dispositions du premier alinéa de l'ar[...]_
    - Reponse du LLM : _{     "valeur": 3.0 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_cm.age_max
    - Description : Âge maximal des enfants pris en compte pour le calcul du Complément familial (CF)
    - 21.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006750615) de type CODE
    - Extrait : _[...]ier alinéa de l'article R. 512-2, les enfants ouvrent droit au complément familial jusqu'à l'âge de vingt et un ans sous réserve que leur rémunération n'excède pas le plafond fixé au deuxième alinéa d[...]_
    - Reponse du LLM : _{     "valeur": 21.0 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_maj_dom.majoration_premier_enfant.taux_tranche_1
    - Description : Taux de la tranche 1 de la majoration pour le premier enfant (en % de la BMAF) pour les DOM - Allocations Familiales (AF)
    - 0.0369
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006775833&cidTexte=JORFTEXT000000571496) de type CODE
    - Extrait : _[...]rticle L. 755-3.
La majoration des allocations familiales pour un seul enfant à charge est fixée à 3,69 p. 100 de la base mensuelle prévue à l'article L. 755-3 à partir de onze ans et à 5,67 p. 100 à[...]_
    - Reponse du LLM : _Pour déterminer la valeur de 'Taux de la tranche 1 de la majoration pour le premier enfant (en % de la BMAF) pour les DOM', nous devons examiner les informations fournies dans le texte. Le texte mentionne les taux pour les allocations familiales et la majoration, mais il est important de comprendre que les pourcentages sont exprimés sous forme mathématique, donc une valeur de X% sera notée X/100 ou 0.X.  Le texte indique : - Le taux pour les allocations familiales pour un seul enfant à charge est fixé à 5,88% de la base mensuelle. - La majoration des allocations familiales pour un seul enfant à charge est fixée à 3,69% de la base mensuelle à partir de onze ans et à 5,67% à partir de seize ans.  Puisque la question concerne spécifiquement le 'Taux de la tranche 1 de la majoration pour le premier enfant', nous nous intéressons à la majoration pour un seul enfant à charge, et plus précisément à la tranche qui correspond à l'âge avant seize ans, car il n'y a pas de détails sur plusieurs tranches pour les enfants de moins de seize ans dans le texte fourni.  La valeur à une autre date de validité était '0.0369', ce qui correspond à 3,69%. Cependant, nous devons vérifier si cette valeur est toujours applicable ou si elle a changé.  Le texte ne fournit pas explicitement de valeur pour la 'tranche 1' de la majoration pour le premier enfant de manière détaillée, mais il mentionne une majoration à 3,69% à partir de onze ans. Il n'y a pas de mention d'une 'tranche 1' spécifique dans le texte fourni, mais on peut déduire que la majoration pour un seul enfant à charge à partir de onze ans pourrait être considérée comme la première tranche de majoration applicable.  Par conséquent, la réponse, en se basant sur les informations disponibles et en considérant que la valeur pour la majoration à partir de onze ans pourrait être la référence la plus proche pour la 'tranche 1', serait :  {     "valeur": 0.0369 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_maj.maj_age_deux_enfants.taux1
    - Description : Taux (en part de la BMAF) de la majoration pour âge des allocations familiales
    - 0.16
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000018730821) de type CODE
    - Extrait : _[...] 41 % pour le troisième enfant à charge et chacun des suivants.
La majoration pour âge est fixée à 16 % de la base mensuelle de calcul des prestations familiales ;
2° Lorsque le ménage ou la personn[...]_
    - Reponse du LLM : _Il n'y a pas de mention spécifique de la valeur de 'Taux (en part de la BMAF) de la majoration pour âge des allocations familiales - prestations_sociales.prestations_familiales.prestations_generales.af.af_maj.maj_age_deux_enfants.taux1' dans le texte fourni. Cependant, on peut trouver des informations sur la majoration pour âge dans les différents cas :  - Lorsque le ménage ou la personne a disposé d'un montant de ressources inférieur ou égal au plafond défini au I de l'article D. 521-3, la majoration pour âge est fixée à 16 % de la base mensuelle de calcul des prestations familiales, ce qui équivaut à 0.16. - Lorsque le ménage ou la personne a disposé d'un montant de ressources supérieur au plafond défini au I de l'article D. 521-3 et inférieur ou égal à celui défini au II du même article, la majoration pour âge est fixée à 8 % de la base mensuelle de calcul des prestations familiales, ce qui équivaut à 0.08. - Lorsque le ménage ou la personne a disposé d'un montant de ressources supérieur au plafond défini au II de l'article D. 521-3, la majoration pour âge est fixée à 4 % de la base mensuelle de calcul des prestations familiales, ce qui équivaut à 0.04.  Puisque la valeur à une autre date de validité était '0.16', il est possible que la valeur recherchée soit également 0.16, mais cela ne peut être confirmé avec certitude en fonction du texte fourni.  La réponse est donc : ``` {     "valeur": 0.16 } ```_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_maj.maj_age_deux_enfants.age1
    - Description : Âge seuil de la majoration pour âge des allocations familiales
    - 14.0
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000018731950/2022-02-28/) de type CODE
    - Extrait : _[...]1-3 à partir duquel les enfants ouvrent droit à la majoration des allocations familiales est fixé à 14 ans.
Le nombre minimum d'enfants à charge, mentionné au deuxième alinéa de l'article L. 521-3 ou[...]_
    - Reponse du LLM : _{     "valeur": 14.0 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_cm.taux.enf2
    - Description : Premier taux, en part de BMAF, servant au calcul des allocations familiales (AF)
    - 0.32
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000030674064) de type CODE
    - Extrait : _[...]ons familiales sont fixés, en pourcentage de la base mensuelle prévue à l'article L. 551-1, à :
a) 32 % pour le deuxième enfant à charge ;
b) 41 % pour le troisième enfant à charge et chacun des sui[...]_
    - Reponse du LLM : _La valeur de 'Premier taux, en part de BMAF, servant au calcul des allocations familiales (AF)' pour le deuxième enfant à charge est donnée dans le texte à 0.32 (32%) pour les ménages ou personnes ayant des ressources inférieures ou égales au plafond défini au I de l'article D. 521-3.  Cependant, il est important de noter que cette valeur peut varier en fonction du niveau de ressources du ménage ou de la personne. Les taux sont les suivants :  - 0.32 (32%) pour les ménages ou personnes ayant des ressources inférieures ou égales au plafond défini au I de l'article D. 521-3, - 0.16 (16%) pour les ménages ou personnes ayant des ressources supérieures au plafond défini au I de l'article D. 521-3 et inférieures ou égales au plafond défini au II du même article, - 0.08 (8%) pour les ménages ou personnes ayant des ressources supérieures au plafond défini au II de l'article D. 521-3.  Puisque la question demande la valeur pour le deuxième enfant à charge sans spécifier le niveau de ressources, il est difficile de donner une réponse unique. Cependant, en fonction des informations fournies, la valeur la plus élevée pour le deuxième enfant à charge est de 0.32.  La réponse est donc :  {     "valeur": 0.32 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_cm.nb_enfants_min_pour_allocation
    - Description : Nombre minimal d'enfants pour avoir droit à l'allocation
    - 2.0
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/id/LEGISCTA000006106589) de type CODE
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _{     "valeur": 2.0 }_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_maj.maj_age_deux_enfants.taux1
    - Description : Taux (en part de la BMAF) de la majoration pour âge des allocations familiales
    - 0.16
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000018730821) de type CODE
    - Extrait : _[...] 41 % pour le troisième enfant à charge et chacun des suivants.
La majoration pour âge est fixée à 16 % de la base mensuelle de calcul des prestations familiales ;
2° Lorsque le ménage ou la personn[...]_
    - Reponse du LLM : _Okay, let's tackle this query step by step. The user is asking for the value of a specific parameter related to the increase in family allowances for age when there are two children. The parameter in question is 'Taux (en part de la BMAF) de la majoration pour âge des allocations familiales - prestations_sociales.prestations_familiales.prestations_generales.af.af_maj.maj_age_deux_enfants.taux1' and they mention that the value at another validity date was 0.16.  First, I need to parse the provided legal text to find the relevant information. The text is divided into sections (I, II) and subsections (1°, 2°, 3°, etc.). The key part here is the "majoration pour âge" (age-related increase) which is mentioned in each subsection.  Looking at the first paragraph under section I, after listing the rates for the second and third children, it states: "La majoration pour âge est fixée à 16 % de la base mensuelle de calcul des prestations familiales ;" So here, the rate is 16%, which converts to 0.16 in decimal. This is under the first scenario where the household's income is below the first threshold (plafond I).  In the second scenario (2°), when income is between plafond I and II, the majoration pour âge is 8% (0.08). The third scenario (3°) sets it at 4% (0.04).   The user is asking for 'maj_age_deux_enfants.taux1'. The 'taux1' might correspond to the first threshold scenario, which is 16% or 0.16. However, the user mentions that the value at another date was 0.16, implying that perhaps the current value is different. But in the provided text, the first scenario's rate is 16%, so unless there's a different date mentioned, this would be the current value.  Wait, the user's question specifies that the value at another validity date was 0.16, but they are asking for the current value. The text provided doesn't mention any dates, so we have to assume that the text is the current regulation. Therefore, the current value for the first threshold (plafond I) is 0.16. However, the parameter name includes 'maj_age_deux_enfants', which refers to the age increase for two children. But in the text, the majoration pour âge is a flat rate regardless of the number of children. The 32%, 41%, etc., are for the allocations familiales based on the number of children, but the majoration pour âge is a separate component. So the 16% applies when the household is under plafond I, regardless of the number of children.   But the parameter in question is specifically for two children. However, the text doesn't differentiate the majoration pour âge based on the number of children. It's a flat rate applied in addition to the allocations. Therefore, the rate for the majoration pour âge is 16% (0.16) in the first bracket, 8% in the second, and 4% in the third. Since the user is asking for 'taux1', which might correspond to the first bracket, the answer should be 0.16. But the user mentioned that the previous value was 0.16, so maybe they are looking for a different rate. However, according to the text provided, the current rate in the first bracket is still 16%, so the answer remains 0.16. Unless there's a misunderstanding in the parameter's structure. But based on the text, the correct value is 0.16 for the first threshold scenario.   ```json {     "valeur": 0.16 } ```_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_maj_dom.majoration_premier_enfant.taux_tranche_2
    - Description : Taux de la tranche 2 de la majoration pour le premier enfant (en % de la BMAF) pour les DOM - allocations familiales (AF)
    - 0.0567
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006775833&cidTexte=JORFTEXT000000571496) de type CODE
    - Extrait : _[...] est fixée à 3,69 p. 100 de la base mensuelle prévue à l'article L. 755-3 à partir de onze ans et à 5,67 p. 100 à partir de seize ans.[...]_
    - Reponse du LLM : _Okay, let's tackle this query step by step. The user is asking for the value of a specific parameter related to the DOM (overseas departments) family allowance (AF) majoration for the first child, specifically the second bracket rate as a percentage of the BMAF. The current value at another validity date was 0.0567, and they want to know the current rate based on the provided text.  First, I need to parse the given text carefully. The relevant section is part II, which mentions the majoration for a single child. The text states that the increase is 3.69% from age 11 and 5.67% from age 16. The user's parameter refers to the second tranche (tranche 2), which would correspond to the higher age threshold, so 16 years and above. The rate here is 5.67%, which converts to 0.0567 in decimal form.   I need to confirm that this rate applies to the DOM. The text references Article L. 755-11, which is related to DOM, as per the context of the question. The first part (I) mentions that the rates are the same as in Article D. 521-1, but part II specifically discusses the rates for the majoration, which aligns with the user's parameter.   Since the text explicitly states 5.67 p. 100 for the second tranche (à partir de seize ans), the value should be 0.0567. The previous value was also 0.0567, but the user is asking for the current value based on the new text. The answer is present in the text, so the response should reflect that.   ```json {     "valeur": 0.0567 } ```_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_cm.complement_familial.taux_cf_base
    - Description : Taux de base (en % de la BMAF) du Complément familial (CF)
    - 0.4165
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006737116/) de type CODE
    - Extrait : _[...]Le montant du complément familial est fixé à 41,65 p. 100 de la base mensuelle de calcul des allocations familiales fixée en application de l'art[...]_
    - Reponse du LLM : _Okay, let's tackle this problem step by step. The user is asking for the value of the 'Taux de base (en % de la BMAF) du Complément familial (CF)' which translates to the base rate percentage of the BMAF for the Family Complement. The current value they have from another date is 0.4165, and they want to confirm if the new text provided updates this value.  Looking at the provided text: "Le montant du complément familial est fixé à 41,65 p. 100 de la base mensuelle..." The key part here is "41,65 p. 100". In French, "p. 100" stands for "pour cent", which is percentage. So 41,65% would be 0.4165 in decimal form.   The user mentioned that the previous value was 0.4165, and the text here states the same number. The system requires percentages to be converted into their decimal equivalents, using a point as the decimal separator. The text uses a comma, which is common in French notation, but we need to replace that with a point. So 41,65 becomes 41.65, and then divided by 100 gives 0.4165.   I need to check if there's any discrepancy or if the text might have a different value. The text clearly states 41,65%, which matches the existing value. There's no mention of a different rate or any date changes in the provided text. Therefore, the value remains the same.   The answer should be a JSON object with the key "valeur" and the value 0.4165. Since the text confirms the existing rate, there's no need to return null here.   ```json {     "valeur": 0.4165 } ```_
    
* prestations_sociales.prestations_familiales.prestations_generales.af.af_maj_dom.majoration_premier_enfant.taux_tranche_2
    - Description : Taux de la tranche 2 de la majoration pour le premier enfant (en % de la BMAF) pour les DOM - allocations familiales (AF)
    - 0.0567
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006775833&cidTexte=JORFTEXT000000571496) de type CODE
    - Extrait : _[...] est fixée à 3,69 p. 100 de la base mensuelle prévue à l'article L. 755-3 à partir de onze ans et à 5,67 p. 100 à partir de seize ans.[...]_
    - Reponse du LLM : _Okay, let's tackle this question step by step. The user is asking for the value of a specific parameter related to the DOM (French overseas departments) family allowances, specifically the rate for the second bracket of the increase for the first child. The parameter in question is 'Taux de la tranche 2 de la majoration pour le premier enfant (en % de la BMAF) pour les DOM - allocations familiales (AF) - prestations_sociales.prestations_familiales.prestations_generales.af.af_maj_dom.majoration_premier_enfant.taux_tranche_2'.   First, I need to look at the provided text to see if this information is present. The text mentions two parts: I and II. Part I refers to the rates being the same as in Article D. 521-1, but since that article isn't provided here, I can't use that. Part II talks about the rates for family allowances for a single child.  The key sentence here is: "La majoration des allocations familiales pour un seul enfant à charge est fixée à 3,69 p. 100 de la base mensuelle prévue à l'article L. 755-3 à partir de onze ans et à 5,67 p. 100 à partir de seize ans." This translates to the increase for a single child being 3.69% from age 11 and 5.67% from age 16.   The user is asking about the second tranche (tranche 2) of the increase. Since the first tranche would be from 11 years (3.69%), the second tranche starting at 16 years would be 5.67%. The question specifies that the previous value was 0.0567, which matches 5.67% (since 5.67% as a decimal is 0.0567).   Therefore, the current value in the text provided is 5.67%, which should be converted to 0.0567 in decimal form. The parameter in question is for the second tranche, so this is the correct value. There's no mention of DOM-specific rates differing here, but since the text is about DOM (as per the question's context), this should be the applicable rate.   ```json {     "valeur": 0.0567 } ```_