### PR TITLE
supprime la variable aides_logement_categorie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# 172.0.0 [2521](https://github.com/openfisca/openfisca-france/pull/2521)
+
+* Correction d'un crash.
+* Périodes concernées : toutes.
+* Zones impactées : `openfisca_france/model/prestations/aides_logement.py`.
+* Détails :
+  - Supprime la variable `aides_logement_categorie` qui posait problème dans le dump (car string) pour l'intégrer directement dans le calcul de la variable qui l'appelait
+
 ### 171.0.2 [2495](https://github.com/openfisca/openfisca-france/pull/2495)
 
 * Changement mineur.

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1611,17 +1611,6 @@ class aides_logement_foyer_k_apl(Variable):
         return plafond_k - (((R_majuscule - (r_minuscule * N))) / (cm1 * N))
 
 
-class aides_logement_categorie(Variable):
-    value_type = str
-    entity = Famille
-    definition_period = MONTH
-    set_input = set_input_dispatch_by_period
-
-    def formula(famille, period, parameters):
-        categorie_apl = famille.demandeur.menage('logement_conventionne', period)
-        return where(categorie_apl, 'apl', 'al')
-
-
 class aides_logement_nb_part(Variable):
     value_type = float
     entity = Famille
@@ -1633,8 +1622,10 @@ class aides_logement_nb_part(Variable):
     def formula(famille, period, parameters):
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
         couple = famille('al_couple', period)
+        
+        categorie_apl = famille.demandeur.menage('logement_conventionne', period)
+        categorie = where(categorie_apl, 'apl', 'al')
 
-        categorie = famille('aides_logement_categorie', period)
         params = parameters(period).prestations_sociales.aides_logement.allocations_logement.foyer.k_coef_prise_en_charge.n_nombre_parts[categorie]
 
         return (

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1622,7 +1622,7 @@ class aides_logement_nb_part(Variable):
     def formula(famille, period, parameters):
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
         couple = famille('al_couple', period)
-        
+
         categorie_apl = famille.demandeur.menage('logement_conventionne', period)
         categorie = where(categorie_apl, 'apl', 'al')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "171.0.2"
+version = "172.0.0"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/model/prestations/aides_logement.py`.
* Détails :
  - Supprime la variable `aides_logement_categorie` qui posait problème dans le dump (car string) pour l'intégrer directement dans le calcul de la variable qui l'appelait

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient l'API publique d'OpenFisca France (par exemple renommage ou suppression de variables).
- Corrigent ou améliorent un calcul déjà existant.
