### PR TITLE
[paramètres] last_value_still_valid_on marché du travail

### DIFF
--- a/.github/lint-changed-yaml-parameters.sh
+++ b/.github/lint-changed-yaml-parameters.sh
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+
+last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
+
+if ! changes=$(git diff-index --name-only --diff-filter=ACMR --exit-code $last_tagged_commit -- "openfisca_france/parameters/*.yaml")
+then
+  echo "Linting the following changed YAML parameters:"
+  echo $changes
+  yamllint $changes
+else echo "No changed YAML parameters to lint"
+fi

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -107,6 +107,8 @@ jobs:
         run: "${GITHUB_WORKSPACE}/.github/lint-changed-python-files.sh"
       - name: Lint YAML tests
         run: "${GITHUB_WORKSPACE}/.github/lint-changed-yaml-tests.sh"
+      - name: Lint YAML parameters
+        run: "${GITHUB_WORKSPACE}/.github/lint-changed-yaml-parameters.sh"
 
   test-python:
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 170.1.2 [2485](https://github.com/openfisca/openfisca-france/pull/2485)
+
+* Changement mineur.
+* Périodes concernées : 2025.
+* Zones impactées :
+  - `openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml`
+  - `openfisca_france/parameters/marche_travail/salaire_minimum/smic/nb_heures_travail_mensuel.yaml`
+  - `openfisca_france/parameters/marche_travail/indemnite_fin_contrat/taux.yaml`
+  - `openfisca_france/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/plafond_exoneration.yaml`
+* Détails :
+  - Mise à jour des `last_value_still_valid_on` et des références sur les paramètres.
+
 ## 170.1.0 [2469](https://github.com/openfisca/openfisca-france/pull/2469)
 
 * Correction d'un crash.

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ check-path-length:
 check-yaml:
 	@# check yaml style
 	.github/lint-changed-yaml-tests.sh
+	.github/lint-changed-yaml-parameters.sh
 
 check-all-yaml:
 	@# check yaml style

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/minstage/taux_gratification_min.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/minstage/taux_gratification_min.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.15
 metadata:
   short_label: Part du PSS
-  last_value_still_valid_on: "2024-03-14"
+  last_value_still_valid_on: "2025-04-01"
   label_en: Minimum compensation for interns
   unit: /1
   reference:

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/nb_heures_travail_mensuel.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/nb_heures_travail_mensuel.yaml
@@ -14,8 +14,8 @@ metadata:
   unit: hour
   reference:
     2002-01-01:
-    - title: Décret 2001-554 du 28/06/2001
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000589597&categorieLien=id
+    - title: Loi n° 2000-37 du 19 janvier 2000 relative à la réduction négociée du temps de travail
+      href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000006658079/2000-02-01/
     - title: Article L3121-27 du Code du Travail
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000033020376
   official_journal_date:

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/nb_heures_travail_mensuel.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/nb_heures_travail_mensuel.yaml
@@ -8,7 +8,7 @@ values:
     value: 151.67
 metadata:
   short_label: Nombre d'heures temps plein
-  last_value_still_valid_on: "2022-08-03"
+  last_value_still_valid_on: "2025-04-01"
   label_en: Minimum wage - Smic
   ipp_csv_id: htp
   unit: hour

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/nb_heures_travail_mensuel.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/nb_heures_travail_mensuel.yaml
@@ -14,13 +14,13 @@ metadata:
   unit: hour
   reference:
     2002-01-01:
-      title: Décret 2001-554 du 28/06/2001
+    - title: Décret 2001-554 du 28/06/2001
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000589597&categorieLien=id
-    2018-01-01:
-      title: Décret 2017-1719 du 20/12/2017
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036240563
+    - title: Article L3121-27 du Code du Travail
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000033020376
   official_journal_date:
     2002-01-01: "2001-06-29"
   notes:
     2001-07-01:
     - title: Attention au passage aux 35 heures. Existence d'un régime transitoire et d'un régime définitif pour les entreprises de plus de 20 salariés. dans l'ancien système. Pour les entreprises de moins de 20 salariés, ancien système. Le Smic donné ici correspond au Smic mensuel pour 39 heures
+documentation: Le montant de 151.67 heures n'est pas dans le code du travail mais se calcul de la façon suivante : 35 heures par semaine * 52 semaines / 12 mois = 151.67 

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/nb_heures_travail_mensuel.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/nb_heures_travail_mensuel.yaml
@@ -23,4 +23,4 @@ metadata:
   notes:
     2001-07-01:
     - title: Attention au passage aux 35 heures. Existence d'un régime transitoire et d'un régime définitif pour les entreprises de plus de 20 salariés. dans l'ancien système. Pour les entreprises de moins de 20 salariés, ancien système. Le Smic donné ici correspond au Smic mensuel pour 39 heures
-documentation: Le montant de 151.67 heures n'est pas dans le code du travail mais se calcul de la façon suivante : 35 heures par semaine * 52 semaines / 12 mois = 151.67 
+documentation: "Le montant de 151.67 heures n'est pas dans le code du travail mais se calcul de la façon suivante : 35 heures par semaine * 52 semaines / 12 mois = 151.67"

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml
@@ -246,7 +246,7 @@ values:
     value: 11.88
 metadata:
   short_label: Smic horaire brut
-  last_value_still_valid_on: "2024-01-03"
+  last_value_still_valid_on: "2025-04-01"
   label_en: Minimum wage - Smic
   ipp_csv_id: smic_h
   unit: currency
@@ -516,7 +516,7 @@ metadata:
       title: Décret 2016-1818 du 22/12/2016
       href: https://www.legifrance.gouv.fr/eli/decret/2016/12/22/2016-1818/jo/texte
     2018-01-01:
-      title: "Décret 2017-1719 du\_20/12/2017"
+      title: "Décret 2017-1719 du 20/12/2017"
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036240563
     2019-01-01:
       title: Décret 2018-1173 du 19/12/2018

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml
@@ -246,7 +246,7 @@ values:
     value: 1801.80 
 metadata:
   short_label: Smic brut mensuel
-  last_value_still_valid_on: "2024-01-03"
+  last_value_still_valid_on: "2025-04-01"
   label_en: Minimum wage - Smic
   ipp_csv_id: smic_m
   unit: currency

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml
@@ -243,7 +243,7 @@ values:
   2024-01-01:
     value: 1766.92
   2024-11-01:
-    value: 1801.80 
+    value: 1801.80
 metadata:
   short_label: Smic brut mensuel
   last_value_still_valid_on: "2025-04-01"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "170.1.0"
+version = "170.1.2"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION

* Changement mineur.
* Périodes concernées : 2025.
* Zones impactées :
    - `openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml`
    - `openfisca_france/parameters/marche_travail/salaire_minimum/smic/nb_heures_travail_mensuel.yaml`
    - `openfisca_france/parameters/marche_travail/indemnite_fin_contrat/taux.yaml`
    - `openfisca_france/parameters/marche_travail/primes_exceptionnelles/prime_partage_valeur/plafond_exoneration.yaml`
    * Détails :
    - Mise à jour des `last_value_still_valid_on`, des valeurs et des références sur les paramètres qui n'étaient plus à jour et dont la nouvelle valeur a pu être trouvée avec un bon niveau de fiabilité.

    - - - -

    Ces changements (effacez les lignes ne correspondant pas à votre cas) :

    - Mise à jour de paramètre.

    - - - -

    Méthodologie :
    1. Récupére les paramètres OpenFisca depuis [leximpact-socio-fiscal-openfisca-json](https://git.leximpact.dev/leximpact/leximpact-socio-fiscal-openfisca-json/-/raw/master/raw_processed_parameters.json?ref_type=heads) et les exportent dans un fichier CSV avec une ligne par paramètres.
    1. Filtre sur les paramètres qui ne sont pas neutralisée, qui ont une référence législative et la date du champ `last_value_still_valid_on` est de plus d'un an.
    1. Regarde dans l'OpenData de Légifrance, via [le GitLab tricoteuses](https://git.en-root.org/tricoteuses/data/dila), si l'article de loi référencé est toujours le dernier en vigueur.
    1. Met à jour la valeur du paramètre en lisant le nouvel article de référence avec un LLM.
    1. Met à jour la `last_value_still_valid_on` à la date du jour.
    1. Met à jour la référence législative.
    1. Crée un tableau récapitulatif pour faciliter la revue.

    Plus d'informations sur le processus de mise à jour des paramètres [sur le Gitlab de LexImpact](https://git.leximpact.dev/leximpact/exploration/update-openfisca-with-ai).

    - - - -

    Quelques conseils à prendre en compte :

    - [X] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
    - [X] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
    - [X] Documentez votre contribution avec des références législatives.
    - [X] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
    - [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
    - [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
    - [X] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
    
    Cette PR propose une mise à jour de paramètres qui sont été identifiés de façon automatique comme ayant changés depuis la date indiquée dans `last_value_still_valid_on`.

    Il s'agit des paramètres suivants :


* marche_travail.salaire_minimum.smic.smic_b_horaire
    - Description : Smic brut (horaire)
    - 11.88
    - [Texte de loi](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050392683) de type DECRET
    - Extrait : _[...] Réunion, à Saint-Barthélemy, à Saint-Martin et à Saint-Pierre-et-Miquelon, son montant est porté à 11,88 euros l'heure ;2° A Mayotte, son montant est fixé à 8,98 euros l'heure.
A compter du 1er novem[...]_
    - Reponse du LLM : _La valeur de 'Smic brut (horaire) - marche_travail.salaire_minimum.smic.smic_b_horaire' est donnée dans le texte pour la métropole et les départements d'outre-mer. La valeur est de 11,88 euros l'heure.  La réponse est donc : ``` {     "valeur": 11.88 } ```_
    
* marche_travail.salaire_minimum.smic.nb_heures_travail_mensuel
    - Description : Nombre d'heures travaillées forfaitaires (temps plein) au Smic
    - 151.67
    - [Texte de loi](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000589597&categorieLien=id) de type DECRET
    - Extrait : Valeur non retrouvée par `find_value_in_texte`
    - Reponse du LLM : _Il n'y a pas d'information directe sur le nombre d'heures travaillées forfaitaires (temps plein) au Smic dans le texte fourni. Cependant, on peut trouver une information indirecte qui pourrait être utile.  En France, le Smic (salaire minimum interprofessionnel de croissance) est généralement calculé sur la base d'un nombre d'heures travaillées par mois, qui est fixé à 151,67 heures par mois pour un temps plein, selon les informations générales disponibles.  Puisque le texte fourni ne contient pas d'information spécifique sur le nombre d'heures travaillées forfaitaires au Smic, mais que nous avons une valeur précédente de 151,67, nous pouvons considérer que cette valeur pourrait être toujours applicable, à moins que des informations contraires soient fournies.  La réponse est donc :  {     "valeur": 151.67 }_
    

* marche_travail.indemnite_fin_contrat.taux
    - Description : Indemnité de fin de contrat (CDD) en pourcentage du salaire de base
    - 0.1
    - [Texte de loi](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006901219) de type CODE
    - Extrait : _[...]té de fin de contrat destinée à compenser la précarité de sa situation.
Cette indemnité est égale à 10 % de la rémunération totale brute versée au salarié.
Elle s'ajoute à la rémunération totale brute[...]_
    - Reponse du LLM : _{     "valeur": 0.1 }_
    
* marche_travail.primes_exceptionnelles.prime_partage_valeur.plafond_exoneration
    - Description : Plafond annuel d'exonération PPV (sous condition de rémunération)
    - 3000
    - [Texte de loi](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046188457/2022-08-18) de type LOI
    - Extrait : _[...]ans les conditions prévues aux II à IV du présent article sont exonérées, dans la limite globale de 3 000 € par bénéficiaire et par année civile, de toutes les cotisations sociales d'origine légale ou[...]_
    - Reponse du LLM : _La valeur de 'Plafond annuel d'exonération PPV (sous condition de rémunération)' est de 3000 euros, comme indiqué dans le texte : "dans la limite globale de 3 000 € par bénéficiaire et par année civile".  La réponse est donc :  ``` {     "valeur": 3000 } ```_