### PR TITLE
Params/maj last value still valid on ppa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 169.18.2 [2464](https://github.com/openfisca/openfisca-france/pull/2464)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa`.*
+* Détails :
+  - Corrige et ajoute des références pour certains paramètres de la prime d'activité
+  - Mets à jour des `last_value_still_valid_on` pour certains paramètres de la prime d'activité
+
+
 ### 169.18.1 [2445](https://github.com/openfisca/openfisca-france/pull/2445)
 
 * Changement mineur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Changement mineur.
 * Périodes concernées : toutes.
-* Zones impactées : `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa`.*
+* Zones impactées : `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa`
 * Détails :
   - Corrige et ajoute des références pour certains paramètres de la prime d'activité
   - Mets à jour des `last_value_still_valid_on` pour certains paramètres de la prime d'activité

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_cond/age_min.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_cond/age_min.yaml
@@ -1,16 +1,17 @@
 description: Âge minimal pour bénéficier de la prime pour l'activité (PPA)
 values:
-  2015-10-01:
+  2016-01-01:
     value: 18
 metadata:
   short_label: Âge minimal
+  last_value_still_valid_on: 2025-03-07
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   unit: year
   reference:
-    2015-10-01:
-    - title: Article D843-1 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673885/
-    - title: Décret 2015-1710 du 21/12/2015, art. 2
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000031665094
+    2016-01-01:
+    - title: Article L842-2 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031087615
+    - title: Loi n°2015-994 du 17/08/2015 realtive au dialogue social et à l'emploi, article 57
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000031046223
   official_journal_date:
-    2015-10-01: "2015-12-22"
+    2016-01-01: "2015-08-18"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_cond/age_min.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_cond/age_min.yaml
@@ -1,6 +1,6 @@
 description: Âge minimal pour bénéficier de la prime pour l'activité (PPA)
 values:
-  2016-01-01:
+  2015-10-01:
     value: 18
 metadata:
   short_label: Âge minimal
@@ -8,10 +8,12 @@ metadata:
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   unit: year
   reference:
-    2016-01-01:
+    2015-10-01:
     - title: Article L842-2 du Code de la sécurité sociale
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031087615
     - title: Loi n°2015-994 du 17/08/2015 realtive au dialogue social et à l'emploi, article 57
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000031046223
   official_journal_date:
-    2016-01-01: "2015-08-18"
+    2015-10-01: "2015-08-18"
+  notes:
+    2015-10-01: La date est mise en octobre 2015 afin de pouvoir calculer la prime d'activité à partir du 1e janvier 2016 dans openfisca france

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_cond/age_min.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_cond/age_min.yaml
@@ -11,7 +11,7 @@ metadata:
     2015-10-01:
     - title: Article L842-2 du Code de la sécurité sociale
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031087615
-    - title: Loi n°2015-994 du 17/08/2015 realtive au dialogue social et à l'emploi, article 57
+    - title: Loi n°2015-994 du 17/08/2015 relative au dialogue social et à l'emploi, article 57
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000031046223
   official_journal_date:
     2015-10-01: "2015-08-18"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_cond/seuil_aah_activite.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_cond/seuil_aah_activite.yaml
@@ -1,7 +1,14 @@
 description: Revenu d'activité minimal perçu pour que l'AAH d'un individu soit considéré comme un revenu d'activité, en multiple du smic horaire brut
 values:
-  2015-10-01:
+  2016-01-01:
     value: 29
 metadata:
   short_label: Seuil AAH activité
+  last_value_still_valid_on: "2025-03-07"
   unit: smic_horaire_brut
+  reference:
+    2016-01-01:
+    - title: Article D843-4 du code de la sécurité sociale (créé en 2018)
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036579172
+    - title: Article L842-8 du code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000033013343/2025-03-07/

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_cond/seuil_aah_activite.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_cond/seuil_aah_activite.yaml
@@ -1,13 +1,13 @@
 description: Revenu d'activité minimal perçu pour que l'AAH d'un individu soit considéré comme un revenu d'activité, en multiple du smic horaire brut
 values:
-  2016-01-01:
+  2015-10-01:
     value: 29
 metadata:
   short_label: Seuil AAH activité
   last_value_still_valid_on: "2025-03-07"
   unit: smic_horaire_brut
   reference:
-    2016-01-01:
+    2015-10-01:
     - title: Article D843-4 du code de la sécurité sociale (créé en 2018)
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036579172
     - title: Article L842-8 du code de la sécurité sociale

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/seuil_bonification.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/seuil_bonification.yaml
@@ -4,15 +4,15 @@ values:
     value: 59
 metadata:
   short_label: Seuil salaire minimal
-  last_value_still_valid_on: "2022-08-03"
+  last_value_still_valid_on: "2025-03-07"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_seuil_min
   unit: currency
   reference:
     2016-01-01:
-    - title: Article D843-1 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673885/
-    - title: Décret 2015-1710 du 21/12/2015, art. 2 (crée art. D843-1 du CSS)
+    - title: Article D843-2 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037873473
+    - title: Décret 2015-1710 du 21/12/2015, art. 2 (crée art. D843-2 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000031665094
   official_journal_date:
     2016-01-01: "2015-12-22"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/seuil_max_bonification.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/seuil_max_bonification.yaml
@@ -14,7 +14,7 @@ metadata:
     - title: Décret 2015-1710 du 21/12/2015, art. 2 (crée art. D843-1 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000031665094
     - title: Article D843-2 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037873473
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673887/2016-01-01/
     2018-10-01:
     - title: Article D843-2 du Code de la sécurité sociale
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037873473

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/seuil_max_bonification.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/seuil_max_bonification.yaml
@@ -6,23 +6,25 @@ values:
     value: 120
 metadata:
   short_label: Seuil salaire bonification max
-  last_value_still_valid_on: "2022-08-03"
+  last_value_still_valid_on: "2025-03-07"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_seuil_max
   reference:
     2016-01-01:
     - title: Décret 2015-1710 du 21/12/2015, art. 2 (crée art. D843-1 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000031665094
-    - title: Article D843-1 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673885/
-    2019-01-01:
-      title: Décret 2018-1197 du 21/12/2018, art. 1
+    - title: Article D843-2 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037873473
+    2018-10-01:
+    - title: Article D843-2 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037873473
+    - title: Décret nº2018-1197 du 21/12/2018
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037846000
   official_journal_date:
     2016-01-01: "2015-12-22"
-    2019-01-01: "2018-12-22"
+    2018-10-01: "2018-12-22"
   notes:
     2016-01-01:
     - title: Création de la prime d'activité.
-    2019-01-01:
+    2018-10-01:
     - title: Revalorisation de la prime d'activité suite à la loi 2018-1213 du 24/12/2018 portant mesures d'urgence économique et sociale. La prime d'activité augmente de 90 euros au niveau du Smic, via une augmentation de la bonification individuelle.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/taux_bonification_max.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/taux_bonification_max.yaml
@@ -6,24 +6,26 @@ values:
     value: 0.29101
 metadata:
   short_label: Montant maximal de la bonification (en % de la base RSA)
-  last_value_still_valid_on: "2022-08-03"
+  last_value_still_valid_on: "2025-03-07"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_bonification
   unit: /1
   reference:
     2016-01-01:
-    - title: Article D843-1 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673885/
+    - title: Article D843-2 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037873473
     - title: Décret 2015-1710 du 21/12/2015, art. 2 (crée art. D843-1 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000031665094
-    2019-01-01:
-      title: Décret nº2018-1197 du 21/12/2018
+    2018-10-01:
+    - title: Article D843-2 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037873473
+    - title: Décret nº2018-1197 du 21/12/2018
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000037846000
   official_journal_date:
     2016-01-01: "2015-12-22"
-    2019-01-01: "2018-12-22"
+    2018-10-01: "2018-12-22"
   notes:
     2016-01-01:
     - title: Création de la prime d'activité.
-    2019-01-01:
+    2018-10-01:
     - title: Revalorisation de la prime d'activité suite à la loi 2018-1213 du 24/12/2018 portant mesures d'urgence économique et sociale. La prime d'activité augmente de 90 euros au niveau du Smic, via une augmentation de la bonification individuelle.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/taux_bonification_max.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/taux_bonification_max.yaml
@@ -13,7 +13,7 @@ metadata:
   reference:
     2016-01-01:
     - title: Article D843-2 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037873473
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673887/2016-01-01/
     - title: Décret 2015-1710 du 21/12/2015, art. 2 (crée art. D843-1 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000031665094
     2018-10-01:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_isolement/femmes_enceintes.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_isolement/femmes_enceintes.yaml
@@ -4,13 +4,15 @@ values:
     value: 1.28412
 metadata:
   short_label: Parents isolés et femmes enceintes
-  last_value_still_valid_on: "2022-08-03"
+  last_value_still_valid_on: "2025-03-07"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_maj5
   unit: /1
   reference:
     2016-01-01:
-      title: Décret 2015-1710 du 21/12/2015, art. 2 (crée art. D843-1 du CSS)
+    - title: Article D843-1 du code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673885
+    - title: Décret 2015-1710 du 21/12/2015, art. 2 (crée art. D843-1 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000031665104
   official_journal_date:
     2016-01-01: "2015-12-22"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_isolement/par_enfant_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_isolement/par_enfant_charge.yaml
@@ -4,13 +4,15 @@ values:
     value: 0.42804
 metadata:
   short_label: Majoration par enfant à charge
-  last_value_still_valid_on: "2022-08-03"
+  last_value_still_valid_on: "2025-03-07"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_maj6
   unit: /1
   reference:
     2016-01-01:
-      title: Décret 2015-1710 du 21/12/2015, art. 2 (crée art. D843-1 du CSS)
+    - title: Article D843-1 du code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673885
+    - title: Décret 2015-1710 du 21/12/2015, art. 2 (crée art. D843-1 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000031665104
   official_journal_date:
     2016-01-01: "2015-12-22"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/couple_1_enfant_2e_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/couple_1_enfant_2e_enfant.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.3
 metadata:
   short_label: Majoration par personne supplémentaire (au-delà de la 1ère)
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-03-07"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_maj3
   unit: /1

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/couples_seul_avec_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/couples_seul_avec_enfant.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.5
 metadata:
   short_label: Majoration pour la 1ère personne supplémentaire
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-03-07"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_maj1
   unit: /1

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/par_enfant_supplementaire.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_montant_maximal/par_enfant_supplementaire.yaml
@@ -4,7 +4,7 @@ values:
     value: 0.4
 metadata:
   short_label: Majoration par personne supplémentaire (au-delà de la 3ème)
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-03-07"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_maj4
   unit: /1

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_ressources_revenus_activite.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_ressources_revenus_activite.yaml
@@ -13,7 +13,7 @@ metadata:
   reference:
     2016-01-01:
     - title: Article D843-3 du code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037462909
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673883/2016-01-01/
     - title: Décret 2015-1710 du 21/12/2015, art. 2 (crée art. D843-1 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000031665094
     2018-08-01:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_ressources_revenus_activite.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_ressources_revenus_activite.yaml
@@ -6,19 +6,21 @@ values:
     value: 0.61
 metadata:
   short_label: pente de la PPA
-  last_value_still_valid_on: "2022-08-03"
+  last_value_still_valid_on: "2025-03-07"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_maj_revenu
   unit: /1
   reference:
     2016-01-01:
-    - title: Article D843-1 du Code de la sécurité sociale
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031673885/
+    - title: Article D843-3 du code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037462909
     - title: Décret 2015-1710 du 21/12/2015, art. 2 (crée art. D843-1 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000031665094
     2018-08-01:
-      title: Décret 2018-836 du 03/10/2018, art. 1 et 2
-      href: https://www.legifrance.gouv.fr/eli/decret/2018/10/3/SSAA1822062D/jo/texte
+    - title: Article D843-3 du code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037462909
+    - title: Décret 2018-836 du 03/10/2018, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000037460547
   official_journal_date:
     2016-01-01: "2015-12-22"
     2018-08-01: "2018-10-04"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/montant_de_base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/montant_de_base.yaml
@@ -62,8 +62,10 @@ metadata:
       title: Décret n° 2023-343 du 4 mai 2023, article 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000047521600
     2024-04-01:
-      title: Décret n° 2024-403 du 1er mai 2024, article 1
+    - title: Décret n° 2024-403 du 1er mai 2024, article 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000049490767
+    - title: Article L842-3 du code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037994814
   official_journal_date:
     2016-01-01: "2015-12-22"
     2016-04-01: "2016-05-03"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/montant_minimum_verse.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/montant_minimum_verse.yaml
@@ -4,7 +4,7 @@ values:
     value: 15
 metadata:
   short_label: Montant minimum
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-03-07"
   label_en: "Active solidarity income - Activity premium (PPA) : minimal amount"
   ipp_csv_id: pa_montant_min
   unit: currency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.18.1"
+version = "169.18.2"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
*  Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa`.*
* Détails :
  - Corrige et ajoute des références pour certains paramètres de la prime d'activité
  - Mets à jour des `last_value_still_valid_on` pour certains paramètres de la prime d'activité

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).
