### PR TITLE
MAJ des last_value_still_valid_on de chomage.allocations_assurance_chomage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 169.16.13 [2453](https://github.com/openfisca/openfisca-france/pull/2453)
+
+* Changement mineur.
+* Périodes concernées : 2024.
+* Zones impactées :
+  - openfisca_france/parameters/chomage/allocations_assurance_chomage/complement_are/taux_remuneration_retenue.yaml
+  - openfisca_france/parameters/chomage/allocations_assurance_chomage/alloc_base_taux/pourcentage_sjr.yaml
+* Détails :
+  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.
+
 ### 169.16.12 [2454](https://github.com/openfisca/openfisca-france/pull/2454)
 
 * Changement mineur.

--- a/openfisca_france/parameters/chomage/allocations_assurance_chomage/alloc_base_taux/pourcentage_sjr.yaml
+++ b/openfisca_france/parameters/chomage/allocations_assurance_chomage/alloc_base_taux/pourcentage_sjr.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.57
 metadata:
   short_label: Pourcentage du SJR
-  last_value_still_valid_on: "2022-01-20"
+  last_value_still_valid_on: "2025-02-20"
   label_en: "UI scheme: rates and maximum"
   ipp_csv_id: base_prct
   unit: /1

--- a/openfisca_france/parameters/chomage/allocations_assurance_chomage/complement_are/taux_remuneration_retenue.yaml
+++ b/openfisca_france/parameters/chomage/allocations_assurance_chomage/complement_are/taux_remuneration_retenue.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.7
 metadata:
   short_label: Taux rémunération
-  last_value_still_valid_on: "2022-08-08"
+  last_value_still_valid_on: "2025-02-20"
   reference:
     2001-07-01:
     - title: Arrêté du 4 décembre 2000 portant agrément de la convention du 1er janvier 2001 relative à l'aide au retour à l'emploi et à l'indemnisation du chômage et du règlement annexé à cette convention

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.16.12"
+version = "169.16.13"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2024.
* Zones impactées :
  - openfisca_france/parameters/chomage/allocations_assurance_chomage/complement_are/taux_remuneration_retenue.yaml
  - openfisca_france/parameters/chomage/allocations_assurance_chomage/alloc_base_taux/pourcentage_sjr.yaml
* Détails :
  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Mise à jour de paramètre.

- - - -

Méthodologie :
1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
1. Vérifie la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
1. Met à jour la `last_value_still_valid_on` à la date du jour.
1. Crée un tableau récapitulatif pour faciliter la revue.

Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

- - - -

Quelques conseils à prendre en compte :

- [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [X] Documentez votre contribution avec des références législatives.
- [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme n'ayant pas changés depuis la date indiquée dans `last_value_still_valid_on`.

Aide à la revue :

* chomage.allocations_assurance_chomage.complement_are.taux_remuneration_retenue
    - Description : Taux de rémunération de reprise d'activité retenue pour le complément de l'aide au retour à l'emploi (ARE)
    - 0.7
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000002221609)
    - Extrait : _[...]odalités ci-dessous.Le nombre de jours indemnisables au cours du mois est déterminé comme suit :

- 70% des rémunérations brutes d'activité exercées au cours d'un mois civil sont soustraites du montan[...]_
    - Reponse du LLM : _{     "valeur": 0.7 }_
    
* chomage.allocations_assurance_chomage.alloc_base_taux.pourcentage_sjr
    - Description : Pourcentage du SJR de l'allocation de base d'assurance chômage
    - 0.57
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000038869220)
    - Extrait : _[...]celui-ci ;- et d'une partie fixe égale à 12 euros.

Lorsque la somme ainsi obtenue est inférieure à 57 % du salaire journalier de référence, ce dernier pourcentage est retenu.Le montant de l'allocatio[...]_
    - Reponse du LLM : _{     "valeur": 0.57 }_