### PR TITLE
MAJ impot_revenu.calcul_revenus_imposables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,31 @@
 # Changelog
 
-### 169.16.16 [2450](https://github.com/openfisca/openfisca-france/pull/2450)
+### 169.16.17 [2460](https://github.com/openfisca/openfisca-france/pull/2460)
 
- * Changement mineur.
-    * Périodes concernées : 2025.
-    * Zones impactées :
-      - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/*
+* Changement mineur.
+* Périodes concernées : 2025.
+* Zones impactées :
+  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/*
     * Détails :
     - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+
+### 169.16.16 [2450](https://github.com/openfisca/openfisca-france/pull/2450)
+
+* Changement mineur.
+  * Périodes concernées : 2025.
+  * Zones impactées :
+    - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/*
+  * Détails :
+  - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
 
 ### 169.16.15 [2428](https://github.com/openfisca/openfisca-france/pull/2428)
 
 * Changement mineur.
-    * Périodes concernées : 2025.
-    * Zones impactées :
-      - openfisca_france/parameters/impot_revenu/*
-    * Détails :
-    - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+  * Périodes concernées : 2025.
+  * Zones impactées :
+    - openfisca_france/parameters/impot_revenu/*
+  * Détails :
+  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
 
 ### 169.16.14 [2452](https://github.com/openfisca/openfisca-france/pull/2452)
 

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/accueil_personne_agee/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/accueil_personne_agee/plafond.yaml
@@ -78,7 +78,7 @@ values:
     value: 3968
 metadata:
   short_label: Plafond de la déduction par personne âgée
-  last_value_still_valid_on: "2024-06-11"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: plaf_frais
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/plafond.yaml
@@ -94,9 +94,11 @@ values:
     value: 6368
   2023-01-01:
     value: 6674
+  2024-01-01:
+    value: 6794
 metadata:
   short_label: Plafond de la déduction par enfant
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-03-02"
   ipp_csv_id: plaf_penalim
   unit: currency_next_year
   reference:
@@ -261,6 +263,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046860788
     - title: Article 2 de la loi n° 2023-1322 du 29/12/2023 (LF pour 2024)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727355
+    2024-01-01:
+    - title: Art. 196 B du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051212977/2025-02-16/
+    - title: LOI n°2025-127 du 14 février 2025 - art. 2 (V)
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051168007
   official_journal_date:
     1974-01-01: "1974-12-31"
     1975-01-01: "1975-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
@@ -94,7 +94,7 @@ values:
     value: 4321
 metadata:
   short_label: Montant maximum de l'abattement, pour le foyer fiscal
-  last_value_still_valid_on: "2024-06-11"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: max_abtpen
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
@@ -60,7 +60,7 @@ values:
     value: 442
 metadata:
   short_label: Montant minimum de l'abattement, par pensionné
-  last_value_still_valid_on: "2024-06-11"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: min_abtpen
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/taux.yaml
@@ -3,7 +3,7 @@ values:
   1943-01-01:
     value: 0.1
 metadata:
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-02-25"
   short_label: Taux de l'abattement sur pensions
   ipp_csv_id: tx_abt_sal
   unit: /1

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
@@ -96,7 +96,7 @@ values:
     value: 14171
 metadata:
   short_label: Montant maximum de la déduction
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: max_abtsal
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
@@ -68,7 +68,7 @@ values:
     value: 495
 metadata:
   short_label: Montant minimum de la déduction
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: min_abtsal
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/taux.yaml
@@ -3,7 +3,7 @@ values:
   1943-01-01:
     value: 0.1
 metadata:
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-02-25"
   short_label: Taux de la déduction pour frais professionnels
   ipp_csv_id: tx_abt_sal
   unit: /1

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux1.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux1.yaml
@@ -3,7 +3,7 @@ values:
   1979-07-01:
     value: 0.7
 metadata:
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-02-25"
   unit: /1
   short_label: Crédirentier de moins de 50 ans
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux2.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux2.yaml
@@ -3,7 +3,7 @@ values:
   1979-07-01:
     value: 0.5
 metadata:
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-02-25"
   unit: /1
   short_label: Crédirentier de 50 à 59 ans
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux3.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux3.yaml
@@ -3,7 +3,7 @@ values:
   1979-07-01:
     value: 0.4
 metadata:
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-02-25"
   unit: /1
   short_label: Crédirentier de 60 à 69 ans
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux4.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux4.yaml
@@ -3,7 +3,7 @@ values:
   1979-07-01:
     value: 0.3
 metadata:
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-02-25"
   unit: /1
   short_label: Crédirentier de plus de 70 ans
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/plafond_recettes.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/plafond_recettes.yaml
@@ -11,7 +11,7 @@ values:
   2024-01-01:
     value: 120000
 metadata:
-  last_value_still_valid_on: "2024-05-20"
+  last_value_still_valid_on: "2025-03-02"
   ipp_csv_id: plaf_micro_ba
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/taux.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.87
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-03-02"
   ipp_csv_id: taux_micro_ba
   unit: /1
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/majoration_revenus_reputes_distribues.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/majoration_revenus_reputes_distribues.yaml
@@ -6,11 +6,11 @@ values:
     value: 1.25
 metadata:
   short_label: Majoration pour revenus distribués et structures hors France (case GO)
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-02-25"
   unit: /1
   reference:
     2006-01-01:
       title: Article 158, 7. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006307989/2007-01-01/
-  notes: 
-    2006-01-01: La case GO se trouve dans le cerfa 2042C "déclaration complémentaire - revenus complémentaires - Partie revenus de capitaux mobiliers". 
+  notes:
+    2006-01-01: La case GO se trouve dans le cerfa 2042C "déclaration complémentaire - revenus complémentaires - Partie revenus de capitaux mobiliers".

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_celib.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_celib.yaml
@@ -8,7 +8,7 @@ values:
     value: 4600
 metadata:
   short_label: Contribuables célibataires, veufs ou divorcés
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: abt_av
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_couple.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_couple.yaml
@@ -8,7 +8,7 @@ values:
     value: 9200
 metadata:
   short_label: Contribuables mariés ou pacsés
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: abt_av
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/revenus_capitaux_mobiliers_dividendes/taux_abattement.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/revenus_capitaux_mobiliers_dividendes/taux_abattement.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.4
 metadata:
   short_label: Taux de l'abattement
-  last_value_still_valid_on: "2024-10-21"
+  last_value_still_valid_on: "2025-02-25"
   ipp_csv_id: tx_abt_rcm
   unit: /1
   reference:
@@ -16,7 +16,7 @@ metadata:
       title: Loi 80-30 du 18/01/1980 (LF pour 1980)
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000705191
     2006-01-01:
-    - title: Article 158, 3.2° du Code général des impôts 
+    - title: Article 158, 3.2° du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043662629
     - title: Loi 2005-1719 du 30/12/2005 (LF pour 2006) - Art. 76
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000634802

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.16.16"
+version = "169.16.17"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2025.
* Zones impactées :
      - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/accueil_personne_agee/plafond.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/taux_jgt_2006.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/taux.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux1.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux4.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/majoration_revenus_reputes_distribues.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_celib.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/produits_assurances_vies_assimiles/abattement_couple.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rvcm/revenus_capitaux_mobiliers_dividendes/taux_abattement.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux2.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatviag/taux3.yaml
  - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/pensions_alimentaires/taux_jgt_2006.yaml
    * Détails :
    - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.

    - - - -

    Ces changements (effacez les lignes ne correspondant pas à votre cas) :

    - Mise à jour de paramètre.

    - - - -

    Méthodologie :
    1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
    1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
    1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
    1. Vérifie la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
    1. Met à jour la `last_value_still_valid_on` à la date du jour.
    1. Crée un tableau récapitulatif pour faciliter la revue.

    Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

    - - - -

    Quelques conseils à prendre en compte :

    - [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
    - [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
    - [X] Documentez votre contribution avec des références législatives.
    - [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
    - [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
    - [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
    - [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
    
    Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme n'ayant pas changés depuis la date indiquée dans `last_value_still_valid_on`.

    Aide à la revue :
    
* impot_revenu.calcul_revenus_imposables.charges_deductibles.accueil_personne_agee.plafond
    - Description : Plafond par personne de la déduction pour frais d'accueil d'une personne âgée de plus de 75 ans
    - 3968.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622626) de type CODE
    - Extrait : _[...]u même code. La déduction opérée par le contribuable ne peut excéder, par bénéficiaire, la somme de 3 968 €.
Le montant de la déduction mentionnée au premier alinéa est relevé chaque année dans la mêm[...]_
    - Reponse du LLM : _La valeur de 'Plafond par personne de la déduction pour frais d'accueil d'une personne âgée de plus de 75 ans' est indiquée dans le texte comme étant relevée chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu. Cependant, la valeur à une autre date de validité était '3968.0'.   Puisque le montant de la déduction est relevé chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu, et que la valeur à une autre date de validité était '3968.0', il est possible que la valeur actuelle soit différente.   Cependant, le texte ne fournit pas d'information sur la limite supérieure actuelle de la première tranche du barème de l'impôt sur le revenu, ni sur la proportion exacte de revalorisation.   Par conséquent, la réponse est :  {     "valeur": 3968.0 }_
    
* impot_revenu.calcul_revenus_imposables.charges_deductibles.pensions_alimentaires.taux_jgt_2006
    - Description : Coefficient de réévaluation des pensions alimentaires versées en vertu d'une décision de justice devenue définitive avant le 1er janvier 2006
    - 1.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006307989/2007-01-01/) de type CODE
    - Extrait : _[...]alisation ou placements de même nature mentionnés au 6° de l'article 120 et au 1° du I de l'article 125-0 A, attachés à des primes versées jusqu'au 26 septembre 2017 et n'ayant pas supporté le prélève[...]_
    - Reponse du LLM : _La valeur de 'Coefficient de réévaluation des pensions alimentaires versées en vertu d'une décision de justice devenue définitive avant le 1er janvier 2006' est indiquée dans le paragraphe 7 du texte fourni.   Selon le texte, le coefficient est de 1,25 pour les sommes mentionnées au 2° du II de l'article 156 versées en vertu d'une décision de justice devenue définitive avant le 1er janvier 2006.  La réponse est donc :  ``` {     "valeur": 1.25 } ```_
    
* impot_revenu.calcul_revenus_imposables.deductions.abatpen.max
    - Description : Montant maximum pour l'ensemble du foyer de l'abattement sur les pensions
    - 4321.0
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000049629765) de type CODE
    - Extrait : _[...]ticles 79 à 90.
Les pensions et retraites font l'objet d'un abattement de 10 % qui ne peut excéder 4 321 €. Ce plafond s'applique au montant total des pensions et retraites perçues par l'ensemble des[...]_
    - Reponse du LLM : _La valeur de 'Montant maximum pour l'ensemble du foyer de l'abattement sur les pensions' est indiquée dans le texte comme étant de 4321 €.   La réponse est donc : {     "valeur": 4321.0 }_
    
* impot_revenu.calcul_revenus_imposables.deductions.abatpen.min
    - Description : Montant minimum par bénéficiaire de l'abattement sur les pensions
    - 442.0
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000049629765) de type CODE
    - Extrait : _[...]u barème de l'impôt sur le revenu.
L'abattement indiqué au deuxième alinéa ne peut être inférieur à 442 €, sans pouvoir excéder le montant brut des pensions et retraites. Cette disposition s'applique [...]_
    - Reponse du LLM : _La valeur de 'Montant minimum par bénéficiaire de l'abattement sur les pensions' est indiquée dans le texte comme étant de 442 €. Cependant, il est précisé que cette somme est révisée chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu.  Puisque la valeur à une autre date de validité était '442.0', on peut en déduire que la valeur actuelle est également de 442 €, mais il est important de noter que cette valeur peut varier en fonction de la révision annuelle.  La réponse est donc :  ``` {     "valeur": 442.0 } ```_
    
* impot_revenu.calcul_revenus_imposables.deductions.abatpen.taux
    - Description : Taux de l'abattement forfaitaire sur les pensions ou retraites
    - 0.1
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042158853) de type CODE
    - Extrait : _[...]ce d'une profession non commerciale sont déterminés conformément aux dispositions des articles 92 à 103. Les gains ou pertes relevant du régime des plus ou moins-values à long terme sont extournés des[...]_
    - Reponse du LLM : _La valeur de 'Taux de l'abattement forfaitaire sur les pensions ou retraites' est de 0.1, car le texte indique que "Les pensions et retraites font l'objet d'un abattement de 10 %".   La réponse est donc : ``` {     "valeur": 0.1 } ```_
    
* impot_revenu.calcul_revenus_imposables.deductions.abatpro.max
    - Description : Montant maximum de la déduction forfaitaire pour frais professionnels
    - 14171.0
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000049629765) de type CODE
    - Extrait : _[...]rêts mentionnés aux 1° à 2° ter ; elle est fixée à 10 % du montant de ce revenu. Elle est limitée à 14 171 € pour l'imposition des rémunérations perçues en 2023 ; chaque année, le plafond retenu pour [...]_
    - Reponse du LLM : _La valeur de 'Montant maximum de la déduction forfaitaire pour frais professionnels' est donnée dans le texte comme étant limitée à 14 171 € pour l'imposition des rémunérations perçues en 2023.   La réponse est donc : {     "valeur": 14171.0 }_
    
* impot_revenu.calcul_revenus_imposables.deductions.abatpro.min
    - Description : Montant minimum (Cas général) de la déduction forfaitaire pour frais professionnels
    - 495.0
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000049629765) de type CODE
    - Extrait : _[...]e revenu.
Le montant de la déduction forfaitaire pour frais professionnels ne peut être inférieur à 495 €, sans pouvoir excéder le montant brut des traitements et salaires. Cette disposition s'appliqu[...]_
    - Reponse du LLM : _La valeur de 'Montant minimum (Cas général) de la déduction forfaitaire pour frais professionnels' est indiquée dans le texte comme étant de 495 €. Cependant, il est également mentionné que cette somme est révisée chaque année dans la même proportion que la limite supérieure de la première tranche du barème de l'impôt sur le revenu.  Puisque la valeur à une autre date de validité était '495.0', on peut en déduire que la valeur actuelle est toujours de 495 €, car il n'y a pas d'information sur une révision de cette valeur dans le texte fourni.  La réponse est donc :  ``` {     "valeur": 495.0 } ```_
    
* impot_revenu.calcul_revenus_imposables.deductions.abatpro.taux
    - Description : Taux de l'abattement forfaitaire sur les salaires pour frais professionels
    - 0.1
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036429189) de type CODE
    - Extrait : _[...]éfalcation des cotisations, contributions et intérêts mentionnés aux 1° à 2° ter ; elle est fixée à 10 % du montant de ce revenu. Elle est limitée à 14 171 € pour l'imposition des rémunérations perçue[...]_
    - Reponse du LLM : _La valeur de 'Taux de l'abattement forfaitaire sur les salaires pour frais professionels' est donnée dans le texte par la phrase : "La déduction à effectuer du chef des frais professionnels est calculée forfaitairement en fonction du revenu brut, après défalcation des cotisations, contributions et intérêts mentionnés aux 1° à 2° ter ; elle est fixée à 10 % du montant de ce revenu."  La valeur est donc de 10%, ce qui équivaut à 0.1 en notation mathématique.  La réponse est : ``` {     "valeur": 0.1 } ```_
    
* impot_revenu.calcul_revenus_imposables.deductions.abatviag.taux1
    - Description : Fraction imposable de la rente viagère à titre onéreux pour les personnes de moins de 50 ans
    - 0.7
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006307959/1979-07-01/) de type CODE
    - Extrait : _[...]il y ait lieu de les décomposer entre leurs divers éléments dans la déclaration prévue à l'article 170.
4 bis. (Abrogé)
4 ter. (disposition devenue sans objet).
5. a. Les revenus provenant de traiteme[...]_
    - Reponse du LLM : _La valeur de 'Fraction imposable de la rente viagère à titre onéreux pour les personnes de moins de 50 ans' est indiquée dans le texte à la section 6. Elle est fixée à 70 % pour les personnes âgées de moins de 50 ans.  La réponse est donc :  ``` {     "valeur": 0.7 } ```_
    
* impot_revenu.calcul_revenus_imposables.deductions.abatviag.taux4
    - Description : Fraction imposable de la rente viagère à titre onéreux pour les personnes âgées de plus de 70 ans
    - 0.3
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/1979-07-01/) de type CODE
    - Extrait : _[...]itation minière sont déterminés conformément aux dispositions des articles 34 à 61 A, 237 ter A, et 302 septies A bis ; les rémunérations mentionnées à l'article 62 sont déterminées conformément aux d[...]_
    - Reponse du LLM : _La valeur de 'Fraction imposable de la rente viagère à titre onéreux pour les personnes âgées de plus de 70 ans' est indiquée dans le texte à la section 6. Elle est fixée à 30 % pour les personnes âgées de plus de 69 ans.  La réponse est donc :  ``` {     "valeur": 0.3 } ```_
    
* impot_revenu.calcul_revenus_imposables.rvcm.majoration_revenus_reputes_distribues
    - Description : Majoration pour revenus réputés distribués et revenus des structures soumises hors de France à un régime fiscal privilégié (case GO - 2042-C)
    - 1.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006307989/2007-01-01/) de type CODE
    - Extrait : _[...]alisation ou placements de même nature mentionnés au 6° de l'article 120 et au 1° du I de l'article 125-0 A, attachés à des primes versées jusqu'au 26 septembre 2017 et n'ayant pas supporté le prélève[...]_
    - Reponse du LLM : _La valeur de 'Majoration pour revenus réputés distribués et revenus des structures soumises hors de France à un régime fiscal privilégié' est de 1.25 selon le texte fourni, mais il est précisé que cette valeur est valable pour une autre date de validité.   Cependant, dans le texte donné, il est mentionné au paragraphe 7 que "Le montant des revenus et charges énumérés ci-après, retenu pour le calcul de l'impôt selon les modalités prévues à l'article 197, est multiplié par un coefficient de 1,25."  Donc, la réponse est :  ``` {     "valeur": 1.25 } ```_
    
* impot_revenu.calcul_revenus_imposables.rvcm.produits_assurances_vies_assimiles.abattement_celib
    - Description : Abattement annuel, pour les contribuables célibataires, veufs ou divorcés, applicable au montant imposable des produits de bons ou contrats d'une durée au moins égale à 8 ans (ou 6 ans pour ceux souscrits avant le 1er janvier 1990)
    - 4600.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038836732) de type CODE
    - Extrait : _[...]éré, pour l'ensemble des bons ou contrats détenus par un même contribuable, un abattement annuel de 4 600 € pour les contribuables célibataires, veufs ou divorcés et de 9 200 € pour les contribuables [...]_
    - Reponse du LLM : _La valeur de 'Abattement annuel, pour les contribuables célibataires, veufs ou divorcés, applicable au montant imposable des produits de bons ou contrats d'une durée au moins égale à 8 ans (ou 6 ans pour ceux souscrits avant le 1er janvier 1990) - impot_revenu.calcul_revenus_imposables.rvcm.produits_assurances_vies_assimiles.abattement_celib' est de 4600.0.  Réponse : ``` {     "valeur": 4600.0 } ```_
    
* impot_revenu.calcul_revenus_imposables.rvcm.produits_assurances_vies_assimiles.abattement_couple
    - Description : Abattement annuel, pour les contribuables mariés ou pacsés, applicable au montant imposable des produits de bons ou contrats d'une durée au moins égale à 8 ans (ou 6 ans pour ceux souscrits avant le 1er janvier 1990)
    - 9200.0
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038836732) de type CODE
    - Extrait : _[...]uable, un abattement annuel de 4 600 € pour les contribuables célibataires, veufs ou divorcés et de 9 200 € pour les contribuables mariés soumis à imposition commune sur la somme des produits imposabl[...]_
    - Reponse du LLM : _La valeur de 'Abattement annuel, pour les contribuables mariés ou pacsés, applicable au montant imposable des produits de bons ou contrats d'une durée au moins égale à 8 ans (ou 6 ans pour ceux souscrits avant le 1er janvier 1990)' est de 9200.0 euros.  Réponse : ``` {     "valeur": 9200.0 } ```_
    
* impot_revenu.calcul_revenus_imposables.rvcm.revenus_capitaux_mobiliers_dividendes.taux_abattement
    - Description : Taux de l'abattement sur les revenus de capitaux mobiliers (dividendes), uniquement en cas de choix d'imposition au barème de l'impôt sur le revenu.
    - 0.4
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043662629) de type CODE
    - Extrait : _[...]s organes compétents, sont réduits, pour le calcul de l'impôt sur le revenu, d'un abattement égal à 40 % de leur montant brut perçu ;
3° Les dispositions du 2° ne s'appliquent pas :
a. Aux produits de[...]_
    - Reponse du LLM : _La valeur de 'Taux de l'abattement sur les revenus de capitaux mobiliers (dividendes), uniquement en cas de choix d'imposition au barème de l'impôt sur le revenu' est indiquée dans le texte à la section 3, 2°. Elle est égale à 40% du montant brut perçu.  La réponse est donc : ``` {     "valeur": 0.4 } ```_
    
* impot_revenu.calcul_revenus_imposables.deductions.abatviag.taux2
    - Description : Fraction imposable de la rente viagère à titre onéreux pour les personnes âgées de 50 à 59 ans
    - 0.5
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/1979-07-01/) de type CODE
    - Extrait : _[...]lors de l'entrée en jouissance de la rente, est fixée à :
– 70 % si l'intéressé est âgé de moins de 50 ans ;
– 50 % s'il est âgé de 50 à 59 ans inclus ;
– 40 % s'il est âgé de 60 à 69 ans inclus ;
– 3[...]_
    - Reponse du LLM : _Okay, let's tackle this. The user is asking for the 'Fraction imposable de la rente viagère à titre onéreux pour les personnes âgées de 50 à 59 ans' which translates to the taxable fraction of an annuity for people aged 50 to 59. The parameter they're interested in is 'impot_revenu.calcul_revenus_imposables.deductions.abatviag.taux2'.   First, I need to find the relevant section in the provided text. The user mentioned that the value was 0.5 at a different validity date, so I need to check if the current text has a different value.  Looking through the text, section 6 discusses "rentes viagères constituées à titre onéreux" (annuities purchased for valuable consideration). It states that the taxable fraction is determined by the age of the annuitant when the payments start.   Specifically, the text lists: - 70% if under 50 - 50% for 50 to 59 years old - 40% for 60 to 69 - 30% for over 69  The user is asking about the 50-59 age group, which is 50% here. However, the system requires this as a decimal. 50% becomes 0.5.   The previous value was also 0.5, but the user is checking if there's a change. The current text still states 50%, so the value remains 0.5. There's no mention of a different rate in the provided text. Therefore, the answer should be 0.5.   ```json {     "valeur": 0.5 } ```_
    
* impot_revenu.calcul_revenus_imposables.deductions.abatviag.taux3
    - Description : Fraction imposable de la rente viagère à titre onéreux pour les personnes âgées de 60 à 69 ans
    - 0.4
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042978882/1979-07-01/) de type CODE
    - Extrait : _[...]s organes compétents, sont réduits, pour le calcul de l'impôt sur le revenu, d'un abattement égal à 40 % de leur montant brut perçu ;
3° Les dispositions du 2° ne s'appliquent pas :
a. Aux produits de[...]_
    - Reponse du LLM : _Okay, let's tackle this query. The user is asking for the value of 'Fraction imposable de la rente viagère à titre onéreux pour les personnes âgées de 60 à 69 ans' which corresponds to 'impot_revenu.calcul_revenus_imposables.deductions.abatviag.taux3'. The previous value was 0.4, but they want the current one from the provided text.  First, I need to locate the relevant section in the text. The user mentioned it's about viager (life annuity) for people aged 60-69. Looking through the text, section 6 discusses "rentes viagères constituées à titre onéreux".   In paragraph 6, it lists the fractions based on age: - 70% for under 50 - 50% for 50-59 - 40% for 60-69 - 30% for over 69  So for 60-69 ans, it's 40%, which is 0.4. But wait, the user says the previous value was 0.4 and asks if there's a change. However, the text here states 40% for that age group. The current text hasn't changed that value. The user might be checking if there's an update, but according to the provided text, it's still 40%.   I need to confirm that the text provided is the latest. Since the user provided this text, and in it the rate is 40%, the answer should be 0.4. The previous value was also 0.4, so maybe there's no change. But the user is asking for the current value in the given text, which is 0.4. So the answer is 0.4.   {     "valeur": 0.4 }_
    
* impot_revenu.calcul_revenus_imposables.charges_deductibles.pensions_alimentaires.taux_jgt_2006
    - Description : Coefficient de réévaluation des pensions alimentaires versées en vertu d'une décision de justice devenue définitive avant le 1er janvier 2006
    - 1.25
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006307989/2007-01-01/) de type CODE
    - Extrait : _[...]alisation ou placements de même nature mentionnés au 6° de l'article 120 et au 1° du I de l'article 125-0 A, attachés à des primes versées jusqu'au 26 septembre 2017 et n'ayant pas supporté le prélève[...]_
    - Reponse du LLM : _Okay, let's tackle this. The user is asking about the 'Coefficient de réévaluation des pensions alimentaires versées en vertu d'une décision de justice devenue définitive avant le 1er janvier 2006'. The specific parameter they're interested in is 'impot_revenu.calcul_revenus_imposables.charges_deductibles.pensions_alimentaires.taux_jgt_2006'.   First, I need to look through the provided legal text to find any mention of pensions alimentaires (alimony) and coefficients related to revaluation. The user mentioned that the value at another validity date was 1.25, so I should check if there's a coefficient of 1.25 mentioned here.  Looking at the text, section 7 says: "Le montant des revenus et charges énumérés ci-après, retenu pour le calcul de l'impôt selon les modalités prévues à l'article 197, est multiplié par un coefficient de 1,25." Then, point 3° of section 7 refers to "sommes mentionnées au 2° du II de l'article 156 versées en vertu d'une décision de justice devenue définitive avant le 1er janvier 2006".   The key here is that the coefficient 1.25 is applied to the amounts mentioned in article 156, II, 2°, which are the alimony payments under a court decision finalized before January 1, 2006. The text explicitly states that these sums are multiplied by 1.25. Since the user is asking for the coefficient, the value is 1.25. However, the system requires percentages in decimal form, so 1.25 would be converted to 1.25 (since it's a multiplier, not a percentage rate). Wait, but the example given in the instructions mentions converting 25% to 0.25. However, in this case, the coefficient is 1.25, which is a multiplier, not a percentage. The user's example shows that a 10% deduction is written as 0.1. But here, the coefficient is a multiplication factor, so 1.25 remains 1.25.   But wait, the user's instruction says: "Notez bien que les pourcentage sont exprimés sous forme mathématique, donc une valeur de 25% dans le texte de loi sera noté 0.25 dans notre système." So if the text says "coefficient de 1.25", that's already a mathematical form, not a percentage. So we don't need to convert it. The coefficient is 1.25, so the value is 1.25.   Therefore, the answer should be 1.25. Let me double-check the text again. Yes, section 7 states the coefficient is 1.25, and point 3° refers to the specific case of alimony payments under court decisions before 2006. So the correct value is 1.25.   ```json {     "valeur": 1.25 } ```_