### PR TITLE
Corrige l'erreur de module 'pkg_resources' introuvable #2437.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 169.18.5 [2470](https://github.com/openfisca/openfisca-france/pull/2470)
+
+* Changement technique.
+* Périodes concernées : aucune.
+* Zones impactées :
+  - `pyproject.toml`
+* Détails :
+  - Corrige l'erreur de module 'pkg_resources' introuvable #2437.
+
 ### 169.18.5 [2443](https://github.com/openfisca/openfisca-france/pull/2443)
 
 * Changement mineur.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.18.5"
+version = "169.18.6"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]
@@ -20,7 +20,8 @@ classifiers = [
 requires-python = ">= 3.9"
 dependencies = [
     "numpy >=1.24.3, <2",
-    "openfisca-core[web-api] >=43, <44"
+    "openfisca-core[web-api] >=43, <44",
+    "setuptools"
 ]
 
 [project.urls]
@@ -31,7 +32,7 @@ Issues = "https://github.com/openfisca/openfisca-france/issues"
 Changelog = "https://github.com/openfisca/openfisca-france/blob/main/CHANGELOG.md"
 
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées :
  - `pyproject.toml`
* Détails :
  - Corrige l'erreur de module 'pkg_resources' introuvable #2437.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Will close  #2437
