### PR TITLE
[Draft] Mise à jour des `last_value_still_valid_on` pour les micro-entreprises

### DIFF
--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/montant_minimum.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/montant_minimum.yaml
@@ -7,6 +7,7 @@ values:
   2001-01-01:
     value: 305
 metadata:
+  last_value_still_valid_on: "2025-08-22"
   short_label: Montant minimum
   ipp_csv_id: abtmin_micro
   unit: currency_next_year
@@ -18,8 +19,10 @@ metadata:
       title: Loi 91-1322 du 30/12/1991 (LF pour 1992)
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000356342
     2001-01-01:
-      title: Loi 2001-1275 du 28/12/2001 (LF pour 2002)
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000592233
+      - title: Article 102 ter du CGI
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006302649/2006-12-22/
+      - title: Loi 2001-1275 du 28/12/2001 (LF pour 2002)
+        href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000592233
   official_journal_date:
     1979-01-01: "1980-01-19"
     1991-01-01: "1991-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/index.yaml
@@ -5,4 +5,6 @@ metadata:
   - plafond_recettes
   - taux
   - maj_frag
-documentation: "Micro-BA : art. 64 bis du CGI. Définition des plafonds de ressources à l'art. 69 du CGI."
+documentation: |-
+  Depuis le 1er janvier 2016, le régime fiscal du forfait agricole a disparu au profit du régime du micro-bénéfice agricole (dit micro-BA). La réforme est entrée en vigueur, fiscalement, pour l'imposition des revenus 2016 et, socialement, pour la détermination des cotisations sociales dues en 2017.
+  Définition des plafonds de ressources à l'art. 69 du CGI.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/maj_frag.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/maj_frag.yaml
@@ -4,3 +4,5 @@ values:
     value: 0.25
 metadata:
   unit: /1
+documentation: |-
+  Il manque une référence legislative pour contrôler la validité de ce paramètre.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/plafond_recettes.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/plafond_recettes.yaml
@@ -11,7 +11,7 @@ values:
   2024-01-01:
     value: 120000
 metadata:
-  last_value_still_valid_on: "2025-03-02"
+  last_value_still_valid_on: "2025-08-22"
   ipp_csv_id: plaf_micro_ba
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/taux.yaml
@@ -6,7 +6,7 @@ values:
     value: 0.87
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "2025-03-02"
+  last_value_still_valid_on: "2025-08-22"
   ipp_csv_id: taux_micro_ba
   unit: /1
   reference:
@@ -14,8 +14,10 @@ metadata:
       title: Loi 80-30 du 18/01/1980 (LF pour 1980)
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000705191
     2016-01-01:
-      title: Loi n° 2015-1786 du 29 décembre 2015 de finances rectificative pour 2015 - Article 33
-      href: https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000031733082&idArticle=LEGIARTI000031757493&dateTexte=20161210&categorieLien=id#LEGIARTI000031757493
+      - title: Article 64 bis du Code général des impôts
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031763527/2016-01-01/
+      - title: Loi n° 2015-1786 du 29 décembre 2015 de finances rectificative pour 2015 - Article 33
+        href: https://www.legifrance.gouv.fr/affichTexteArticle.do?cidTexte=JORFTEXT000031733082&idArticle=LEGIARTI000031757493&dateTexte=20161210&categorieLien=id#LEGIARTI000031757493
   official_journal_date:
     1979-01-01: "1980-01-19"
     2016-01-01: "2017-05-04"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bic/marchandises/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bic/marchandises/plafond.yaml
@@ -26,7 +26,7 @@ values:
     value: 188700
 metadata:
   short_label: Plafond
-  last_value_still_valid_on: "2024-05-20"
+  last_value_still_valid_on: "2024-08-22"
   ipp_csv_id: limit_micro
   unit: currency_next_year
   reference:
@@ -64,8 +64,10 @@ metadata:
       title: Décret n° 2020-897 du 22 juillet 2020, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042143201
     2023-01-01:
-    - title: Décret n° 2023-422 du 31/05/2023, art. 1
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+      - title: Article 50-0 du CGI
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048844097/2023-12-31/
+      - title: Décret n° 2023-422 du 31/05/2023, art. 1
+        href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1991-01-01: "1991-12-31"
     1996-01-01: "1996-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bic/marchandises/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bic/marchandises/taux.yaml
@@ -28,8 +28,10 @@ metadata:
       title: Loi 2002-1575 du 30/12/2002 (LF pour 2003)
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000234121
     2006-01-01:
-      title: Loi 2006-1666 du 21/12/2006 (LF pour 2007)
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000615000
+      - title: Article 50-0 du CGI
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031781671/2016-01-01/
+      - title: Loi 2006-1666 du 21/12/2006 (LF pour 2007)
+        href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000615000
   official_journal_date:
     1979-01-01: "1980-01-19"
     1991-01-01: "1991-12-31"
@@ -39,3 +41,5 @@ metadata:
   notes:
     1999-01-01:
     - title: Jusqu'à l'imposition des revenus de 1998, les régimes spéciaux(appelé micro et micro_service ici) concernent les locations meublés non professionnelles, les BIC non professionnelles (depuis 98 seulement) et les autres activités industrielles et commerciales
+documentation: |-
+  "montant du chiffre d'affaires hors taxes diminué d'un abattement de 71 %"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bic/services/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bic/services/plafond.yaml
@@ -26,7 +26,7 @@ values:
     value: 77700
 metadata:
   short_label: Plafond
-  last_value_still_valid_on: "2024-05-20"
+  last_value_still_valid_on: "2025-08-22"
   ipp_csv_id: limit_micro_service
   unit: currency_next_year
   reference:
@@ -64,8 +64,10 @@ metadata:
       title: Décret n° 2020-897 du 22 juillet 2020, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042143201
     2023-01-01:
-    - title: Décret n° 2023-422 du 31/05/2023, art. 1
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+      - title: Article 50-0 du CGI
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048844097/2023-12-31/
+      - title: Décret n° 2023-422 du 31/05/2023, art. 1
+        href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1979-01-01: "1980-01-19"
     1991-01-01: "1991-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bic/services/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bic/services/taux.yaml
@@ -9,6 +9,7 @@ values:
   2006-01-01:
     value: 0.5
 metadata:
+  last_value_still_valid_on: "2024-08-22"
   short_label: Taux (Prestations de services)
   ipp_csv_id: txabt_micro_service
   unit: /1
@@ -23,8 +24,10 @@ metadata:
       title: Loi 2002-1575 du 30/12/2002 (LF pour 2003)
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000234121
     2006-01-01:
-      title: Loi 2006-1666 du 21/12/2006 (LF pour 2007)
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000615000
+      - title: Article 50-0 du CGI
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000031781671/2016-01-01/
+      - title: Loi 2006-1666 du 21/12/2006 (LF pour 2007)
+        href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000615000
   official_journal_date:
     1979-01-01: "1980-01-19"
     1991-01-01: "1991-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/plafond.yaml
@@ -26,7 +26,7 @@ values:
     value: 77700
 metadata:
   short_label: Plafond
-  last_value_still_valid_on: "2024-05-20"
+  last_value_still_valid_on: "2025-08-22"
   ipp_csv_id: limit_micro_service
   unit: currency_next_year
   reference:
@@ -64,8 +64,10 @@ metadata:
       title: Décret n° 2020-897 du 22 juillet 2020, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042143201
     2023-01-01:
-    - title: Décret n° 2023-422 du 31/05/2023, art. 1
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+      - title: Article 50-0 du CGI
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048844097/2023-12-31/
+      - title: Décret n° 2023-422 du 31/05/2023, art. 1
+        href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
   official_journal_date:
     1991-01-01: "1991-12-31"
     1996-01-01: "1996-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/taux.yaml
@@ -11,6 +11,7 @@ values:
   2006-01-01:
     value: 0.34
 metadata:
+  last_value_still_valid_on: "2025-08-22"
   short_label: Taux
   ipp_csv_id: txabt_microbnc
   unit: /1
@@ -28,8 +29,10 @@ metadata:
       title: Loi 2002-1575 du 30/12/2002 (LF pour 2003)
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000234121
     2006-01-01:
-      title: Loi 2006-1666 du 21/12/2006 (LF pour 2007)
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000615000
+      - title: Article 102 ter du CGI
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000006302649/2006-12-22/
+      - title: Loi 2006-1666 du 21/12/2006 (LF pour 2007)
+        href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000000615000
   official_journal_date:
     1979-01-01: "1980-01-19"
     1991-01-01: "1991-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microfoncier/plafond_recettes.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microfoncier/plafond_recettes.yaml
@@ -8,7 +8,7 @@ values:
     value: 15000
 metadata:
   short_label: Plafond de recettes
-  last_value_still_valid_on: "2025-03-25"
+  last_value_still_valid_on: "2025-08-22"
   ipp_csv_id: plaf_micro_foncier
   unit: currency_next_year
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microfoncier/taux.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microfoncier/taux.yaml
@@ -8,7 +8,7 @@ values:
     value: 0.3
 metadata:
   short_label: Taux
-  last_value_still_valid_on: "2025-03-25"
+  last_value_still_valid_on: "2025-08-22"
   ipp_csv_id: abt_micro_fon
   unit: /1
   reference:

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/microsocial/bnc.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/microsocial/bnc.yaml
@@ -4,13 +4,26 @@ values:
     value: null
   2009-01-01:
     value: 0.022
+  2023-01-01:
+    value: 0.212
+  2024-07-01:
+    value: 0.232
 metadata:
+  last_value_still_valid_on: "2025-08-22"
   short_label: Taux (micro BNC)
   ipp_csv_id: tx_bnc_vl
   unit: /1
   reference:
     2009-01-01:
-      title: Loi 2009-1673 du 30/12/2009 (LF pour 2010)
-      href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000021557902
+      - title: Article D613-4 du CSS
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041918199/2020-05-25/
+      - title: Loi 2009-1673 du 30/12/2009 (LF pour 2010)
+        href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000021557902
+    2023-01-01:
+      - title: Article D613-4 du CSS
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046714712/2022-12-10/
+    2024-07-01:
+      - title: Article D613-4 du CSS
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043656794/2024-07-01/
   official_journal_date:
     2009-01-01: "2009-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/microsocial/servi.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/microsocial/servi.yaml
@@ -1,10 +1,21 @@
-description: Taux du versement libératoire pour les activités de prestations et de services (régime auto-entrepreneur/micro-social)
+description: Taux du versement libératoire pour les activités de prestations et de services BNC ne relevant pas de la CIPAV (régime auto-entrepreneur/micro-social)
 values:
   1979-01-01:
     value: null
   2009-01-01:
     value: 0.017
+  2021-01-01:
+    value: 0.22
+  2022-10-01:
+    value: 0.211
+  2024-07-01:
+    value: 0.231
+  2025-01-01:
+    value: 0.246
+  2026-01-01:
+    value: 0.261
 metadata:
+  last_value_still_valid_on: "2025-08-22"
   short_label: Taux (micro BIC service)
   ipp_csv_id: tx_bic_service_vl
   unit: /1
@@ -12,5 +23,20 @@ metadata:
     2009-01-01:
       title: Loi 2009-1673 du 30/12/2009 (LF pour 2010)
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000021557902
+    2021-01-01:
+      - title: Article D613-4 du CSS
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046714712/2021-01-01/
+    2022-10-01:
+      - title: Article D613-4 du CSS
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043656794/2022-10-01/
+    2024-07-01:
+      - title: Article D613-4 du CSS
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043656794/2024-07-01/
+    2025-01-01:
+      - title: Article D613-4 du CSS
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049624125/2025-01-01/
+    2026-01-01:
+      - title: Article D613-4 du CSS
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000049624125/2026-01-01/
   official_journal_date:
     2009-01-01: "2009-12-31"

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/microsocial/vente.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/microsocial/vente.yaml
@@ -1,10 +1,15 @@
-description: Taux du versement libératoire pour les activités de ventes (régime auto-entrepreneur/micro-social)
+description: Taux du versement libératoire pour les activités de ventes (BIC régime auto-entrepreneur/micro-social)
 values:
   1979-01-01:
     value: null
   2009-01-01:
     value: 0.01
+  2021-01-01:
+    value: 0.128
+  2023-01-01:
+    value: 0.123
 metadata:
+  last_value_still_valid_on: "2025-08-22"
   short_label: Taux (micro BIC vente)
   ipp_csv_id: tx_bic_vente_vl
   unit: /1
@@ -15,6 +20,12 @@ metadata:
     2009-01-01:
       title: Loi 2009-1673 du 30/12/2009 (LF pour 2010)
       href: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000021557902
+    2021-01-01:
+      - title: Article D613-4 du CSS
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000046714712/2021-01-01/
+    2023-01-01:
+      - title: Article D613-4 du CSS
+        href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000043656794/2023-01-01/
   official_journal_date:
     1979-01-01: "1980-01-19"
     2009-01-01: "2009-12-31"


### PR DESCRIPTION
* Changement mineur.
* Périodes concernées : toutes.
* Zones impactées : `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/*`.
* Détails :
  - Mise à jour des `last_value_still_valid_on` et de certaines références.

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus
