### PR TITLE
Corrige le short label des paramètres spécifiques AL en secteur foyer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 170.1.9 [2483](https://github.com/openfisca/openfisca-france/pull/2493)
+
+* Changement mineur.
+* Périodes concernées : 2025.
+* Zones impactées :
+  - `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/al/index.yaml`
+
+* Détails :
+  - Corrige le short label des paramètres spécifiques AL en secteur foyer
+
 ### 170.1.8 [2492](https://github.com/openfisca/openfisca-france/pull/2492)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/al/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/al/index.yaml
@@ -1,6 +1,6 @@
 description: Allocations logement - Secteur foyer (AL)
 metadata:
-  short_label: Paramètres spécifiques APL
+  short_label: Paramètres spécifiques AL
   order:
   - formule
   - minimum_depense_nette_logement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "170.1.8"
+version = "170.1.9"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2025
* Zones impactées : `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/al/index.yaml`.
* Détails :
  - Corrige le short label des paramètres spécifiques AL en secteur foyer

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
