### PR TITLE
Ajoute un attribut de classe calculate_output_add aux diverses classes crds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+### 170.1.6 [2490](https://github.com/openfisca/openfisca-france/pull/2490)
+
+* Changement mineur.
+* Périodes concernées : 2025.
+* Zones impactées :
+  - `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py`
+  - `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py`
+  - `openfisca_france/model/prestations/minima_sociaux/anciens_ms.py`
+  - `openfisca_france/model/prestations/minima_sociaux/ppa.py`
+  - `openfisca_france/model/prestations/minima_sociaux/rsa.py`
+  - `openfisca_france/model/prestations/prestations_familiales/ars.py`
+  - `openfisca_france/model/prestations/prestations_familiales/asf.py`
+  - `openfisca_france/model/prestations/prestations_familiales/cf.py`
+  - `openfisca_france/model/prestations/prestations_familiales/paje.py`
+
+* Détails :
+  - Ajoute un attribut de classe calculate_output_add aux diverses classes crds
+
 ### 170.1.5 [2481](https://github.com/openfisca/openfisca-france/pull/2481)
 
 * Changement mineur.

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py
@@ -442,6 +442,7 @@ class csg_deductible_non_salarie(Variable):
 
 
 class crds_non_salarie(Variable):
+    calculate_output = calculate_output_add
     value_type = float
     entity = Individu
     label = 'Assiette CSG des personnes non salariées'

--- a/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
+++ b/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py
@@ -383,6 +383,7 @@ class csg_revenus_capital(Variable):
 
 
 class crds_revenus_capital(Variable):
+    calculate_output = calculate_output_add
     value_type = float
     entity = FoyerFiscal
     label = 'CRDS sur les revenus du capital'

--- a/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
+++ b/openfisca_france/model/prestations/minima_sociaux/anciens_ms.py
@@ -173,6 +173,7 @@ class rsa_activite(Variable):
 
 
 class crds_rsa_activite(Variable):
+    calculate_output = calculate_output_add
     value_type = float
     entity = Famille
     end = '2015-12-31'

--- a/openfisca_france/model/prestations/minima_sociaux/ppa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/ppa.py
@@ -520,6 +520,7 @@ class ppa(Variable):
 
 
 class crds_ppa(Variable):
+    calculate_output = calculate_output_add
     value_type = float
     entity = Famille
     label = "CRDS sur la prime pour l'activité"

--- a/openfisca_france/model/prestations/minima_sociaux/rsa.py
+++ b/openfisca_france/model/prestations/minima_sociaux/rsa.py
@@ -252,6 +252,7 @@ class rsa_base_ressources_prestations_familiales(Variable):
 
 
 class crds_mini(Variable):
+    calculate_output = calculate_output_add
     value_type = float
     entity = Famille
     label = 'CRDS versée sur les minimas sociaux'

--- a/openfisca_france/model/prestations/prestations_familiales/ars.py
+++ b/openfisca_france/model/prestations/prestations_familiales/ars.py
@@ -65,6 +65,7 @@ class ars(Variable):
 
 
 class crds_ars(Variable):
+    calculate_output = calculate_output_add
     value_type = float
     entity = Famille
     label = "CRDS sur l'allocation de rentrée scolaire"

--- a/openfisca_france/model/prestations/prestations_familiales/asf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/asf.py
@@ -82,6 +82,7 @@ class asf(Variable):
 
 
 class crds_asf(Variable):
+    calculate_output = calculate_output_add
     value_type = float
     entity = Famille
     label = "CRDS sur l'allocation de soutien familial'"

--- a/openfisca_france/model/prestations/prestations_familiales/cf.py
+++ b/openfisca_france/model/prestations/prestations_familiales/cf.py
@@ -346,6 +346,7 @@ class cf(Variable):
 
 
 class crds_cf(Variable):
+    calculate_output = calculate_output_add
     value_type = float
     entity = Famille
     label = 'CRDS sur le complément familial'

--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -755,6 +755,7 @@ class ape(Variable):
 
 
 class crds_ape(Variable):
+    calculate_output = calculate_output_add
     value_type = float
     entity = Famille
     label = "CRDS sur l'allocation parentale d'éducation"
@@ -803,6 +804,7 @@ class apje(Variable):
 
 
 class crds_apje(Variable):
+    calculate_output = calculate_output_add
     value_type = float
     entity = Famille
     label = "CRDS sur l'allocation pour le jeune enfant"
@@ -980,6 +982,7 @@ class paje_colca(Variable):
 
 
 class crds_paje(Variable):
+    calculate_output = calculate_output_add
     value_type = float
     entity = Famille
     label = 'CRDS sur la PAJE - Ensemble des prestations'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "170.1.5"
+version = "170.1.6"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : 
 - `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/activite.py`
 - `openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/capital.py`
 - `openfisca_france/model/prestations/minima_sociaux/anciens_ms.py`
 - `openfisca_france/model/prestations/minima_sociaux/ppa.py`
 - `openfisca_france/model/prestations/minima_sociaux/rsa.py`
 - `openfisca_france/model/prestations/prestations_familiales/ars.py`
 - `openfisca_france/model/prestations/prestations_familiales/asf.py`
 - `openfisca_france/model/prestations/prestations_familiales/cf.py`
 - `openfisca_france/model/prestations/prestations_familiales/paje.py`
* Détails :
  - Ajoute un attribut de classe calculate_output_add aux diverses classes crds
