### PR TITLE
Fiabilisation aide logement secteur conventionné coeff K APL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 171.0.3
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/model/prestations/aides_logement.py`
+* Détails :
+    - Fiabilisation de l'aide au logement pour le secteur Foyer conventionné en s'assurant que le coefficient "K" utilisé pour le calcul ne puisse pas dépasser sa valeur plafond, ce qui peut arriver dans de très rares cas.
+    - Par exemple, une personne seule, sans revenus, en zone I, au plafond de l'équivalence loyer/charges E (locataire d'un logement en foyer conventionné dans le 92800 pour un loyer de 500€), dont le coefficient "K" atteint la valeur "1,04" si elle n'est pas plafonnée.
+
 ### 171.0.2 [2495](https://github.com/openfisca/openfisca-france/pull/2495)
 
 * Changement mineur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 171.0.3
+### 171.0.3 [2510](https://github.com/openfisca/openfisca-france/pull/2510)
 
 * Changement mineur.
 * Périodes concernées : toutes.

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1608,7 +1608,7 @@ class aides_logement_foyer_k_apl(Variable):
         R_majuscule = famille('aide_logement_base_ressources', period)
         N = famille('aides_logement_nb_part', period)
 
-        return plafond_k - (((R_majuscule - (r_minuscule * N))) / (cm1 * N))
+        return min_(plafond_k, plafond_k - (((R_majuscule - (r_minuscule * N))) / (cm1 * N)))
 
 
 class aides_logement_categorie(Variable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "171.0.2"
+version = "171.0.3"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/formulas/aides_logement_foyer.yaml
+++ b/tests/formulas/aides_logement_foyer.yaml
@@ -97,3 +97,21 @@
     aides_logement_foyer_plafond_mensualite: 383.47 # L.PLA
     aide_logement_montant_brut_avant_degressivite: 161.11 # APL = k*((L+C)-(L0-C))
     aide_logement: 155.78
+
+- name: 'Cas 6: Personne réside dans une chambre conventionnée en logement foyer, zone 1, fiabilisation coefficient K'
+  period: 2025-05
+  relative_error_margin: 0.02
+  input:
+    age: 38
+    loyer: 500
+    zone_apl: zone_1
+    statut_occupation_logement: locataire_foyer
+    salaire_imposable:
+      2025: 0
+      2024: 0
+      2023: 0
+    logement_conventionne: true
+    logement_chambre: true
+  output:
+    aides_logement_k: 0.95 # K
+    aide_logement: 456.56


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées : `model/prestations/aides_logement.py`.
* Détails :
  - Fiabilisation de l'aide au logement pour le secteur Foyer conventionné en s'assurant que le coefficient "K" utilisé pour le calcul ne puisse pas dépasser sa valeur plafond, ce qui peut arriver dans de très rares cas.
  - Par exemple, une personne seule, sans revenus, en zone I, au plafond de l'équivalence loyer/charges E (locataire d'un logement en foyer conventionné dans le 92800 pour un loyer de 500€), dont le coefficient "K" atteint la valeur "1,04" si elle n'est pas plafonnée.

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.