### PR TITLE
Update pandas requirement from <2.0,>=1.5.3 to >=1.5.3,<3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ de_net_a_brut = [
     "scipy >=1.10.1, <2.0",
 ]
 taxipp = [
-    "pandas >=1.5.3, <2.0",
+    "pandas >=1.5.3, <3.0",
 ]
 casd-dev = [
     # Same as dev with packages not available at CASD removed


### PR DESCRIPTION
This pull request restores #2574 whose contents were destroyed following a [Shai Hulud 2](https://about.gitlab.com/blog/gitlab-discovers-widespread-npm-supply-chain-attack/) attack.

As the original contents were force-pushed after PR closure, we are not able to restore the original PR. See the original PR for discussion and context.
