### PR TITLE
MAJ last_value_still_valid_on contributions_assises_specifiquement_accessoires_salaire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 169.16.12 [2454](https://github.com/openfisca/openfisca-france/pull/2454)
+
+* Changement mineur.
+* Périodes concernées : 2025.
+* Zones impactées :
+  - openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_1.yaml
+* Détails :
+  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.
+
 ### 169.16.11 [2456](https://github.com/openfisca/openfisca-france/pull/2456)
 * Changement mineur.
 * Périodes concernées : 2024.

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_1.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_1.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.08
 metadata:
   short_label: Taux réduit 1
-  last_value_still_valid_on: "2023-01-30"
+  last_value_still_valid_on: "2025-02-21"
   label_en: Contribution levied on various earnings supplements ("Forfait social")
   ipp_csv_id: forf_soc_tx2
   unit: /1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.16.11"
+version = "169.16.12"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2025.
* Zones impactées :
  - openfisca_france/parameters/prelevements_sociaux/contributions_assises_specifiquement_accessoires_salaire/forfait_social/taux_reduit_1.yaml
* Détails :
  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Mise à jour de paramètre.

- - - -

Méthodologie :
1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
1. Vérifie la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
1. Met à jour la `last_value_still_valid_on` à la date du jour.
1. Crée un tableau récapitulatif pour faciliter la revue.

Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

- - - -

Quelques conseils à prendre en compte :

- [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [X] Documentez votre contribution avec des références législatives.
- [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme n'ayant pas changés depuis la date indiquée dans `last_value_still_valid_on`.

Aide à la revue :

* prelevements_sociaux.contributions_assises_specifiquement_accessoires_salaire.forfait_social.taux_reduit_1
    - Description : Taux réduit 1 du forfait social
    - 0.08
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000044626637)
    - Extrait : _[...] de la contribution mentionnée à l'article L. 137-15 est fixé à 20 %.
Toutefois, ce taux est fixé à 8 % pour les contributions des employeurs destinées au financement des prestations complémentaires d[...]_
    - Reponse du LLM : _Bon, je dois extraire la valeur du 'Taux réduit 1 du forfait social' à partir du texte fourni. Le texte parle de plusieurs taux de contribution.   Je commence par lire chaque paragraphe. Le premier paragraphe fixe le taux de base à 20%. Ensuite, le deuxième paragraphe mentionne un taux réduit à 8% pour certaines contributions, notamment pour les prestations complémentaires de prévoyance et les contributions publiques. Cela semble correspondre au 'Taux réduit 1' car c'est la première réduction mentionnée après le taux de base.  Ensuite, il y a un taux de 10% pour d'autres cas, et plus tard un taux de 16% pour des versements spécifiques. Mais la question concerne spécifiquement le 'Taux réduit 1', donc je me concentre sur la première réduction, qui est de 8%.   Comme indiqué, la valeur précédente était 0.08, ce qui correspond à 8%, donc cela confirme que c'est la bonne information. Aucun autre taux réduit n'est mentionné avant celui-ci, donc je peux conclure que la valeur actuelle est bien 0.08.   ```json {     "valeur": 0.08 } ```_