### PR TITLE
[paramètres] last_value_still_valid_on pour la CSG et la CRDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# 170.0.1 [2423](https://github.com/openfisca/openfisca-france/pull/2423)
+
+* Changement mineur.
+* Périodes concernées : aucunes.
+* Zones impactées : `openfisca_france/parameters/taxation_capital/prelevements_sociaux/*`.
+* Détails :
+  - Mise à jour de la last_value_still_valid_on et des références.
+
 # 170.0.0 [2423](https://github.com/openfisca/openfisca-france/pull/2423)
 
 * Évolution du système socio-fiscal | Réorganisation des dossiers de paramètres des allocations logement

--- a/openfisca_france/parameters/taxation_capital/prelevements_sociaux/crds/produits_de_placement.yaml
+++ b/openfisca_france/parameters/taxation_capital/prelevements_sociaux/crds/produits_de_placement.yaml
@@ -3,9 +3,8 @@ values:
   1996-02-01:
     value: 0.005
 metadata:
-  last_value_still_valid_on: "2025-03-31"
   short_label: Produits de placement
-  last_value_still_valid_on: "1996-01-01"
+  last_value_still_valid_on: "2025-03-31"
   label_en: CRDS on financial income
   ipp_csv_id: tx_crds_rk_plac
   unit: /1

--- a/openfisca_france/parameters/taxation_capital/prelevements_sociaux/crds/produits_de_placement.yaml
+++ b/openfisca_france/parameters/taxation_capital/prelevements_sociaux/crds/produits_de_placement.yaml
@@ -3,6 +3,7 @@ values:
   1996-02-01:
     value: 0.005
 metadata:
+  last_value_still_valid_on: "2025-03-31"
   short_label: Produits de placement
   last_value_still_valid_on: "1996-01-01"
   label_en: CRDS on financial income
@@ -10,4 +11,5 @@ metadata:
   unit: /1
   reference:
     1996-02-01:
-      title: Ordonnance 96-50 du 24/01/1996, art. 15, 16 et 19
+      - title: Ordonnance 96-50 du 24/01/1996, art. 15, 16 et 19
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000041466982

--- a/openfisca_france/parameters/taxation_capital/prelevements_sociaux/crds/revenus_du_patrimoine.yaml
+++ b/openfisca_france/parameters/taxation_capital/prelevements_sociaux/crds/revenus_du_patrimoine.yaml
@@ -3,9 +3,8 @@ values:
   1996-02-01:
     value: 0.005
 metadata:
-  last_value_still_valid_on: "2025-03-31"
   short_label: Taux CRDS capital revenus du patrimoine
-  last_value_still_valid_on: "1996-01-01"
+  last_value_still_valid_on: "2025-03-31"
   label_en: CRDS on financial income
   ipp_csv_id: tx_crds_rk_patr
   unit: /1

--- a/openfisca_france/parameters/taxation_capital/prelevements_sociaux/crds/revenus_du_patrimoine.yaml
+++ b/openfisca_france/parameters/taxation_capital/prelevements_sociaux/crds/revenus_du_patrimoine.yaml
@@ -3,6 +3,7 @@ values:
   1996-02-01:
     value: 0.005
 metadata:
+  last_value_still_valid_on: "2025-03-31"
   short_label: Taux CRDS capital revenus du patrimoine
   last_value_still_valid_on: "1996-01-01"
   label_en: CRDS on financial income
@@ -10,4 +11,5 @@ metadata:
   unit: /1
   reference:
     1996-02-01:
-      title: Ordonnance 96-50 du 24/01/1996, art. 15, 16 et 19
+      - title: Ordonnance 96-50 du 24/01/1996, art. 15, 16 et 19
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000041466982

--- a/openfisca_france/parameters/taxation_capital/prelevements_sociaux/csg/taux_deductible/produits_de_placement.yaml
+++ b/openfisca_france/parameters/taxation_capital/prelevements_sociaux/csg/taux_deductible/produits_de_placement.yaml
@@ -10,7 +10,7 @@ values:
     value: 0.068
 metadata:
   short_label: Produits de placement
-  last_value_still_valid_on: "2024-05-14"
+  last_value_still_valid_on: "2025-03-31"
   label_en: CSG on financial income
   ipp_csv_id: tx_csg_ded_rk_plac
   unit: /1
@@ -24,10 +24,12 @@ metadata:
       title: Loi 2012-1509 du 29/12/2012, art. 9 (LF pour 2013)
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000026872653&cidTexte=JORFTEXT000026856853
     2018-01-01:
+    - title: Code de la sécurité sociale - art. L136-8
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546/2019-01-01/
     - title: Loi 2017-1836 du 30/12/2017 - art. 8 (V) (modifie l'art. L136-8 du CSS)
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036358456&cidTexte=JORFTEXT000036339090
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000042683772
     - title: Loi 2017-1837 du 30/12/2017 - art. 67 (modifie l'art. 154 quinquies)
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036377512&cidTexte=JORFTEXT000036339197
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036377512
     - title: LOI 2018-1203 du 22/12/2018, art. 26 (modifie l'art. L136-8 du CSS)
   official_journal_date:
     1990-01-01: "1990-12-30"

--- a/openfisca_france/parameters/taxation_capital/prelevements_sociaux/csg/taux_deductible/revenus_du_patrimoine.yaml
+++ b/openfisca_france/parameters/taxation_capital/prelevements_sociaux/csg/taux_deductible/revenus_du_patrimoine.yaml
@@ -14,7 +14,7 @@ values:
     value: 0.068
 metadata:
   short_label: Revenus du patrimoine
-  last_value_still_valid_on: "2017-01-01"
+  last_value_still_valid_on: "2025-03-31"
   label_en: CSG on financial income
   ipp_csv_id: tx_csg_ded_rk_patr
   unit: /1

--- a/openfisca_france/parameters/taxation_capital/prelevements_sociaux/csg/taux_global/produits_de_placement.yaml
+++ b/openfisca_france/parameters/taxation_capital/prelevements_sociaux/csg/taux_global/produits_de_placement.yaml
@@ -18,7 +18,7 @@ values:
     value: 0.092
 metadata:
   short_label: Produits de placement
-  last_value_still_valid_on: "2019-01-01"
+  last_value_still_valid_on: "2025-03-31"
   label_en: CSG on financial income
   ipp_csv_id: tx_csg_rk_plac
   unit: /1
@@ -49,8 +49,12 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036377512&cidTexte=JORFTEXT000036339197
     - title: LOI 2018-1203 du 22/12/2018, art. 26 (modifie l'art. L136-8 du CSS)
     2019-01-01:
-      title: Loi 2018-1203 du 22/12/2018 - art. 26 (modifie l'art. L136-8 du CSS)
-      href: https://www.legifrance.gouv.fr/eli/loi/2018/12/22/CPAX1824950L/jo/texte
+      - title: Code de la sécurité sociale - art. L136-6
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000033812508/2019-01-01/
+      - title: Code de la sécurité sociale - art. L136-8
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042683546/2019-01-01/
+      - title: Loi 2018-1203 du 22/12/2018 - art. 26 (modifie l'art. L136-8 du CSS)
+        href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000037847610
   official_journal_date:
     1990-01-01: "1990-12-30"
     1991-02-01: "1990-12-30"

--- a/openfisca_france/parameters/taxation_capital/prelevements_sociaux/csg/taux_global/revenus_du_patrimoine.yaml
+++ b/openfisca_france/parameters/taxation_capital/prelevements_sociaux/csg/taux_global/revenus_du_patrimoine.yaml
@@ -16,7 +16,7 @@ values:
     value: 0.092
 metadata:
   short_label: Revenus du patrimoine
-  last_value_still_valid_on: "2019-01-01"
+  last_value_still_valid_on: "2025-03-31"
   label_en: CSG and CRDS on financial income
   ipp_csv_id: tx_csg_rk_patr
   unit: /1
@@ -46,10 +46,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036377512&cidTexte=JORFTEXT000036339197
     2018-01-01:
     - title: Loi 2017-1836 du 30/12/2017 - art. 8 (V) (modifie l'art. L136-8 du CSS)
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036358456&cidTexte=JORFTEXT000036339090
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000042683772/2018-01-01/
     - title: Loi 2017-1837 du 30/12/2017 - art. 67 (modifie l'art. 154 quinquies)
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000036377512&cidTexte=JORFTEXT000036339197
-    - title: LOI 2018-1203 du 22/12/2018, art. 26 (modifie l'art. L136-8 du CSS)
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000036377512/2018-01-01/
+    - title: Loi 2018-1203 du 22/12/2018 - art. 26 (modifie l'art. L136-8 du CSS)
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000037847610
   official_journal_date:
     1993-07-01: "1993-07-23"
     1996-01-01: 1996-12-29; 1996-12-31

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "170.0.0"
+version = "170.0.1"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : aucunes.
* Zones impactées : `openfisca_france/parameters/taxation_capital/prelevements_sociaux/*`.
* Détails :
  - Mise à jour de la last_value_still_valid_on et des références.

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
