### PR TITLE
MAJ contributions_sociales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 169.16.10 [2457](https://github.com/openfisca/openfisca-france/pull/2457)
+
+* Changement mineur.
+* Périodes concernées : 2024.
+* Zones impactées :
+  - openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/deductible/taux.yaml
+  - openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/taux_global.yaml
+
+* Détails :
+  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+
 ### 169.16.9 [2458](https://github.com/openfisca/openfisca-france/pull/2458)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/deductible/taux.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/deductible/taux.yaml
@@ -6,9 +6,11 @@ values:
     value: 0.01
   1998-01-01:
     value: 0.038
+  2020-12-16:
+    value: 0.062
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "1998-01-01"
+  last_value_still_valid_on: "2025-02-21"
   ipp_csv_id: csg_ij_ded
   unit: /1
   reference:
@@ -21,6 +23,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006740334/1998-01-01/
     - title: Loi 97-1164 du 19/12/1997, art. 5 (LFSS pour 1998)
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006757359&cidTexte=JORFTEXT000000569121
+    2020-12-16:
+    - title: Art. L136-8 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546/2020-12-16/
+    - title: LOI n°2020-1576 du 14 décembre 2020 - art. 8 (V)
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042665307
   official_journal_date:
     1991-02-01: "1990-12-30"
     1997-01-01: "1996-12-29"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/deductible/taux.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/deductible/taux.yaml
@@ -6,8 +6,6 @@ values:
     value: 0.01
   1998-01-01:
     value: 0.038
-  2020-12-16:
-    value: 0.062
 metadata:
   short_label: Taux
   last_value_still_valid_on: "2025-02-21"
@@ -23,11 +21,6 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006740334/1998-01-01/
     - title: Loi 97-1164 du 19/12/1997, art. 5 (LFSS pour 1998)
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006757359&cidTexte=JORFTEXT000000569121
-    2020-12-16:
-    - title: Art. L136-8 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546/2020-12-16/
-    - title: LOI n°2020-1576 du 14 décembre 2020 - art. 8 (V)
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042665307
   official_journal_date:
     1991-02-01: "1990-12-30"
     1997-01-01: "1996-12-29"

--- a/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/taux_global.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/taux_global.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.062
 metadata:
   short_label: Taux global
-  last_value_still_valid_on: "1998-01-01"
+  last_value_still_valid_on: "2025-02-21"
   ipp_csv_id: csg_ij
   unit: /1
   reference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.16.9"
+version = "169.16.10"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2024.
* Zones impactées :
  - openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/deductible/taux.yaml
  - openfisca_france/parameters/prelevements_sociaux/contributions_sociales/csg/remplacement/indemnites_journalieres/taux_global.yaml

* Détails :
  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Mise à jour de paramètre.

- - - -

Méthodologie :
1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
1. Met à jour la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
1. Met à jour la `last_value_still_valid_on` à la date du jour.
1. Met à jour la référence législative.
1. Crée un tableau récapitulatif pour faciliter la revue.

Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

- - - -

Quelques conseils à prendre en compte :

- [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [X] Documentez votre contribution avec des références législatives.
- [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme ayant changés depuis la date indiquée dans `last_value_still_valid_on`.

Il s'agit des paramètres suivants :
* prelevements_sociaux.contributions_sociales.csg.remplacement.indemnites_journalieres.taux_global
    - Description : Taux global de la contribution sociale généralisée (CSG) sur les indemnités journalières (IJ)
    - 0.062
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006740335/1997-12-23/) de type CODE
    - Extrait : _[...]1 ;
2° A 9,2 % pour les contributions sociales mentionnées aux articles L. 136-6 et L. 136-7 ;
3° A 6,2 % pour la contribution sociale mentionnée au I de l'article L. 136-7-1.
II.-Par dérogation au I [...]_
    - Reponse du LLM : _La valeur de 'Taux global de la contribution sociale généralisée (CSG) sur les indemnités journalières (IJ)' est spécifiée dans le texte comme suit :  "b) Les indemnités journalières et allocations versées par les organismes de sécurité sociale ou, pour leur compte, par les employeurs, à l'occasion de la maladie, de la maternité ou de la paternité et de l'accueil de l'enfant, des accidents du travail et des maladies professionnelles ;"  Ces indemnités sont assujetties à la contribution au taux de 6,2 % comme indiqué dans le point 1° du II.  La réponse est donc :  {     "valeur": 0.062 }_
* prelevements_sociaux.contributions_sociales.csg.remplacement.indemnites_journalieres.deductible.taux
    - Description : Taux de la contribution sociale généralisée (CSG) déductible sur les indemnités journalières (IJ)
    - 0.038
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006740334/1998-01-01/) de type CODE
    - Extrait : _[...]ité.
III.-Par dérogation aux I, II et III bis, sont assujettis à la contribution sociale au taux de 3,8 % les revenus mentionnés au 1° et au premier alinéa du 4° du II de l'article L. 136-1-2 des pers[...]_
    - Reponse du LLM : _La valeur de 'Taux de la contribution sociale généralisée (CSG) déductible sur les indemnités journalières (IJ)' est spécifiée dans le texte comme suit :  Les indemnités journalières sont assujetties à la contribution au taux de 6,2 %.  La réponse est donc :  {     "valeur": 0.062 }_