### PR TITLE
Remplace pkg_resources par importlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 174.0.1 [2506](https://github.com/openfisca/openfisca-france/pull/2506)
+
+* Amélioration technique.
+* Détails :
+  - Remplace l'usage de `pkg_resources` par `importlib` pour éviter les warnings de dépréciation.
+
 # 174.0.0 [2547](https://github.com/openfisca/openfisca-france/pull/2547)
 
 * Changement majeur.

--- a/openfisca_france/model/prelevements_obligatoires/taxe_habitation/taxe_habitation_import_baremes_locaux.py
+++ b/openfisca_france/model/prelevements_obligatoires/taxe_habitation/taxe_habitation_import_baremes_locaux.py
@@ -1,7 +1,7 @@
 import os
 import csv
 import codecs
-import pkg_resources
+import importlib
 import openfisca_france
 from numpy import fromiter
 from openfisca_france.model.base import *
@@ -14,10 +14,10 @@ def preload_parametres_locaux_taxe_habitation(year = None, variable_to_load = No
     assert variable_to_load is not None
     assert year is not None
     if os.path.isfile('{}/assets/taxe_habitation/parametres_th_{}.csv'.format(openfisca_france.__name__, year)):
-        with pkg_resources.resource_stream(
-                openfisca_france.__name__,
+        with importlib.resources.files(
+                openfisca_france.__name__).joinpath(
                 'assets/taxe_habitation/parametres_th_{}.csv'.format(year),
-                ) as csv_file:
+                ).open('rb') as csv_file:
             utf8_reader = codecs.getreader('utf-8')
             csv_reader = csv.DictReader(utf8_reader(csv_file))
             return {

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -2,7 +2,7 @@ import csv
 import codecs
 import json
 import logging
-import pkg_resources
+import importlib
 import sys
 
 from numpy import ceil, datetime64, fromiter, int16, logical_or as or_, logical_and as and_, logical_not as not_
@@ -1469,10 +1469,11 @@ zone_apl_by_depcom = None
 def preload_zone_apl():
     global zone_apl_by_depcom
     if zone_apl_by_depcom is None:
-        with pkg_resources.resource_stream(
-                openfisca_france.__name__,
-                'assets/apl/20110914_zonage.csv',
-                ) as csv_file:
+        with importlib.resources.files(
+                openfisca_france.__name__
+                ).joinpath(
+                'assets/apl/20110914_zonage.csv'
+                ).open('rb') as csv_file:
             if sys.version_info < (3, 0):
                 csv_reader = csv.DictReader(csv_file)
             else:
@@ -1484,10 +1485,11 @@ def preload_zone_apl():
                 for row in csv_reader
                 }
         # Add subcommunes (arrondissements and communes associées), use the same value as their parent commune.
-        with pkg_resources.resource_stream(
-                openfisca_france.__name__,
+        with importlib.resources.files(
+                openfisca_france.__name__
+                ).joinpath(
                 'assets/apl/commune_depcom_by_subcommune_depcom.json',
-                ) as json_file:
+                ).open('rb') as json_file:
             commune_depcom_by_subcommune_depcom = json.load(json_file)
             for subcommune_depcom, commune_depcom in commune_depcom_by_subcommune_depcom.items():
                 zone_apl_by_depcom[subcommune_depcom] = zone_apl_by_depcom[commune_depcom]

--- a/openfisca_france/model/prestations/bail_reel_solidaire.py
+++ b/openfisca_france/model/prestations/bail_reel_solidaire.py
@@ -2,18 +2,21 @@ from openfisca_france.model.base import *
 import openfisca_france
 import csv
 import codecs
-import pkg_resources
+import importlib
 import numpy as np
 
 
 def bail_reel_solidaire_zones_elligibles():
-    with pkg_resources.resource_stream(openfisca_france.__name__, 'assets/zonage-communes/zonage-abc-juillet-2024.csv') as csv_file:
+    with importlib.resources.files(
+        openfisca_france.__name__).joinpath(
+        'assets/zonage-communes/zonage-abc-juillet-2024.csv'
+    ).open('rb') as csv_file:
         utf8_reader = codecs.getreader('utf-8')
         csv_reader = csv.DictReader(utf8_reader(csv_file), delimiter=';')
         return {
             row['CODGEO']: row['Zone en vigueur depuis le 5 juillet 2024']
             for row in csv_reader
-            }
+        }
 
 
 class bail_reel_solidaire_zones_menage(Variable):
@@ -25,9 +28,10 @@ class bail_reel_solidaire_zones_menage(Variable):
     def formula(menage, period):
         depcom = menage('depcom', period)
         return np.fromiter(
-            (bail_reel_solidaire_zones_elligibles().get(depcom_cell.decode('utf-8')) for depcom_cell in depcom),
+            (bail_reel_solidaire_zones_elligibles().get(
+                depcom_cell.decode('utf-8')) for depcom_cell in depcom),
             dtype='<U4'  # String length max for zones (A, Abis, B1, B2, C)
-            )
+        )
 
 
 class bail_reel_solidaire_plafond_total(Variable):
@@ -47,20 +51,22 @@ class bail_reel_solidaire_plafond_total(Variable):
         def calcul_plafonds_zone(zone):
             plafond_zone = plafonds_par_zones[f'zone_{zone}']
             plafond_base = select(
-                [nb_personnes == i if i < 6 else nb_personnes >= i for i in range(1, 7)],
+                [nb_personnes == i if i < 6 else nb_personnes >=
+                    i for i in range(1, 7)],
                 [plafond_zone[f'nb_personnes_{i}'] for i in range(1, 7)]
-                )
+            )
             plafond_supp = where(
                 nb_personnes > nb_personnes_max,
-                (nb_personnes - nb_personnes_max) * plafond_zone.nb_personnes_supplementaires,
+                (nb_personnes - nb_personnes_max) *
+                plafond_zone.nb_personnes_supplementaires,
                 0
-                )
+            )
             return plafond_base + plafond_supp
 
         return select(
             [zones_menage == zone for zone in zones_abc_eligibles],
             [calcul_plafonds_zone(zone) for zone in zones_abc_eligibles]
-            )
+        )
 
 
 class bail_reel_solidaire(Variable):
@@ -71,10 +77,11 @@ class bail_reel_solidaire(Variable):
     reference = [
         'https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000032918488',
         'https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000437021'
-        ]
+    ]
 
     def formula(menage, period):
         plafond_total = menage('bail_reel_solidaire_plafond_total', period)
         zones_menage = menage('bail_reel_solidaire_zones_menage', period)
-        rfr = menage.sum(menage.members.foyer_fiscal('rfr', period.n_2), role=FoyerFiscal.DECLARANT_PRINCIPAL)
+        rfr = menage.sum(menage.members.foyer_fiscal(
+            'rfr', period.n_2), role=FoyerFiscal.DECLARANT_PRINCIPAL)
         return where(zones_menage is not None, rfr <= plafond_total, False)

--- a/openfisca_france/model/prestations/bail_reel_solidaire.py
+++ b/openfisca_france/model/prestations/bail_reel_solidaire.py
@@ -10,13 +10,15 @@ def bail_reel_solidaire_zones_elligibles():
     with importlib.resources.files(
         openfisca_france.__name__).joinpath(
         'assets/zonage-communes/zonage-abc-juillet-2024.csv'
-    ).open('rb') as csv_file:
+        ).open(
+            'rb'
+            ) as csv_file:
         utf8_reader = codecs.getreader('utf-8')
         csv_reader = csv.DictReader(utf8_reader(csv_file), delimiter=';')
         return {
             row['CODGEO']: row['Zone en vigueur depuis le 5 juillet 2024']
             for row in csv_reader
-        }
+            }
 
 
 class bail_reel_solidaire_zones_menage(Variable):
@@ -31,7 +33,7 @@ class bail_reel_solidaire_zones_menage(Variable):
             (bail_reel_solidaire_zones_elligibles().get(
                 depcom_cell.decode('utf-8')) for depcom_cell in depcom),
             dtype='<U4'  # String length max for zones (A, Abis, B1, B2, C)
-        )
+            )
 
 
 class bail_reel_solidaire_plafond_total(Variable):
@@ -51,22 +53,20 @@ class bail_reel_solidaire_plafond_total(Variable):
         def calcul_plafonds_zone(zone):
             plafond_zone = plafonds_par_zones[f'zone_{zone}']
             plafond_base = select(
-                [nb_personnes == i if i < 6 else nb_personnes >=
-                    i for i in range(1, 7)],
+                [nb_personnes == i if i < 6 else nb_personnes >= i for i in range(1, 7)],
                 [plafond_zone[f'nb_personnes_{i}'] for i in range(1, 7)]
-            )
+                )
             plafond_supp = where(
                 nb_personnes > nb_personnes_max,
-                (nb_personnes - nb_personnes_max) *
-                plafond_zone.nb_personnes_supplementaires,
+                (nb_personnes - nb_personnes_max) * plafond_zone.nb_personnes_supplementaires,
                 0
-            )
+                )
             return plafond_base + plafond_supp
 
         return select(
             [zones_menage == zone for zone in zones_abc_eligibles],
             [calcul_plafonds_zone(zone) for zone in zones_abc_eligibles]
-        )
+            )
 
 
 class bail_reel_solidaire(Variable):
@@ -77,7 +77,7 @@ class bail_reel_solidaire(Variable):
     reference = [
         'https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000032918488',
         'https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000437021'
-    ]
+        ]
 
     def formula(menage, period):
         plafond_total = menage('bail_reel_solidaire_plafond_total', period)

--- a/openfisca_france/scripts/performance/measure_tests_performance.py
+++ b/openfisca_france/scripts/performance/measure_tests_performance.py
@@ -10,7 +10,7 @@ Usage example:
 import os
 import time
 import logging
-import pkg_resources
+import importlib
 
 from openfisca_core.tools.test_runner import run_tests
 from openfisca_france import CountryTaxBenefitSystem
@@ -30,8 +30,8 @@ tbs = CountryTaxBenefitSystem()
 time_spent_tbs = time.time() - start_time_tbs
 
 
-openfisca_france_dir = pkg_resources.get_distribution('OpenFisca-France').location
-yaml_tests_dir = os.path.join(openfisca_france_dir, 'tests', 'mes-aides.gouv.fr')
+folder = os.path.join('tests', 'mes-aides.gouv.fr')
+yaml_tests_dir = importlib.resources.path('OpenFisca-France', folder)
 
 
 # Time openfisca-run-test runner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "174.0.0"
+version = "174.0.1"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]
@@ -21,7 +21,6 @@ requires-python = ">= 3.9"
 dependencies = [
     "numpy >=1.24.3, <2",
     "openfisca-core[web-api] >=43, <44",
-    "setuptools"
 ]
 
 [project.urls]


### PR DESCRIPTION
* Amélioration technique.
* Détails :
  - Remplace l'usage de `pkg_resources` pas `importlib`

- - - -


[`pkg_resources`](https://setuptools.pypa.io/en/latest/pkg_resources.html) est déprécié et remplacé par `importlib`.

`pkg_resources` n'est pas inclus pas défaut (semble-t-il) avec python 3.12 et donc il faut soit spécifié `setuptools` dans les dépendences d'OpenFisca France (qui importe le module `pkg_resources`) soit migrer à `importlib`.
