### PR TITLE
MAJ des `last_value_still_valid_on` de l'IFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+### 169.16.14 [2452](https://github.com/openfisca/openfisca-france/pull/2452)
+
+* Changement mineur.
+* Périodes concernées : 2024.
+* Zones impactées :
+  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/reduc_impot/reduction_dons_certains_organismes_interet_general/taux.yaml
+  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/reduc_impot/reduction_dons_certains_organismes_interet_general/limite_reduction.yaml
+  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/seuil.yaml
+  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/majoration_forfaitaire.yaml
+  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/taux_bois_forets.yaml
+  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/taux_biens_ruraux.yaml
+  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/decote/parametre_calcul_decote.yaml
+* Détails :
+  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+
 ### 169.16.13 [2453](https://github.com/openfisca/openfisca-france/pull/2453)
 
 * Changement mineur.

--- a/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/decote/parametre_calcul_decote.yaml
+++ b/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/decote/parametre_calcul_decote.yaml
@@ -4,7 +4,7 @@ values:
     value: 17500
 metadata:
   short_label: Paramètre de calcul
-  last_value_still_valid_on: "2022-04-28"
+  last_value_still_valid_on: "2025-02-20"
   label_en: Décote computation
   ipp_csv_id: decote_1_ifi
   unit: currency

--- a/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/majoration_forfaitaire.yaml
+++ b/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/majoration_forfaitaire.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.05
 metadata:
   short_label: Majoration forfaitaire
-  last_value_still_valid_on: "2022-05-12"
+  last_value_still_valid_on: "2025-02-20"
   label_en: Furniture package
   ipp_csv_id: tx_majo_ifi
   unit: /1

--- a/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/seuil.yaml
+++ b/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/seuil.yaml
@@ -3,7 +3,7 @@ values:
   2018-01-01:
     value: 101897
 metadata:
-  last_value_still_valid_on: "2022-05-12"
+  last_value_still_valid_on: "2025-02-20"
   unit: currency
   reference:
     2018-01-01:

--- a/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/taux_biens_ruraux.yaml
+++ b/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/taux_biens_ruraux.yaml
@@ -3,7 +3,7 @@ values:
   2018-01-01:
     value: 0.25
 metadata:
-  last_value_still_valid_on: "2022-05-16"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     2018-01-01:

--- a/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/taux_bois_forets.yaml
+++ b/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/taux_bois_forets.yaml
@@ -3,7 +3,7 @@ values:
   2018-01-01:
     value: 0.25
 metadata:
-  last_value_still_valid_on: "2022-05-16"
+  last_value_still_valid_on: "2025-02-20"
   unit: /1
   reference:
     2018-01-01:

--- a/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/reduc_impot/reduction_dons_certains_organismes_interet_general/limite_reduction.yaml
+++ b/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/reduc_impot/reduction_dons_certains_organismes_interet_general/limite_reduction.yaml
@@ -4,7 +4,7 @@ values:
     value: 50000
 metadata:
   short_label: Limite de la réduction
-  last_value_still_valid_on: "2022-05-10"
+  last_value_still_valid_on: "2025-02-20"
   label_en: Tax reductions for investment and donations
   unit: currency
   reference:

--- a/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/reduc_impot/reduction_dons_certains_organismes_interet_general/taux.yaml
+++ b/openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/reduc_impot/reduction_dons_certains_organismes_interet_general/taux.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.75
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "2022-05-12"
+  last_value_still_valid_on: "2025-02-20"
   label_en: Tax reductions for investment and donations
   unit: /1
   reference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.16.13"
+version = "169.16.14"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2024.
* Zones impactées :
  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/reduc_impot/reduction_dons_certains_organismes_interet_general/taux.yaml
  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/reduc_impot/reduction_dons_certains_organismes_interet_general/limite_reduction.yaml
  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/seuil.yaml
  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/majoration_forfaitaire.yaml
  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/taux_bois_forets.yaml
  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/taux_biens_ruraux.yaml
  - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/decote/parametre_calcul_decote.yaml
* Détails :
  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Mise à jour de paramètre.

- - - -

Méthodologie :
1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
1. Vérifie la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
1. Met à jour la `last_value_still_valid_on` à la date du jour.
1. Crée un tableau récapitulatif pour faciliter la revue.

Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

- - - -

Quelques conseils à prendre en compte :

- [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [X] Documentez votre contribution avec des références législatives.
- [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme n'ayant pas changés depuis la date indiquée dans `last_value_still_valid_on`.

Aide à la revue :

* taxation_capital.impot_fortune_immobiliere_ifi_partir_2018.reduc_impot.reduction_dons_certains_organismes_interet_general.taux
    - Description : Taux de la réduction pour dons à certains organismes d'intérêt général de l'impôt sur la fortune immobilière
    - 0.75
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037988624/)
    - Extrait : _[...]I.-Le redevable peut imputer sur l'impôt sur la fortune immobilière, dans la limite de 50 000 €, 75 % du montant des dons en numéraire et dons en pleine propriété de titres de sociétés admis aux né[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction pour dons à certains organismes d'intérêt général de l'impôt sur la fortune immobilière' est de 0,75, car le texte indique que le redevable peut imputer sur l'impôt sur la fortune immobilière "75 % du montant des dons en numéraire et dons en pleine propriété de titres de sociétés".  Réponse : ``` {     "valeur": 0.75 } ```_
    
* taxation_capital.impot_fortune_immobiliere_ifi_partir_2018.reduc_impot.reduction_dons_certains_organismes_interet_general.limite_reduction
    - Description : Limite de la réduction pour dons à certains organismes d'intérêt général de l'impôt sur la fortune immobilière (IFI)
    - 50000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037988624/)
    - Extrait : _[...]I.-Le redevable peut imputer sur l'impôt sur la fortune immobilière, dans la limite de 50 000 €, 75 % du montant des dons en numéraire et dons en pleine propriété de titres de sociétés ad[...]_
    - Reponse du LLM : _La valeur de 'Limite de la réduction pour dons à certains organismes d'intérêt général de l'impôt sur la fortune immobilière (IFI)' est de 50 000 €.   La réponse est donc : {     "valeur": 50000.0 }_
    
* taxation_capital.impot_fortune_immobiliere_ifi_partir_2018.forfait_mobilier.non_bati.seuil
    - Description : Seuil biens ruraux, ISF-IFI sur l'immobilier non-bâti
    - 101897.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036385037)
    - Extrait : _[...]leur valeur lorsque la valeur totale des biens loués, quel que soit le nombre de baux, n'excède pas 101 897 € et pour moitié au delà de cette limite, sous réserve que la durée du bail soit au minimum [...]_
    - Reponse du LLM : _La valeur de 'Seuil biens ruraux, ISF-IFI sur l'immobilier non-bâti' est indiquée dans le texte comme étant de 101 897 €.   La réponse est donc : {     "valeur": 101897.0 }_
    
* taxation_capital.impot_fortune_immobiliere_ifi_partir_2018.forfait_mobilier.majoration_forfaitaire
    - Description : Majoration forfaitaire du Forfait mobilier de l'impôt sur la fortune immobilière
    - 0.05
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036377428&cidTexte=JORFTEXT000036339197)
    - Extrait : _[...]
I à VIII.-A modifié les dispositions suivantes :
-Code général des impôts, CGI.
Art. 83, Art. 150 duodecies, Art. 150-0 B bis, Art. 150-0 C, Art. 150 U, Art. 151 septies A, Art. 151 nonies, Art. [...]_
    - Reponse du LLM : _La valeur de 'Majoration forfaitaire du Forfait mobilier de l'impôt sur la fortune immobilière' n'est pas explicitement mentionnée dans le texte fourni. Cependant, il est mentionné que "la valeur des biens est déterminée suivant les règles en vigueur en matière de droits de mutation par décès" et qu'il faut se référer à l'article 764 I-3° du CGI qui codifie les règles d'évaluation des biens mobiliers dans le cadre des DMTG. Selon cet article, "pour les meubles meublants, et sans que l'administration ait à en justifier l'existence, la valeur imposable ne peut être inférieure à 5 % de l'ensemble des autres valeurs mobilières et immobilières de la succession".  La valeur à une autre date de validité était '0.05', ce qui correspond à 5%.   La réponse est donc : {     "valeur": 0.05 }_
    
* taxation_capital.impot_fortune_immobiliere_ifi_partir_2018.forfait_mobilier.non_bati.taux_bois_forets
    - Description : Taux bois et forêts, ISF-IFI sur l'immobilier non-bâti
    - 0.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036385037)
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _Bon, je dois analyser ce texte pour trouver la valeur du 'taux bois et forêts' pour l'impôt IFI. Le paramètre en question est 'taxation_capital.impot_fortune_immobiliere_ifi_partir_2018.forfait_mobilier.non_bati.taux_bois_forets'.   D'après le texte fourni, je cherche des mentions de taux d'imposition ou d'exonération spécifiques aux bois et forêts.   Au paragraphe I, il est dit que les propriétés en nature de bois et forêts sont exonérées à concurrence des trois quarts de leur valeur imposable. Cela signifie une exonération de 75%, donc le taux applicable serait 25% (1 - 0.75).   Je vérifie si d'autres paragraphes mentionnent un taux différent, mais les autres sections parlent principalement d'exonérations conditionnelles ou de parts de groupements, sans modifier le taux de base pour les bois et forêts.   Ainsi, le taux applicable reste 0.25.   ```json {     "valeur": 0.25 } ```_
    
* taxation_capital.impot_fortune_immobiliere_ifi_partir_2018.forfait_mobilier.non_bati.taux_biens_ruraux
    - Description : Taux biens ruraux, ISF-IFI sur l'immobilier non-bâti
    - 0.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036385037)
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _Bon, je dois analyser ce texte pour trouver la valeur du 'taux biens ruraux' pour l'ISF-IFI sur l'immobilier non-bâti. La valeur précédente était de 0.25, donc je cherche s'il y a une modification ou confirmation de ce taux.  Je lis le texte fourni. Il semble s'agir d'exonérations pour différents biens ruraux. Les sections I à V parlent d'exonérations à concurrence de trois quarts ou de la moitié de la valeur imposable. Par exemple, la section I exonère les bois et forêts à 3/4 de leur valeur. De même, la section III mentionne une exonération de 3/4 sous certaines conditions.  Cependant, je ne vois pas de mention explicite d'un taux global applicable aux biens ruraux non-bâtis pour l'IFI. Les exonérations sont conditionnelles et varient en fonction de la situation, comme la durée du bail ou le lien de parenté. Aucun pourcentage fixe n'est indiqué pour l'impôt lui-même, seulement les exonérations.  Donc, il semble que le texte ne fournit pas de nouvelle valeur pour le taux biens ruraux. La valeur reste donc à 0.25 comme précédemment.   ```json {     "valeur": 0.25 } ```_
    
* taxation_capital.impot_fortune_immobiliere_ifi_partir_2018.decote.parametre_calcul_decote
    - Description : Paramètre de calcul de la décote de l'impôt sur la fortune immobilière (IFI)
    - 17500.0
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036377428&cidTexte=JORFTEXT000036339197)
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _Bon, je dois extraire la valeur du paramètre de calcul de la décote de l'impôt sur la fortune immobilière (IFI) à partir du texte fourni. La valeur précédente était 17500.0, donc je cherche si elle a changé.  Je regarde le texte fourni. Il s'agit principalement de modifications apportées à divers articles du Code général des impôts et d'autres codes. La partie qui m'intéresse est celle concernant l'IFI, créée en 2018.  Je cherche des mentions de "décote" ou de paramètres de calcul. Dans le texte, il est question de la création de sections dans le CGI relatives à l'IFI, comme les articles 964 à 983. Cependant, je ne vois pas d'indications spécifiques sur les paramètres de la décote.  Le texte parle de l'abrogation de l'impôt de solidarité sur la fortune (ISF) et de la création de l'IFI. Il mentionne les dates d'application, comme le 1er janvier 2018, mais sans détails sur les montants.  Comme la valeur précédente était 17500.0 et qu'il n'y a pas de nouvelle information dans le texte, je suppose qu'elle reste inchangée. Donc, la valeur est toujours 17500.0.   ```json {     "valeur": 17500.0 } ```_