### PR TITLE
Corrige la date de la référence législative pour le RSA (avril 2025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 171.0.1 [2498](https://github.com/openfisca/openfisca-france/pull/2498)
+
+* Changement mineur.
+* Périodes concernées : 2025
+* Zones impactées : 
+  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_m/montant_de_base_du_rsa.yaml`
+* Détails :
+  - Corrige la date de la référence législative pour le RSA (avril 2025)
+
 # 171.0.0 [2496](https://github.com/openfisca/openfisca-france/pull/2496)
 
 * Amélioration technique.

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_m/montant_de_base_du_rsa.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_m/montant_de_base_du_rsa.yaml
@@ -121,7 +121,7 @@ metadata:
     2024-04-01:
       title: Décret n° 2024-396 du 29/04/2024, article 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000049486518
-    2025-01-01:
+    2025-04-01:
       title: Décret n° 2025-293 du 29 mars 2025, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000051393086
   official_journal_date:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "171.0.0"
+version = "171.0.1"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : 2025
* Zones impactées : 
- `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/rsa/rsa_m/montant_de_base_du_rsa.yaml`.
* Détails :
  - Corrige la date de la référence législative pour le RSA (avril 2025)
