### PR TITLE
[paramètres] last_value_still_valid_on et références pour le SFT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 169.19.0 [2472](https://github.com/openfisca/openfisca-france/pull/2472)
+
+* Changement mineur.
+* Périodes concernées : depuis 2024.
+* Zones impactées :
+  - `openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/*`
+* Détails :
+  - Mise à jour des plafonds et `last_value_still_valid_on` pour le SFT.
+
 ### 169.18.5 [2443](https://github.com/openfisca/openfisca-france/pull/2443)
 
 * Changement mineur.

--- a/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/indice_majore_minimal.yaml
+++ b/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/indice_majore_minimal.yaml
@@ -67,7 +67,6 @@ values:
 metadata:
   last_value_still_valid_on: "2025-03-25"
   short_label: Traitement minimal dans la FP
-  last_value_still_valid_on: "2023-05-25"
   label_en: Minimum wage, civil servants
   unit: /1
   reference:

--- a/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/indice_majore_minimal.yaml
+++ b/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/indice_majore_minimal.yaml
@@ -62,7 +62,10 @@ values:
     value: 353
   2023-05-01:
     value: 361
+  2024-01-01:
+    value: 366
 metadata:
+  last_value_still_valid_on: "2025-03-25"
   short_label: Traitement minimal dans la FP
   last_value_still_valid_on: "2023-05-25"
   label_en: Minimum wage, civil servants
@@ -72,7 +75,7 @@ metadata:
       title: Décret n° 86-167 du 31 janvier 1986 modifiant le décret n° 85-1148 du 24 octobre 1985 relatif à la rémunération des personnels civils et militaires de l’État et des personnels des collectivités territoriales
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000518259
     1985-11-01:
-      title: Décret n° 85-1148 du 24 octobre 1985 relatif à la rémunération des personnels civils et militaires de ‎l'Etat et des personnels des collectivités territoriales
+      title: Décret n° 85-1148 du 24 octobre 1985 relatif à la rémunération des personnels civils et militaires de l'Etat et des personnels des collectivités territoriales
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000872483
     1987-08-01:
       title: Décret n° 87-589 du 30 juillet 1987 portant modification du décret n° 85-1148 du 24 octobre 1985 et majoration de la rémunération des personnels civils et militaires de l’État et des personnels des collectivités territoriales à compter du 1er août 1987
@@ -164,6 +167,11 @@ metadata:
     2023-05-01:
       title: Décret n° 2023-312 du 26 avril 2023 portant relèvement du minimum de traitement dans la fonction publique
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000047496223
+    2024-01-01:
+      - title: Décret 85-1148 du 24/10/1985 - art. 8
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000047781343/2024-01-01/
+      - title: Décret n° 2023-519 du 28 juin 2023 portant majoration de la rémunération des personnels
+        href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000047749229
   official_journal_date:
     1985-07-01: "1986-02-07"
     1985-11-01: "1985-11-05"
@@ -196,3 +204,4 @@ metadata:
     2022-05-01: "2022-04-21"
     2023-01-01: "2022-12-23"
     2023-05-01: "2023-04-27"
+    2024-01-01: "2023-06-28"

--- a/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/im_plafond.yaml
+++ b/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/im_plafond.yaml
@@ -8,7 +8,10 @@ values:
     value: 716
   2006-11-01:
     value: 717
+  2024-01-01:
+    value: 722
 metadata:
+  last_value_still_valid_on: "2025-03-25"
   short_label: IM Plafond
   label_en: Maximal increased index
   ipp_csv_id: im_plafond
@@ -24,8 +27,17 @@ metadata:
     2006-11-01:
       title: Décret 2006-1283 du 19/10/2006
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000615828
+    2024-01-01:
+      - title: Décret 85-1148 du 24/10/1985 - art. 10 bis
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006454606/1985-11-01
+      - title: Décret n° 2023-519 du 28 juin 2023 portant majoration de la rémunération des personnels
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000047780477/2024-01-01
   official_journal_date:
     1985-11-01: "1985-11-05"
     1988-02-07: "1986-02-07"
     1988-03-01: "1988-03-13"
     2006-11-01: "2006-10-20"
+    2024-01-01: "2023-06-28"
+documentation: |-
+  Le texte de référence indique les plafonds en indice brut, alors qu'il s'agit ici de l'indice majoré. La correspondance est la suivante : https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000047780477/2024-01-01
+  Donc l'indice brut 879 mentionné dans Article 10 bis, correspond à l'indice majoré 722.

--- a/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/im_plancher.yaml
+++ b/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/im_plancher.yaml
@@ -20,7 +20,10 @@ values:
     value: 448
   2006-11-01:
     value: 449
+  2024-01-01:
+    value: 454
 metadata:
+  last_value_still_valid_on: "2025-03-25"
   short_label: Indice majoré plancher
   label_en: Lower increased index
   ipp_csv_id: im_plancher
@@ -52,6 +55,11 @@ metadata:
     2006-11-01:
       title: Décret 2006-1283 du 19/10/2006
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000615828
+    2024-01-01:
+      - title: Décret 85-1148 du 24/10/1985 - art. 10 bis
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006454606/1985-11-01
+      - title: Décret n° 2023-519 du 28 juin 2023 portant majoration de la rémunération des personnels
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000047780477/2024-01-01
   official_journal_date:
     1985-11-01: "1985-11-05"
     1988-02-07: "1986-02-07"
@@ -63,3 +71,7 @@ metadata:
     1999-03-20: "1999-06-13"
     2002-01-01: "2001-09-29"
     2006-11-01: "2006-10-20"
+    2024-01-01: "2023-06-28"
+documentation: |-
+  Le texte de référence indique les plafonds en indice brut, alors qu'il s'agit ici de l'indice majoré. La correspondance est la suivante : https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000047780477/2024-01-01
+  Donc l'indice brut 524 mentionné dans Article 10 bis, correspond à l'indice majoré 454.

--- a/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/part_fixe/deux_enfants.yaml
+++ b/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/part_fixe/deux_enfants.yaml
@@ -7,6 +7,7 @@ values:
   2002-01-01:
     value: 10.67
 metadata:
+  last_value_still_valid_on: "2025-03-25"
   short_label: Part pour deux enfants
   label_en: Family income supplement (SFT)
   ipp_csv_id: enf2
@@ -18,8 +19,10 @@ metadata:
     1988-02-07:
       title: Décret 86-167 du 31/01/1986, art. 1 VI
     2002-01-01:
-      title: Décret 2001-895 du 26/09/2001
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000773694&categorieLien=id
+      - title: Décret 85-1148 du 24/10/1985 - art. 10 bis
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006454606/2002-01-01/
+      - title: Décret 2001-895 du 26/09/2001
+        href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000773694
   official_journal_date:
     1985-11-01: "1985-11-05"
     1988-02-07: "1986-02-07"

--- a/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/part_fixe/enfant_supplementaire.yaml
+++ b/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/part_fixe/enfant_supplementaire.yaml
@@ -7,19 +7,22 @@ values:
   2002-01-01:
     value: 4.57
 metadata:
+  last_value_still_valid_on: "2025-03-25"
   short_label: Part fixe par enfant supplémentaire
   label_en: Family income supplement (SFT)
   ipp_csv_id: enf4
   unit: currency
   reference:
     1985-11-01:
-      title: Décret 85-1148 du 24/10/1985 - art. 10
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006454594&cidTexte=JORFTEXT000000872483
+      - title: Décret 85-1148 du 24/10/1985 - art. 10
+        href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006454594&cidTexte=JORFTEXT000000872483
     1988-02-07:
       title: Décret 86-167 du 31/01/1986, art. 1 VI
     2002-01-01:
-      title: Décret 2001-895 du 26/09/2001
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000773694&categorieLien=id
+      - title: Décret 85-1148 du 24/10/1985 - art. 10 bis
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006454606/2002-01-01/
+      - title: Décret 2001-895 du 26/09/2001
+        href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000773694
   official_journal_date:
     1985-11-01: "1985-11-05"
     1988-02-07: "1986-02-07"

--- a/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/part_fixe/un_enfant.yaml
+++ b/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/part_fixe/un_enfant.yaml
@@ -5,17 +5,20 @@ values:
   2002-01-01:
     value: 2.29
 metadata:
+  last_value_still_valid_on: "2025-03-25"
   short_label: Part fixe pour un enfant
   label_en: Family income supplement (SFT)
   ipp_csv_id: enf1
   unit: currency
   reference:
     1985-11-01:
-      title: Décret 85-1148 du 24/10/1985 - art. 10
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006454594&cidTexte=JORFTEXT000000872483
+      - title: Décret 85-1148 du 24/10/1985 - art. 10
+        href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006454594&cidTexte=JORFTEXT000000872483
     2002-01-01:
-      title: Décret 2001-895 du 26/09/2001
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000773694&categorieLien=id
+      - title: Décret 85-1148 du 24/10/1985 - art. 10 bis
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006454606/2002-01-01/
+      - title: Décret 2001-895 du 26/09/2001
+        href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000773694
   official_journal_date:
     1985-11-01: "1985-11-05"
     2002-01-01: "2001-09-29"

--- a/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/part_proportionnelle/deux_enfants.yaml
+++ b/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/part_proportionnelle/deux_enfants.yaml
@@ -3,13 +3,16 @@ values:
   1985-11-01:
     value: 0.03
 metadata:
+  last_value_still_valid_on: "2025-03-25"
   short_label: Taux pour deux enfants
   label_en: Family income supplement (SFT)
   ipp_csv_id: txenf2
   unit: /1
   reference:
     1985-11-01:
-      title: Décret 85-1148 du 24/10/1985 - art. 10
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006454594&cidTexte=JORFTEXT000000872483
+      - title: Décret 85-1148 du 24/10/1985 - art. 10 bis
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006454606/1985-11-01/
+      - title: Décret 85-1148 du 24/10/1985 - art. 10
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006454603
   official_journal_date:
     1985-11-01: "1985-11-05"

--- a/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/part_proportionnelle/enfant_supplementaire.yaml
+++ b/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/part_proportionnelle/enfant_supplementaire.yaml
@@ -3,13 +3,16 @@ values:
   1985-11-01:
     value: 0.06
 metadata:
+  last_value_still_valid_on: "2025-03-25"
   short_label: Par enfant supplémentaire au delà de 3 enfants
   label_en: Family income supplement (SFT)
   ipp_csv_id: txenf4
   unit: /1
   reference:
     1985-11-01:
-      title: Décret 85-1148 du 24/10/1985 - art. 10
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006454594&cidTexte=JORFTEXT000000872483
+      - title: Décret 85-1148 du 24/10/1985 - art. 10 bis
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006454606/1985-11-01/
+      - title: Décret 85-1148 du 24/10/1985 - art. 10
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006454603
   official_journal_date:
     1985-11-01: "1985-11-05"

--- a/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/part_proportionnelle/trois_enfants.yaml
+++ b/openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/part_proportionnelle/trois_enfants.yaml
@@ -3,13 +3,16 @@ values:
   1985-11-01:
     value: 0.08
 metadata:
+  last_value_still_valid_on: "2025-03-25"
   short_label: Taux pour trois enfants
   label_en: Family income supplement (SFT)
   ipp_csv_id: txenf3
   unit: /1
   reference:
     1985-11-01:
-      title: Décret 85-1148 du 24/10/1985 - art. 10
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006454594&cidTexte=JORFTEXT000000872483
+      - title: Décret 85-1148 du 24/10/1985 - art. 10 bis
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006454606/1985-11-01/
+      - title: Décret 85-1148 du 24/10/1985 - art. 10
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006454603
   official_journal_date:
     1985-11-01: "1985-11-05"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.18.5"
+version = "169.19.0"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/parameters/marche_travail/remuneration_dans_fonction_publique/sft/*`.
* Détails :
  - Mise à jour des références

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
