### PR TITLE
[paramètres] prélèvements sociaux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### 170.1.4 [2483](https://github.com/openfisca/openfisca-france/pull/2483)
+
+* Changement mineur.
+* Périodes concernées : 2025.
+* Zones impactées :
+  - `openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/casa/pensions_retraite_preretraite_invalidite.yaml`
+  - `openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/complementaire_sante/part_employeur.yaml`
+  - `openfisca_france/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/ati/ati.yaml`
+  - `openfisca_france/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/pension/employeur/civils/pension.yaml`
+  - `openfisca_france/parameters/prelevements_sociaux/professions_liberales/ret_pl/assurance_vieillesse/*`
+* Détails :
+- Mise à jour des `last_value_still_valid_on`, des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.
+
 ### 170.1.3 [2487](https://github.com/openfisca/openfisca-france/pull/2487)
 
 * Amélioration technique.

--- a/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/complementaire_sante/part_employeur.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/complementaire_sante/part_employeur.yaml
@@ -3,12 +3,13 @@ values:
   2016-01-01:
     value: 0.5
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Part employeur minimum
   label_en: Minimum employer share in the mandatory complementary health insurance scheme
   unit: /1
   reference:
     2016-01-01:
-      title: Article 1, II, Loi n°2013-504 du 14 juin 2013 relative à la sécurisation de l'emploi
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000027546648
+    - title: Article 1, II, LOI n° 2013-504 du 14 juin 2013 relative à la sécurisation de l'emploi
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000027546718#:~:text=L'employeur%20assure%20au%20minimum%20la%20moiti%C3%A9%20du%20financement%20de%20cette%20couverture.
   official_journal_date:
     2016-01-01: "2013-06-16"

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/ati/ati.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/ati/ati.yaml
@@ -18,7 +18,7 @@ brackets:
       value: 0.0032
 metadata:
   short_label: Allocations temporaires d'invalidité (ATI)
-  last_value_still_valid_on: "2021-08-24"
+  last_value_still_valid_on: "2025-04-01"
   label_en: Contributions for pensions - central government (employer contribution)
   ipp_csv_id: txexp_ati_p
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/pension/employeur/civils/pension.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/pension/employeur/civils/pension.yaml
@@ -30,7 +30,7 @@ brackets:
       value: 0.7428
 metadata:
   short_label: Barème
-  last_value_still_valid_on: "2021-08-24"
+  last_value_still_valid_on: "2025-04-01"
   label_en: Contributions for pensions - central government (employer contribution)
   ipp_csv_id: txexp_civ_p
   reference:

--- a/openfisca_france/parameters/prelevements_sociaux/professions_liberales/ret_pl/assurance_vieillesse/entre_1_et_5_pss.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/professions_liberales/ret_pl/assurance_vieillesse/entre_1_et_5_pss.yaml
@@ -3,13 +3,16 @@ values:
   2015-01-01:
     value: 0.0187
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Taux entre 1 et 5 PSS
   label_en: SSCs for old-age insurance (professionals)
   ipp_csv_id: ret_plib_1_5
   unit: /1
   reference:
     2015-01-01:
-      title: Décret 2014-1413 du 27/11/2014
+    - title: Article D642-3 du code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029825130/2015-01-01/#:~:text=A%201%2C87%20%25%20sur%20les%20revenus%20d%C3%A9finis
+    - title: Décret 2014-1413 du 27/11/2014
       href: https://www.legifrance.gouv.fr/eli/decret/2014/11/27/2014-1413/jo/texte
   official_journal_date:
     2015-01-01: "2014-11-29"

--- a/openfisca_france/parameters/prelevements_sociaux/professions_liberales/ret_pl/assurance_vieillesse/sous_1_pss.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/professions_liberales/ret_pl/assurance_vieillesse/sous_1_pss.yaml
@@ -3,13 +3,16 @@ values:
   2015-01-01:
     value: 0.0823
 metadata:
+  last_value_still_valid_on: "2025-04-01"
   short_label: Taux sous 1 PSS
   label_en: SSCs for old-age insurance (professionals)
   ipp_csv_id: ret_plib_1
   unit: /1
   reference:
     2015-01-01:
-      title: Décret 2014-1413 du 27/11/2014
+    - title: Article D642-3 du code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000029825130/2015-01-01/#:~:text=A%208%2C23%20%25%20sur%20les%20revenus%20d%C3%A9finis
+    - title: Décret 2014-1413 du 27/11/2014
       href: https://www.legifrance.gouv.fr/eli/decret/2014/11/27/2014-1413/jo/texte
   official_journal_date:
     2015-01-01: "2014-11-29"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "170.1.3"
+version = "170.1.4"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
    * Changement mineur.
    * Périodes concernées : 2025.
    * Zones impactées :
      - `openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/casa/pensions_retraite_preretraite_invalidite.yaml`
  - `openfisca_france/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/ati/ati.yaml`
  - `openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/complementaire_sante/part_employeur.yaml`
  - `openfisca_france/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/ati/ati.yaml`
  - `openfisca_france/parameters/prelevements_sociaux/cotisations_secteur_public/retraite/pension/employeur/civils/pension.yaml`
  - `openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/casa/pensions_retraite_preretraite_invalidite.yaml`
  - `openfisca_france/parameters/prelevements_sociaux/professions_liberales/ret_pl/assurance_vieillesse/entre_1_et_5_pss.yaml`
  - `openfisca_france/parameters/prelevements_sociaux/professions_liberales/ret_pl/assurance_vieillesse/sous_1_pss.yaml`
    * Détails :
    - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.

    - - - -

    Ces changements (effacez les lignes ne correspondant pas à votre cas) :

    - Mise à jour de paramètre.

    - - - -

    Méthodologie :
    1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
    1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
    1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
    1. Met à jour la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
    1. Met à jour la `last_value_still_valid_on` à la date du jour.
    1. Met à jour la référence législative.
    1. Crée un tableau récapitulatif pour faciliter la revue.

    Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

    - - - -

    Quelques conseils à prendre en compte :

    - [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
    - [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
    - [X] Documentez votre contribution avec des références législatives.
    - [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
    - [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
    - [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
    - [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
    
    Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme ayant changés depuis la date indiquée dans `last_value_still_valid_on`.

    Il s'agit des paramètres suivants :
    
* prelevements_sociaux.cotisations_securite_sociale_regime_general.casa.pensions_retraite_preretraite_invalidite
    - Description : Contribution additionnelle solidarité autonomie (CASA) sur les pensions de retraite, préretraite et d'invalidité
    - nan
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042675242) de type CODE
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _```json {     "brackets": [         {"threshold": 0, "rate": 0.003}     ] } ```_
    
* prelevements_sociaux.cotisations_secteur_public.retraite.ati.ati
    - Description : Cotisations au régime de Retraite de la fonction publique (RAFP), allocations temporaires d'invalidité (ATI)
    - nan
    - [Texte de loi](https://www.legifrance.gouv.fr/eli/decret/2012/12/27/2012-1507/jo/texte) de type DECRET
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _```json {     "brackets": [         {"threshold": 0, "rate": 0.0032, "date": "2013-01-01"}     ] } ```_
    
* prelevements_sociaux.autres_taxes_participations_assises_salaires.complementaire_sante.part_employeur
    - Description : Part minimum de la contribution employeur dans la complémentaire santé obligatoire
    - 0.5
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000027546648) de type LOI
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _La valeur de 'Part minimum de la contribution employeur dans la complémentaire santé obligatoire' est de 0.5, car selon le texte de loi, "L'employeur assure au minimum la moitié du financement de cette couverture.".  Réponse : ``` {     "valeur": 0.5 } ```_
    
* prelevements_sociaux.cotisations_secteur_public.retraite.ati.ati
    - Description : Cotisations au régime de Retraite de la fonction publique (RAFP), allocations temporaires d'invalidité (ATI)
    - nan
    - [Texte de loi](https://www.legifrance.gouv.fr/eli/decret/2012/12/27/2012-1507/jo/texte) de type DECRET
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _```json {     "brackets": [         {"threshold": 0, "rate": 0.0032, "date": "2013-01-01"}     ] } ```_
    
* prelevements_sociaux.cotisations_secteur_public.retraite.pension.employeur.civils.pension
    - Description : Barème des pensions civiles (TI et NBI) - cotisations employeur retraite spécifiques à la fonction publique
    - nan
    - [Texte de loi](https://www.legifrance.gouv.fr/eli/decret/2012/12/27/2012-1507/jo/texte) de type DECRET
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _Il semble que le texte fourni ne contienne pas de nouvelles informations sur le barème pour 'Barème des pensions civiles (TI et NBI) - cotisations employeur retraite spécifiques à la fonction publique - prelevements_sociaux.cotisations_secteur_public.retraite.pension.employeur.civils.pension' qui modifierait le barème existant. Le texte mentionne des taux de contribution employeur, mais il ne fournit pas de nouveaux barèmes ou de modifications aux barèmes existants pour les pensions civiles.  La réponse est donc :  ```json {     "brackets": [         {"threshold": 0, "rate": 0.7428, "date": "2014-01-01"}     ] } ```  Cependant, comme le texte ne fournit pas de nouvelles informations sur le barème, il est possible de considérer que la réponse est nulle pour les nouvelles informations :  ```json {     "valeur": null, } ```_
    
* prelevements_sociaux.cotisations_securite_sociale_regime_general.casa.pensions_retraite_preretraite_invalidite
    - Description : Contribution additionnelle solidarité autonomie (CASA) sur les pensions de retraite, préretraite et d'invalidité
    - nan
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042675242) de type CODE
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _```json {     "brackets": [         {"threshold": 0, "rate": 0.003}     ] } ```_
    
* prelevements_sociaux.professions_liberales.ret_pl.assurance_vieillesse.entre_1_et_5_pss
    - Description : Taux entre 1 et 5 PSS de la cotisation de sécurité sociale (SS) branche vieillesse des professions libérales
    - 0.0187
    - [Texte de loi](https://www.legifrance.gouv.fr/eli/decret/2014/11/27/2014-1413/jo/texte) de type DECRET
    - Extrait : _[...]le L. 241-3 en vigueur au 1er janvier de l'année au titre de laquelle la cotisation est due ;« 2° A 1,87 % sur les revenus définis à l'article L. 642-2 pour la part de ces revenus n'excédant pas cinq [...]_
    - Reponse du LLM : _La valeur de 'Taux entre 1 et 5 PSS de la cotisation de sécurité sociale (SS) branche vieillesse des professions libérales' est donnée dans le texte à l'alinéa 2° : « 2° A 1,87 % sur les revenus définis à l'article L. 642-2 pour la part de ces revenus n'excédant pas cinq fois le plafond annuel prévu au premier alinéa de l'article L. 241-3 en vigueur au 1er janvier de l'année au titre de laquelle la cotisation est due. »  La valeur est donc de 1,87%, ce qui équivaut à 0,0187 en notation mathématique.  La réponse est : ``` {     "valeur": 0.0187 } ```_
    
* prelevements_sociaux.professions_liberales.ret_pl.assurance_vieillesse.sous_1_pss
    - Description : Taux sous 1 PSS de la cotisation de sécurité sociale (SS) branche vieillesse des professions libérales
    - 0.0823
    - [Texte de loi](https://www.legifrance.gouv.fr/eli/decret/2014/11/27/2014-1413/jo/texte) de type DECRET
    - Extrait : _[...]sixième » ;2° Les deuxième à septième alinéas sont remplacés par deux alinéas ainsi rédigés :« 1° A 8,23 % sur les revenus définis à l'article L. 642-2 pour la part de ces revenus n'excédant pas le pl[...]_
    - Reponse du LLM : _La valeur de 'Taux sous 1 PSS de la cotisation de sécurité sociale (SS) branche vieillesse des professions libérales' est donnée dans le texte à l'article D. 642-3 du code de la sécurité sociale, qui stipule que la cotisation est de 8,23 % sur les revenus définis à l'article L. 642-2 pour la part de ces revenus n'excédant pas le plafond annuel prévu au premier alinéa de l'article L. 241-3.  La valeur est donc de 0,0823.  Réponse : ``` {     "valeur": 0.0823 } ```_