### PR TITLE
Mise à jour des last_value_still_valid_on pour les prestations familiales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 173.1.1 [2564](https://github.com/openfisca/openfisca-france/pull/2564)
+
+* Changement mineur.
+* Périodes concernées : aucune.
+* Zones impactées :
+  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/*`
+* Détails :
+  - Mise à jour des last_value_still_valid_on.
+
 ### 173.1.0 [2565](https://github.com/openfisca/openfisca-france/pull/2565)
 
 * Changement mineur.

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_cm2/montant/prime_adoption.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_cm2/montant/prime_adoption.yaml
@@ -5,6 +5,7 @@ values:
   2005-08-01:
     value: 4.595
 metadata:
+  last_value_still_valid_on: "2025-08-20"
   short_label: Prime adoption
   label_en: Adoption premium amount
   ipp_csv_id: tx_paje_adopt
@@ -16,6 +17,8 @@ metadata:
     - title: Décret 2003-1394 du 31/12/2003, art. 1 (crée art. D531-2 du CSS)
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006227364&cidTexte=JORFTEXT000000797514
     2005-08-01:
+    - title: Article D531-2 du Code de la sécurité sociale
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006737122/2005-09-17/
     - title: Loi 2005-744 du 04/07/2005, art. 8 (modif art. L531-2 du CSS)
       href: https://www.legifrance.gouv.fr/affichTexteArticle.do?idArticle=LEGIARTI000006242678&cidTexte=JORFTEXT000000262154
     - title: Décret 2005-1172 du 12/09/2005, art. 1 (modif art. D531-2 du CSS)

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_cm2/montant/prime_naissance.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/petite_enfance/paje/paje_cm2/montant/prime_naissance.yaml
@@ -4,7 +4,7 @@ values:
     value: 2.2975
 metadata:
   short_label: Prime naissance
-  last_value_still_valid_on: "2023-05-27"
+  last_value_still_valid_on: "2025-08-20"
   label_en: Birth bonus amount
   ipp_csv_id: tx_paje_naiss
   unit: BMAF

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/duree_majoration_plus_de_20_ans.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/duree_majoration_plus_de_20_ans.yaml
@@ -6,7 +6,7 @@ values:
     value: 1
 metadata:
   short_label: Durée versement maj.>20 ans
-  last_value_still_valid_on: "2022-02-23"
+  last_value_still_valid_on: "2025-08-20"
   label_en: "Family allowances (AF): Extra allowances"
   ipp_csv_id: duree_maj
   unit: year

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age1.yaml
@@ -6,7 +6,7 @@ values:
     value: 14
 metadata:
   short_label: Âge seuil de la majoration
-  last_value_still_valid_on: "2025-02-27"
+  last_value_still_valid_on: "2025-08-20"
   unit: year
   reference:
     2008-04-30:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age2.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age2.yaml
@@ -6,7 +6,7 @@ values:
     value: null
 metadata:
   short_label: Âge seuil augmentation majoration
-  last_value_still_valid_on: "2024-01-05"
+  last_value_still_valid_on: "2025-08-20"
   unit: year
   reference:
     2002-01-01:

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/nb_enfants_min_pour_aine_donne_droit_a_majoration.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/nb_enfants_min_pour_aine_donne_droit_a_majoration.yaml
@@ -4,7 +4,7 @@ values:
     value: 3
 metadata:
   short_label: Nb d'enfant pour que l'aîné donne droit à majoration
-  last_value_still_valid_on: "2024-04-26"
+  last_value_still_valid_on: "2025-08-20"
   label_en: "Family allowances (AF): Extra allowances"
   ipp_csv_id: nb_enf_maj
   unit: year

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/nb_enfants_min_pour_majoration_forfaitaire_plus_20ans.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/nb_enfants_min_pour_majoration_forfaitaire_plus_20ans.yaml
@@ -6,7 +6,7 @@ values:
     value: 3
 metadata:
   short_label: Nb min d'enfants pour la maj. forfaitaire (>20 ans)
-  last_value_still_valid_on: "2025-02-20"
+  last_value_still_valid_on: "2025-08-20"
   label_en: "Family allowances (AF): Extra allowances"
   ipp_csv_id: afmaj_nenf_min
   unit: year

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/duree_majoration_plus_de_20_ans.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj_dom/duree_majoration_plus_de_20_ans.yaml
@@ -4,7 +4,7 @@ values:
     value: 1
 metadata:
   short_label: Durée versement majoration
-  last_value_still_valid_on: "2022-03-10"
+  last_value_still_valid_on: "2025-08-20"
   label_en: "Family allowances (AF): Extra allowances for oversea territories"
   ipp_csv_id: duree_maj_dom
   unit: year

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "173.1.0"
+version = "173.1.1"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/parameters/prestations_sociales/prestations_familiales/*`.
* Détails :
  - Mise à jour des `last_value_still_valid_on` et de certaines références.

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
