### PR TITLE
Ajout de la metadata income_tax_year au paramètre impot_revenu

### DIFF
--- a/openfisca_france/parameters/impot_revenu/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/index.yaml
@@ -1,5 +1,6 @@
 description: Impôts sur le revenu
 metadata:
+  income_tax_year: true
   order:
   - bareme_ir_depuis_1945
   - anciens_baremes_igr


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/parameters/impot_revenu/index.yaml`. 
* Détails :
  - Ajoute une metadata income_tax_year au paramètre `impot_revenu` afin de permettre à des visualisateurs de paramètres d'afficher les années de l'impôt sur le revenu en plus des dates de ce paramètre (et de ses enfants)
