### PR TITLE
[paramètres] Prestations sociales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+### 170.1.5 [2481](https://github.com/openfisca/openfisca-france/pull/2481)
+
+* Changement mineur.
+* Périodes concernées : 2025.
+* Zones impactées :
+  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/patrimoine/abattement_valeur_locative_terrains_non_loues.yaml`
+  - `openfisca_france/parameters/prestations_sociales/education/bourses/bourses_education/bourse_college/montant_taux_1.yaml`
+  - `openfisca_france/parameters/prestations_sociales/education/bourses/bourses_education/bourse_college/montant_taux_3.yaml`
+  - `openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/*`
+  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm_dom/complement_familial_dom/taux_majore_dom.yaml`
+  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/patrimoine/taux_interet_forfaitaire_epargne_non_imposable.yaml`
+* Détails :
+  - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+
 ### 170.1.4 [2483](https://github.com/openfisca/openfisca-france/pull/2483)
 
 * Changement mineur.

--- a/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/outremer_investissement/domsoc/retrocession_taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_reductions_impots/outremer_investissement/domsoc/retrocession_taux.yaml
@@ -5,6 +5,7 @@ values:
   2015-01-01:
     value: 0.7
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Taux de rétrocession de la réduction d'impôt
   unit: /1
   reference:

--- a/openfisca_france/parameters/prestations_sociales/education/bourses/bourses_education/bourse_college/montant_taux_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/bourses/bourses_education/bourse_college/montant_taux_1.yaml
@@ -5,9 +5,12 @@ values:
   2017-05-07:
     value: 0.256
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Montant échelon 1
   unit: currency
   reference:
     2017-05-07:
-      title: Décret n° 2017-792 du 05/05/2017
+    - title: Décret n° 2017-792 du 05/05/2017
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000034601676
+    - title: Code de l'éducation - Article D531-7
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000034629530

--- a/openfisca_france/parameters/prestations_sociales/education/bourses/bourses_education/bourse_college/montant_taux_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/bourses/bourses_education/bourse_college/montant_taux_2.yaml
@@ -5,9 +5,12 @@ values:
   2017-05-07:
     value: 0.7091
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Montant échelon 2
   unit: currency
   reference:
     2017-05-07:
-      title: Décret n° 2017-792 du 05/05/2017
+    - title: Décret n° 2017-792 du 05/05/2017
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000034601676
+    - title: Code de l'éducation - Article D531-7
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000034629530

--- a/openfisca_france/parameters/prestations_sociales/education/bourses/bourses_education/bourse_college/montant_taux_3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/education/bourses/bourses_education/bourse_college/montant_taux_3.yaml
@@ -5,9 +5,12 @@ values:
   2017-05-07:
     value: 1.1075
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Montant échelon 3
   unit: currency
   reference:
     2017-05-07:
-      title: Décret n° 2017-792 du 05/05/2017
+    - title: Décret n° 2017-792 du 05/05/2017
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000034601676
+    - title: Code de l'éducation - Article D531-7
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000034629530

--- a/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/abattement_conjoint/abattement_forfaitaire/base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/abattement_conjoint/abattement_forfaitaire/base.yaml
@@ -2,7 +2,10 @@ description: Abattement forfaitaire de base sur les revenus du conjoint (revenus
 values:
   2022-01-01:
     value: 5000
+  2023-10-01:
+    value: null
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Abattement forfaitaire de base
   label_en: Adult disability allowance (AAH)
   ipp_csv_id: abattement_aah_conjoint_forfaitaire_base
@@ -11,5 +14,9 @@ metadata:
     2022-01-01:
       title: Décret n° 2022-42 du 19/01/2022
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045038484#:~:text=Il%20fixe%20notamment%20le%20montant,au%20sens%20des%20prestations%20familiales.
+    2023-10-01:
+      title: Décret n° 2023-360 du 11/05/2023
+      href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000047543093/2023-10-01/
   official_journal_date:
     2022-01-01: "2022-01-20"
+documentation: Article D821-8-1 est Abrogé par le Décret n° 2023-360 du 11 mai 2023 relatif à la déconjugalisation

--- a/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/abattement_conjoint/abattement_forfaitaire/base.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/abattement_conjoint/abattement_forfaitaire/base.yaml
@@ -2,8 +2,6 @@ description: Abattement forfaitaire de base sur les revenus du conjoint (revenus
 values:
   2022-01-01:
     value: 5000
-  2023-10-01:
-    value: null
 metadata:
   last_value_still_valid_on: "2025-04-01"
   short_label: Abattement forfaitaire de base
@@ -14,9 +12,6 @@ metadata:
     2022-01-01:
       title: Décret n° 2022-42 du 19/01/2022
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045038484#:~:text=Il%20fixe%20notamment%20le%20montant,au%20sens%20des%20prestations%20familiales.
-    2023-10-01:
-      title: Décret n° 2023-360 du 11/05/2023
-      href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000047543093/2023-10-01/
   official_journal_date:
     2022-01-01: "2022-01-20"
-documentation: Article D821-8-1 est Abrogé par le Décret n° 2023-360 du 11 mai 2023 relatif à la déconjugalisation
+documentation: Article D821-8-1 est Abrogé par le Décret n° 2023-360 du 11 mai 2023, cependant la page https://www.monparcourshandicap.gouv.fr/aides/lallocation-aux-adultes-handicapes-aah mentionne toujours cette abattement.

--- a/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/abattement_conjoint/abattement_forfaitaire/majoration_pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/abattement_conjoint/abattement_forfaitaire/majoration_pac.yaml
@@ -3,6 +3,7 @@ values:
   2022-01-01:
     value: 1400
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Majoration par enfant à charge
   label_en: Adult disability allowance (AAH)
   ipp_csv_id: abattement_aah_conjoint_forfaitaire_majoration_pac
@@ -13,3 +14,4 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045038484#:~:text=Il%20fixe%20notamment%20le%20montant,au%20sens%20des%20prestations%20familiales.
   official_journal_date:
     2022-01-01: "2022-01-20"
+documentation: Article D821-8-1 est Abrogé par le Décret n° 2023-360 du 11 mai 2023,  cependant la page https://www.monparcourshandicap.gouv.fr/aides/lallocation-aux-adultes-handicapes-aah mentionne toujours cette majoration.

--- a/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/abattement_conjoint/abattement_forfaitaire/majoration_pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/abattement_conjoint/abattement_forfaitaire/majoration_pac.yaml
@@ -14,4 +14,4 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045038484#:~:text=Il%20fixe%20notamment%20le%20montant,au%20sens%20des%20prestations%20familiales.
   official_journal_date:
     2022-01-01: "2022-01-20"
-documentation: Article D821-8-1 est Abrogé par le Décret n° 2023-360 du 11 mai 2023,  cependant la page https://www.monparcourshandicap.gouv.fr/aides/lallocation-aux-adultes-handicapes-aah mentionne toujours cette majoration.
+documentation: Article D821-8-1 est Abrogé par le Décret n° 2023-360 du 11 mai 2023, cependant la page https://www.monparcourshandicap.gouv.fr/aides/lallocation-aux-adultes-handicapes-aah mentionne toujours cette majoration.

--- a/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/travail_ordinaire/abattement_30.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/travail_ordinaire/abattement_30.yaml
@@ -3,13 +3,16 @@ values:
   2011-01-01:
     value: 0.8
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Taux d'abattement (revenus < 0,3 Smic)
   label_en: Adult disability allowance (AAH)
   ipp_csv_id: abattement_ordinaire_30
   unit: /1
   reference:
     2011-01-01:
-      title: Décret n° 2010-1403 du 12/11/2010, art. 1 (modifie art. D821-9 du CSS)
+    - title: Décret n° 2010-1403 du 12/11/2010, art. 1 (modifie art. D821-9 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000023086051/#JORFARTI000023086056
+    - title: Code de la sécurité sociale - Article D821-9
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023097737/2010-11-17/
   official_journal_date:
     2011-01-01: "2010-11-16"

--- a/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/travail_ordinaire/abattement_sup.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/travail_ordinaire/abattement_sup.yaml
@@ -3,13 +3,16 @@ values:
   2011-01-01:
     value: 0.4
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Taux d'abattement (revenus > 0,3 Smic)
   label_en: Adult disability allowance (AAH)
   ipp_csv_id: abattement_ordinaire_sup
   unit: /1
   reference:
     2011-01-01:
-      title: Décret n° 2010-1403 du 12/11/2010, art. 1 (modifie art. D821-9 du CSS)
+    - title: Décret n° 2010-1403 du 12/11/2010, art. 1 (modifie art. D821-9 du CSS)
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000023086051/#JORFARTI000023086056
+    - title: Code de la sécurité sociale - Article D821-9
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023097737/2010-11-17/
   official_journal_date:
     2011-01-01: "2010-11-16"

--- a/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/travail_ordinaire/plafond_ressources.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/travail_ordinaire/plafond_ressources.yaml
@@ -5,6 +5,7 @@ values:
   2011-01-01:
     value: 3
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Plafond de ressources
   label_en: Adult disability allowance (AAH)
   ipp_csv_id: plaf_ressources_aah_activite
@@ -14,8 +15,10 @@ metadata:
       title: Décret 2005-725 du 29/06/2005 art. 6 créé art. D821-9 du CSS
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000006242585/2005-06-30
     2011-01-01:
-      title: Décret 2010-1403 du 12/11/2010 - art. 1
+    - title: Décret 2010-1403 du 12/11/2010 - art. 1
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000023092048/2010-11-17/
+    - title: Code de la sécurité sociale - Article D821-9
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000023097725/2010-11-17/
   official_journal_date:
     2005-07-01: "2005-07-01"
     2011-01-01: "2010-11-16"

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm_dom/complement_familial_dom/taux_base_dom.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm_dom/complement_familial_dom/taux_base_dom.yaml
@@ -9,6 +9,7 @@ values:
   2020-04-01:
     value: 0.4165
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Taux de base
   label_en: Prime rate
   unit: BMAF
@@ -23,8 +24,10 @@ metadata:
       title: Décret 2017-551 du 2017-04-14 - art. 4
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000034429420
     2020-04-01:
-      title: Décret 2017-551 du 2017-04-14 - art. 2 et 4
+    - title: Décret 2017-551 du 2017-04-14 - art. 2 et 4
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000034429420
+    - title: Article D755-6 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000034433417/2020-04-01/
   official_journal_date:
     2002-01-01: "1991-08-06"
     2018-04-01: "2017-04-16"

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm_dom/complement_familial_dom/taux_majore_dom.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm_dom/complement_familial_dom/taux_majore_dom.yaml
@@ -17,6 +17,7 @@ values:
   2020-04-01:
     value: 0.6248
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Taux majoré
   label_en: Increased rate
   unit: BMAF
@@ -43,8 +44,10 @@ metadata:
       title: Décret 2017-551 du 2017-04-14 - art. 4
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000034429420
     2020-04-01:
-      title: Décret 2017-551 du 2017-04-14 - art. 2 et 4
+    - title: Décret 2017-551 du 2017-04-14 - art. 2 et 4
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000034429420
+    - title: Article D755-6-1 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000034433595/2020-04-01/
   official_journal_date:
     2002-01-01: "1991-08-06"
     2014-04-01: "2014-04-25"

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/patrimoine/abattement_valeur_locative_terrains_non_loues.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/patrimoine/abattement_valeur_locative_terrains_non_loues.yaml
@@ -3,7 +3,7 @@ values:
   2009-01-01:
     value: 0.8
 metadata:
-  last_value_still_valid_on: "2022-04-04"
+  last_value_still_valid_on: "2025-04-01"
   unit: /1
   reference:
     2009-01-01:

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/patrimoine/taux_interet_forfaitaire_epargne_non_imposable.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/patrimoine/taux_interet_forfaitaire_epargne_non_imposable.yaml
@@ -3,7 +3,7 @@ values:
   2009-01-01:
     value: 0.03
 metadata:
-  last_value_still_valid_on: "2022-04-04"
+  last_value_still_valid_on: "2025-04-01"
   unit: /1
   reference:
     2009-01-01:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "170.1.4"
+version = "170.1.5"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
    * Périodes concernées : 2025.
    * Zones impactées :
      - openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/patrimoine/abattement_valeur_locative_terrains_non_loues.yaml
  - openfisca_france/parameters/prestations_sociales/education/bourses/bourses_education/bourse_college/montant_taux_1.yaml
  - openfisca_france/parameters/prestations_sociales/education/bourses/bourses_education/bourse_college/montant_taux_3.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/abattement_conjoint/abattement_forfaitaire/base.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/abattement_conjoint/abattement_forfaitaire/majoration_pac.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/age_fin_educ.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/age_minimal.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/travail_ordinaire/abattement_30.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_etat_de_sante/invalidite/aah/travail_ordinaire/abattement_sup.yaml
  - openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/cf/cf_cm_dom/complement_familial_dom/taux_majore_dom.yaml
  - openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_cond/patrimoine/taux_interet_forfaitaire_epargne_non_imposable.yaml
    * Détails :
    - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.

    - - - -

    Ces changements (effacez les lignes ne correspondant pas à votre cas) :

    - Mise à jour de paramètre.

    - - - -

    Méthodologie :
    1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
    1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
    1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
    1. Met à jour la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
    1. Met à jour la `last_value_still_valid_on` à la date du jour.
    1. Met à jour la référence législative.
    1. Crée un tableau récapitulatif pour faciliter la revue.

    Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

    - - - -

    Quelques conseils à prendre en compte :

    - [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
    - [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
    - [X] Documentez votre contribution avec des références législatives.
    - [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
    - [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
    - [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
    - [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
    
    Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme ayant changés depuis la date indiquée dans `last_value_still_valid_on`.

    Il s'agit des paramètres suivants :
    
* prestations_sociales.solidarite_insertion.minima_sociaux.rsa.rsa_cond.patrimoine.abattement_valeur_locative_terrains_non_loues
    - Description : Abattement appliqué sur la valeur locative des terrains non loués
    - 0.8
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006178301/) de type CODE
    - Extrait : _[...]mme procurant un revenu annuel égal à 50 % de leur valeur locative s'il s'agit d'immeubles bâtis, à 80 % de cette valeur s'il s'agit de terrains non bâtis et à 3 % du montant des capitaux.
[...]_
    - Reponse du LLM : _Pour déterminer la valeur de 'Abattement appliqué sur la valeur locative des terrains non loués', il faut comprendre que l'abattement est une réduction appliquée à la valeur locative. Cependant, le texte fourni ne parle pas explicitement d'un abattement mais plutôt de la façon dont les biens non productifs de revenu sont considérés pour l'appréciation des ressources des postulants.  Selon le texte, les terrains non bâtis (qui peuvent être considérés comme des terrains non loués dans ce contexte) sont considérés comme procurant un revenu annuel égal à 80 % de leur valeur locative. Cela signifie que 80 % de la valeur locative est considérée comme revenu, et non qu'il y a un abattement de 80 %.  Cependant, si l'on considère l'abattement comme la proportion de la valeur locative qui n'est pas considérée comme revenu, alors pour les terrains non bâtis, 20 % de la valeur locative ne serait pas considérée comme revenu (100 % - 80 % = 20 %).   Donc, la valeur de 'Abattement appliqué sur la valeur locative des terrains non loués' pourrait être interprétée comme 0.2 (20 %), mais cela nécessite une interprétation du concept d'abattement dans ce contexte spécifique.  La réponse est donc :  ``` {     "valeur": 0.2 } ```_
    
* prestations_sociales.aides_logement.allocations_logement.ressources.dar_3
    - Description : Coefficient R. 351-7-1
    - 16.25
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000001502517) de type ARRETE
    - Extrait : _[...] R. 351-7-1 est fixé à 8 000 euros.
   2° Le coefficient prévu au 2 du I du même article est fixé à 16,25.[...]_
    - Reponse du LLM : _La valeur de 'Coefficient R. 351-7-1 - prestations_sociales.aides_logement.allocations_logement.ressources.dar_3 - nan' est donnée dans le texte comme étant 16,25. Cependant, il est important de noter que les pourcentages sont exprimés sous forme mathématique, mais dans ce cas, la valeur est déjà donnée sous forme numérique et non sous forme de pourcentage.  La réponse est donc :  {     "valeur": 16.25 }_
    
* prestations_sociales.education.bourses.bourses_education.bourse_college.montant_taux_1
    - Description : Montant mensuel échelon 1 (en % de la BMAF) de la bourse de l'Éducation nationale pour le collège
    - 0.256
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000034601676) de type DECRET
    - Extrait : _[...]dispositions suivantes : « Les pourcentages applicables selon les échelons sont les suivants : « 1° 25,60 % (premier échelon) ; « 2° 70,91 % (deuxième échelon) ; « 3° 110,75 % (troisième échelon). »
L[...]_
    - Reponse du LLM : _La valeur de 'Montant mensuel échelon 1 (en % de la BMAF) de la bourse de l'Éducation nationale pour le collège' est donnée dans le texte comme 25,60 %. Pour la convertir en valeur décimale, on divise par 100, ce qui donne 0,256.  La réponse est donc : ``` {     "valeur": 0.256 } ```_
    
* prestations_sociales.education.bourses.bourses_education.bourse_college.montant_taux_3
    - Description : Montant mensuel échelon 3, de la bourse de l'Éducation nationale pour le collège
    - 1.1075
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000034601676) de type DECRET
    - Extrait : _[...]chelons sont les suivants : « 1° 25,60 % (premier échelon) ; « 2° 70,91 % (deuxième échelon) ; « 3° 110,75 % (troisième échelon). »
Les dispositions de l'article D. 531-7 du code de l'éducation, dans [...]_
    - Reponse du LLM : _{     "valeur": 1.1075 }_
    
* prestations_sociales.prestations_etat_de_sante.invalidite.aah.abattement_conjoint.abattement_forfaitaire.base
    - Description : Abattement forfaitaire de base sur les revenus du conjoint (revenus d'activité, pensions, rentes viagères à titre gratuit) pour le calcul de l'allocation aux adultes handicapés (AAH)
    - 5000
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045038484#:~:text=Il%20fixe%20notamment%20le%20montant,au%20sens%20des%20prestations%20familiales.) de type DECRET
    - Extrait : _[...]ciée au regard de revenus perçus au cours d'une année civile de référence, le montant annuel est de 5 000 euros, auquel s'ajoute une somme de 1 400 euros par enfant à charge au sens des articles L. 51[...]_
    - Reponse du LLM : _La valeur de 'Abattement forfaitaire de base sur les revenus du conjoint (revenus d'activité, pensions, rentes viagères à titre gratuit) pour le calcul de l'allocation aux adultes handicapés (AAH)' est de 5000 euros.  Réponse : ``` {     "valeur": 5000 } ```_
    
* prestations_sociales.prestations_etat_de_sante.invalidite.aah.abattement_conjoint.abattement_forfaitaire.majoration_pac
    - Description : Majoration par enfant à charge de l'abattement forfaitaire sur les revenus du conjoint (revenus d'activité, pensions, rentes viagères à titre gratuit) pour le calcul de l'allocation aux adultes handicapés (AAH)
    - 1400
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045038484#:~:text=Il%20fixe%20notamment%20le%20montant,au%20sens%20des%20prestations%20familiales.) de type DECRET
    - Extrait : _[...]d'une année civile de référence, le montant annuel est de 5 000 euros, auquel s'ajoute une somme de 1 400 euros par enfant à charge au sens des articles L. 512-3, L. 512-4 et L. 521-2 ; « 2° Lorsque l[...]_
    - Reponse du LLM : _La valeur de 'Majoration par enfant à charge de l'abattement forfaitaire sur les revenus du conjoint' est de 1400 euros.   La réponse est donc : ``` {     "valeur": 1400 } ```_
    
* prestations_sociales.prestations_etat_de_sante.invalidite.aah.age_fin_educ
    - Description : Âge minimal si l'individu n'est plus éligible aux allocations familiales pour bénéficier de l'allocation aux adultes handicapés (AAH)
    - 16
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000866621) de type CODE
    - Extrait : _[...] l'enfant handicapé pour l'application des articles L. 821-1 et suivants tout enfant âgé d'au moins seize ans qui cesse de réunir les conditions exigées pour ouvrir droit aux allocations familiales.
[...]_
    - Reponse du LLM : _La valeur de 'Âge minimal si l'individu n'est plus éligible aux allocations familiales pour bénéficier de l'allocation aux adultes handicapés (AAH)' est toujours de 16 ans, car le texte indique que l'âge minimal ouvrant droit à l'AAH est abaissé à 16 ans lorsque le bénéficiaire n'est plus considéré à la charge de ses parents pour le bénéfice des prestations familiales.  La réponse est donc : ``` {     "valeur": 16 } ```_
    
* prestations_sociales.prestations_etat_de_sante.invalidite.aah.age_minimal
    - Description : Âge minimal pour bénéficier de l'allocation aux adultes handicapés (AAH)
    - 20
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000000866621) de type CODE
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _La valeur de 'Âge minimal pour bénéficier de l'allocation aux adultes handicapés (AAH)' n'est pas explicitement mentionnée dans le texte fourni. Cependant, il est mentionné que l'enfant âgé d'au moins seize ans qui cesse de réunir les conditions exigées pour ouvrir droit aux allocations familiales est regardé comme ayant dépassé l'âge d'ouverture du droit à l'allocation d'éducation de l'enfant handicapé.  Cela implique que l'âge minimal pour bénéficier de l'allocation aux adultes handicapés pourrait être lié à l'âge où les allocations familiales ne sont plus versées. Étant donné que la valeur à une autre date de validité était '20', il est possible que l'âge minimal pour bénéficier de l'allocation aux adultes handicapés soit également de 20 ans, mais cela n'est pas explicitement mentionné dans le texte fourni.  Par conséquent, la réponse est :  ``` {     "valeur": 20 } ```_
    
* prestations_sociales.prestations_etat_de_sante.invalidite.aah.travail_ordinaire.abattement_30
    - Description : Taux d'abattement des revenus d'activité du bénéficiaire de l'allocation aux adultes handicapés (AAH) pour la tranche de revenus inférieure à 30% du Smic
    - 0.8
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000023086051/#JORFARTI000023086056) de type DECRET
    - Extrait : _[...]la situation antérieure, arrondi à la dizaine inférieure. La valeur de l'abattement ne peut excéder 80 %. « Cet abattement s'applique à compter du premier jour du mois civil suivant celui au cours duq[...]_
    - Reponse du LLM : _La valeur de 'Taux d'abattement des revenus d'activité du bénéficiaire de l'allocation aux adultes handicapés (AAH) pour la tranche de revenus inférieure à 30% du Smic' est de 0.8.  Cependant, selon le texte fourni, cette valeur est précisée à l'article D. 821-9, 2° a) comme étant de 80 % pour la tranche de revenus inférieure ou égale, en moyenne mensuelle, à 30 % de la valeur mensuelle du salaire minimum de croissance.  La réponse est donc : ``` {     "valeur": 0.8 } ```_
    
* prestations_sociales.prestations_etat_de_sante.invalidite.aah.travail_ordinaire.abattement_sup
    - Description : Taux d'abattement des revenus d'activité du bénéficiaire de l'allocation aux adultes handicapés (AAH) pour la tranche de revenus supérieure à 30% du Smic
    - 0.4
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000023086051/#JORFARTI000023086056) de type DECRET
    - Extrait : _[...] croissance calculé pour 151,67 heures en vigueur le dernier jour de la période de référence ; « b) 40 % pour la tranche de revenus supérieure, en moyenne mensuelle, à 30 % de la valeur mensuelle du s[...]_
    - Reponse du LLM : _La valeur de 'Taux d'abattement des revenus d'activité du bénéficiaire de l'allocation aux adultes handicapés (AAH) pour la tranche de revenus supérieure à 30% du Smic' est de 0,4.  Réponse au format JSON : ``` {     "valeur": 0.4 } ```_
    
* prestations_sociales.prestations_familiales.prestations_generales.cf.cf_cm_dom.complement_familial_dom.taux_majore_dom
    - Description : Taux majoré (en % de la BMAF) dans les DOM du Complément familial (CF)
    - 0.6248
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000034429420) de type DECRET
    - Extrait : _[...]e taux : « 41,65 % » ;2° A l'article D. 755-6-1, le taux : « 33,31 % » est remplacé par le taux : « 62,48 % ».
L'article 2 du décret du 23 avril 2014 susvisé est abrogé.
I.-Les dispositions de l'artic[...]_
    - Reponse du LLM : _La valeur de 'Taux majoré (en % de la BMAF) dans les DOM du Complément familial (CF)' est donnée dans le texte à l'article D. 755-6-1, où le taux est remplacé par « 62,48 % ». Cependant, il est important de noter que ce taux est exprimé en pourcentage et doit être converti en une valeur décimale pour correspondre au format requis.  La valeur de 'Taux majoré (en % de la BMAF) dans les DOM du Complément familial (CF)' est donc de 0,6248.  Cependant, le texte fourni mentionne également des modifications de ces taux pour des périodes spécifiques, mais il n'y a pas de mention d'une date de validité qui correspond exactement à la demande. La valeur la plus proche et pertinente est donc celle qui correspond à la dernière mise à jour du taux, qui est de 0,6248.  La réponse est donc :  ``` {     "valeur": 0.6248 } ```_
    
* prestations_sociales.solidarite_insertion.minima_sociaux.rsa.rsa_cond.patrimoine.taux_interet_forfaitaire_epargne_non_imposable
    - Description : Taux d'intérêt forfaitaire appliqué à l'épargne générant des revenus non imposables
    - 0.03
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006178301/) de type CODE
    - Extrait : _[...]Pour l'appréciation des ressources des postulants prévue à l'article L. 132-1, les biens non productifs de revenu, à l'exclusion de ceux constituant l'habitation principale [...]_
    - Reponse du LLM : _{     "valeur": 0.03 }_