### PR TITLE
MAJ impot_revenu.calcul_reductions_impots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 169.16.20 [2459](https://github.com/openfisca/openfisca-france/pull/2459)
+
+* Changement mineur.
+* Périodes concernées : 2024.
+* Zones impactées :
+  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/*
+* Détails :
+  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la valeur a pu être trouvée avec un bon niveau de fiabilité.
+  - Ajout d'un dispositif de réduction concernant les dons dédiés à la préservation du patrimoine religieux.
+
 ### 169.16.19 [2455](https://github.com/openfisca/openfisca-france/pull/2455)
 
 * Changement mineur.
@@ -7,7 +17,7 @@
 * Zones impactées :
   - openfisca_france/parameters/prelevements_sociaux/professions_liberales/*
 * Détails :
-  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la valeur a pu être trouvée avec un bon niveau de fiabilité.
 
 ### 169.16.18 [2447](https://github.com/openfisca/openfisca-france/pull/2447)
 
@@ -16,7 +26,7 @@
 * Zones impactées :
   - openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/*
 * Détails :
-  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la valeur a pu être trouvée avec un bon niveau de fiabilité.
 
 ### 169.16.17 [2460](https://github.com/openfisca/openfisca-france/pull/2460)
 
@@ -25,7 +35,7 @@
 * Zones impactées :
   - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/*
 * Détails :
-  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la valeur a pu être trouvée avec un bon niveau de fiabilité.
 
 ### 169.16.16 [2450](https://github.com/openfisca/openfisca-france/pull/2450)
 
@@ -34,7 +44,7 @@
 * Zones impactées :
   - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/*
 * Détails :
-  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la valeur a pu être trouvée avec un bon niveau de fiabilité.
 
 ### 169.16.15 [2428](https://github.com/openfisca/openfisca-france/pull/2428)
 
@@ -58,7 +68,7 @@
   - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/forfait_mobilier/non_bati/taux_biens_ruraux.yaml
   - openfisca_france/parameters/taxation_capital/impot_fortune_immobiliere_ifi_partir_2018/decote/parametre_calcul_decote.yaml
 * Détails :
-  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la valeur a pu être trouvée avec un bon niveau de fiabilité.
 
 ### 169.16.13 [2453](https://github.com/openfisca/openfisca-france/pull/2453)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_deplafonnees.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_deplafonnees.py
@@ -439,6 +439,41 @@ class dfppce(Variable):
         rni = foyer_fiscal('rni', period)
         f7uf = foyer_fiscal('f7uf', period)
         f7uh = foyer_fiscal('f7uh', period)
+        f7uj_2022 = foyer_fiscal('f7uj_2022', period)
+        f7xs = foyer_fiscal('f7xs', period)
+        f7xt = foyer_fiscal('f7xt', period)
+        f7xu = foyer_fiscal('f7xu', period)
+        f7xw = foyer_fiscal('f7xw', period)
+        f7xy = foyer_fiscal('f7xy', period)
+        f7va = foyer_fiscal('f7va', period)
+        f7ud = foyer_fiscal('f7ud', period)
+        f7vc = foyer_fiscal('f7vc', period)
+
+        P = parameters(period).impot_revenu.calcul_reductions_impots.dons
+        plafond_reduction_don_coluche = parameters(period).impot_revenu.calcul_reductions_impots.dons.dons_coluche.plafond
+        taux_donapd = parameters(period).impot_revenu.calcul_reductions_impots.dons.dons_coluche.taux
+
+        red_7ud_7va = min_(plafond_reduction_don_coluche, f7va + f7ud) * taux_donapd
+        report_f7va_f7ud = max_(0, f7va + f7ud - plafond_reduction_don_coluche)
+
+        red_7uj = min_(P.dons_cultuels.plafond_dons, f7uj_2022) * taux_donapd
+        report_7uj = max_(0, f7uj_2022 - P.dons_cultuels.plafond_dons)
+
+        dons_partipol = min_(P.dons_aux_partis_politiques.plafond_foyer, f7uh)
+
+        base = f7uf + f7vc + f7xs + f7xt + f7xu + f7xw + f7xy + report_f7va_f7ud + report_7uj + dons_partipol
+        max = P.plafond_dons * rni
+
+        return red_7ud_7va + red_7uj + P.taux_reduction * min_(base, max)
+
+    def formula_2023_01_01(foyer_fiscal, period, parameters):
+        '''
+        Dons versés à d’autres organismes d’intérêt général,
+        aux associations d’utilité publique, aux candidats aux élections (2021)
+        '''
+        rni = foyer_fiscal('rni', period)
+        f7uf = foyer_fiscal('f7uf', period)
+        f7uh = foyer_fiscal('f7uh', period)
         f7uj = foyer_fiscal('f7uj', period)
         f7xs = foyer_fiscal('f7xs', period)
         f7xt = foyer_fiscal('f7xt', period)
@@ -456,8 +491,8 @@ class dfppce(Variable):
         red_7ud_7va = min_(plafond_reduction_don_coluche, f7va + f7ud) * taux_donapd
         report_f7va_f7ud = max_(0, f7va + f7ud - plafond_reduction_don_coluche)
 
-        red_7uj = min_(P.dons_cultuels.plafond_dons, f7uj) * taux_donapd
-        report_7uj = max_(0, f7uj - P.dons_cultuels.plafond_dons)
+        red_7uj = min_(P.dons_patrimoine_religieux.plafond, f7uj) * taux_donapd
+        report_7uj = max_(0, f7uj - P.dons_patrimoine_religieux.plafond)
 
         dons_partipol = min_(P.dons_aux_partis_politiques.plafond_foyer, f7uh)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/variables_reductions_credits.py
@@ -5642,13 +5642,35 @@ class f7uj_2002(Variable):
     definition_period = YEAR
 
 
-class f7uj(Variable):
+class f7uj_2022(Variable):
+    '''
+    Pour les dons effectués entre le 2 juin et le 31.12.2021, vous bénéficierez d'une réduction d'impôt égale à 75 % des versements retenus dans la limite de 554 €.
+     Source : https://simulateur-ir-ifi.impots.gouv.fr/calcul_impot/2022/aides/reductions_s.htm
+    Pour les dons effectués en 2022, vous bénéficierez d'une réduction d'impôt égale à 75 % des versements retenus dans la limite de 562 €.
+     Source : https://simulateur-ir-ifi.impots.gouv.fr/calcul_impot/2023/aides/reductions_s.htm
+    '''
     cerfa_field = '7UJ'
     value_type = int
     unit = 'currency'
     entity = FoyerFiscal
     # start_date = date(2021, 1, 1)
-    label = 'Dons versés du 2.6 au 31.12.2021 à des associations cultuelles'
+    label = 'Dons versés du 2.6.2021 au 31.12.2022 à des associations cultuelles'
+    end = '2022-12-31'
+    definition_period = YEAR
+
+
+class f7uj(Variable):
+    '''
+    Il s'agit des versements effectués entre le 15.9.2023 et le 31.12.2025 au profit de la Fondation du patrimoine en vue d'assurer,
+    dans le cadre de son activité d'intérêt général de sauvegarde du patrimoine local, la conservation et la restauration du patrimoine
+    immobilier religieux appartenant aux communes de France métropolitaine de moins de 10 000 habitants ou aux communes d'outre-mer de moins de 20 000 habitants.
+    https://simulateur-ir-ifi.impots.gouv.fr/calcul_impot/2024/aides/reductions_s.htm
+    '''
+    cerfa_field = '7UJ'
+    value_type = int
+    unit = 'currency'
+    entity = FoyerFiscal
+    label = 'Dons effectés à pour la sauvegarde du patrimoine religieux'
     definition_period = YEAR
 
 
@@ -10903,9 +10925,9 @@ class f7hs(Variable):
 # Investissements locatifs dans les résidences de tourisme situées dans une zone de
 # revitalisation rurale
 
-# """
+# '''
 # réutilisation de cases en 2013
-# """
+# '''
 
 
 # vérif <=2012
@@ -11233,9 +11255,9 @@ class f7bm(Variable):
     # start_date = date(2018, 1, 1)
     definition_period = YEAR
 
-# """
+# '''
 # réutilisation de case pour 2013
-# """
+# '''
 
 
 class f7sd_2015(Variable):

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/interets_emprunt_reprise_societe/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/interets_emprunt_reprise_societe/plafond.yaml
@@ -7,6 +7,7 @@ values:
   2008-01-01:
     value: 20000
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Plafond
   ipp_csv_id: plaf_repsoc
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/interets_emprunt_reprise_societe/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/interets_emprunt_reprise_societe/taux.yaml
@@ -5,6 +5,7 @@ values:
   2004-01-01:
     value: 0.25
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Taux
   ipp_csv_id: tx_repsoc
   unit: /1

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/interets_paiements_differes_agriculteurs/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/interets_paiements_differes_agriculteurs/plafond.yaml
@@ -5,6 +5,7 @@ values:
   2005-01-01:
     value: 5000
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Plafond
   ipp_csv_id: plaf_intagri
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/interets_paiements_differes_agriculteurs/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/interets_paiements_differes_agriculteurs/taux.yaml
@@ -5,6 +5,7 @@ values:
   2005-01-01:
     value: 0.5
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Taux
   ipp_csv_id: taux_intagri
   unit: /1

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/rente_survie/increment.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/rente_survie/increment.yaml
@@ -11,6 +11,7 @@ values:
   2004-01-01:
     value: 300
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Majoration du plafond par personne à charge
   ipp_csv_id: increment_survie
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/rente_survie/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/rente_survie/plafond.yaml
@@ -13,6 +13,7 @@ values:
   2004-01-01:
     value: 1525
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Plafond
   ipp_csv_id: plaf_survie
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/rente_survie/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/rente_survie/taux.yaml
@@ -7,6 +7,7 @@ values:
   1983-01-01:
     value: 0.25
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Taux
   ipp_csv_id: tx_survie
   unit: /1

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/restauration_monuments_historiques/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/restauration_monuments_historiques/plafond.yaml
@@ -5,6 +5,7 @@ values:
   2008-01-01:
     value: 20000
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Plafond
   ipp_csv_id: plaf_monhist
   unit: currency_next_year
@@ -12,4 +13,4 @@ metadata:
     2008-01-01:
       title: Article 199 duovicies III. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037099626
-  
+

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/restauration_monuments_historiques/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/restauration_monuments_historiques/taux.yaml
@@ -9,6 +9,7 @@ values:
   2012-01-01:
     value: 0.18
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Taux
   ipp_csv_id: tx_monhist
   unit: /1

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_coluche/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_coluche/plafond.yaml
@@ -62,7 +62,7 @@ values:
     value: 1000
 metadata:
   short_label: Plafond des versements
-  last_value_still_valid_on: "2024-11-14"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: plafcoluche
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_coluche/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_coluche/taux.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.75
 metadata:
   short_label: Taux de la réduction d'impôt
-  last_value_still_valid_on: "2024-11-14"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: txcoluche
   unit: /1
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_cultuels/plafond_dons.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_cultuels/plafond_dons.yaml
@@ -5,9 +5,7 @@ values:
   2022-01-01:
     value: 562
   2023-01-01:
-    value: 593
-  2024-01-01:
-    value: 1000
+    value: null
 metadata:
   short_label: Plafond réduction d'impôt
   last_value_still_valid_on: "2025-02-25"
@@ -21,17 +19,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
     - title: Article 200, 1 ter du CGI
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018619914
-    2023-01-01:
-    - title: Décret n° 2024-496 du 30/05/2024, art. 1
-      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000049629765
-    - title: Article 200, 1 ter du CGI
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018619914
-    2024-01-01:
-    - title: Art. 200 du Code général des impôts
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051200406/2025-02-16/
-    - title: LOI n°2025-127 du 14 février 2025 - art. 6
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051168007
 documentation: |-
   Notes :
   Ref : Article 200, 1 ter du CGI.
   La limite de versements est relevée chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu de l'année précédant celle des versements. Le montant obtenu est arrondi, s'il y a lieu, à l'euro supérieur.
+  Ce paramètre est limité aux associations cultuelles qui ont bénéficiés d'un régime exceptionnel de 75% au lieu de 66% pendant deux ans.
+  7UJ : Pour les dons effectués entre le 2 juin et le 31.12.2021, vous bénéficierez d'une réduction d'impôt égale à 75 % des versements retenus dans la limite de 554 €. https://simulateur-ir-ifi.impots.gouv.fr/calcul_impot/2022/aides/reductions_s.htm
+  7UJ : Pour les dons effectués en 2022, vous bénéficierez d'une réduction d'impôt égale à 75 % des versements retenus dans la limite de 562 € : https://simulateur-ir-ifi.impots.gouv.fr/calcul_impot/2023/aides/reductions_s.htm
+  Pour les impôt 2024, la case 7UJ existe toujours mais s'applique aux dons affectés à la sauvegarde du patrimoine religieux, qui bénéficient d'une réduction d'impôt égale à 75 % des versements retenus dans la limite de 1000 € : https://simulateur-ir-ifi.impots.gouv.fr/calcul_impot/2024/aides/reductions_s.htm, il faut donc désactiver ce paramètre.

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_cultuels/plafond_dons.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_cultuels/plafond_dons.yaml
@@ -6,9 +6,11 @@ values:
     value: 562
   2023-01-01:
     value: 593
+  2024-01-01:
+    value: 1000
 metadata:
   short_label: Plafond réduction d'impôt
-  last_value_still_valid_on: "2024-06-11"
+  last_value_still_valid_on: "2025-02-25"
   unit: currency_next_year
   reference:
     2021-01-01:
@@ -24,6 +26,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000049629765
     - title: Article 200, 1 ter du CGI
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000018619914
+    2024-01-01:
+    - title: Art. 200 du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051200406/2025-02-16/
+    - title: LOI n°2025-127 du 14 février 2025 - art. 6
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051168007
 documentation: |-
   Notes :
   Ref : Article 200, 1 ter du CGI.

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_notre_dame/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_notre_dame/plafond.yaml
@@ -4,7 +4,10 @@ values:
     value: null
   2019-01-01:
     value: 1000
+  2020-01-01:
+    value: null
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: plaf_ND
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_notre_dame/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_notre_dame/taux.yaml
@@ -4,7 +4,10 @@ values:
     value: null
   2019-01-01:
     value: 0.75
+  2020-01-01:
+    value: null
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: tx_ND
   unit: /1
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_patrimoine_religieux/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_patrimoine_religieux/index.yaml
@@ -1,0 +1,6 @@
+description: Réduction d'impôt sur le revenu (IR) au titre des dons pour la sauvegarde du patrimoine religieux (cases 7UJ)
+metadata:
+  short_label: Dons pour la sauvegarde du patrimoine religieux (cases 7UJ)
+  order:
+  - plafond
+documentation: "Dons pour la sauvegarde du patrimoine religieux : art. 200-1 ter du CGI"

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_patrimoine_religieux/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_patrimoine_religieux/plafond.yaml
@@ -1,0 +1,18 @@
+description: Plafond des dépenses ouvrant à une réduction d'impôt de 75 % des dons pour la sauvegarde du patrimoine religieux (cases 7UJ)
+values:
+  2023-01-01:
+    value: 1000
+  2026-01-01:
+    value: null
+metadata:
+  short_label: Plafond réduction d'impôt
+  last_value_still_valid_on: "2025-03-03"
+  unit: currency_next_year
+  reference:
+    2024-01-01:
+    - title: LOI n° 2023-1322 du 29 décembre 2023 de finances pour 2024 - art. 30
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727383
+documentation: |-
+  Notes :
+  Annoncée en septembre 2023 par le Président Emmanuel Macon à l'occasion des journées européennes du patrimoine, une collecte nationale a été lancée pour la conservation du patrimoine immobilier religieux des petites communes.
+  Ce texte n'a pas été repris dans l'article 200 du Code général des impôts.

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/plafond_dons.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/plafond_dons.yaml
@@ -16,7 +16,7 @@ values:
     value: 0.2
 metadata:
   short_label: Plafond des dons (en % du revenu imposable)
-  last_value_still_valid_on: "2024-11-14"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: plaf_donsintgene
   unit: /1
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/taux_reduction.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/taux_reduction.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.66
 metadata:
   short_label: Taux général de réduction d'impôt
-  last_value_still_valid_on: "2024-11-14"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: txdons
   unit: /1
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/enfants_scolarises/college.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/enfants_scolarises/college.yaml
@@ -8,7 +8,7 @@ values:
     value: 61
 metadata:
   short_label: Montant de la réduction par enfant au collège (case 7EA)
-  last_value_still_valid_on: "2024-11-07"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: reduc_enfscol1
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/enfants_scolarises/lycee.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/enfants_scolarises/lycee.yaml
@@ -6,7 +6,7 @@ values:
     value: 153
 metadata:
   short_label: Montant de la réduction par enfant au lycée (case 7EC)
-  last_value_still_valid_on: "2024-11-07"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: reduc_enfscol2
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/enfants_scolarises/universite.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/enfants_scolarises/universite.yaml
@@ -6,7 +6,7 @@ values:
     value: 183
 metadata:
   short_label: Montant de la réduction par enfant suivant une formation d'enseignement supérieur (case 7EF)
-  last_value_still_valid_on: "2024-11-07"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: reduc_enfscol3
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/defense_forets_contre_incendies/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/defense_forets_contre_incendies/plafond.yaml
@@ -5,6 +5,7 @@ values:
   2006-01-01:
     value: 1000
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Plafond des cotisations
   ipp_csv_id: plaf_incendie
   unit: currency_next_year

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/defense_forets_contre_incendies/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/defense_forets_contre_incendies/taux.yaml
@@ -5,6 +5,7 @@ values:
   2006-01-01:
     value: 0.5
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Taux de la réduction d'impôt
   ipp_csv_id: taux_incendie
   unit: /1

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/depenses_investissement_forestier/acquisition/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/depenses_investissement_forestier/acquisition/taux.yaml
@@ -12,7 +12,7 @@ values:
     value: 0.25
 metadata:
   short_label: Taux du crédit d'impôt
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: tx_foret
   unit: /1
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/depenses_investissement_forestier/travaux/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/depenses_investissement_forestier/travaux/taux.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.25
 metadata:
   short_label: Taux du crédit d'impôt
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-02-25"
   unit: /1
   reference:
     2014-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissements_immobiliers/dispositif_scellier/taux_prorogation.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissements_immobiliers/dispositif_scellier/taux_prorogation.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.04
 metadata:
   short_label: Taux additionnel
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-02-25"
   unit: /1
   reference:
     2009-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/location_meublee/taux11.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/location_meublee/taux11.yaml
@@ -3,6 +3,7 @@ values:
   2012-01-01:
     value: 0.11
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Taux pour les logements acquis à compter de 2012
   unit: /1
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/prestations_compensatoires/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/prestations_compensatoires/plafond.yaml
@@ -8,12 +8,12 @@ values:
     value: 30500
 metadata:
   short_label: Plafond des versements effectués et des biens ou des droits attribués
-  last_value_still_valid_on: "2024-11-07"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: plaf_prestcomp
   unit: currency_next_year
   reference:
     2000-01-01:
-      title: "Loi 2000-596 du 30 juin\_2000"
+      title: "Loi 2000-596 du 30 juin 2000"
     2001-01-01:
       title: Article 199 octodecies du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042907654

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/prestations_compensatoires/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/prestations_compensatoires/taux.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.25
 metadata:
   short_label: Taux de la réduction d'impôt
-  last_value_still_valid_on: "2024-11-07"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: tx_prestcomp
   unit: /1
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil.yaml
@@ -8,7 +8,7 @@ values:
     value: 50000
 metadata:
   short_label: Plafond des versements pour célibataire, veuf ou divorcé
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-02-25"
   unit: currency_next_year
   reference:
     2001-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.18
 metadata:
   short_label: Taux de la réduction d'impôt
-  last_value_still_valid_on: "2024-11-18"
+  last_value_still_valid_on: "2025-02-25"
   unit: /1
   reference:
     1994-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux18.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux18.yaml
@@ -3,6 +3,7 @@ values:
   2012-01-01:
     value: 0.18
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Taux de la réduction d’impôt pour les versements PME et ESUS effectués du 01.01.2023 au 11.03.2023 (case 7CI)
   unit: /1
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/plafond.yaml
@@ -7,16 +7,16 @@ values:
   2001-01-01:
     value: 18000
 metadata:
-  short_label: Plafond des versements (second plafond, en €) 
-  last_value_still_valid_on: "2024-11-18"
+  short_label: Plafond des versements (second plafond, en €)
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: plaf_sofica
   unit: currency_next_year
   reference:
     2001-01-01:
-      - title: Article 199 2. unvicies du Code général des impôts
-        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438
-      - title: Décret n°2002-923 du 6 juin 2002, art. 4
-        href: https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000000596281&idArticle=LEGIARTI000006212781&dateTexte=20040531&categorieLien=id
+    - title: Article 199 2. unvicies du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438
+    - title: Décret n°2002-923 du 6 juin 2002, art. 4
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000000596281&idArticle=LEGIARTI000006212781&dateTexte=20040531&categorieLien=id
   notes:
     2007-01-01:
     - title: Devient une réduction d'impôt => changement de méthode de calcul

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/plafond_revenu_net_global.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/plafond_revenu_net_global.yaml
@@ -5,16 +5,16 @@ values:
   1985-01-01:
     value: 0.25
 metadata:
-  short_label: Plafond des versements (premier plafond, en % du revenu net global) 
-  last_value_still_valid_on: "2024-11-18"
+  short_label: Plafond des versements (premier plafond, en % du revenu net global)
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: base_sofica
   unit: /1
   reference:
     1985-01-01:
-      - title: Article 199 2. unvicies du Code général des impôts
-        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438
-      - title: Loi 85-695 du 11/07/1985 - art. 40-IV
-        href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006274634&cidTexte=JORFTEXT000000693456
+    - title: Article 199 2. unvicies du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438
+    - title: Loi 85-695 du 11/07/1985 - art. 40-IV
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006274634&cidTexte=JORFTEXT000000693456
   official_journal_date:
     1985-01-01: "1985-07-12"
   notes:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/taux_majore_1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/taux_majore_1.yaml
@@ -11,7 +11,7 @@ values:
 metadata:
   short_label: Taux de la réduction d'impôt lorsque la SOFICA s’engage à investir 10 % en sociétés de réalisation (case 7GN)
   ipp_csv_id: tx_sofica_1
-  last_value_still_valid_on: "2024-11-18"
+  last_value_still_valid_on: "2025-02-25"
   unit: /1
   reference:
     2006-01-01:
@@ -22,10 +22,10 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000025048618&cidTexte=JORFTEXT000025044460
     - title: BOI N°31 du 14/03/2012 - 5-B12-12
     2012-01-01:
-      - title: Article 199 3. unvicies du Code général des impôts
-        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438
-      - title: Décret 2012-547, art. 1 du 23/04/2012
-        href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000025744568&cidTexte=JORFTEXT000025743483
+    - title: Article 199 3. unvicies du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438
+    - title: Décret 2012-547, art. 1 du 23/04/2012
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000025744568&cidTexte=JORFTEXT000025743483
   official_journal_date:
     2006-01-01: "2006-12-31"
     2011-01-01: "2011-12-29"

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/taux_majore_2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/taux_majore_2.yaml
@@ -5,8 +5,8 @@ values:
   2017-01-01:
     value: 0.48
 metadata:
-  short_label: Taux de la réduction d'impôt lorsque la SOFICA s’engage à investir 10 % en sociétés de réalisation et à consacrer 10 % aux œuvres audiovisuelles (séries ou droits internationaux) (case 7EN) 
-  last_value_still_valid_on: "2024-11-18"
+  short_label: Taux de la réduction d'impôt lorsque la SOFICA s’engage à investir 10 % en sociétés de réalisation et à consacrer 10 % aux œuvres audiovisuelles (séries ou droits internationaux) (case 7EN)
+  last_value_still_valid_on: "2025-02-25"
   unit: /1
   reference:
     2017-01-01:

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/taux_reduction_normal.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/taux_reduction_normal.yaml
@@ -10,7 +10,7 @@ values:
     value: 0.3
 metadata:
   short_label: Taux de la réduction d'impôt (case 7FN)
-  last_value_still_valid_on: "2024-11-18"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: tx_sofica_2
   unit: /1
   reference:
@@ -22,10 +22,10 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000025048618&cidTexte=JORFTEXT000025044460
     - title: BOI N°31 du 14/03/2012 - 5-B12-12
     2012-01-01:
-      - title: Article 199 3. unvicies du Code général des impôts
-        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438
-      - title: Décret 2012-547, art. 1 du 23/04/2012
-        href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000025744568&cidTexte=JORFTEXT000025743483
+    - title: Article 199 3. unvicies du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438
+    - title: Décret 2012-547, art. 1 du 23/04/2012
+      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000025744568&cidTexte=JORFTEXT000025743483
   official_journal_date:
     2006-01-01: "2006-12-31"
     2011-01-01: "2011-12-29"

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/souscriptions_parts_fcpi_fip/plafond_celibataire.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/souscriptions_parts_fcpi_fip/plafond_celibataire.yaml
@@ -8,10 +8,10 @@ values:
     value: 12000
 metadata:
   short_label: Plafond des versements pour contribuable célibataire, veuf ou divorcé
-  last_value_still_valid_on: "2024-11-18"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: plaffcp_celib
   unit: currency_next_year
   reference:
-   2002-01-01:
+    2002-01-01:
     - title: Article 199 terdecies-0 A, VI. 2. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042912844

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/souscriptions_parts_fcpi_fip/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/souscriptions_parts_fcpi_fip/taux.yaml
@@ -11,6 +11,7 @@ values:
   2024-01-01:
     value: 0.18
 metadata:
+  last_value_still_valid_on: "2025-02-25"
   short_label: Taux de la réduction d'impôt (cases 7GQ et 7FQ)
   ipp_csv_id: txfcp_1
   unit: /1

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/souscriptions_parts_fcpi_fip/taux_special.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/souscriptions_parts_fcpi_fip/taux_special.yaml
@@ -3,7 +3,7 @@ values:
   2020-08-01:
     value: 0.25
 metadata:
-  last_value_still_valid_on: "2024-11-18"
+  last_value_still_valid_on: "2025-02-25"
   short_label: Taux spécial de la réduction d'impôt pour les versements entre 2020 et 2023 (cases 7GR et 7FT)
   unit: /1
   reference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.16.19"
+version = "169.16.20"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/calculateur_impots/yaml/reduc_dfppce.yaml
+++ b/tests/calculateur_impots/yaml/reduc_dfppce.yaml
@@ -360,7 +360,7 @@
       f7uf: 5000
       f7uh: 6000
       f7ud: 2000
-      f7uj: 3700
+      f7uj_2022: 3700
       f7vc: 5000
       f7va: 1500
       f7xs: 7000
@@ -392,6 +392,35 @@
     protection_patrimoine_naturel: 0.0
     rbg: 45000.0
     reductions: 7106.0
+    rfr: 45000.0
+
+- name: reduc_dons_patrimoine_religieux
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      caseF: false
+      declarants:
+      - ind0
+      f7uj: 1000
+    individus:
+      ind0:
+        activite: actif
+        date_naissance: '1970-01-01'
+        salaire_imposable: 50000.0
+        statut_marital: celibataire
+    famille:
+      parents:
+      - ind0
+    menage:
+      personne_de_reference: ind0
+  output:
+    iai: 5915.0
+    impot_revenu_restant_a_payer: -5915.0
+    nbptr: 1.0
+    protection_patrimoine_naturel: 0.0
+    rbg: 45000.0
+    reductions: 750.0
     rfr: 45000.0
 
 - name: reduc_dfppce


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2025.
* Zones impactées :
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/interets_emprunt_reprise_societe/plafond.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/interets_emprunt_reprise_societe/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/interets_paiements_differes_agriculteurs/plafond.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/interets_paiements_differes_agriculteurs/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/rente_survie/increment.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/rente_survie/plafond.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/rente_survie/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/restauration_monuments_historiques/plafond.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/divers/restauration_monuments_historiques/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_coluche/plafond.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_coluche/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_notre_dame/plafond.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/dons_notre_dame/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/enfants_scolarises/universite.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/defense_forets_contre_incendies/plafond.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/defense_forets_contre_incendies/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/depenses_investissement_forestier/acquisition/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/depenses_investissement_forestier/travaux/plafond.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/depenses_investissement_forestier/travaux/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/location_meublee/taux11.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/prestations_compensatoires/plafond.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/prestations_compensatoires/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/seuil.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/plafond.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/plafond_revenu_net_global.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/taux_majore_1.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/taux_majore_2.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/sofica/taux_reduction_normal.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/souscriptions_parts_fcpi_fip/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/souscriptions_parts_fcpi_fip/taux_special.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissement_forestier/depenses_investissement_forestier/travaux/plafond.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/enfants_scolarises/college.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/enfants_scolarises/lycee.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/plafond_dons.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/dons/taux_reduction.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/enfants_scolarises/lycee.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/investissements_immobiliers/dispositif_scellier/taux_prorogation.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_reductions_impots/souscriptions/pme/souscription_capital/taux18.yaml
    * Détails :
    - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.

    - - - -

    Ces changements (effacez les lignes ne correspondant pas à votre cas) :

    - Mise à jour de paramètre.

    - - - -

    Méthodologie :
    1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
    1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
    1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
    1. Vérifie la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
    1. Met à jour la `last_value_still_valid_on` à la date du jour.
    1. Crée un tableau récapitulatif pour faciliter la revue.

    Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

    - - - -

    Quelques conseils à prendre en compte :

    - [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
    - [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
    - [X] Documentez votre contribution avec des références législatives.
    - [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
    - [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
    - [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
    - [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
    
    Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme n'ayant pas changés depuis la date indiquée dans `last_value_still_valid_on`.

    Aide à la revue :
    
* impot_revenu.calcul_reductions_impots.divers.interets_emprunt_reprise_societe.plafond
    - Description : Plafond (personne seule) de la réduction d'impôts sur les intérêts d'emprunt pour reprise de société
    - 20000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036428982/2018-01-01/) de type CODE
    - Extrait : _[...]2003-721 du 1er août 2003 pour l'initiative économique. Ils sont retenus dans la limite annuelle de 20 000 € pour les contribuables célibataires, veufs ou divorcés et de 40 000 € pour les contribuable[...]_
    - Reponse du LLM : _La valeur de 'Plafond (personne seule) de la réduction d'impôts sur les intérêts d'emprunt pour reprise de société' est indiquée dans le texte à la section II : "Ils sont retenus dans la limite annuelle de 20 000 € pour les contribuables célibataires, veufs ou divorcés".  La réponse est donc : ``` {     "valeur": 20000.0 } ```_
    
* impot_revenu.calcul_reductions_impots.divers.interets_emprunt_reprise_societe.taux
    - Description : Taux de la réduction d'impôts sur les intérêts d'emprunt pour reprise de société
    - 0.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036428982/2018-01-01/) de type CODE
    - Extrait : _[...]nce au sens de l'article 4 B peuvent bénéficier d'une réduction de leur impôt sur le revenu égale à 25 % du montant des intérêts des emprunts contractés pour acquérir, dans le cadre d'une opération de[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction d'impôts sur les intérêts d'emprunt pour reprise de société' est indiquée dans le texte comme étant de 25 % du montant des intérêts des emprunts contractés.   En convertissant ce pourcentage en valeur décimale, on obtient :  {     "valeur": 0.25 }_
    
* impot_revenu.calcul_reductions_impots.divers.interets_paiements_differes_agriculteurs.plafond
    - Description : Plafond de la réduction d'impôt sur les intérêts de paiements différés accordés aux agriculteurs
    - 5000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006303322/2006-01-06) de type CODE
    - Extrait : _[...]r le revenu défini au 1 du I de l'article 197. Les intérêts sont retenus dans la limite annuelle de 5 000 € pour les contribuables célibataires, veufs ou divorcés et de 10 000 € pour les contribuables[...]_
    - Reponse du LLM : _La valeur de 'Plafond de la réduction d'impôt sur les intérêts de paiements différés accordés aux agriculteurs' est donnée dans le paragraphe 3 du texte. Il est indiqué que les intérêts sont retenus dans la limite annuelle de 5 000 € pour les contribuables célibataires, veufs ou divorcés et de 10 000 € pour les contribuables mariés ou pour les partenaires liés par un pacte civil de solidarité soumis à une imposition commune.  La réponse est donc :  {     "valeur": 5000.0 }  ou   {     "valeur": 10000.0 }  Cependant, comme la question demande une valeur unique, il est probable que la valeur demandée soit celle pour les contribuables célibataires, veufs ou divorcés, qui est la même que la valeur donnée à une autre date de validité.  La réponse est donc :  {     "valeur": 5000.0 }_
    
* impot_revenu.calcul_reductions_impots.divers.interets_paiements_differes_agriculteurs.taux
    - Description : Taux de la réduction d'impôt sur les intérêts de paiements différés accordés aux agriculteurs
    - 0.5
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006303322/2006-01-06) de type CODE
    - Extrait : _[...]u a dans la limite du taux de l'échéance constante à dix ans.

3. La réduction d'impôt est égale à 50 % des intérêts imposés dans la catégorie des revenus de capitaux mobiliers et soumis au barème de[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction d'impôt sur les intérêts de paiements différés accordés aux agriculteurs' est de 0.5, car le texte indique que "La réduction d'impôt est égale à 50 % des intérêts imposés".  Réponse : ``` {     "valeur": 0.5 } ```_
    
* impot_revenu.calcul_reductions_impots.divers.rente_survie.increment
    - Description : Majoration du plafond de la réduction d'impôts sur rente survie et contrat d'épargne handicap par personne à charge
    - 300.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806424/2024-01-01/) de type CODE
    - Extrait : _[...]le revenu de 25 % dans la limite d'un plafond global de versements annuels égal à 1 525 € majoré de 300 € par personne à charge :
1° Les primes afférentes à des contrats d'assurance en cas de décès, l[...]_
    - Reponse du LLM : _La valeur de 'Majoration du plafond de la réduction d'impôts sur rente survie et contrat d'épargne handicap par personne à charge' est de 300 €.  La réponse est : {     "valeur": 300.0 }_
    
* impot_revenu.calcul_reductions_impots.divers.rente_survie.plafond
    - Description : Plafond de la réduction d'impôts sur rente survie et contrat d'épargne handicap
    - 1525.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806424/2024-01-01/) de type CODE
    - Extrait : _[...]ction d'impôt sur le revenu de 25 % dans la limite d'un plafond global de versements annuels égal à 1 525 € majoré de 300 € par personne à charge :
1° Les primes afférentes à des contrats d'assurance [...]_
    - Reponse du LLM : _La valeur de 'Plafond de la réduction d'impôts sur rente survie et contrat d'épargne handicap' est de 1525.0 €, ce qui correspond à la valeur précédente fournie. Le texte ne fournit pas de nouvelle valeur pour cette année, mais il confirme que le plafond est de 1 525 € majoré de 300 € par personne à charge. Cependant, la valeur de base reste la même.  {     "valeur": 1525.0 }_
    
* impot_revenu.calcul_reductions_impots.divers.rente_survie.taux
    - Description : Taux de la réduction d'impôts sur rente survie et contrat d'épargne handicap
    - 0.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806424/2024-01-01/) de type CODE
    - Extrait : _[...]tion des revenus des différentes catégories, ouvrent droit à une réduction d'impôt sur le revenu de 25 % dans la limite d'un plafond global de versements annuels égal à 1 525 € majoré de 300 € par per[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction d'impôts sur rente survie et contrat d'épargne handicap' est de 25%, ce qui équivaut à 0,25 en notation mathématique.  La réponse est donc : ``` {     "valeur": 0.25 } ```_
    
* impot_revenu.calcul_reductions_impots.divers.restauration_monuments_historiques.plafond
    - Description : Taux de la réduction d'impôt sur les dépenses de restauration des monuments historiques
    - 20000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037099626) de type CODE
    - Extrait : _[...]s effectivement versées et restant à la charge du propriétaire, retenues dans la limite annuelle de 20 000 € par contribuable.
IV. – En cas de non-respect d'une des conditions fixées au II ou de cessi[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction d'impôt sur les dépenses de restauration des monuments historiques' est de 0.18, et le plafond est de 20000.0.   La réponse est donc : {     "valeur": 20000.0,     "taux": 0.18 }_
    
* impot_revenu.calcul_reductions_impots.divers.restauration_monuments_historiques.taux
    - Description : Taux de la réduction d'impôt sur les dépenses de restauration des monuments historiques
    - 0.18
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037099626) de type CODE
    - Extrait : _[...]u moins les cinq années suivant celui-ci, exposé au public.
III. – La réduction d'impôt est égale à 18 % des sommes effectivement versées et restant à la charge du propriétaire, retenues dans la limit[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction d'impôt sur les dépenses de restauration des monuments historiques' est indiquée dans le texte à la section III : "La réduction d'impôt est égale à 18 % des sommes effectivement versées et restant à la charge du propriétaire".  La valeur est donc 0.18.  Réponse : ``` {     "valeur": 0.18 } ```_
    
* impot_revenu.calcul_reductions_impots.dons.dons_coluche.plafond
    - Description : Plafond des versements ouvrant droit à la réduction d'impôt sur le revenu (IR) au titre des dons faits aux organismes d'aide aux personnes en difficulté ("Dons Coluche")
    - 1000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000045764695) de type CODE
    - Extrait : _[...]mai 2011, ou contribuent à favoriser leur relogement. Ces versements sont retenus dans la limite de 1 000 € à compter de l'imposition des revenus de l'année 2024. Il n'en est pas tenu compte pour l'ap[...]_
    - Reponse du LLM : _La valeur de 'Plafond des versements ouvrant droit à la réduction d'impôt sur le revenu (IR) au titre des dons faits aux organismes d'aide aux personnes en difficulté ("Dons Coluche")' est de 1000 euros.  Réponse : ``` {     "valeur": 1000.0 } ```_
    
* impot_revenu.calcul_reductions_impots.dons.dons_coluche.taux
    - Description : Taux de la réduction d'impôt sur le revenu (IR) au titre des dons faits aux organismes d'aide aux personnes en difficulté ("Dons Coluche")
    - 0.75
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000045764695) de type CODE
    - Extrait : _[...]on d'impôt dans les mêmes conditions.
1 ter. Le taux de la réduction d'impôt visée au 1 est porté à 75 % pour les versements effectués au profit d'organismes sans but lucratif qui procèdent à la fourn[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction d'impôt sur le revenu (IR) au titre des dons faits aux organismes d'aide aux personnes en difficulté ("Dons Coluche")' est de 0.75.  Réponse : ``` {     "valeur": 0.75 } ```_
    
* impot_revenu.calcul_reductions_impots.dons.dons_notre_dame.plafond
    - Description : Plafond
    - 1000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFARTI000038843054) de type LOI
    - Extrait : _[...]icle 200 du code général des impôts est porté à 75 %. Ces versements sont retenus dans la limite de 1 000 €. Il n'en est pas tenu compte pour l'application de la limite de 20 % du revenu imposable men[...]_
    - Reponse du LLM : _La valeur de 'Plafond - impot_revenu.calcul_reductions_impots.dons.dons_notre_dame.plafond' est de 1000.0, car le texte indique que "Ces versements sont retenus dans la limite de 1 000 €".  Réponse : {     "valeur": 1000.0 }_
    
* impot_revenu.calcul_reductions_impots.dons.dons_notre_dame.taux
    - Description : Taux
    - 0.75
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFARTI000038843054) de type LOI
    - Extrait : _[...]le taux de la réduction d'impôt prévue au 1 de l'article 200 du code général des impôts est porté à 75 %. Ces versements sont retenus dans la limite de 1 000 €. Il n'en est pas tenu compte pour l'appl[...]_
    - Reponse du LLM : _La valeur de 'Taux - impot_revenu.calcul_reductions_impots.dons.dons_notre_dame.taux' est la même que celle indiquée pour la période du 16 avril 2019 au 31 décembre 2019, soit 0.75.  Réponse : {     "valeur": 0.75 }_
    
* impot_revenu.calcul_reductions_impots.enfants_scolarises.universite
    - Description : Montant de la réduction d'impôts sur le revenu (IR) par enfant à charge suivant une formation d'enseignement supérieur (case 7EF)
    - 183.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006303194) de type CODE
    - Extrait : _[...]r enfant fréquentant un lycée d'enseignement général et technologique ou un lycée professionnel ;

183 € par enfant suivant une formation d'enseignement supérieur.

Les montants mentionnés aux aliné[...]_
    - Reponse du LLM : _{     "valeur": 183.0 }_
    
* impot_revenu.calcul_reductions_impots.investissement_forestier.defense_forets_contre_incendies.plafond
    - Description : Plafond des cotisations pour la défense des forêts contre les incendies ouvrant droit à la réduction d'impôt sur le revenu (IR)
    - 1000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000028447536) de type CODE
    - Extrait : _[...]même code.

La réduction d'impôt est égale à 50 % des cotisations versées prises dans la limite de 1 000 € par foyer fiscal.

La cotisation versée ouvre droit au bénéfice de la réduction d'impôt, so[...]_
    - Reponse du LLM : _La valeur de 'Plafond des cotisations pour la défense des forêts contre les incendies ouvrant droit à la réduction d'impôt sur le revenu' est toujours la même, à savoir 1000.0.  Réponse : {     "valeur": 1000.0 }_
    
* impot_revenu.calcul_reductions_impots.investissement_forestier.defense_forets_contre_incendies.taux
    - Description : Taux de la réduction d'impôt pour la défense des forêts contre les incendies
    - 0.5
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006601284&cidTexte=JORFTEXT000000264992) de type CODE
    - Extrait : _[...]es massifs visés aux articles L. 133-1 et L. 133-2 du même code.

La réduction d'impôt est égale à 50 % des cotisations versées prises dans la limite de 1 000 € par foyer fiscal.

La cotisation vers[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction d'impôt pour la défense des forêts contre les incendies' est indiquée dans le texte comme étant de 50 % des cotisations versées.   Pour obtenir la valeur numérique, il faut convertir le pourcentage en décimal.   50 % = 0,5  La réponse est donc :  {     "valeur": 0.5 }_
    
* impot_revenu.calcul_reductions_impots.investissement_forestier.depenses_investissement_forestier.acquisition.taux
    - Description : Taux du crédit d'impôt pour les acquisitions d'investissement forestier
    - 0.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042912274/2020-12-31) de type CODE
    - Extrait : _[...]'acquisition ou de souscription mentionnés au A du III sont globalement retenus dans la limite de 6 250 € pour une personne célibataire, veuve ou divorcée et de 12 500 € pour un couple marié ou pour l[...]_
    - Reponse du LLM : _La valeur de 'Taux du crédit d'impôt pour les acquisitions d'investissement forestier' est indiquée dans le texte à la section VI.-A. : "Le taux du crédit d'impôt est de 25 %."  En convertissant ce pourcentage en une valeur décimale, on obtient :  0,25  La réponse est donc :  ``` {     "valeur": 0.25 } ```_
    
* impot_revenu.calcul_reductions_impots.investissement_forestier.depenses_investissement_forestier.travaux.plafond
    - Description : Plafond de dépenses de travaux et assurances d'investissement forestier
    - 6250.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042912274) de type CODE
    - Extrait : _[...] d'acquisition ou de souscription mentionnés au A du III sont globalement retenus dans la limite de 6 250 € pour une personne célibataire, veuve ou divorcée et de 12 500 € pour un couple marié ou pour[...]_
    - Reponse du LLM : _La valeur de 'Plafond de dépenses de travaux et assurances d'investissement forestier' est indiquée dans le texte à plusieurs endroits, notamment au IV.-A et IV.-B.   Selon le IV.-A, le prix d'acquisition ou de souscription est globalement retenu dans la limite de 6 250 € pour une personne célibataire, veuve ou divorcée et de 12 500 € pour un couple marié ou pour les partenaires liés par un pacte civil de solidarité soumis à une imposition commune.  Selon le IV.-B, les dépenses et la fraction des dépenses sont globalement retenues dans la limite de 6 250 € pour une personne célibataire, veuve ou divorcée et de 12 500 € pour un couple marié ou pour les partenaires liés par un pacte civil de solidarité soumis à une imposition commune.  La valeur de 'Plafond de dépenses de travaux et assurances d'investissement forestier' est donc de 6250.0.  Réponse : ``` {     "valeur": 6250.0 } ```_
    
* impot_revenu.calcul_reductions_impots.investissement_forestier.depenses_investissement_forestier.travaux.taux
    - Description : Taux du crédit d'impôt pour les travaux réguliers
    - 0.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047810819/2023-07-12/) de type CODE
    - Extrait : _[...]'acquisition ou de souscription mentionnés au A du III sont globalement retenus dans la limite de 6 250 € pour une personne célibataire, veuve ou divorcée et de 12 500 € pour un couple marié ou pour l[...]_
    - Reponse du LLM : _La valeur de 'Taux du crédit d'impôt pour les travaux réguliers' est indiquée dans le texte à la section VI.-A. : "Le taux du crédit d'impôt est de 25 %."  En convertissant ce pourcentage en valeur décimale, on obtient :  0,25  La réponse est donc :  ``` {     "valeur": 0.25 } ```_
    
* impot_revenu.calcul_reductions_impots.location_meublee.taux11
    - Description : Taux de la réduction d'impôt "Censi-Bouvard" pour l'investissement locatif meublé exercé à titre non professionnel dans certaines résidences acquises à compter de 2012
    - 0.11
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000026856853&idArticle=LEGIARTI000026872827&dateTexte=20161231&categorieLien=id#LEGIARTI000026872827) de type CODE
    - Extrait : _[...]ôt est de 25 % pour les logements acquis en 2009 et en 2010, de 18 % pour les logements acquis en 2011 et de 11 % pour ceux acquis à compter de 2012.
Toutefois, pour les logements acquis en 2012, le t[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction d'impôt "Censi-Bouvard" pour l'investissement locatif meublé exercé à titre non professionnel dans certaines résidences acquises à compter de 2012' est de 0.11.  Réponse au format JSON : ``` {     "valeur": 0.11 } ```_
    
* impot_revenu.calcul_reductions_impots.prestations_compensatoires.plafond
    - Description : Plafond des versements de sommes d'argent et l'attribution de biens ou de droits effectués en exécution de la prestation compensatoire pris en compte dans le calcul de la réduction de l'impôt sur le revenu (IR)
    - 30500.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042907654) de type CODE
    - Extrait : _[...]divorce homologuée par le juge ou par le jugement de divorce, et dans la limite d'un plafond égal à 30 500 € apprécié par rapport à la période mentionnée au premier alinéa.
Lorsque la prestation compe[...]_
    - Reponse du LLM : _La valeur de 'Plafond des versements de sommes d'argent et l'attribution de biens ou de droits effectués en exécution de la prestation compensatoire pris en compte dans le calcul de la réduction de l'impôt sur le revenu (IR)' est de 30500.0.  Réponse : ``` {     "valeur": 30500.0 } ```_
    
* impot_revenu.calcul_reductions_impots.prestations_compensatoires.taux
    - Description : Taux de la réduction d'impôt sur le revenu (IR) sur les prestations compensatoires
    - 0.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042907654) de type CODE
    - Extrait : _[...]ent de personnes domiciliées en France au sens de l'article 4 B.

La réduction d'impôt est égale à 25 % du montant des versements effectués, des biens ou des droits attribués, retenu pour la valeur f[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction d'impôt sur le revenu (IR) sur les prestations compensatoires' est de 25 % du montant des versements effectués, des biens ou des droits attribués.   En convertissant cela en notation mathématique, cela équivaut à 0,25.  La réponse est donc : {     "valeur": 0.25 }_
    
* impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital.seuil
    - Description : Plafond des versements, pour une personne célibataire, veuve, ou divorcé, ouvrant droit à la réduction d'impôt sur le revenu (IR) sur les souscriptions en numéraire au capital initial ou aux augmentations de capital de sociétés
    - 50000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000021629212/2023-10-17/) de type CODE
    - Extrait : _[...]ements ouvrant droit à la réduction d'impôt mentionnée au I sont retenus dans la limite annuelle de 50 000 € pour les contribuables célibataires, veufs ou divorcés et de 100 000 € pour les contribuabl[...]_
    - Reponse du LLM : _La valeur de 'Plafond des versements, pour une personne célibataire, veuve, ou divorcé, ouvrant droit à la réduction d'impôt sur le revenu (IR) sur les souscriptions en numéraire au capital initial ou aux augmentations de capital de sociétés' est indiquée dans le texte comme étant de 50 000 € pour les contribuables célibataires, veufs ou divorcés.  La réponse est donc : ``` {     "valeur": 50000.0 } ```_
    
* impot_revenu.calcul_reductions_impots.souscriptions.sofica.plafond
    - Description : Plafond en euros des versements pris en compte pour le calcul de la réduction d'impôt sur le revenu (IR) liée à la souscription de parts au capital d'œuvres cinématographiques ou audiovisuelles (SOFICA) (case 7FN)
    - 18000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438) de type CODE
    - Extrait : _[...]pour les souscriptions mentionnées au 1, retenues dans la limite de 25 % du revenu net global et de 18 000 €.
3. La réduction d'impôt est égale à 30 % des sommes retenues au 2.
Le taux mentionné au pr[...]_
    - Reponse du LLM : _La valeur de 'Plafond en euros des versements pris en compte pour le calcul de la réduction d'impôt sur le revenu (IR) liée à la souscription de parts au capital d'œuvres cinématographiques ou audiovisuelles (SOFICA)' est indiquée dans le texte comme étant de 18 000 €.  La réponse est donc : {     "valeur": 18000.0 }_
    
* impot_revenu.calcul_reductions_impots.souscriptions.sofica.plafond_revenu_net_global
    - Description : Plafond en pourcentage du revenu net fiscal des versements pris en compte pour le calcul de la réduction d'impôt sur le revenu (IR) liée à la souscription de parts au capital d'œuvres cinématographiques ou audiovisuelles (SOFICA) (case 7FN)
    - 0.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438) de type CODE
    - Extrait : _[...]ux sommes effectivement versées pour les souscriptions mentionnées au 1, retenues dans la limite de 25 % du revenu net global et de 18 000 €.
3. La réduction d'impôt est égale à 30 % des sommes retenu[...]_
    - Reponse du LLM : _La valeur de 'Plafond en pourcentage du revenu net fiscal des versements pris en compte pour le calcul de la réduction d'impôt sur le revenu (IR) liée à la souscription de parts au capital d'œuvres cinématographiques ou audiovisuelles (SOFICA)' est de 0.25.  Réponse : {     "valeur": 0.25 }_
    
* impot_revenu.calcul_reductions_impots.souscriptions.sofica.taux_majore_1
    - Description : Taux majoré de la réduction d'impôt sur le revenu (IR) sur la souscription de parts au capital d'oeuvres cinématographiques ou audiovisuelles (SOFICA) lorsque la Sofica s'engage à réaliser au moins 10 % de ses investissements dans des sociétés de production avant le 31 décembre de l'année suivant celle de la souscription (case 7GN)
    - 0.36
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438) de type CODE
    - Extrait : _[...] d'impôt est égale à 30 % des sommes retenues au 2.
Le taux mentionné au premier alinéa est porté à 36 % lorsque la société s'engage à réaliser au moins 10 % de ses investissements dans les conditions[...]_
    - Reponse du LLM : _La valeur de 'Taux majoré de la réduction d'impôt sur le revenu (IR) sur la souscription de parts au capital d'oeuvres cinématographiques ou audiovisuelles (SOFICA) lorsque la Sofica s'engage à réaliser au moins 10 % de ses investissements dans des sociétés de production avant le 31 décembre de l'année suivant celle de la souscription' est de 0.36.  Cependant, le texte fourni ne donne pas de valeur spécifique à la date de validité demandée, mais il est mentionné que le taux est porté à 36 % lorsque la société s'engage à réaliser au moins 10 % de ses investissements dans les conditions prévues.  La réponse est donc :  {     "valeur": 0.36 }_
    
* impot_revenu.calcul_reductions_impots.souscriptions.sofica.taux_majore_2
    - Description : Taux majoré de la réduction d'impôt sur le revenu (IR) sur la souscription de parts au capital d'oeuvres cinématographiques ou audiovisuelles (SOFICA) lorsque la Sofica s'engage à consacrer 10 % de ses investissements soit à des dépenses de développement d'œuvres de fiction, de documentaires et d'animation sous forme de séries ; soit à l'acquisition de droits portant exclusivement sur les recettes d'exploitation des œuvres cinématographiques ou audiovisuelles à l'étranger (case 7EN)
    - 0.48
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438) de type CODE
    - Extrait : _[...]nnée suivant celle de la souscription.
Le taux mentionné au premier alinéa du présent 3 est porté à 48 % lorsque, d'une part, la réalisation d'investissements dans les conditions mentionnées au deuxiè[...]_
    - Reponse du LLM : _La valeur de 'Taux majoré de la réduction d'impôt sur le revenu (IR) sur la souscription de parts au capital d'oeuvres cinématographiques ou audiovisuelles (SOFICA) lorsque la Sofica s'engage à consacrer 10 % de ses investissements soit à des dépenses de développement d'œuvres de fiction, de documentaires et d'animation sous forme de séries ; soit à l'acquisition de droits portant exclusivement sur les recettes d'exploitation des œuvres cinématographiques ou audiovisuelles à l'étranger' est de 0.48.  Réponse : ``` {     "valeur": 0.48 } ```_
    
* impot_revenu.calcul_reductions_impots.souscriptions.sofica.taux_reduction_normal
    - Description : Taux de la réduction d'impôt sur le revenu (IR) sur la souscription de parts au capital d'oeuvres cinématographiques ou audiovisuelles (SOFICA) (case 7FN)
    - 0.3
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048806438) de type CODE
    - Extrait : _[...]ues dans la limite de 25 % du revenu net global et de 18 000 €.
3. La réduction d'impôt est égale à 30 % des sommes retenues au 2.
Le taux mentionné au premier alinéa est porté à 36 % lorsque la socié[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction d'impôt sur le revenu (IR) sur la souscription de parts au capital d'oeuvres cinématographiques ou audiovisuelles (SOFICA) (case 7FN) - impot_revenu.calcul_reductions_impots.souscriptions.sofica.taux_reduction_normal - Taux 2 : taux normal' est de 0.3.  Cependant, il est important de noter que le texte fourni mentionne également d'autres taux de réduction d'impôt, notamment 0.36 et 0.48, qui s'appliquent dans des conditions spécifiques. Mais le taux normal mentionné au paragraphe 3 est bien de 0.3.  La réponse est donc :  {     "valeur": 0.3 }_
    
* impot_revenu.calcul_reductions_impots.souscriptions.souscriptions_parts_fcpi_fip.taux
    - Description : Taux de la réduction d'impôt sur le revenu (IR) sur la souscription de parts de fonds communs de placement dans l'innovation (FCPI) ou de fonds d'investissement de proximité (FIP) (cases 7GQ et 7FQ)
    - 0.18
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042912844/2020-12-31/) de type CODE
    - Extrait : _[...]ciliés fiscalement en France peuvent bénéficier d'une réduction de leur impôt sur le revenu égale à 18 % des versements effectués au titre :
1° Des souscriptions en numéraire :
a) Au capital initial d[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction d'impôt sur le revenu (IR) sur la souscription de parts de fonds communs de placement dans l'innovation (FCPI) ou de fonds d'investissement de proximité (FIP)' est de 0.18, mais ce taux n'est pas explicitement mentionné dans le texte fourni pour les FCPI ou les FIP. Cependant, le texte mentionne un taux de réduction d'impôt de 18 % pour certaines souscriptions, ce qui correspond à 0.18.  Cependant, comme le texte ne mentionne pas explicitement les FCPI ou les FIP, mais parle de souscriptions en général, et que la valeur à une autre date de validité était '0.18', on peut supposer que le taux reste le même.  La réponse est donc : ``` {     "valeur": 0.18 } ```_
    
* impot_revenu.calcul_reductions_impots.souscriptions.souscriptions_parts_fcpi_fip.taux_special
    - Description : Taux de la réduction d'impôt sur le revenu (IR) sur la souscription de parts de fonds communs de placement dans l'innovation (FCPI) ou de fonds d'investissement de proximité (FIP), dans sa version entre 2020 et 2023 (cases 7GR et 7FT)
    - 0.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042912844/2020-12-31/) de type CODE
    - Extrait : _[...]ciliés fiscalement en France peuvent bénéficier d'une réduction de leur impôt sur le revenu égale à 25 % des versements effectués au titre de souscriptions en numéraire de parts de fonds communs de pl[...]_
    - Reponse du LLM : _La valeur de 'Taux de la réduction d'impôt sur le revenu (IR) sur la souscription de parts de fonds communs de placement dans l'innovation (FCPI) ou de fonds d'investissement de proximité (FIP)' n'est pas explicitement mentionnée dans le texte fourni. Cependant, il est mentionné que le taux de 18 % s'applique avant le 10 août 2020 et que le taux de 25 % s'applique aux versements effectués entre le 10 août et le 31 décembre 2020, ainsi qu'aux versements effectués en 2021 et 2022.  Puisque la valeur à une autre date de validité était '0.25', on peut supposer que le taux de réduction d'impôt sur le revenu est de 25 % pour les versements effectués entre 2020 et 2023.  La réponse est donc :  ``` {     "valeur": 0.25 } ```_
    
* impot_revenu.calcul_reductions_impots.investissement_forestier.depenses_investissement_forestier.travaux.plafond
    - Description : Plafond de dépenses de travaux et assurances d'investissement forestier
    - 6250.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042912274) de type CODE
    - Extrait : _[...] d'acquisition ou de souscription mentionnés au A du III sont globalement retenus dans la limite de 6 250 € pour une personne célibataire, veuve ou divorcée et de 12 500 € pour un couple marié ou pour[...]_
    - Reponse du LLM : _La valeur de 'Plafond de dépenses de travaux et assurances d'investissement forestier' est indiquée dans le texte à plusieurs endroits, notamment au IV.-A et IV.-B.   Selon le IV.-A, le prix d'acquisition ou de souscription est globalement retenu dans la limite de 6 250 € pour une personne célibataire, veuve ou divorcée et de 12 500 € pour un couple marié ou pour les partenaires liés par un pacte civil de solidarité soumis à une imposition commune.  Selon le IV.-B, les dépenses et la fraction des dépenses sont globalement retenues dans la limite de 6 250 € pour une personne célibataire, veuve ou divorcée et de 12 500 € pour un couple marié ou pour les partenaires liés par un pacte civil de solidarité soumis à une imposition commune.  La valeur de 'Plafond de dépenses de travaux et assurances d'investissement forestier' est donc de 6250.0.  Réponse : ``` {     "valeur": 6250.0 } ```_
    
* impot_revenu.calcul_reductions_impots.enfants_scolarises.college
    - Description : Montant de la réduction d'impôts sur le revenu (IR) par enfant à charge fréquentant un collège (case 7EA)
    - 61.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006303194) de type CODE
    - Extrait : _[...]n cours au 31 décembre de l'année d'imposition.

Le montant de la réduction d'impôt est fixé à :

61 € par enfant fréquentant un collège ;

153 € par enfant fréquentant un lycée d'enseignement géné[...]_
    - Reponse du LLM : _Bon, je dois extraire la valeur de la réduction d'impôt sur le revenu pour un enfant à charge fréquentant un collège. Le texte fourni mentionne explicitement que le montant est de 61 € par enfant. Comme indiqué, les pourcentages doivent être convertis en décimal, mais ici il s'agit d'une valeur fixe. La valeur précédente était 61.0, donc je suppose qu'il s'agit de la même valeur. Je dois donc renvoyer 61.0 dans un format JSON.   ```json {     "valeur": 61.0 } ```_
    
* impot_revenu.calcul_reductions_impots.enfants_scolarises.lycee
    - Description : Montant de la réduction d'impôts sur le revenu (IR) par enfant à charge fréquentant un lycée d'enseignement général et technologique ou un lycée professionnel (case 7EC)
    - 153.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006303194) de type CODE
    - Extrait : _[...]ion.

Le montant de la réduction d'impôt est fixé à :

61 € par enfant fréquentant un collège ;

153 € par enfant fréquentant un lycée d'enseignement général et technologique ou un lycée profession[...]_
    - Reponse du LLM : _Bon, je dois extraire la valeur de la réduction d'impôt pour un enfant à charge fréquentant un lycée d'enseignement général et technologique ou un lycée professionnel. Le texte fourni mentionne explicitement les montants pour chaque type d'établissement.   Je cherche spécifiquement la case 7EC, qui correspond à ce type de lycée. Dans le texte, il est indiqué que le montant est de 153 € par enfant. Comme indiqué dans les instructions, je dois convertir ce montant en chiffre sans le symbole € et utiliser un point comme séparateur décimal.   Je vérifie que la valeur est bien présente et correspond à la description. Aucune mention de division ou de modification n'est applicable ici, donc je prends directement 153.0.   Je m'assure que le format JSON est correct, avec la clé "valeur" et la valeur numérique sans guillemets.   ```json {     "valeur": 153.0 } ```_
    
* impot_revenu.calcul_reductions_impots.dons.plafond_dons
    - Description : Plafond (en % du revenu imposable) des dons pris en compte pour la réduction d'impôt sur le revenu (IR)
    - 0.2
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000045764695) de type CODE
    - Extrait : _[...]ne réduction d'impôt sur le revenu égale à 66 % de leur montant les sommes prises dans la limite de 20 % du revenu imposable qui correspondent à des dons et versements, y compris l'abandon exprès de r[...]_
    - Reponse du LLM : _Okay, let's tackle this. The user is asking for the 'Plafond (en % du revenu imposable) des dons pris en compte pour la réduction d'impôt sur le revenu (IR)'. The key here is to find the percentage limit of the taxable income that can be considered for the tax reduction on donations.  Looking at the provided text, the first paragraph mentions "dans la limite de 20 % du revenu imposable". That translates to a 20% limit of the taxable income. The example given in the instructions says that 10% becomes 0.10, so 20% should be 0.20.   The user also mentioned that the previous value was 0.2, which aligns with this 20% figure. The text doesn't mention any other percentage for the general plafond, except in specific cases like 1 ter where there's a different limit (1000€) but that's not the general case. The main limit here is 20%, so the answer should be 0.20.   ```json {     "valeur": 0.20 } ```_
    
* impot_revenu.calcul_reductions_impots.dons.taux_reduction
    - Description : Taux général de réduction d'impôt sur le revenu (IR) appliqué aux dons
    - 0.66
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000045764695) de type CODE
    - Extrait : _[...]1. Ouvrent droit à une réduction d'impôt sur le revenu égale à 66 % de leur montant les sommes prises dans la limite de 20 % du revenu imposable qui correspondent [...]_
    - Reponse du LLM : _Okay, let's tackle this. The user is asking for the current tax reduction rate for donations under 'impot_revenu.calcul_reductions_impots.dons.taux_reduction'. The previous rate was 0.66, but they want to know if there's a new rate mentioned in the provided text.  First, I need to scan through the legal text to find any mention of the reduction rate. The user mentioned that the previous rate was 66%, which is 0.66 in decimal. The example given in the instructions shows that percentages should be converted to decimals, so I need to look for similar phrasing.  Looking at the first paragraph: "Ouvrent droit à une réduction d'impôt sur le revenu égale à 66 % de leur montant..." Here, it clearly states a 66% reduction, which translates to 0.66. But wait, the user mentioned that the previous rate was 0.66 and is asking if there's a new rate. However, in the text provided, under paragraph 1 ter, there's a mention: "Le taux de la réduction d'impôt visée au 1 est porté à 75 % pour les versements effectués au profit d'organismes sans but lucratif..." So, for certain organizations, the rate is increased to 75% (0.75), but this is specific to donations to non-profit organizations providing meals, housing, healthcare to people in need, etc. The general rate, however, remains at 66% as stated in the first paragraph. The 75% rate is an exception under specific conditions, not the general rate.  The user is specifically asking for the 'taux général', which is the general rate. The 75% is a special case, so the general rate is still 66% (0.66). Therefore, the value hasn't changed from the previous 0.66. But wait, the user is asking if there's a new rate at a different validity date. The text provided doesn't mention any change to the general rate; it only introduces a higher rate for specific cases. Therefore, the general rate remains 66%, so the answer should be 0.66. However, the user's question mentions that the previous value was 0.66 and asks for the current value. If the text doesn't indicate a change to the general rate, then the current value is still 0.66. But I need to confirm if the text here is the updated one. Since the text in paragraph 1 ter mentions "à compter de l'imposition des revenus de l'année 2024," which might imply that the 75% rate starts from 2024, but the general rate in paragraph 1 is still 66%. Therefore, unless there's a different mention elsewhere, the general rate remains 0.66. However, the user's question might be implying that there's a new rate, but according to the provided text, the general rate is still 66%. Therefore, the answer should be 0.66. But wait, the user's question is phrased as looking for 'nan' which might be a placeholder. Wait, the exact parameter is 'Taux général de réduction d'impôt sur le revenu (IR) appliqué aux dons - impot_revenu.calcul_reductions_impots.dons.taux_reduction - nan'. The 'nan' here might indicate that the system is missing the value. The user is asking for the current value given that the previous was 0.66. The text provided in the first paragraph states 66%, which is 0.66. So unless there's a more recent update in the text, the value remains 0.66. Therefore, the answer is 0.66.   ```json {     "valeur": 0.66 } ```_
    
* impot_revenu.calcul_reductions_impots.enfants_scolarises.lycee
    - Description : Montant de la réduction d'impôts sur le revenu (IR) par enfant à charge fréquentant un lycée d'enseignement général et technologique ou un lycée professionnel (case 7EC)
    - 153.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006303194) de type CODE
    - Extrait : _[...]ion.

Le montant de la réduction d'impôt est fixé à :

61 € par enfant fréquentant un collège ;

153 € par enfant fréquentant un lycée d'enseignement général et technologique ou un lycée profession[...]_
    - Reponse du LLM : _Okay, let's tackle this query step by step. The user is asking for the current value of the tax reduction for a child attending a lycée (high school) in the case 7EC. The previous value was 153.0, but they want to know if there's an updated amount in the provided text.  First, I need to look through the given text to find the relevant information. The text mentions different amounts for different educational levels. Let me parse each paragraph carefully.  The key section here is: "153 € par enfant fréquentant un lycée d'enseignement général et technologique ou un lycée professionnel ;" This clearly states that the amount is 153 euros per child attending a lycée. The user mentioned that the previous value was 153.0, and the current text still lists 153 €.   I should check if there's any mention of a change in the date or validity period that might affect this value. However, the text provided doesn't indicate any changes in dates or different validity periods for the amounts listed. All the figures are presented as current without any reference to future or past adjustments. The note about amounts being halved in cases of shared custody doesn't affect the base value, only its application in specific situations.  Since the text explicitly states 153 € for lycée students and there's no conflicting information or updates mentioned, the value remains 153.0. The user's instruction was to return null if the information isn't found, but here it's clearly present. Therefore, the correct value to report is 153.0.   ```json {     "valeur": 153.0 } ```_
    
* impot_revenu.calcul_reductions_impots.investissements_immobiliers.dispositif_scellier.taux_prorogation
    - Description : Taux additionnel de réduction d'impôt les 3 années suivantes en cas d'éligibilité au dispositif Scellier intermédiaire (renouvelable une fois)
    - 0.04
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/id/LEGIARTI000025744568/2012-04-26/) de type CODE
    - Extrait : _[...]I. – 1. Les contribuables domiciliés en France au sens de l'article 4 B qui acquièrent, entre le 1er janvier 2009 et le 31 décembre 2012, un logement neuf ou en l'état [...]_
    - Reponse du LLM : _Okay, let's tackle this question step by step. The user is asking about the 'Taux additionnel de réduction d'impôt les 3 années suivantes en cas d'éligibilité au dispositif Scellier intermédiaire (renouvelable une fois)' which translates to the additional tax reduction rate for the following 3 years if eligible for the Scellier intermediate scheme, renewable once. The parameter in question is 'impot_revenu.calcul_reductions_impots.investissements_immobiliers.dispositif_scellier.taux_prorogation' and the previous value was 0.04.  First, I need to locate where in the provided text this information might be. The user mentioned that if the exact value isn't found, look for the closest match. The text is quite long, so I'll scan through the sections.  Looking at Section V: It discusses the continuation of the tax reduction if the property remains rented after the initial period. It states that the taxpayer can benefit from the reduction for up to six additional years, divided into three-year periods. The annual reduction is 4% of the property's cost per triennial period, imputed at one-third each year.  The key phrase here is "la réduction d'impôt annuelle est égale à 4 % du prix de revient du logement par période triennale". This translates to a 4% rate, which in decimal is 0.04. However, the user mentioned that the previous value was 0.04 and is asking for the current value. But the text doesn't mention any change to this rate; it just states it as 4%. Since there's no indication of a different rate in the text provided, and the previous value was 0.04, it's possible that the current value remains the same. However, the user is asking for the 'taux_prorogation' which refers to the renewal rate. The text specifies 4% for each triennial period, which aligns with the previous value. There's no mention of a different rate elsewhere in the text. Therefore, the value should be 0.04. But wait, the user mentioned that if the value isn't found, we should return null. However, in this case, the text does mention 4%, which is 0.04. So the answer should be 0.04. But the user's example uses 0.25 for 25%, so following that format, 4% becomes 0.04. Therefore, the correct value is 0.04.   ```json {     "valeur": 0.04 } ```_
    
* impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital.taux
    - Description : Taux de la réduction d'impôt sur le revenu (IR) sur les versements  effectués au titre de souscriptions en numéraire au capital initial ou aux augmentations de capital de sociétés
    - 0.18
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000026948386/2013-01-01/) de type CODE
    - Extrait : _[...]ciliés fiscalement en France peuvent bénéficier d'une réduction de leur impôt sur le revenu égale à 18 % des versements effectués au titre :
1° Des souscriptions en numéraire :
a) Au capital initial d[...]_
    - Reponse du LLM : _Okay, let's tackle this. The user is asking for the current tax reduction rate for investments in SMEs through capital subscriptions. The previous rate was 0.18, but they want to know if there's a new rate in the provided text.  First, I need to look through the text for mentions of the tax reduction rate. The user mentioned the specific path 'impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital.taux', which refers to the SME capital subscription rate.  Looking at the text, in section I-A, the first paragraph states: "Les contribuables... peuvent bénéficier d'une réduction de leur impôt sur le revenu égale à 18 % des versements effectués..." So here, the rate is 18%, which translates to 0.18. But wait, the user said the previous rate was 0.18 and is asking if there's a new one. However, in the same text, under section VI-A, there's a mention of a 25% reduction for investments in innovation funds. Then, in VII and VIII, there's a 30% rate for specific regional funds. But those are different categories (innovation funds, proximity funds in Corsica, overseas departments, etc.), not the general SME capital subscriptions covered in I-A.  The key here is to ensure we're looking at the correct section. The user's parameter is specifically for SME capital subscriptions, which is addressed in I-A. The rate there is clearly 18%, which is 0.18. The other sections (VI, VII, VIII) refer to different types of investments (innovation funds, proximity funds) with higher rates, but those are separate from the SME capital subscriptions.   Therefore, the rate for 'souscription_capital.taux' under PME remains 0.18 as per the text provided. There's no mention of a change in this specific rate; the other rates apply to different investment vehicles. So the answer should be 0.18.   ```json {     "valeur": 0.18 } ```_
    
* impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital.taux18
    - Description : Taux de la réduction d'impôt sur le revenu (IR) sur les versements  effectués au titre de souscriptions en numéraire au capital initial ou aux augmentations de capital de sociétés, dans sa version depuis 2012 (case 7CI)
    - 0.18
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000025743489) de type CODE
    - Extrait : _[...]ciliés fiscalement en France peuvent bénéficier d'une réduction de leur impôt sur le revenu égale à 18 % des versements effectués au titre :
1° Des souscriptions en numéraire :
a) Au capital initial d[...]_
    - Reponse du LLM : _Okay, let's tackle this. The user is asking for the tax reduction rate for investments in SMEs under case 7CI, specifically the parameter 'impot_revenu.calcul_reductions_impots.souscriptions.pme.souscription_capital.taux18'. They mention that the rate was 0.18 at a different validity date and want to know the current rate based on the provided text.  First, I need to look through the given legal text to find where the reduction rate is mentioned. The key part here is the section that states the percentage of the tax reduction.  Looking at the text, in the first paragraph under "I.-A.-", it says: "Les contribuables domiciliés fiscalement en France peuvent bénéficier d'une réduction de leur impôt sur le revenu égale à 18 % des versements effectués au titre..." So here, the rate is clearly 18%, which translates to 0.18 in decimal form.  The user also mentioned that there's a different rate (25%) in another part. Scanning further, in section "VI.-A.-", there's a 25% rate for investments in innovation funds, and in "VII" and "VIII", there's a 30% rate for specific regional funds. But the question specifically asks about the SME capital subscriptions under case 7CI, which corresponds to the initial 18% rate mentioned in section I.  The text doesn't mention any changes to this 18% rate in the sections provided. The other rates (25%, 30%) apply to different types of investments, not the general SME capital subscriptions covered in section I. Therefore, the current rate remains 18%, which is 0.18 in the required format.  I need to confirm that there's no update or modification to this rate elsewhere in the text. Checking sections C, D, and others, there's no mention of altering the 18% rate for the general case. The conditions for eligibility are detailed, but the rate itself isn't changed. Thus, the correct value is 0.18.   ```json {     "valeur": 0.18 } ```_