### PR TITLE
AF - Amélioration du calcul prenant en compte la clause transitoire du décret portant à 18 ans l'âge de la majoration des allocations familiales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+### 175.0.44 [#2754](https://github.com/openfisca/openfisca-france/pull/2754)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/03/2026.
+* Zones impactées :
+  - `openfisca_france/model/prestations/prestations_familiales/af.py`
+  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age1.yaml`
+  - `tests/formulas/af_age_pivot_2026.yaml`
+* Détails :
+  - Prise en compte du décret n° 2026-138 du 27 février 2026 portant à dix-huit ans l'âge de la majoration des allocations familiales.
+  - Passage du seuil d'âge de la majoration des allocations familiales de 14 à 18 ans à partir du 1er mars 2026.
+  - Application de la clause transitoire prévue par le décret : les enfants nés avant le 1er mars 2012 conservent l'ancien seuil de 14 ans ; les enfants nés à partir du 1er mars 2012 relèvent du nouveau seuil de 18 ans.
+  - Ajout de tests sur la date de naissance pivot du 1er mars 2012.
+  - À partir de mars 2026, le calcul de `af_majoration_enfant` dépend de `date_naissance` afin de distinguer les enfants relevant de l'ancien régime et ceux relevant du nouveau régime. Les simulations qui renseignent uniquement `age`, sans `date_naissance`, peuvent ne pas permettre de déterminer correctement le régime applicable autour de la date pivot du 1er mars 2012.
+
 ### 175.0.43 [#2737](https://github.com/openfisca/openfisca-france/pull/2737)
 
 * Changement mineur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@
 * Zones impactées :
   - `openfisca_france/model/prestations/prestations_familiales/af.py`
   - `openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age1.yaml`
-  - `tests/formulas/af_age_pivot_2026.yaml`
+  - `tests/formulas/af_majoration_age_2026.yaml`
 * Détails :
   - Prise en compte du décret n° 2026-138 du 27 février 2026 portant à dix-huit ans l'âge de la majoration des allocations familiales.
   - Passage du seuil d'âge de la majoration des allocations familiales de 14 à 18 ans à partir du 1er mars 2026.
   - Application de la clause transitoire prévue par le décret : les enfants nés avant le 1er mars 2012 conservent l'ancien seuil de 14 ans ; les enfants nés à partir du 1er mars 2012 relèvent du nouveau seuil de 18 ans.
-  - Ajout de tests sur la date de naissance pivot du 1er mars 2012.
-  - À partir de mars 2026, le calcul de `af_majoration_enfant` dépend de `date_naissance` afin de distinguer les enfants relevant de l'ancien régime et ceux relevant du nouveau régime. Les simulations qui renseignent uniquement `age`, sans `date_naissance`, peuvent ne pas permettre de déterminer correctement le régime applicable autour de la date pivot du 1er mars 2012.
+  - Lorsque `date_naissance` est renseignée, elle est utilisée pour déterminer précisément le régime applicable.
+  - Lorsque `date_naissance` n'est pas renseignée, le régime applicable est approximé à partir de `age` et de la période de calcul afin d'éviter l'utilisation implicite de la valeur par défaut de `date_naissance`.
+  - Cette approximation ne permet pas de trancher tous les cas autour de la date pivot du 1er mars 2012 : le calcul exact de la clause transitoire nécessite de renseigner `date_naissance`.
+  - Ajout de tests sur la date de naissance pivot du 1er mars 2012 et sur le fallback lorsque seule la variable `age` est renseignée.
 
 ### 175.0.43 [#2737](https://github.com/openfisca/openfisca-france/pull/2737)
 

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -184,7 +184,6 @@ class af_majoration_enfant(Variable):
     def formula_2026_03_01(individu, period, parameters):
         pfam_enfant_a_charge = individu('prestations_familiales_enfant_a_charge', period)
         age = individu('age', period)
-        date_naissance = individu('date_naissance', period)
         garde_alternee = individu('garde_alternee', period)
 
         af_nbenf = individu.famille('af_nbenf', period)
@@ -202,12 +201,37 @@ class af_majoration_enfant(Variable):
             * af.af_maj_dom.majoration_premier_enfant.taux_tranche_2
             )
 
-        ancien_regime = date_naissance < datetime64('2012-03-01')
-        seuil_age_ancien_regime = 14  # valeur de 2008
+        seuil_ancien_regime = 14  # valeur de af.af_maj.maj_age_deux_enfants.age1 en 2008
         seuil_nouveau_regime = af.af_maj.maj_age_deux_enfants.age1
+
+        date_naissance_holder = individu.get_holder('date_naissance')
+        date_naissance = individu('date_naissance', period)
+        date_naissance_par_defaut = date_naissance_holder.default_array()
+
+        date_naissance_renseignee = date_naissance != date_naissance_par_defaut
+
+        ancien_regime_selon_date_naissance = date_naissance < datetime64('2012-03-01')
+
+        # Lorsque date_naissance n'est pas renseignée, on évite d'utiliser sa
+        # valeur par défaut et on approxime le régime applicable à partir de
+        # l'âge et de la période de calcul. Cette approximation ne permet pas de
+        # trancher tous les cas autour de la date pivot du 1er mars 2012.
+        annee_naissance_estimee = period.start.year - age
+        ancien_regime_selon_age = or_(
+            annee_naissance_estimee < 2012,
+            (annee_naissance_estimee == 2012)
+            * (period.start.month < 3),
+            )
+
+        ancien_regime = where(
+            date_naissance_renseignee,
+            ancien_regime_selon_date_naissance,
+            ancien_regime_selon_age,
+            )
+
         age_ouverture_droit = where(
             ancien_regime,
-            seuil_age_ancien_regime,
+            seuil_ancien_regime,
             seuil_nouveau_regime,
             )
 

--- a/openfisca_france/model/prestations/prestations_familiales/af.py
+++ b/openfisca_france/model/prestations/prestations_familiales/af.py
@@ -1,4 +1,4 @@
-from numpy import logical_or as or_
+from numpy import logical_or as or_, datetime64
 
 from openfisca_france.model.base import *
 from openfisca_france.model.prestations.prestations_familiales.base_ressource import nb_enf
@@ -180,6 +180,56 @@ class af_majoration_enfant(Variable):
     label = "Allocations familiales - Majoration pour âge applicable à l'enfant"
     definition_period = MONTH
     set_input = set_input_divide_by_period
+
+    def formula_2026_03_01(individu, period, parameters):
+        pfam_enfant_a_charge = individu('prestations_familiales_enfant_a_charge', period)
+        age = individu('age', period)
+        date_naissance = individu('date_naissance', period)
+        garde_alternee = individu('garde_alternee', period)
+
+        af_nbenf = individu.famille('af_nbenf', period)
+        af_base = individu.famille('af_base', period)
+        age_aine = individu.famille('af_age_aine', period)
+
+        af = parameters(period).prestations_sociales.prestations_familiales.prestations_generales.af
+        bmaf = parameters(period).prestations_sociales.prestations_familiales.bmaf.bmaf
+
+        montant_enfant_seul = bmaf * (
+            (af.af_maj_dom.tranches_age.age_debut_premiere_tranche <= age)
+            * (age < af.af_maj_dom.tranches_age.age_debut_deuxieme_tranche)
+            * af.af_maj_dom.majoration_premier_enfant.taux_tranche_1
+            + (af.af_maj_dom.tranches_age.age_debut_deuxieme_tranche <= age)
+            * af.af_maj_dom.majoration_premier_enfant.taux_tranche_2
+            )
+
+        ancien_regime = date_naissance < datetime64('2012-03-01')
+        seuil_age_ancien_regime = 14  # valeur de 2008
+        seuil_nouveau_regime = af.af_maj.maj_age_deux_enfants.age1
+        age_ouverture_droit = where(
+            ancien_regime,
+            seuil_age_ancien_regime,
+            seuil_nouveau_regime,
+            )
+
+        montant_plusieurs_enfants = bmaf * (
+            (age_ouverture_droit <= age)
+            * af.af_maj.maj_age_deux_enfants.taux1
+            )
+
+        montant = (af_nbenf == 1) * montant_enfant_seul + (af_nbenf > 1) * montant_plusieurs_enfants
+
+        # Attention ! Ne fonctionne pas pour les enfants du même âge (typiquement les jumeaux...)
+        pas_aine = or_(af_nbenf != 2, (af_nbenf == 2) * not_(age == age_aine))
+
+        coeff_garde_alternee = where(garde_alternee, af.af_cm.facteur_garde_alternee, 1)
+
+        return (
+            pfam_enfant_a_charge
+            * (af_base > 0)
+            * pas_aine
+            * montant
+            * coeff_garde_alternee
+            )
 
     def formula_2008_05_01(individu, period, parameters):
         pfam_enfant_a_charge = individu('prestations_familiales_enfant_a_charge', period)

--- a/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age1.yaml
+++ b/openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age1.yaml
@@ -5,10 +5,10 @@ values:
   2008-05-01:
     value: 14
   2026-03-01:
-    value: 15
+    value: 18
 metadata:
   short_label: Âge seuil de la majoration
-  last_value_still_valid_on: "2026-01-12"
+  last_value_still_valid_on: "2026-05-26"
   unit: year
   reference:
     2008-05-01:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "175.0.43"
+version = "175.0.44"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/formulas/af_age_pivot_2026.yaml
+++ b/tests/formulas/af_age_pivot_2026.yaml
@@ -1,0 +1,57 @@
+- name: Allocations familiales - Majoration pour âge - maintien à 14 ans pour les enfants dont le 14e anniversaire précède le 1er mars 2026
+  description: Un enfant né avant le 1er mars 2012 relève de l'ancien régime et ouvre droit à la majoration dès 14 ans.
+  period: 2026-03
+  absolute_error_margin: 0.01
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2, enfant3]
+    foyer_fiscal:
+      declarants: [parent1, parent2]
+      personnes_a_charge: [enfant1, enfant2, enfant3]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1, enfant2, enfant3]
+    individus:
+      parent1:
+        date_naissance: '1980-01-01'
+      parent2:
+        date_naissance: '1980-01-01'
+      enfant1:
+        date_naissance: '2012-02-28'
+      enfant2:
+        date_naissance: '2014-01-01'
+      enfant3:
+        date_naissance: '2016-01-01'
+  output:
+    af_majoration: 474.37 * 0.16
+
+- name: Allocations familiales - Majoration pour âge - passage à 18 ans pour les enfants dont le 14e anniversaire intervient à compter du 1er mars 2026
+  description: Un enfant né le 1er mars 2012 relève du nouveau régime et n'ouvre pas droit à la majoration à 14 ans.
+  period: 2026-03
+  absolute_error_margin: 0.01
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2, enfant3]
+    foyer_fiscal:
+      declarants: [parent1, parent2]
+      personnes_a_charge: [enfant1, enfant2, enfant3]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1, enfant2, enfant3]
+    individus:
+      parent1:
+        date_naissance: '1980-01-01'
+      parent2:
+        date_naissance: '1980-01-01'
+      enfant1:
+        date_naissance: '2012-03-01'
+      enfant2:
+        date_naissance: '2014-01-01'
+      enfant3:
+        date_naissance: '2016-01-01'
+  output:
+    af_majoration: 0

--- a/tests/formulas/af_majoration_age_2026.yaml
+++ b/tests/formulas/af_majoration_age_2026.yaml
@@ -55,3 +55,62 @@
         date_naissance: '2016-01-01'
   output:
     af_majoration: 0
+
+
+- name: Allocations familiales - Majoration pour âge - fallback age seul - nouveau régime approximé à 14 ans en mars 2026
+  description: Lorsque date_naissance n'est pas renseignée, un enfant de 14 ans en mars 2026 est rattaché au nouveau régime par approximation et n'ouvre pas droit à la majoration.
+  period: 2026-03
+  absolute_error_margin: 0.01
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2, enfant3]
+    foyer_fiscal:
+      declarants: [parent1, parent2]
+      personnes_a_charge: [enfant1, enfant2, enfant3]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1, enfant2, enfant3]
+    individus:
+      parent1:
+        age: 46
+      parent2:
+        age: 46
+      enfant1:
+        age: 14
+      enfant2:
+        age: 12
+      enfant3:
+        age: 10
+  output:
+    af_majoration: 0
+
+- name: Allocations familiales - Majoration pour âge - fallback age seul - ancien régime approximé à 15 ans en mars 2026
+  description: Lorsque date_naissance n'est pas renseignée, un enfant de 15 ans en mars 2026 est rattaché à l'ancien régime par approximation et ouvre droit à la majoration.
+  period: 2026-03
+  absolute_error_margin: 0.01
+  input:
+    famille:
+      parents: [parent1, parent2]
+      enfants: [enfant1, enfant2, enfant3]
+    foyer_fiscal:
+      declarants: [parent1, parent2]
+      personnes_a_charge: [enfant1, enfant2, enfant3]
+    menage:
+      personne_de_reference: parent1
+      conjoint: parent2
+      enfants: [enfant1, enfant2, enfant3]
+    individus:
+      parent1:
+        age: 46
+      parent2:
+        age: 46
+      enfant1:
+        age: 15
+      enfant2:
+        age: 12
+      enfant3:
+        age: 10
+  output:
+    af_majoration: 474.37 * 0.16

--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-france"
-version = "175.0.29"
+version = "175.0.41"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
AF - Prend en compte la clause transitoire du décret portant à 18 ans l'âge de la majoration des allocations familiales

* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/03/2026.
* Zones impactées :
  - `openfisca_france/model/prestations/prestations_familiales/af.py`
  - `openfisca_france/parameters/prestations_sociales/prestations_familiales/prestations_generales/af/af_maj/maj_age_deux_enfants/age1.yaml`
  - `tests/formulas/af_age_pivot_2026.yaml`
* Détails :
  - Applique le décret n° 2026-138 du 27 février 2026 portant à dix-huit ans l'âge de la majoration des allocations familiales.
  - Le seuil de majoration est porté à 18 ans à partir du 1er mars 2026.
  - La clause transitoire est prise en compte : les enfants nés avant le 1er mars 2012 conservent l'ancien seuil de 14 ans, tandis que les enfants nés à partir du 1er mars 2012 relèvent du nouveau seuil de 18 ans.
  - La formule `af_majoration_enfant` distingue désormais l'ancien et le nouveau régime à partir de la date de naissance de l'enfant.
  - Des tests sont ajoutés pour vérifier le comportement autour de la date pivot du 1er mars 2012.

Référence législative :
- Décret n° 2026-138 du 27 février 2026 portant à dix-huit ans l'âge de la majoration des allocations familiales : https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000053594174

- - - -

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Checklist :

- [x] J'ai regardé le guide de contribution.
- [x] J'ai vérifié s'il existait déjà une proposition introduisant ces mêmes changements.
- [x] J'ai documenté la contribution avec des références législatives.
- [x] J'ai mis à jour ou ajouté des tests correspondant à la contribution.
- [x] J'ai augmenté le numéro de version dans `pyproject.toml`.
- [x] J'ai mis à jour le `CHANGELOG.md`.
- [x] J'ai décrit la contribution comme indiqué ci-dessus.