### PR TITLE
Met à jour la fraction des revenus professionnels de la prime d'activité

### DIFF
--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/seuil_bonification.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/seuil_bonification.yaml
@@ -7,7 +7,6 @@ metadata:
   last_value_still_valid_on: "2025-03-07"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_seuil_min
-  unit: currency
   reference:
     2016-01-01:
     - title: Article D843-2 du Code de la sécurité sociale

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/taux_bonification_max.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/bonification/taux_bonification_max.yaml
@@ -1,11 +1,11 @@
-description: Montant maximal de la bonification (en % de la base RSA) pour la prime pour l'activité (PPA)
+description: Montant maximal de la bonification (en % de la base PPA) pour la prime pour l'activité (PPA)
 values:
   2016-01-01:
     value: 0.12782
   2018-10-01:
     value: 0.29101
 metadata:
-  short_label: Montant maximal de la bonification (en % de la base RSA)
+  short_label: Montant maximal de la bonification (en % de la base PPA)
   last_value_still_valid_on: "2025-03-07"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_bonification

--- a/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_ressources_revenus_activite.yaml
+++ b/openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_ressources_revenus_activite.yaml
@@ -4,9 +4,11 @@ values:
     value: 0.62
   2018-08-01:
     value: 0.61
+  2025-04-01:
+    value: 0.5985
 metadata:
   short_label: pente de la PPA
-  last_value_still_valid_on: "2025-03-07"
+  last_value_still_valid_on: "2025-06-26"
   label_en: "Active solidarity income - Activity premium (PPA) : Amounts"
   ipp_csv_id: pa_maj_revenu
   unit: /1
@@ -21,6 +23,12 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037462909
     - title: Décret 2018-836 du 03/10/2018, art. 2
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000037460547
+    2025-04-01:
+    - title: Article D843-3 du code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037462909
+    - title: Décret 2018-836 du 03/10/2018, art. 1
+      href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000051395359/2025-03-31/
   official_journal_date:
     2016-01-01: "2015-12-22"
     2018-08-01: "2018-10-04"
+    2025-04-01: "2025-03-30"


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/04/2025.
* Zones impactées : 
  - `openfisca_france/parameters/prestations_sociales/solidarite_insertion/minima_sociaux/ppa/pa_m/majoration_ressources_revenus_activite.yaml`.
* Détails :
  - Met à jour la fraction des revenus professionnels de la prime d'activité

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -
