### PR TITLE
Date de fin pour dons_patrimoine_religieux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 170.1.0 [2469](https://github.com/openfisca/openfisca-france/pull/2469)
+
+* Correction d'un crash.
+* Périodes concernées : à partir du 01/01/2026.
+* Zones impactées : openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_deplafonnees.py.
+* Détails :
+  - Les dons au patrimoine religieux prennent fin le 31 décembre 2025. Le paramètre était bien éteint mais pas dans la variable.
+
 ### 170.0.2 [2480](https://github.com/openfisca/openfisca-france/pull/2480)
 
 * Amélioration technique.

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_deplafonnees.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_deplafonnees.py
@@ -505,6 +505,9 @@ class dfppce(Variable):
         '''
         Dons versés à d’autres organismes d’intérêt général,
         aux associations d’utilité publique, aux candidats aux élections (2021)
+        
+        2026-01-01 : On retire la réduction exceptionnelle pour les dons aux patrimoines religieux,
+            voir Article 30 de la LF 2024 : https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727383
         '''
         rni = foyer_fiscal('rni', period)
         f7uf = foyer_fiscal('f7uf', period)

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_deplafonnees.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_deplafonnees.py
@@ -505,7 +505,6 @@ class dfppce(Variable):
         '''
         Dons versés à d’autres organismes d’intérêt général,
         aux associations d’utilité publique, aux candidats aux élections (2021)
-        
         2026-01-01 : On retire la réduction exceptionnelle pour les dons aux patrimoines religieux,
             voir Article 30 de la LF 2024 : https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727383
         '''

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_deplafonnees.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_deplafonnees.py
@@ -501,6 +501,37 @@ class dfppce(Variable):
 
         return red_7ud_7va + red_7uj + P.taux_reduction * min_(base, max)
 
+    def formula_2026_01_01(foyer_fiscal, period, parameters):
+        '''
+        Dons versés à d’autres organismes d’intérêt général,
+        aux associations d’utilité publique, aux candidats aux élections (2021)
+        '''
+        rni = foyer_fiscal('rni', period)
+        f7uf = foyer_fiscal('f7uf', period)
+        f7uh = foyer_fiscal('f7uh', period)
+        f7xs = foyer_fiscal('f7xs', period)
+        f7xt = foyer_fiscal('f7xt', period)
+        f7xu = foyer_fiscal('f7xu', period)
+        f7xw = foyer_fiscal('f7xw', period)
+        f7xy = foyer_fiscal('f7xy', period)
+        f7va = foyer_fiscal('f7va', period)
+        f7ud = foyer_fiscal('f7ud', period)
+        f7vc = foyer_fiscal('f7vc', period)
+
+        P = parameters(period).impot_revenu.calcul_reductions_impots.dons
+        plafond_reduction_don_coluche = parameters(period).impot_revenu.calcul_reductions_impots.dons.dons_coluche.plafond
+        taux_donapd = parameters(period).impot_revenu.calcul_reductions_impots.dons.dons_coluche.taux
+
+        red_7ud_7va = min_(plafond_reduction_don_coluche, f7va + f7ud) * taux_donapd
+        report_f7va_f7ud = max_(0, f7va + f7ud - plafond_reduction_don_coluche)
+
+        dons_partipol = min_(P.dons_aux_partis_politiques.plafond_foyer, f7uh)
+
+        base = f7uf + f7vc + f7xs + f7xt + f7xu + f7xw + f7xy + report_f7va_f7ud + dons_partipol
+        max = P.plafond_dons * rni
+
+        return red_7ud_7va + P.taux_reduction * min_(base, max)
+
 
 class reduction_enfants_scolarises(Variable):
     value_type = float

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "170.0.2"
+version = "170.1.0"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/calculateur_impots/yaml/reduc_dfppce.yaml
+++ b/tests/calculateur_impots/yaml/reduc_dfppce.yaml
@@ -423,6 +423,36 @@
     reductions: 750.0
     rfr: 45000.0
 
+
+- name: reduc_dons_patrimoine_religieux_fin
+  period: 2026
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      caseF: false
+      declarants:
+      - ind0
+      f7uj: 1000
+    individus:
+      ind0:
+        activite: actif
+        date_naissance: '1970-01-01'
+        salaire_imposable: 50000.0
+        statut_marital: celibataire
+    famille:
+      parents:
+      - ind0
+    menage:
+      personne_de_reference: ind0
+  output:
+    iai: 6665.0
+    impot_revenu_restant_a_payer: -6665.0
+    nbptr: 1.0
+    protection_patrimoine_naturel: 0.0
+    rbg: 45000.0
+    reductions: 0.0
+    rfr: 45000.0
+
 - name: reduc_dfppce
   period: 2021
   absolute_error_margin: 1


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : à partir du 01/01/2026.
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/reductions_impot_deplafonnees.py`.
* Détails :
  - Les dons au patrimoine religieux prennent fin le 31 décembre 2025. Le paramètre était bien éteint mais pas dans la variable.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
