### PR TITLE
MAJ prestations_etat_de_sante

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 169.16.11 [2456](https://github.com/openfisca/openfisca-france/pull/2456)
+* Changement mineur.
+* Périodes concernées : 2024.
+* Zones impactées :
+  - openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/caah/majoration_vie_autonome.yaml
+  - openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/majoration_plafond/majoration_par_enfant_supplementaire.yaml
+* Détails :
+  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.
+
 ### 169.16.10 [2457](https://github.com/openfisca/openfisca-france/pull/2457)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/majoration_plafond/majoration_par_enfant_supplementaire.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/majoration_plafond/majoration_par_enfant_supplementaire.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.5
 metadata:
   short_label: Par enfant supplémentaire
-  last_value_still_valid_on: "2023-03-08"
+  last_value_still_valid_on: "2025-02-21"
   label_en: Adult disability allowance (AAH)
   ipp_csv_id: maj_enf_aah
   unit: /1

--- a/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/caah/majoration_vie_autonome.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/caah/majoration_vie_autonome.yaml
@@ -12,7 +12,7 @@ values:
     value: 104.77
 metadata:
   short_label: Majoration
-  last_value_still_valid_on: "2022-01-03"
+  last_value_still_valid_on: "2025-02-21"
   label_en: Additional adult disability allowance (CAAH)
   unit: currency
   reference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.16.10"
+version = "169.16.11"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2024.
* Zones impactées :
  - openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/caah/majoration_vie_autonome.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/majoration_plafond/majoration_par_enfant_supplementaire.yaml
* Détails :
  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Mise à jour de paramètre.

- - - -

Méthodologie :
1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
1. Vérifie la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
1. Met à jour la `last_value_still_valid_on` à la date du jour.
1. Crée un tableau récapitulatif pour faciliter la revue.

Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

- - - -

Quelques conseils à prendre en compte :

- [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [X] Documentez votre contribution avec des références législatives.
- [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme n'ayant pas changés depuis la date indiquée dans `last_value_still_valid_on`.

Aide à la revue :

* prestations_sociales.prestations_etat_de_sante.invalidite.caah.majoration_vie_autonome
    - Description : Montant mensuel de la majoration pour la vie autonome (MVA)
    - 104.77
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000019505277/) de type CODE
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _{     "valeur": 104.77 }_
    
* prestations_sociales.prestations_etat_de_sante.invalidite.aah.majoration_plafond.majoration_par_enfant_supplementaire
    - Description : Majoration de plafond pour personne à charge (en pourcentage du plafond de base) de l'allocation aux adultes handicapés
    - 0.5
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000039211076) de type CODE
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _La valeur de 'Majoration de plafond pour personne à charge (en pourcentage du plafond de base) de l'allocation aux adultes handicapés' est égale à la moitié du plafond pour chacun des enfants.   Cela peut être représenté par 0.5.  La réponse est donc : {     "valeur": 0.5 }_