### PR TITLE
MSA : Revalorisations pour la Réduction de Loyer de Solidarité (RLS) pour janvier 2026

### DIFF
--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/couples.yaml
@@ -28,7 +28,7 @@ values:
     value: 74.07
 metadata:
   short_label: Couple sans personne à charge
-  last_value_still_valid_on: "2025-06-06"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: rls_z1_couple
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/famille_1pac.yaml
@@ -28,7 +28,7 @@ values:
     value: 83.46
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 1 personne à charge
-  last_value_still_valid_on: "2025-06-06"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: rls_z1_famille_1pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/majoration_par_pac_supp.yaml
@@ -28,7 +28,7 @@ values:
     value: 11.75
 metadata:
   short_label: Majoration par personne à charge supplémentaire
-  last_value_still_valid_on: "2025-06-06"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: rls_z1_pac_supplementaire
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_1/personnes_seules.yaml
@@ -28,7 +28,7 @@ values:
     value: 61.13
 metadata:
   short_label: Bénéficiaire isolé
-  last_value_still_valid_on: "2025-06-06"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: rls_z1_personne_isolee
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/couples.yaml
@@ -28,7 +28,7 @@ values:
     value: 65.83
 metadata:
   short_label: Couple sans personne à charge
-  last_value_still_valid_on: "2025-06-06"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: rls_z2_couple
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/famille_1pac.yaml
@@ -28,7 +28,7 @@ values:
     value: 72.89
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 1 personne à charge
-  last_value_still_valid_on: "2025-06-06"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: rls_z2_famille_1pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/majoration_par_pac_supp.yaml
@@ -28,7 +28,7 @@ values:
     value: 10.58
 metadata:
   short_label: Majoration par personne à charge supplémentaire
-  last_value_still_valid_on: "2025-06-06"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: rls_z2_pac_supplementaire
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_2/personnes_seules.yaml
@@ -28,7 +28,7 @@ values:
     value: 54.07
 metadata:
   short_label: Bénéficiaire isolé
-  last_value_still_valid_on: "2025-06-06"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: rls_z2_personne_isolee
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/couples.yaml
@@ -28,7 +28,7 @@ values:
     value: 61.13
 metadata:
   short_label: Couple sans personne à charge
-  last_value_still_valid_on: "2025-06-06"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: rls_z3_couple
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/famille_1pac.yaml
@@ -28,7 +28,7 @@ values:
     value: 68.18
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 1 personne à charge
-  last_value_still_valid_on: "2025-06-06"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: rls_z3_famille_1pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/majoration_par_pac_supp.yaml
@@ -28,7 +28,7 @@ values:
     value: 9.4
 metadata:
   short_label: Majoration par personne à charge supplémentaire
-  last_value_still_valid_on: "2025-06-06"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: rls_z3_pac_supplementaire
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant/par_zone/zone_3/personnes_seules.yaml
@@ -28,7 +28,7 @@ values:
     value: 50.56
 metadata:
   short_label: Bénéficiaire isolé
-  last_value_still_valid_on: "2025-06-06"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: rls_z3_personne_isolee
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/couples.yaml
@@ -12,7 +12,7 @@ values:
     value: 1168
 metadata:
   short_label: Couple
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z1_couple
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_1pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 1486
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 1 personne à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z1_famille_1pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_2pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 1768
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 2 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z1_famille_2pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_3pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 2165
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 3 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z1_famille_3pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_4pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 2497
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 4 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z1_famille_4pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_5pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 2781
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 5 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z1_famille_5pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/famille_6pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 3079
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 6 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z1_famille_6pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/majoration_par_pac_supp.yaml
@@ -12,7 +12,7 @@ values:
     value: 300
 metadata:
   short_label: Majoration par personne à charge supplémentaire
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z1_pac_supplementaire
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_1/personnes_seules.yaml
@@ -12,7 +12,7 @@ values:
     value: 970
 metadata:
   short_label: Bénéficiaire isolé
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z1_personne_isolee
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/couples.yaml
@@ -12,7 +12,7 @@ values:
     value: 1104
 metadata:
   short_label: Couple sans personne à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z2_couple
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_1pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 1408
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 1 personne à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z2_famille_1pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_2pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 1677
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 2 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z2_famille_2pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_3pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 2059
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 3 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z2_famille_3pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_4pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 2377
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 4 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z2_famille_4pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_5pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 2646
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 5 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z2_famille_5pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/famille_6pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 2929
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 6 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z2_famille_6pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/majoration_par_pac_supp.yaml
@@ -12,7 +12,7 @@ values:
     value: 282
 metadata:
   short_label: Majoration par personne à charge supplémentaire
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z2_pac_supplementaire
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_2/personnes_seules.yaml
@@ -12,7 +12,7 @@ values:
     value: 905
 metadata:
   short_label: Bénéficiaire isolé
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z2_personne_isolee
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/couples.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/couples.yaml
@@ -12,7 +12,7 @@ values:
     value: 1068
 metadata:
   short_label: Couple sans personne à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z3_couple
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_1pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 1366
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 1 personne à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z3_famille_1pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_2pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 1628
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 2 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z3_famille_2pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_3pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 1989
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 3 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z3_famille_3pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_4pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 2298
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 4 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z3_famille_4pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_5pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 2555
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 5 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z3_famille_5pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/famille_6pac.yaml
@@ -12,7 +12,7 @@ values:
     value: 2830
 metadata:
   short_label: Bénéficiaire isolé ou couple ayant 6 personnes à charge
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z3_famille_6pac
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/majoration_par_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/majoration_par_pac_supp.yaml
@@ -12,7 +12,7 @@ values:
     value: 262
 metadata:
   short_label: Majoration par personne à charge supplémentaire
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z3_pac_supplementaire
   unit: currency
   reference:

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/personnes_seules.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources/par_zone/zone_3/personnes_seules.yaml
@@ -12,7 +12,7 @@ values:
     value: 878
 metadata:
   short_label: Bénéficiaire isolé
-  last_value_still_valid_on: "2023-05-24"
+  last_value_still_valid_on: "2026-01-08"
   ipp_csv_id: plafond_ressources_rls_z3_personne_isolee
   unit: currency
   reference:


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2026
* Zones impactées :
  - `openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/montant`
  - `openfisca_france/parameters/prestations_sociales/aides_logement/reduction_loyer_solidarite/plafond_ressources`
* Détails :
  - Mise à jour des paramètres de la Réduction du Loyer de Solidarité (RLS) pour janvier 2026

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.