### PR TITLE
[paramètres] last_value_still_valid_on et références de la PPV et du micro-foncier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 169.19.2 [2473](https://github.com/openfisca/openfisca-france/pull/2473)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `openfisca_france/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/*`
+  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microfoncier/*`
+* Détails :
+  - Mise à jour des `last_value_still_valid_on` et références de la PPV et du micro-foncier.
+
 ## 169.19.1 [2476](https://github.com/openfisca/openfisca-france/pull/2476)
 
 * Changement mineur.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microfoncier/plafond_recettes.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microfoncier/plafond_recettes.yaml
@@ -8,6 +8,7 @@ values:
     value: 15000
 metadata:
   short_label: Plafond de recettes
+  last_value_still_valid_on: "2025-03-25"
   ipp_csv_id: plaf_micro_foncier
   unit: currency_next_year
   reference:
@@ -18,8 +19,10 @@ metadata:
       title: Loi 99-1172 du 30/12/1999 (LF pour 2000)
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000762233
     2001-01-01:
-      title: Loi 2001-1275 du 28/12/2001 (LF pour 2002)
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000592233
+      - title: Code général des impôts - Art. 32
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048847610
+      - title: Loi 2001-1275 du 28/12/2001 (LF pour 2002) - Art. 12
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006321124
   official_journal_date:
     1997-01-01: "1997-12-31"
     1999-01-01: "1999-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microfoncier/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microfoncier/taux.yaml
@@ -8,6 +8,7 @@ values:
     value: 0.3
 metadata:
   short_label: Taux
+  last_value_still_valid_on: "2025-03-25"
   ipp_csv_id: abt_micro_fon
   unit: /1
   reference:
@@ -18,8 +19,10 @@ metadata:
       title: Loi 99-1172 du 30/12/1999 (LF pour 2000)
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000762233
     2006-01-01:
-      title: Loi 2006-1666 du 21/12/2006 (LF pour 2007)
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000615000
+      - title: Code général des impôts - Art. 32
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048847610
+      - title: Loi 2006-1666 du 21/12/2006 (LF pour 2007)
+        href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000615000
   official_journal_date:
     1997-01-01: "1997-12-31"
     1999-01-01: "1999-12-31"

--- a/openfisca_france/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/plafond_exoneration_avec_accord_interessement.yaml
+++ b/openfisca_france/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/plafond_exoneration_avec_accord_interessement.yaml
@@ -4,7 +4,7 @@ values:
     value: 6000
 metadata:
   short_label: Deuxième plafond d'exonération sous condition employeur
-  last_value_still_valid_on: "2024-03-13"
+  last_value_still_valid_on: "2025-03-25"
   unit: currency
   reference:
     2022-07-01:

--- a/openfisca_france/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/plafond_salaire.yaml
+++ b/openfisca_france/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/plafond_salaire.yaml
@@ -4,6 +4,7 @@ values:
     value: 3
 metadata:
   short_label: Salaire maximal d'éligibilité à la PPV, en nombre de Smic annuels
+  last_value_still_valid_on: "2025-03-25"
   unit: smic_annuel
   reference:
     2022-07-01:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "169.19.1"
+version = "169.19.2"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
   * Changement mineur.
    * Périodes concernées : 2025.
    * Zones impactées :
      - openfisca_france/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/*
      - openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microfoncier/*
    * Détails :
    - Mise à jour des `last_value_still_valid_on`, sur les paramètres dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.

----

    Ces changements :

    - Mise à jour de paramètre.

----

    Méthodologie :
    1. Récupère les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
    1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
    1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
    1. Vérifie la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
    1. Met à jour la `last_value_still_valid_on` à la date du jour.
    1. Crée un tableau récapitulatif pour faciliter la revue.

    Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

----

    Quelques conseils à prendre en compte :

    - [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
    - [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
    - [X] Documentez votre contribution avec des références législatives.
    - [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
    - [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
    - [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
    - [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
    
    Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme n'ayant pas changés depuis la date indiquée dans `last_value_still_valid_on`.

    Aide à la revue :
    
* marche_travail.primes_exceptionnelles.prime_partage_valeur.plafond_exoneration
    - Description : Plafond annuel d'exonération PPV (sous condition de rémunération)
    - 3000.0
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046188457/2022-08-18) de type LOI
    - Extrait : _[...]ans les conditions prévues aux II à IV du présent article sont exonérées, dans la limite globale de 3 000 € par bénéficiaire et par année civile, de toutes les cotisations sociales d'origine légale ou[...]_
    - Reponse du LLM : _La valeur de 'Plafond annuel d'exonération PPV (sous condition de rémunération)' est de 3000 €, mais il est également mentionné que la limite peut être portée à 6000 € pour les employeurs mettant en œuvre un dispositif d'intéressement ou de participation.  Cependant, la question demande la valeur sous condition de rémunération, qui est de 3000 €.  La réponse est donc : ``` {     "valeur": 3000.0 } ```_