### PR TITLE
MAJ reductions_cotisations_sociales

### DIFF
--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
@@ -4,7 +4,7 @@ values:
     value: 1.6
 metadata:
   short_label: Point d'annulation TO-DE
-  last_value_still_valid_on: "2022-09-21"
+  last_value_still_valid_on: "2025-02-21"
   label_en: Ceiling of resources in SSCs exemption for casual worker job seeker (TO-DE, agricultural worker)
   unit: smic
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/alleg_gen/mmid/taux.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/alleg_gen/mmid/taux.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.06
 metadata:
   short_label: Taux d'allègement des cotisations d'assurance maladie
-  last_value_still_valid_on: "2023-01-30"
+  last_value_still_valid_on: "2025-02-21"
   label_en: SSCs for sickness, maternity, disability and death benefits
   unit: /1
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_cotisation_allocations_familiales/reduction.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_cotisation_allocations_familiales/reduction.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.018
 metadata:
   short_label: Taux d'allègement des cotisations famille
-  last_value_still_valid_on: "2023-01-30"
+  last_value_still_valid_on: "2025-02-21"
   label_en: Reduction in SSCs for family benefits
   ipp_csv_id: tx_red_fam
   unit: /1

--- a/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_general/ensemble_des_entreprises/plafond.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_general/ensemble_des_entreprises/plafond.yaml
@@ -4,7 +4,7 @@ values:
     value: 1.6
 metadata:
   short_label: Plafond de rémunération des salariés
-  last_value_still_valid_on: "2023-01-30"
+  last_value_still_valid_on: "2025-02-21"
   label_en: General SSC reductions, so called Fillon reductions
   ipp_csv_id: plaf_fillon
   unit: smic_annuel


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2024.
* Zones impactées :
  - openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_general/ensemble_des_entreprises/plafond.yaml
  - openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/allegement_cotisation_allocations_familiales/reduction.yaml
  - openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/alleg_gen/mmid/taux.yaml
  - openfisca_france/parameters/prelevements_sociaux/reductions_cotisations_sociales/agricole/tode/plafond.yaml
* Détails :
  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvé avec un bon niveau de fiabilité.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Mise à jour de paramètre.

- - - -

Méthodologie :
1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
1. Vérifie la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
1. Met à jour la `last_value_still_valid_on` à la date du jour.
1. Crée un tableau récapitulatif pour faciliter la revue.

Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

- - - -

Quelques conseils à prendre en compte :

- [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [X] Documentez votre contribution avec des références législatives.
- [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme n'ayant pas changés depuis la date indiquée dans `last_value_still_valid_on`.

Aide à la revue :

* prelevements_sociaux.reductions_cotisations_sociales.allegement_general.ensemble_des_entreprises.plafond
    - Description : Plafond de rémunération (en nombre de Smic) des salariés concernés par l'allègement (toutes entreprises) de cotisations de sécurité sociale (SS) sur les bas salaires
    - 1.6
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006185779/) de type CODE
    - Extrait : _[...] rapport mentionné au deuxième alinéa du présent III et devient nulle lorsque ce rapport est égal à 1,6.
La rémunération prise en compte pour la détermination du coefficient est celle définie à l'arti[...]_
    - Reponse du LLM : _La valeur de 'Plafond de rémunération (en nombre de Smic) des salariés concernés par l'allègement (toutes entreprises) de cotisations de sécurité sociale (SS) sur les bas salaires' est indiquée dans le texte comme étant le rapport entre les revenus d'activité et le salaire minimum de croissance majoré de 60 % au-delà duquel la réduction devient nulle.   Ce rapport est égal à 1,6.  La réponse est donc : {     "valeur": 1.6 }_
    
* prelevements_sociaux.reductions_cotisations_sociales.allegement_cotisation_allocations_familiales.reduction
    - Description : Taux d'allègement des cotisations pour la branche famille des cotisations de Sécurité sociale
    - 0.018
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037947548) de type CODE
    - Extrait : _[...],8 point pour les salariés dont l'employeur entre dans le champ d'application du II de l'article L. 241-13 et dont les revenus d'activité tels qu'ils sont pris en compte pour la détermination des assi[...]_
    - Reponse du LLM : _La valeur de 'Taux d'allègement des cotisations pour la branche famille des cotisations de Sécurité sociale' est de 0,018, car le texte indique que le taux des cotisations d'allocations familiales est réduit de 1,8 point, ce qui correspond à une valeur de 0,018 (1,8 point = 1,8/100 = 0,018).  La réponse est donc : ``` {     "valeur": 0.018 } ```_
    
* prelevements_sociaux.reductions_cotisations_sociales.alleg_gen.mmid.taux
    - Description : Taux d'allègement des cotisations du régime d'assurance maladie sous 2,5 Smic
    - 0.06
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037069704/2019-01-01/) de type CODE
    - Extrait : _[...]Le taux des cotisations d'assurance maladie est réduit de 6 points pour les salariés dont l'employeur entre dans le champ d'application du II de l'article L. [...]_
    - Reponse du LLM : _Okay, let's tackle this question step by step. The user is asking for the value of a specific parameter related to the reduction rate of health insurance contributions for salaries under 2.5 times the SMIC (minimum wage) starting from 2019. The previous value was 0.06, but they need the current one based on the provided text.  First, I need to parse the given text. The key part here is the first paragraph: "Le taux des cotisations d'assurance maladie est réduit de 6 points..." The phrase "réduit de 6 points" translates to a reduction of 6 percentage points. In the context of tax or social contributions, a reduction of 6 points would mean subtracting 6% from the original rate. However, the user mentioned that percentages in the system should be represented as decimals. So 6% becomes 0.06.  Wait, but the question mentions that the previous value was 0.06, and they want the current rate starting from 2019. The text provided is from a law that mentions 2023, so maybe the rate changed? Let me check the text again. The text states that the reduction is 6 points for salaries not exceeding 2.5 times the SMIC applicable as of December 31, 2023. The mention of 2023 might be the effective date for the SMIC calculation, but the reduction rate itself is still 6 points, which is 0.06 in decimal.   The user is asking if the rate changed from the previous 0.06. The text specifies a 6-point reduction, which is the same as the previous value. However, the question states that before 2019, there were brackets, and now it's a flat rate. The text here describes a flat reduction of 6 points, so the current rate should be 0.06. But wait, the user might be confused because the previous system had brackets, but the current one is a flat rate. However, the value here is still 0.06. The text doesn't mention any change in the rate percentage, just the structure (from brackets to a flat rate). Therefore, the value remains 0.06.   But the user is asking for the value starting from 2019. The text refers to 2023, but that's about the SMIC calculation date, not the rate. The rate reduction is still 6 points. So the answer should be 0.06. However, the previous value was also 0.06. Maybe there's a mistake here. Wait, the user says the previous value was 0.06, but the current text might have a different rate. Let me check again. The text says "réduit de 6 points" which is 6%, so 0.06. Therefore, the answer is 0.06. But the user is asking if there's a change. The text doesn't indicate a different rate; it's still 6 points. So the answer should be 0.06. However, the user might have expected a different rate because the date in the text is 2023, but the rate itself hasn't changed. Therefore, the correct value is 0.06.   ```json {     "valeur": 0.06 } ```_
    
* prelevements_sociaux.reductions_cotisations_sociales.agricole.tode.plafond
    - Description : Plafond de ressources (en nombre de Smic) pour exonération travailleur occasionnel demandeur d'emploi (TO-DE) du secteur agricole
    - 1.6
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006585701/2019-01-01/) de type CODE
    - Extrait : _[...]e montant de l'exonération est déterminé par l'application de la formule suivante :
1,2 × C/0,40 × (1,6 × montant mensuel du SMIC/ rémunération mensuelle brute hors heures supplémentaires et complémen[...]_
    - Reponse du LLM : _Okay, let's tackle this problem step by step. The user is asking for the value of 'Plafond de ressources (en nombre de Smic) pour exonération travailleur occasionnel demandeur d'emploi (TO-DE) du secteur agricole - prelevements_sociaux.reductions_cotisations_sociales.agricole.tode.plafond' based on the provided text. They mentioned that the value at another validity date was '1.6', so I need to check if the current text mentions a similar figure.  Looking at the text, there's a formula provided: 1,6 × montant mensuel du SMIC / rémunération mensuelle brute... The key part here is "1,6 × montant mensuel du SMIC". In French, commas are used as decimal separators, so "1,6" translates to 1.6 in numerical terms. This seems to directly reference the plafond as 1.6 times the SMIC.   The formula is part of calculating the exemption amount, and the threshold (plafond) is indeed 1.6 times the SMIC. Since the user is asking for the current value and the text includes "1,6", which matches the previous value they mentioned, it's safe to conclude that the current plafond is still 1.6. There's no indication of a different value in the provided text, so the answer should be 1.6.   ```json {     "valeur": 1.6 } ```_