### PR TITLE
Mensualisation du calcul de l'age

### DIFF
--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -75,8 +75,8 @@ class age(Variable):
                             )
 
         date_naissance = individu('date_naissance', period)
-        epsilon = timedelta64(1)
-        return (datetime64(period.start) - date_naissance + epsilon).astype('timedelta64[Y]')
+        epsilon = timedelta64(1, 'M')
+        return ((datetime64(period.start, 'M') + epsilon) - date_naissance).astype('timedelta64[Y]')
 
 
 class age_en_mois(Variable):

--- a/openfisca_france/model/prestations/pass_culture.py
+++ b/openfisca_france/model/prestations/pass_culture.py
@@ -11,6 +11,6 @@ class pass_culture(Variable):
 
     def formula(individu, period, parameters):
         montant = parameters(period).prestations_sociales.education.pass_culture.montants
-        age = individu('age', period.offset(1, 'month'))
+        age = individu('age', period)
         age_maximum = parameters(period).prestations_sociales.education.pass_culture.age_maximum
         return montant.calc(age) * (age <= age_maximum)

--- a/tests/formulas/paje/paje_cmg_couple.yaml
+++ b/tests/formulas/paje/paje_cmg_couple.yaml
@@ -51,7 +51,7 @@
           ETERNITY: 1990-10-15
       bebe1:
         date_naissance:
-          ETERNITY: 2024-05-15
+          ETERNITY: 2024-11-15
   output:
     familles:
       famille:

--- a/tests/formulas/ppa/ppa.yaml
+++ b/tests/formulas/ppa/ppa.yaml
@@ -34,7 +34,7 @@
   period: 2016-01
   relative_error_margin: 0.05
   input:
-    date_naissance: '1997-11-15' # age > 18 seulemet sur 1 mois du TR
+    date_naissance: '1997-12-15' # age > 18 seulemet sur 1 mois du TR
     salaire_net:
       2015-12: 918
       2015-11: 918

--- a/tests/formulas/rsa/rsa_celibataire.yaml
+++ b/tests/formulas/rsa/rsa_celibataire.yaml
@@ -246,7 +246,7 @@
 - period: 2015-01
   name: Pas de RSA si âge < 25
   input:
-    date_naissance: '1990-01-02'  # 24 ans
+    date_naissance: '1990-02-02'  # 24 ans
   output:
     rsa: 0
 

--- a/tests/formulas/taxe_habitation.yaml
+++ b/tests/formulas/taxe_habitation.yaml
@@ -311,7 +311,7 @@
         2000: 0.02
     individus:
       parent1:
-        date_naissance: '1953-01-01'
+        date_naissance: '1953-02-01'
       parent2:
         date_naissance: '1963-01-01'
   output:

--- a/tests/leximpact/2024/couple_1actif_1inactif_0.8_SMIC_3_enfants_d1.yml
+++ b/tests/leximpact/2024/couple_1actif_1inactif_0.8_SMIC_3_enfants_d1.yml
@@ -203,7 +203,7 @@ input:
         2024: marie
     enfant_1:
       date_naissance:
-        2024: '2014-01-01'
+        2024: '2014-02-01'
       garde_alternee:
         2024: false
       rempli_obligation_scolaire:

--- a/tests/leximpact/2024/couple_1actif_1inactif_1.5_SMIC_3_enfants_d2.yml
+++ b/tests/leximpact/2024/couple_1actif_1inactif_1.5_SMIC_3_enfants_d2.yml
@@ -203,7 +203,7 @@ input:
         2024: marie
     enfant_1:
       date_naissance:
-        2024: '2014-01-01'
+        2024: '2014-02-01'
       garde_alternee:
         2024: false
       rempli_obligation_scolaire:


### PR DESCRIPTION
Merci de contribuer à OpenFisca ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)

* Amélioration technique.
* Périodes concernées : toutes. 
* Zones impactées :
  *  `openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py`
  * `openfisca_france\model\prestations\pass_culture.py`
* Détails :
  - Correction d'un bug lié au calcul de l'âge. En effet, l'âge étant une variable définie sur un mois (`definition_period = MONTH`) or son calcul se fait au 1er jour du mois. La correction ci-après consiste à faire le calcul au dernier jour du mois.
  - Exemple : une famille avec un seul enfant, dont la prise en charge commence le mois de sa naissance. La famille devrait avoir droit à la CMG, mais à cause du bug la simulation répondait qu'elle était inéligible.
  - Le calcul du pass culture décalait la date de référence d'un mois en avant, ce qui n'est plus nécessaire avec la modification du calcul de l'âge, du coup ce décalage a été supprimé.

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.

- - - -
