### PR TITLE
feat(PTD-3436): corrections paramètres et calcul APL Accession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 172.0.6 [2543](https://github.com/openfisca/openfisca-france/pull/2543)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2004.
+* Zones impactées :
+  - `openfisca_france/model/prestations/prestations_familiales/paje.py`.
+* Détails :
+  - Ajout de la variable "paje_adoption" pour le calcul de la prime d'adoption de la PAJE, pour compléter celui de la prime de naissance.
+
 ### 172.0.5 [2532](https://github.com/openfisca/openfisca-france/pull/2532)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -285,6 +285,22 @@ class aide_logement_date_pret_conventionne(Variable):
     definition_period = ETERNITY
 
 
+class aide_logement_est_pret_conventionne(Variable):
+    value_type = bool
+    default_value = False
+    entity = Menage
+    label = "Indique que le ménage a contracté un prêt conventionné pour l'acquisition un logement"
+    definition_period = ETERNITY
+
+
+class aide_logement_date_pret(Variable):
+    value_type = date
+    default_value = date.max
+    entity = Menage
+    label = "Date de contraction d'un prêt pour l'acquisition d'un logement"
+    definition_period = ETERNITY
+
+
 class date_debut_chomage(Variable):
     value_type = date
     default_value = date.max
@@ -307,7 +323,14 @@ class aides_logement_primo_accedant_eligibilite(Variable):
 
         zone_apl = menage('zone_apl', period)
         aide_logement_etat_logement = menage('etat_logement', period)
-        aide_logement_date_pret_conventionne = menage('aide_logement_date_pret_conventionne', period)
+
+        date_pret_conventionne = menage('aide_logement_date_pret_conventionne', period)
+        date_pret_conventionne_est_valide = (date_pret_conventionne is not None) * (date_pret_conventionne < date.max)
+        est_pret_conventionne = (menage('aide_logement_est_pret_conventionne', period)
+                                + date_pret_conventionne_est_valide)
+        aide_logement_date_pret = where(
+            date_pret_conventionne_est_valide, date_pret_conventionne, menage('aide_logement_date_pret', period))
+
         est_logement_ancien = (
             (aide_logement_etat_logement == TypeEtatLogement.acquisition_amelioration)
             + (aide_logement_etat_logement == TypeEtatLogement.acquisition_sans_amelioration_logement_existant)
@@ -316,12 +339,12 @@ class aides_logement_primo_accedant_eligibilite(Variable):
             )
 
         est_zone_3 = (zone_apl == TypesZoneApl.zone_3)
-        date_pret_conventionne_avant_2018_01 = (aide_logement_date_pret_conventionne < date(2018, 1, 1))
-        date_pret_conventionne_avant_2020_01 = (aide_logement_date_pret_conventionne < date(2020, 1, 1))
+        date_pret_avant_2018_01 = (aide_logement_date_pret < date(2018, 1, 1))
+        date_pret_avant_2020_01 = (aide_logement_date_pret < date(2020, 1, 1))
 
         eligibilite = select(
-            [date_pret_conventionne_avant_2018_01, date_pret_conventionne_avant_2020_01],
-            [True, (est_logement_ancien * est_zone_3)], default = False
+            [date_pret_avant_2018_01, date_pret_avant_2020_01],
+            [True, (est_pret_conventionne * est_logement_ancien * est_zone_3)], default = False
             )
 
         return accedant * eligibilite
@@ -1637,7 +1660,7 @@ class aides_logement_k(Variable):
 class aides_logement_primo_accedant_k(Variable):
     value_type = float
     entity = Famille
-    label = 'Allocation logement pour les primo-accédants K'
+    label = "Coefficient K pour l'allocation logement et l'aide personnalisée au logement pour les primo-accédants K"
     reference = 'https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006073189&idArticle=LEGIARTI000006737341&dateTexte=&categorieLien=cid'
     definition_period = MONTH
     set_input = set_input_divide_by_period
@@ -1646,13 +1669,19 @@ class aides_logement_primo_accedant_k(Variable):
         # en accession-al, le coefficient K est celui defini pour le secteur foyer-al
         param = parameters(period).prestations_sociales.aides_logement.allocations_logement.foyer.k_coef_prise_en_charge
 
-        plafond_k = param.plafonds.plafond_apl2_et_al
-        cm2 = param.cm_et_r.cm2_apl2_et_al
+        # Le coefficient K n'est pas le même selon qu'il s'agisse d'un prêt conventionné ou non
+        date_pret_conventionne = famille.demandeur.menage('aide_logement_date_pret_conventionne', period)
+        date_pret_conventionne_est_valide = (date_pret_conventionne is not None) * (date_pret_conventionne < date.max)
+        est_pret_conventionne = (famille.demandeur.menage('aide_logement_est_pret_conventionne', period)
+                                + date_pret_conventionne_est_valide)
+
+        plafond_k = where(est_pret_conventionne, param.plafonds.plafond_apl1, param.plafonds.plafond_apl2_et_al)
+        cm = where(est_pret_conventionne, param.cm_et_r.cm3_apl3, param.cm_et_r.cm2_apl2_et_al)
 
         R = famille('aide_logement_base_ressources', period)
         N = famille('aides_logement_nb_part', period)
 
-        return plafond_k - (R / (cm2 * N))
+        return min_(plafond_k, plafond_k - (R / (cm * N)))
 
 
 class aides_logement_foyer_k_al(Variable):

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/cm_et_r/cm3_apl3.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/cm_et_r/cm3_apl3.yaml
@@ -1,0 +1,22 @@
+description: Coefficient multiplicateur cm3 dans la formule de K (paramètre de calcul des aides logements en secteur foyer et accession) pour les APL3
+values:
+  2007-07-01:
+    value: 22111.33
+metadata:
+  short_label: cm3
+  last_value_still_valid_on: "2025-07-23"
+  label_en: Parameters for new home-buyers (APL)
+  ipp_csv_id: mult_k_apl_accession
+  unit: currency
+  reference:
+    2007-07-01:
+    - title: Arrêté du 27/09/2019, art. 22
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000039160769
+  official_journal_date:
+    2007-07-01: "2007-07-12"
+  notes:
+    2007-07-01:
+    - title: Paramètres dispo dans "Eléments de calcul des aides personnelles au logement", 2013
+documentation: |-
+  Notes :
+  L'APL est réformée en 2001 et les paramètres ci-dessus peuvent remonter jusqu'à 2001.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "172.0.5"
+version = "172.0.6"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/formulas/aides_logement_accedant_eligibilite.yaml
+++ b/tests/formulas/aides_logement_accedant_eligibilite.yaml
@@ -357,3 +357,378 @@
       - parent1
   output:
     aides_logement_primo_accedant_eligibilite: 0
+
+
+# ---------- Utilisation de aide_logement_est_pret_conventionne et aide_logement_date_pret ---------- #
+
+- name: "Cas 1 (est_pret_conventionne et date_pret) eligible APL accession: - prêt conclu avant le 1er janvier 2018 - prêt conclu en zone 2 pour l'acquisition d'un logement neuf"
+  description: Eligiblite APL accession
+  period: 2018-04
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1, enfant2]
+      statut_occupation_logement: primo_accedant
+      aide_logement_est_pret_conventionne: true
+      aide_logement_date_pret: 2017-12-20
+      etat_logement: construction_acquisition_logement_neuf
+      zone_apl: zone_2
+    individus:
+      parent1: {}
+      parent2: {}
+      enfant1: {}
+      enfant2: {}
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+      foyer_fiscal_2:
+        declarants:
+        - enfant1
+      foyer_fiscal_3:
+        declarants:
+        - enfant2
+  output:
+    aides_logement_primo_accedant_eligibilite: 1
+
+- name: "Cas 2 (est_pret_conventionne et date_pret) eligible APL accession: - prêt conclu avant le 1er janvier 2018 - prêt conclu en zone 2 pour l'acquisition d'un logement neuf"
+  description: Eligiblite APL accession
+  period: 2018-04
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1, enfant2]
+      statut_occupation_logement: primo_accedant
+      aide_logement_est_pret_conventionne: true
+      aide_logement_date_pret: 2017-12-20
+      etat_logement: construction_acquisition_logement_neuf
+      zone_apl: zone_2
+    individus:
+      parent1: {}
+      parent2: {}
+      enfant1: {}
+      enfant2: {}
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+      foyer_fiscal_2:
+        declarants:
+        - enfant1
+      foyer_fiscal_3:
+        declarants:
+        - enfant2
+  output:
+    aides_logement_primo_accedant_eligibilite: 1
+
+- name: "Cas 3 (est_pret_conventionne et date_pret) eligible APL accession: - prêt conclu avant le 1er janvier 2018 - prêt conclu en zone 3 pour l'acquisition d'un logement ancien"
+  description: Eligiblite APL accession
+  period: 2018-04
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1, enfant2]
+      statut_occupation_logement: primo_accedant
+      aide_logement_est_pret_conventionne: true
+      aide_logement_date_pret: 2017-12-20
+      etat_logement: acquisition_sans_amelioration_logement_existant
+      zone_apl: zone_3
+    individus:
+      parent1: {}
+      parent2: {}
+      enfant1: {}
+      enfant2: {}
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+      foyer_fiscal_2:
+        declarants:
+        - enfant1
+      foyer_fiscal_3:
+        declarants:
+        - enfant2
+  output:
+    aides_logement_primo_accedant_eligibilite: 1
+
+- name: "Cas 4 (est_pret_conventionne et date_pret) eligible APL accession: - prêt conclu avant le 1er janvier 2020 - prêt conclu en zone 3 pour l'acquisition d'un logement ancien"
+  description: Eligiblite APL accession
+  period: 2018-04
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1, enfant2]
+      statut_occupation_logement: primo_accedant
+      aide_logement_est_pret_conventionne: true
+      aide_logement_date_pret: 2018-02-02
+      etat_logement: acquisition_sans_amelioration_logement_existant
+      zone_apl: zone_3
+    individus:
+      parent1: {}
+      parent2: {}
+      enfant1: {}
+      enfant2: {}
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+      foyer_fiscal_2:
+        declarants:
+        - enfant1
+      foyer_fiscal_3:
+        declarants:
+        - enfant2
+  output:
+    aides_logement_primo_accedant_eligibilite: 1
+
+- name: "Cas 5 (est_pret_conventionne et date_pret) eligible APL accession: - prêt conclu avant le 1er janvier 2018 - prêt conclu en zone 1 pour l'amelioration d'un logement ancien"
+  description: Eligiblite APL accession
+  period: 2018-04
+  input:
+    famille:
+      parents: [parent1, parent2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      statut_occupation_logement: primo_accedant
+      aide_logement_est_pret_conventionne: true
+      aide_logement_date_pret: 2017-12-20
+      etat_logement: amelioration
+      zone_apl: zone_1
+    individus:
+      parent1: {}
+      parent2: {}
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+  output:
+    aides_logement_primo_accedant_eligibilite: 1
+
+- name: "Cas 6 (est_pret_conventionne et date_pret) eligible APL accession: - prêt conclu avant le 1er janvier 2018 - prêt conclu en zone 3 pour l'acquisition d'un logement neuf"
+  description: Eligiblite APL accession
+  period: 2018-04
+  input:
+    famille:
+      parents: [parent1, parent2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      statut_occupation_logement: primo_accedant
+      aide_logement_est_pret_conventionne: true
+      aide_logement_date_pret: 2017-12-20
+      etat_logement: construction_acquisition_logement_neuf
+      zone_apl: zone_3
+    individus:
+      parent1: {}
+      parent2: {}
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+  output:
+    aides_logement_primo_accedant_eligibilite: 1
+
+- name: "Cas 7 (est_pret_conventionne et date_pret) eligible APL accession: - prêt conclu avant le 1er janvier 2018 - prêt conclu en zone 1 pour l'acquisition d'un logement neuf"
+  description: Eligiblite APL accession
+  period: 2018-04
+  input:
+    famille:
+      parents: [parent1]
+    menage:
+      personne_de_reference: parent1
+      statut_occupation_logement: primo_accedant
+      aide_logement_est_pret_conventionne: true
+      aide_logement_date_pret: 2002-04-10
+      etat_logement: construction_acquisition_logement_neuf
+      zone_apl: zone_1
+    individus:
+      parent1: {}
+    foyer_fiscal:
+      declarants:
+      - parent1
+  output:
+    aides_logement_primo_accedant_eligibilite: 1
+
+- name: "Cas 1 (est_pret_conventionne et date_pret) non eligible APL accession: - prêt conclu avant le 1er janvier 2020 - prêt conclu en zone 2 pour l'acquisition d'un logement neuf"
+  description: Non eligiblite APL accession
+  period: 2018-04
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1, enfant2]
+      statut_occupation_logement: primo_accedant
+      aide_logement_est_pret_conventionne: true
+      aide_logement_date_pret: 2018-02-02
+      etat_logement: construction_acquisition_logement_neuf
+      zone_apl: zone_2
+    individus:
+      parent1: {}
+      parent2: {}
+      enfant1: {}
+      enfant2: {}
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+      foyer_fiscal_2:
+        declarants:
+        - enfant1
+      foyer_fiscal_3:
+        declarants:
+        - enfant2
+  output:
+    aides_logement_primo_accedant_eligibilite: 0
+
+- name: "Cas 2 (est_pret_conventionne et date_pret) non eligible APL accession: - prêt conclu avant le 1er janvier 2020 - prêt conclu en zone 2 pour l'acquisition d'un logement neuf"
+  description: Non eligiblite APL accession
+  period: 2018-04
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1, enfant2]
+      statut_occupation_logement: primo_accedant
+      aide_logement_est_pret_conventionne: true
+      aide_logement_date_pret: 2018-02-02
+      etat_logement: construction_acquisition_logement_neuf
+      zone_apl: zone_2
+    individus:
+      parent1: {}
+      parent2: {}
+      enfant1: {}
+      enfant2: {}
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+      foyer_fiscal_2:
+        declarants:
+        - enfant1
+      foyer_fiscal_3:
+        declarants:
+        - enfant2
+  output:
+    aides_logement_primo_accedant_eligibilite: 0
+
+- name: "Cas 3 (est_pret_conventionne et date_pret) non eligible APL accession: - prêt conclu avant le 1er janvier 2020 - prêt conclu en zone 1 pour l'amelioration d'un logement ancien"
+  description: Non eligiblite APL accession
+  period: 2018-04
+  input:
+    famille:
+      parents: [parent1, parent2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      statut_occupation_logement: primo_accedant
+      aide_logement_est_pret_conventionne: true
+      aide_logement_date_pret: 2018-02-02
+      etat_logement: amelioration
+      zone_apl: zone_1
+    individus:
+      parent1: {}
+      parent2: {}
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+  output:
+    aides_logement_primo_accedant_eligibilite: 0
+
+- name: "Cas 4 (est_pret_conventionne et date_pret) non eligible APL accession: - prêt conclu avant le 1er janvier 2020 - prêt conclu en zone 3 pour l'acquisition d'un logement neuf"
+  description: Non eligiblite APL accession
+  period: 2018-04
+  input:
+    famille:
+      parents: [parent1, parent2]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      statut_occupation_logement: primo_accedant
+      aide_logement_est_pret_conventionne: true
+      aide_logement_date_pret: 2018-02-02
+      etat_logement: construction_acquisition_logement_neuf
+      zone_apl: zone_3
+    individus:
+      parent1: {}
+      parent2: {}
+    foyers_fiscaux:
+      foyer_fiscal_0:
+        declarants:
+        - parent1
+      foyer_fiscal_1:
+        declarants:
+        - parent2
+  output:
+    aides_logement_primo_accedant_eligibilite: 0
+
+- name: "Cas 5 (est_pret_conventionne et date_pret) non eligible APL accession: - prêt conclu avant le 1er janvier 2020 - prêt conclu en zone 1 pour l'acquisition d'un logement neuf"
+  description: Non eligiblite APL accession
+  period: 2018-04
+  input:
+    famille:
+      parents: [parent1]
+    menage:
+      personne_de_reference: parent1
+      statut_occupation_logement: primo_accedant
+      aide_logement_est_pret_conventionne: true
+      aide_logement_date_pret: 2018-02-02
+      etat_logement: construction_acquisition_logement_neuf
+      zone_apl: zone_1
+    individus:
+      parent1: {}
+    foyer_fiscal:
+      declarants:
+      - parent1
+  output:
+    aides_logement_primo_accedant_eligibilite: 0

--- a/tests/mes-aides.gouv.fr/500E_mois_APL_Zone_1.yaml
+++ b/tests/mes-aides.gouv.fr/500E_mois_APL_Zone_1.yaml
@@ -302,4 +302,4 @@ input:
     aide_logement_date_pret_conventionne: 2017-01-01
 output:
   aides_logement_primo_accedant_eligibilite: true
-  aide_logement: 127
+  aide_logement: 142.86

--- a/tests/mes-aides.gouv.fr/500E_mois_APL_Zone_2.yaml
+++ b/tests/mes-aides.gouv.fr/500E_mois_APL_Zone_2.yaml
@@ -300,4 +300,4 @@ input:
       2017-08: primo_accedant
     aide_logement_date_pret_conventionne: 2017-01-01
 output:
-  aide_logement: 105
+  aide_logement: 118.38

--- a/tests/mes-aides.gouv.fr/500E_mois_APL_Zone_3.yaml
+++ b/tests/mes-aides.gouv.fr/500E_mois_APL_Zone_3.yaml
@@ -325,4 +325,4 @@ input:
       2017-08: primo_accedant
     aide_logement_date_pret_conventionne: 2017-01-01
 output:
-  aide_logement: 95
+  aide_logement: 107.54

--- a/tests/mes-aides.gouv.fr/aides_logement_primo_accedant_AL_Zone_1_450E_mois.yaml
+++ b/tests/mes-aides.gouv.fr/aides_logement_primo_accedant_AL_Zone_1_450E_mois.yaml
@@ -1,0 +1,392 @@
+name: AL Accession 450€/mois
+keywords:
+- Propriétaire ou accédant à la propriété
+- al
+description: |-
+  Métropole : accession en AL
+  Soit un couple avec deux enfants à charge, ayant des ressources annuelles prises en
+  compte de 17 450 €, soient 17 500 € arrondies à la centaine d'euros supérieure. Il accède
+  à la propriété en octobre 2017 à l'aide d'un prêt libre, avec une mensualité de 450 €,
+  pour un logement en zone I.
+  Le calcul est effectué pour le droit de janvier 2024.
+period: month:2024-01
+relative_error_margin: 0.05
+input:
+  individus:
+    demandeur:
+      salaire_imposable:
+        2023-01: 1700
+        2023-02: 1700
+        2023-03: 1700
+        2023-04: 1700
+        2023-05: 1700
+        2023-06: 1700
+        2023-07: 1700
+        2023-08: 1700
+        2023-09: 1700
+        2023-10: 1700
+        2023-11: 1700
+        2023-12: 1700
+      aah:
+        2023-01: 0
+        2023-02: 0
+        2023-03: 0
+        2023-04: 0
+        2023-05: 0
+        2023-06: 0
+        2023-07: 0
+        2023-08: 0
+        2023-09: 0
+        2023-10: 0
+        2023-11: 0
+        2023-12: 0
+      age:
+        2023-10: 27
+        2023-11: 27
+        2023-12: 27
+        2024-01: 27
+      age_en_mois:
+        2023-10: 331
+        2023-11: 331
+        2023-12: 331
+        2024-01: 331
+      boursier:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      date_arret_de_travail:
+        2023-10: '2024-01-10'
+        2023-11: '2024-01-10'
+        2023-12: '2024-01-10'
+        2024-01: '2024-01-10'
+      date_naissance:
+        2023-10: '1990-01-01'
+        2023-11: '1990-01-01'
+        2023-12: '1990-01-01'
+        2024-01: '1990-01-01'
+      bourse_criteres_sociaux_echelon:
+        2023-10: -1
+        2023-11: -1
+        2023-12: -1
+        2024-01: -1
+      enfant_a_charge:
+        '2017': false
+      enfant_place:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      etudiant:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      handicap:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      inapte_travail:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      taux_incapacite:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      valeur_locative_immo_non_loue:
+        2012-01: 0
+      valeur_locative_terrains_non_loues:
+        2012-01: 0
+    conjoint:
+      aah:
+        2023-01: 0
+        2023-02: 0
+        2023-03: 0
+        2023-04: 0
+        2023-05: 0
+        2023-06: 0
+        2023-07: 0
+        2023-08: 0
+        2023-09: 0
+        2023-10: 0
+        2023-11: 0
+        2023-12: 0
+      age:
+        2023-10: 27
+        2023-11: 27
+        2023-12: 27
+        2024-01: 27
+      age_en_mois:
+        2023-10: 331
+        2023-11: 331
+        2023-12: 331
+        2024-01: 331
+      boursier:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      date_arret_de_travail:
+        2023-10: '2024-01-10'
+        2023-11: '2024-01-10'
+        2023-12: '2024-01-10'
+        2024-01: '2024-01-10'
+      date_naissance:
+        2023-10: '1990-01-01'
+        2023-11: '1990-01-01'
+        2023-12: '1990-01-01'
+        2024-01: '1990-01-01'
+      bourse_criteres_sociaux_echelon:
+        2023-10: -1
+        2023-11: -1
+        2023-12: -1
+        2024-01: -1
+      enfant_a_charge:
+        '2017': false
+      enfant_place:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      etudiant:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      handicap:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      inapte_travail:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      taux_incapacite:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      valeur_locative_immo_non_loue:
+        2012-01: 0
+      valeur_locative_terrains_non_loues:
+        2012-01: 0
+    enfant1:
+      date_naissance:
+        'ETERNITY': '2013-12-12'
+      age:
+        2023-10: 10
+        2023-11: 10
+        2023-12: 10
+        2024-01: 10
+    enfant2:
+      date_naissance:
+        'ETERNITY': '2016-04-06'
+      age:
+        2023-10: 7
+        2023-11: 7
+        2023-12: 7
+        2024-01: 7
+  famille:
+    acs:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    af:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    aide_logement:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    alf:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    als:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    apl:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    asf:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    aspa:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    bourse_college:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    bourse_lycee:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    cf:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    enfants: [enfant1, enfant2]
+    paje_base:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    parents:
+    - demandeur
+    - conjoint
+  foyer_fiscal:
+    declarants:
+    - demandeur
+    - conjoint
+    personnes_a_charge: []
+  menage:
+    coloc:
+      2023-10: false
+      2023-11: false
+      2023-12: false
+      2024-01: false
+    depcom:
+      2017-05: '75101'
+      2017-06: '75101'
+      2017-07: '75101'
+      2017-08: '75101'
+    enfants: [enfant1, enfant2]
+    logement_chambre:
+      2023-10: false
+      2023-11: false
+      2023-12: false
+      2024-01: false
+    loyer:
+      2023-10: 450
+      2023-11: 450
+      2023-12: 450
+      2024-01: 450
+    personne_de_reference: demandeur
+    statut_occupation_logement:
+      2023-10: primo_accedant
+      2023-11: primo_accedant
+      2023-12: primo_accedant
+      2024-01: primo_accedant
+    aide_logement_est_pret_conventionne: false
+    aide_logement_date_pret: 2017-10-05
+output:
+  aide_logement: 124

--- a/tests/mes-aides.gouv.fr/aides_logement_primo_accedant_APL_Zone_2_650E_mois.yaml
+++ b/tests/mes-aides.gouv.fr/aides_logement_primo_accedant_APL_Zone_2_650E_mois.yaml
@@ -1,0 +1,391 @@
+name: APL Accession Zone 2 650€/mois
+keywords:
+- Propriétaire ou accédant à la propriété
+- al
+description: |-
+  Métropole : APL - acquisition d'un logement neuf - contrat signé en déc. 2017
+  Soit un couple avec deux enfants à charge, ayant des ressources annuelles prises en
+  compte de 17 937 €, soient 18 000 € arrondies à la centaine d'euros supérieure. Il acquiert
+  un logement neuf avec un prêt aidé par l'État dont le contrat a été signé le 5 décembre
+  2017, dans une grande ville de province (zone II). Il paie une mensualité de 650 €.
+  Le calcul est effectué pour le droit de janvier 2024.
+period: month:2024-01
+relative_error_margin: 0.05
+input:
+  individus:
+    demandeur:
+      salaire_imposable:
+        2023-01: 1494
+        2023-02: 1494
+        2023-03: 1494
+        2023-04: 1494
+        2023-05: 1494
+        2023-06: 1494
+        2023-07: 1494
+        2023-08: 1494
+        2023-09: 1494
+        2023-10: 1494
+        2023-11: 1494
+        2023-12: 1494
+      aah:
+        2023-01: 0
+        2023-02: 0
+        2023-03: 0
+        2023-04: 0
+        2023-05: 0
+        2023-06: 0
+        2023-07: 0
+        2023-08: 0
+        2023-09: 0
+        2023-10: 0
+        2023-11: 0
+        2023-12: 0
+      age:
+        2023-10: 27
+        2023-11: 27
+        2023-12: 27
+        2024-01: 27
+      age_en_mois:
+        2023-10: 331
+        2023-11: 331
+        2023-12: 331
+        2024-01: 331
+      boursier:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      date_arret_de_travail:
+        2023-10: '2024-01-10'
+        2023-11: '2024-01-10'
+        2023-12: '2024-01-10'
+        2024-01: '2024-01-10'
+      date_naissance:
+        2023-10: '1990-01-01'
+        2023-11: '1990-01-01'
+        2023-12: '1990-01-01'
+        2024-01: '1990-01-01'
+      bourse_criteres_sociaux_echelon:
+        2023-10: -1
+        2023-11: -1
+        2023-12: -1
+        2024-01: -1
+      enfant_a_charge:
+        '2017': false
+      enfant_place:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      etudiant:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      handicap:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      inapte_travail:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      taux_incapacite:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      valeur_locative_immo_non_loue:
+        2012-01: 0
+      valeur_locative_terrains_non_loues:
+        2012-01: 0
+    conjoint:
+      aah:
+        2023-01: 0
+        2023-02: 0
+        2023-03: 0
+        2023-04: 0
+        2023-05: 0
+        2023-06: 0
+        2023-07: 0
+        2023-08: 0
+        2023-09: 0
+        2023-10: 0
+        2023-11: 0
+        2023-12: 0
+      age:
+        2023-10: 27
+        2023-11: 27
+        2023-12: 27
+        2024-01: 27
+      age_en_mois:
+        2023-10: 331
+        2023-11: 331
+        2023-12: 331
+        2024-01: 331
+      boursier:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      date_arret_de_travail:
+        2023-10: '2024-01-10'
+        2023-11: '2024-01-10'
+        2023-12: '2024-01-10'
+        2024-01: '2024-01-10'
+      date_naissance:
+        2023-10: '1990-01-01'
+        2023-11: '1990-01-01'
+        2023-12: '1990-01-01'
+        2024-01: '1990-01-01'
+      bourse_criteres_sociaux_echelon:
+        2023-10: -1
+        2023-11: -1
+        2023-12: -1
+        2024-01: -1
+      enfant_a_charge:
+        '2017': false
+      enfant_place:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      etudiant:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      handicap:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      inapte_travail:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      taux_incapacite:
+        2023-10: false
+        2023-11: false
+        2023-12: false
+        2024-01: false
+      valeur_locative_immo_non_loue:
+        2012-01: 0
+      valeur_locative_terrains_non_loues:
+        2012-01: 0
+    enfant1:
+      date_naissance:
+        'ETERNITY': '2013-12-12'
+      age:
+        2023-10: 10
+        2023-11: 10
+        2023-12: 10
+        2024-01: 10
+    enfant2:
+      date_naissance:
+        'ETERNITY': '2016-04-06'
+      age:
+        2023-10: 7
+        2023-11: 7
+        2023-12: 7
+        2024-01: 7
+  famille:
+    acs:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    af:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    aide_logement:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    alf:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    als:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    apl:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    asf:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    aspa:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    bourse_college:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    bourse_lycee:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    cf:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    enfants: [enfant1, enfant2]
+    paje_base:
+      2023-01: 0
+      2023-02: 0
+      2023-03: 0
+      2023-04: 0
+      2023-05: 0
+      2023-06: 0
+      2023-07: 0
+      2023-08: 0
+      2023-09: 0
+      2023-10: 0
+      2023-11: 0
+      2023-12: 0
+    parents:
+    - demandeur
+    - conjoint
+  foyer_fiscal:
+    declarants:
+    - demandeur
+    - conjoint
+    personnes_a_charge: []
+  menage:
+    coloc:
+      2023-10: false
+      2023-11: false
+      2023-12: false
+      2024-01: false
+    depcom:
+      2023-10: '33090'
+      2023-11: '33090'
+      2023-12: '33090'
+      2024-01: '33090'
+    enfants: [enfant1, enfant2]
+    logement_chambre:
+      2023-10: false
+      2023-11: false
+      2023-12: false
+      2024-01: false
+    loyer:
+      2023-10: 650
+      2023-11: 650
+      2023-12: 650
+      2024-01: 650
+    personne_de_reference: demandeur
+    statut_occupation_logement:
+      2023-10: primo_accedant
+      2023-11: primo_accedant
+      2023-12: primo_accedant
+      2024-01: primo_accedant
+    aide_logement_date_pret_conventionne: 2017-12-05
+output:
+  aide_logement: 185

--- a/tests/mes-aides.gouv.fr/aides_logement_primo_accedant_dhup.yaml
+++ b/tests/mes-aides.gouv.fr/aides_logement_primo_accedant_dhup.yaml
@@ -381,4 +381,4 @@ input:
       2017-03: primo_accedant
     aide_logement_date_pret_conventionne: 2017-01-01
 output:
-  aide_logement: 154
+  aide_logement: 171.27

--- a/tests/mes-aides.gouv.fr/testMAcas1_6_couple_accedant_a_la_propriete_AL_1126_E_M_de_salaire_net.yaml
+++ b/tests/mes-aides.gouv.fr/testMAcas1_6_couple_accedant_a_la_propriete_AL_1126_E_M_de_salaire_net.yaml
@@ -469,4 +469,4 @@ input:
       2017-08: primo_accedant
     aide_logement_date_pret_conventionne: 2017-01-01
 output:
-  aide_logement: 60
+  aide_logement: 67.2


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : toutes.
* Zones impactées :
  * `openfisca_france/model/prestations/aides_logement.py`
  * `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/foyer/k_coef_prise_en_charge/cm_et_r/cm3_apl3.yaml`
* Détails :
  - On a modifié `aides_logement_primo_accedant_eligibilite` afin qu'une règle spécifique à l'éligibilité à l'APL Accession ne soit pas appliquée à l'AL Accession.
  - Le calcul du coefficient "K" pour l'APL Accession a été implémenté.
  - Les variables `aide_logement_est_pret_conventionne` et `aide_logement_date_pret` ont été créées afin de pouvoir différencier un prêt conventionné d'un prêt qui ne l'est pas. On a quand même gardé la variable `aide_logement_date_pret_conventionne` qui peut être utilisée pour déterminer s'il s'agit d'un prêt conventionné.

- - - -

Ces changements :

- Ajoutent une fonctionnalité : variables `aide_logement_est_pret_conventione` et `aide_logement_date_pret`.
- Corrigent ou améliorent un calcul déjà existant.
