### PR TITLE
Correction des labels aides logement et du nombre de parts APL foyer isolé

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 170.1.8 [2492](https://github.com/openfisca/openfisca-france/pull/2492)
+
+* Changement mineur.
+* Périodes concernées : 2025.
+* Zones impactées :
+  - `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement`
+  - `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/isole_0_personne_a_charge.yaml`
+
+* Détails :
+  - Correction les short_label et références aides logement
+  - Correction du nombre de parts pour les APL en secteur foyer (bénéficiaire isolé)
+
 ### 170.1.7 [2488](https://github.com/openfisca/openfisca-france/pull/2488)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/al/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/al/index.yaml
@@ -1,6 +1,6 @@
 description: Allocations logement - Secteur foyer (AL)
 metadata:
-  short_label: Termes de la formule
+  short_label: Paramètres spécifiques APL
   order:
   - formule
   - minimum_depense_nette_logement

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/menage_ou_isole_avec_1_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/menage_ou_isole_avec_1_enfant.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/menage_ou_isole_avec_2_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/menage_ou_isole_avec_2_enfants.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/menage_ou_isole_avec_3_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/menage_ou_isole_avec_3_enfants.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/menage_ou_isole_avec_4_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/menage_ou_isole_avec_4_enfants.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/menage_ou_isole_par_enfant_en_plus.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/menage_ou_isole_par_enfant_en_plus.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/menage_seul.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/menage_seul.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/personne_isolee_sans_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_1/personne_isolee_sans_enfant.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/menage_ou_isole_avec_1_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/menage_ou_isole_avec_1_enfant.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/menage_ou_isole_avec_2_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/menage_ou_isole_avec_2_enfants.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/menage_ou_isole_avec_3_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/menage_ou_isole_avec_3_enfants.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/menage_ou_isole_avec_4_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/menage_ou_isole_avec_4_enfants.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/menage_ou_isole_par_enfant_en_plus.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/menage_ou_isole_par_enfant_en_plus.yaml
@@ -44,7 +44,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/menage_seul.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/menage_seul.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/personne_isolee_sans_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_2/personne_isolee_sans_enfant.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/menage_ou_isole_avec_1_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/menage_ou_isole_avec_1_enfant.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/menage_ou_isole_avec_2_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/menage_ou_isole_avec_2_enfants.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/menage_ou_isole_avec_3_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/menage_ou_isole_avec_3_enfants.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/menage_ou_isole_avec_4_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/menage_ou_isole_avec_4_enfants.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/menage_ou_isole_par_enfant_en_plus.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/menage_ou_isole_par_enfant_en_plus.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/menage_seul.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/menage_seul.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/personne_isolee_sans_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/apl/formule/e_equiv_loyers_eligible/zone_3/personne_isolee_sans_enfant.yaml
@@ -42,7 +42,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 27
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286612/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/1_personne_a_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/1_personne_a_charge.yaml
@@ -11,5 +11,5 @@ metadata:
   last_value_still_valid_on: "2023-02-23"
   reference:
     1988-07-01:
-      title: Article D832-25, 2° du Code de la construction et de l'habitation
+      title: Article D832-25, 1° du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878710/2019-09-01/

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/2_personnes_a_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/2_personnes_a_charge.yaml
@@ -7,5 +7,5 @@ metadata:
   last_value_still_valid_on: "2023-02-23"
   reference:
     1988-07-01:
-      title: Article D832-25, 2° du Code de la construction et de l'habitation
+      title: Article D832-25, 1° du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878710/2019-09-01/

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/3_personnes_a_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/3_personnes_a_charge.yaml
@@ -7,5 +7,5 @@ metadata:
   last_value_still_valid_on: "2023-02-23"
   reference:
     1988-07-01:
-      title: Article D832-25, 2° du Code de la construction et de l'habitation
+      title: Article D832-25, 1° du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878710/2019-09-01/

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/4_personnes_a_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/4_personnes_a_charge.yaml
@@ -7,5 +7,5 @@ metadata:
   last_value_still_valid_on: "2023-02-23"
   reference:
     1988-07-01:
-      title: Article D832-25, 2° du Code de la construction et de l'habitation
+      title: Article D832-25, 1° du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878710/2019-09-01/

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/isole_0_personne_a_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/isole_0_personne_a_charge.yaml
@@ -2,8 +2,6 @@ description: Paramètre « N » pour un bénéficiaire isolé pour le calcul de 
 values:
   2007-07-01:
     value: 1.4
-  2023-04-05:
-    value: 1.2
 metadata:
   short_label: Bénéficiaire isolé
   last_value_still_valid_on: "2025-02-20"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/menage_0_personnes_a_charge.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/menage_0_personnes_a_charge.yaml
@@ -7,5 +7,5 @@ metadata:
   last_value_still_valid_on: "2023-02-23"
   reference:
     2007-07-01:
-      title: Article D832-25, 2° du Code de la construction et de l'habitation
+      title: Article D832-25, 1° du Code de la construction et de l'habitation
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878710/2019-09-01/

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/coefficients_degressivite_suppression/zone_1/degressivite.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/coefficients_degressivite_suppression/zone_1/degressivite.yaml
@@ -7,5 +7,7 @@ metadata:
   last_value_still_valid_on: "2023-02-20"
   reference:
     2016-07-01:
-      title: Arrêté du 27/09/2019, art. 10
+    - title: Arrêté du 27/09/2019, art. 10
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039160745
+    - title: Article D823-16 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878905

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/coefficients_degressivite_suppression/zone_1/suppression.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/coefficients_degressivite_suppression/zone_1/suppression.yaml
@@ -7,5 +7,7 @@ metadata:
   last_value_still_valid_on: "2023-02-20"
   reference:
     2016-07-01:
-      title: Arrêté du 27/09/2019, art. 10
+    - title: Arrêté du 27/09/2019, art. 10
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039160745
+    - title: Article D823-16 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878905

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/coefficients_degressivite_suppression/zone_2/degressivite.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/coefficients_degressivite_suppression/zone_2/degressivite.yaml
@@ -7,5 +7,7 @@ metadata:
   last_value_still_valid_on: "2023-02-20"
   reference:
     2016-07-01:
-      title: Arrêté du 27/09/2019, art. 10
+    - title: Arrêté du 27/09/2019, art. 10
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039160745
+    - title: Article D823-16 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878905

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/coefficients_degressivite_suppression/zone_2/suppression.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/coefficients_degressivite_suppression/zone_2/suppression.yaml
@@ -7,5 +7,7 @@ metadata:
   last_value_still_valid_on: "2023-02-20"
   reference:
     2016-07-01:
-      title: Arrêté du 27/09/2019, art. 10
+    - title: Arrêté du 27/09/2019, art. 10
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039160745
+    - title: Article D823-16 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878905

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/coefficients_degressivite_suppression/zone_3/degressivite.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/coefficients_degressivite_suppression/zone_3/degressivite.yaml
@@ -7,5 +7,7 @@ metadata:
   last_value_still_valid_on: "2023-02-20"
   reference:
     2016-07-01:
-      title: Arrêté du 27/09/2019, art. 10
+    - title: Arrêté du 27/09/2019, art. 10
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039160745
+    - title: Article D823-16 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878905

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/coefficients_degressivite_suppression/zone_3/suppression.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/coefficients_degressivite_suppression/zone_3/suppression.yaml
@@ -7,5 +7,7 @@ metadata:
   last_value_still_valid_on: "2023-02-20"
   reference:
     2016-07-01:
-      title: Arrêté du 27/09/2019, art. 10
+    - title: Arrêté du 27/09/2019, art. 10
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039160745
+    - title: Article D823-16 du Code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878905

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_colocataires/beneficiaire_isole.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_colocataires/beneficiaire_isole.yaml
@@ -101,7 +101,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 16
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286625/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1 6° b)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_colocataires/couple_sans_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_colocataires/couple_sans_enfant.yaml
@@ -105,7 +105,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 16
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286625/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1 6° b)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_colocataires/majoration_par_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_colocataires/majoration_par_enfant.yaml
@@ -105,7 +105,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 16
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286625/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1 6° b)
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_general/cas_general.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_general/cas_general.yaml
@@ -104,10 +104,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 9
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286639/2024-09-29
-    - title: Arrêté du 27/09/2024, art. 1
+    - title: Arrêté du 27/09/2024, art. 1, 3°
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 9
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286639/2024-09-29    
   official_journal_date:
     1994-07-01: "1994-11-16"
     1997-07-01: "1997-09-11"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_general/cas_general.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_general/cas_general.yaml
@@ -107,7 +107,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1, 3°
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 9
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286639/2024-09-29    
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286639/2024-09-29
   official_journal_date:
     1994-07-01: "1994-11-16"
     1997-07-01: "1997-09-11"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_general/majoration_par_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_general/majoration_par_enfant.yaml
@@ -104,10 +104,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 9
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
-    - title: Arrêté du 27/09/2024, art. 1
+    - title: Arrêté du 27/09/2024, art. 1, 3°
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 9
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/    
   official_journal_date:
     1994-07-01: "1994-11-16"
     1997-07-01: "1997-09-11"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_general/majoration_par_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/c_forfait_charges/cas_general/majoration_par_enfant.yaml
@@ -107,7 +107,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1, 3°
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 9
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/    
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
   official_journal_date:
     1994-07-01: "1994-11-16"
     1997-07-01: "1997-09-11"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/coef_chambre_et_colocation/coef_chambre.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/coef_chambre_et_colocation/coef_chambre.yaml
@@ -10,3 +10,5 @@ metadata:
     2002-01-01:
     - title: Arrêté du 27 septembre 2019, art. 8
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286643/2024-09-29
+    - title: Article D823-16 du code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878905

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/coef_chambre_et_colocation/coef_colocation.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/coef_chambre_et_colocation/coef_colocation.yaml
@@ -10,3 +10,5 @@ metadata:
     2002-01-01:
     - title: Arrêté du 27 septembre 2019, art. 16 1°
       href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286643/2024-09-29
+    - title: Article D823-16 du code de la construction et de l'habitation
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878905

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/couples.yaml
@@ -120,10 +120,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 7
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/couples.yaml
@@ -123,7 +123,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/majoration_par_enf_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/majoration_par_enf_supp.yaml
@@ -120,10 +120,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 7
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/majoration_par_enf_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/majoration_par_enf_supp.yaml
@@ -123,7 +123,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/personnes_seules.yaml
@@ -123,7 +123,7 @@ metadata:
       - title: Arrêté du 27/09/2024, art. 1
         href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
       - title: Arrêté du 27/09/2019, art. 7
-        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29      
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/personnes_seules.yaml
@@ -120,10 +120,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-      - title: Arrêté du 27/09/2019, art. 7
-        href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
       - title: Arrêté du 27/09/2024, art. 1
         href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+      - title: Arrêté du 27/09/2019, art. 7
+        href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29      
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/un_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/un_enfant.yaml
@@ -123,7 +123,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/    
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/un_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_1/un_enfant.yaml
@@ -120,10 +120,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 7
+      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/    
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/couples.yaml
@@ -120,10 +120,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 7
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/couples.yaml
@@ -123,7 +123,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/majoration_par_enf_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/majoration_par_enf_supp.yaml
@@ -120,10 +120,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 7
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/majoration_par_enf_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/majoration_par_enf_supp.yaml
@@ -123,7 +123,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/personnes_seules.yaml
@@ -120,10 +120,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 7
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/personnes_seules.yaml
@@ -123,7 +123,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/un_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/un_enfant.yaml
@@ -120,10 +120,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 7
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/un_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_2/un_enfant.yaml
@@ -123,7 +123,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/couples.yaml
@@ -120,10 +120,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 7
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/couples.yaml
@@ -123,7 +123,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/majoration_par_enf_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/majoration_par_enf_supp.yaml
@@ -120,10 +120,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 7
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/majoration_par_enf_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/majoration_par_enf_supp.yaml
@@ -123,7 +123,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/personnes_seules.yaml
@@ -120,10 +120,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 7
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/personnes_seules.yaml
@@ -123,7 +123,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/un_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/un_enfant.yaml
@@ -120,10 +120,10 @@ metadata:
       title: Arrêté du 22/09/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
-    - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
+    - title: Arrêté du 27/09/2019, art. 7
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/un_enfant.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/l_plafonds_loyers/par_zone/zone_3/un_enfant.yaml
@@ -123,7 +123,7 @@ metadata:
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
     - title: Arrêté du 27/09/2019, art. 7
-      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29    
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286647/2024-09-29
   official_journal_date:
     2001-01-01: "2000-12-28"
     2001-07-01: "2001-08-02"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/p0_particip_min/p0_forfait.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/p0_particip_min/p0_forfait.yaml
@@ -116,7 +116,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000048107807
     2024-10-01:
     - title: Arrêté du 27/09/2019, art. 13
-      href: https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-09-29/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286634/2024-09-29
     - title: Arrêté du 27/09/2024, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000050278404
   official_journal_date:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/tp_taux/tl_loyer/seuils/seuil_1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/tp_taux/tl_loyer/seuils/seuil_1.yaml
@@ -10,6 +10,8 @@ metadata:
   unit: /1
   reference:
     2001-01-01:
+    - title: Arrêté du 27/09/2019, article 14, 2°
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286630
     - title: Décret 2000-1269, art. 2 du 26/12/2000 (crée art. D542-5-2 du CSS)
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006779920&cidTexte=JORFTEXT000000578227
     - title: Arrêté du 26/12/2000

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/tp_taux/tl_loyer/seuils/seuil_2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/tp_taux/tl_loyer/seuils/seuil_2.yaml
@@ -10,6 +10,8 @@ metadata:
   unit: /1
   reference:
     2001-01-01:
+    - title: Arrêté du 27/09/2019, article 14, 2°
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000050286630
     - title: Décret 2000-1269, art. 2 du 26/12/2000 (crée art. D542-5-2 du CSS)
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006779920&cidTexte=JORFTEXT000000578227
     - title: Arrêté du 26/12/2000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "170.1.7"
+version = "170.1.8"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2025
* Zones impactées : 
- `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement`.
- `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/n_nombre_parts/apl/isole_0_personne_a_charge.yaml`
* Détails :
  - Correction les short_label et références des aides logement
  - Correction du nombre de parts pour les APL en secteur foyer (bénéficiaire isolé)

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.
- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).