### PR TITLE
us: PTD-3275 montant frais de garde nul

### DIFF
--- a/openfisca_france/model/prestations/prestations_familiales/paje.py
+++ b/openfisca_france/model/prestations/prestations_familiales/paje.py
@@ -558,9 +558,9 @@ class paje_cmg(Variable):
 
         frais_garde = famille('frais_garde', period)
         # Le montant de la CMG ne doit pas dépasser 85% des frais de garde de la famille
-        montant_cmg = where(frais_garde > 0.0,
+        montant_cmg = where(frais_garde >= 0.0,
                             min_(montant_cmg, frais_garde * paje.paje_cmg.taux_prise_en_charge_maximale),
-                            montant_cmg
+                            0
                             )
         paje_cmg = eligible * montant_cmg
         # TODO: connecter avec le crédit d'impôt

--- a/tests/formulas/paje/paje_cmg.yaml
+++ b/tests/formulas/paje/paje_cmg.yaml
@@ -33,11 +33,15 @@
         enfants: [enfant1, enfant2]
         af_nbenf: 2
         ass_mat: 1
+        frais_garde:
+          2017-04: 1500
       famille_1:
         parents: [parent3, parent4]
         enfants: [enfant3, enfant4]
         af_nbenf: 2
         ass_mat: 1
+        frais_garde:
+          2017-04: 1500
     foyers_fiscaux:
       foyer_fiscal_0:
         declarants: [parent1, parent2]
@@ -95,11 +99,15 @@
         enfants: [enfant1, enfant2]
         af_nbenf: 2
         ass_mat: 1
+        frais_garde:
+          2018-04: 1500
       famille_1:
         parents: [parent3, parent4]
         enfants: [enfant3, enfant4]
         af_nbenf: 2
         ass_mat: 1
+        frais_garde:
+          2018-04: 1500
     foyers_fiscaux:
       foyer_fiscal_0:
         declarants: [parent1, parent2]

--- a/tests/formulas/paje/paje_cmg_couple.yaml
+++ b/tests/formulas/paje/paje_cmg_couple.yaml
@@ -1,3 +1,33 @@
+- name: 'Cas montant frais de garde nul'
+  period: 2024-11
+  relative_error_margin: 0.01
+  input:
+    familles:
+      famille:
+        parents: [parent1, parent2]
+        enfants: [bebe1]
+        prestations_familiales_base_ressources:
+          2024-11: 20000
+        frais_garde:
+          2024-11: 0
+        ass_mat:
+          2024-11: 1
+    individus:
+      parent1:
+        date_naissance:
+          ETERNITY: 2000-10-15
+      parent2:
+        date_naissance:
+          ETERNITY: 1990-10-15
+      bebe1:
+        date_naissance:
+          ETERNITY: 2024-05-15
+  output:
+    familles:
+      famille:
+        paje_cmg:
+          2024-11: 0
+
 - name: 'Cas P2B1E0S1 : Assistant maternel, Nombre de parents : 2, Nombre de bébés : 1, Revenu imposable < Seuil1, 85% des frais > CMG max'
   period: 2024-11
   relative_error_margin: 0.01


### PR DESCRIPTION
Dans le simulateur CMG, lorsque les frais de garde sont égaux à 0, on obtient un montant CMG positif.

Le montant de CMG ne pouvant dépasser 85% des frais de garde, le résultat n’est pas cohérent