### PR TITLE
Update flake8 requirement from <7.0.0,>=6.0.0 to >=6.0.0,<8.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ build-backend = "setuptools.build_meta"
 dev = [
     "autopep8 >=2.0.2, <3.0",
     "Flake8-pyproject>=1.2.3, <2.0.0",  # To read flake8 configuration from pyproject.toml
-    "flake8 >=6.0.0, <7.0.0",
+    "flake8 >=6.0.0, <8.0.0",
     "flake8-print >=5.0.0, <6.0.0",
     "flake8-quotes >=3.3.2",
     "pytest",  # Let OpenFisca-Core decide pytest version


### PR DESCRIPTION
This pull request restores #2573 whose contents were destroyed following a [Shai Hulud 2](https://about.gitlab.com/blog/gitlab-discovers-widespread-npm-supply-chain-attack/) attack.

As the original contents were force-pushed after PR closure, we are not able to restore the original PR. See the original PR for discussion and context.
