### PR TITLE
Augmentation du SMIC au 1er juin 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 175.0.41
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/06/2026.
+* Zones impactées :
+    - `openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml`
+    - `openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml`
+* Détails :
+  - Revalorisation du SMIC au 1er juin 2026
+
 ### 175.0.40
 
 * Évolution du système socio-fiscal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 175.0.41
+### 175.0.41[#2757](https://github.com/openfisca/openfisca-france/pull/2757)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/06/2026.

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml
@@ -681,7 +681,7 @@ metadata:
     2024-01-01: "2023-12-21"
     2024-11-01: "2024-10-24"
     2026-01-01: "2025-12-18"
-    2026-01-01: "2026-05-24"
+    2026-06-01: "2026-05-24"
   notes:
     1971-01-01:
     - title: Abattement pour les jeunes de moins de 17 ans (-20%) et de moins de 18 ans (-10%). Décret 71-101 du 02/02/1971 pour la plasturgie

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml
@@ -250,7 +250,7 @@ values:
     value: 12.31
 metadata:
   short_label: Smic horaire brut
-  last_value_still_valid_on: "2026-01-12"
+  last_value_still_valid_on: "2026-06-01"
   label_en: Minimum wage - Smic
   ipp_csv_id: smic_h
   unit: currency

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml
@@ -246,6 +246,8 @@ values:
     value: 11.88
   2026-01-01:
     value: 12.02
+  2026-06-01:
+    value: 12.31
 metadata:
   short_label: Smic horaire brut
   last_value_still_valid_on: "2026-01-12"
@@ -556,6 +558,9 @@ metadata:
     2026-01-01:
       title: Décret n° 2025-1228 du 17/12/2025 portant relèvement du salaire minimum de croissance
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000053042520
+    2026-06-01:
+      title: Arrêté du 22 mai 2026 relatif au relèvement du salaire minimum de croissance
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054126589
   official_journal_date:
     1970-01-01: "1970-01-04"
     1970-03-01: "1970-03-01"
@@ -676,6 +681,7 @@ metadata:
     2024-01-01: "2023-12-21"
     2024-11-01: "2024-10-24"
     2026-01-01: "2025-12-18"
+    2026-01-01: "2026-05-24"
   notes:
     1971-01-01:
     - title: Abattement pour les jeunes de moins de 17 ans (-20%) et de moins de 18 ans (-10%). Décret 71-101 du 02/02/1971 pour la plasturgie

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml
@@ -681,7 +681,7 @@ metadata:
     2024-01-01: "2023-12-21"
     2024-11-01: "2024-10-24"
     2026-01-01: "2025-12-18"
-    2026-01-01: "2026-05-24"
+    2026-06-01: "2026-05-24"
   notes:
     1971-01-01:
     - title: Abattement pour les jeunes de moins de 17 ans (-20%) et de moins de 18 ans (-10%). Décret 71-101 du 02/02/1971 pour la plasturgie

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml
@@ -246,6 +246,8 @@ values:
     value: 1801.80
   2026-01-01:
     value: 1823.03
+  2026-06-01:
+    value: 1867.02
 metadata:
   short_label: Smic brut mensuel
   last_value_still_valid_on: "2026-01-12"
@@ -556,6 +558,9 @@ metadata:
     2026-01-01:
       title: Décret n° 2025-1228 du 17/12/2025 portant relèvement du salaire minimum de croissance
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000053042520
+    2026-06-01:
+      title: Arrêté du 22 mai 2026 relatif au relèvement du salaire minimum de croissance
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054126589
   official_journal_date:
     1970-01-01: "1970-01-04"
     1970-03-01: "1970-03-01"
@@ -676,6 +681,7 @@ metadata:
     2024-01-01: "2023-12-21"
     2024-11-01: "2024-10-24"
     2026-01-01: "2025-12-18"
+    2026-01-01: "2026-05-24"
   notes:
     1971-01-01:
     - title: Abattement pour les jeunes de moins de 17 ans (-20%) et de moins de 18 ans (-10%). Décret 71-101 du 02/02/1971 pour la plasturgie

--- a/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml
+++ b/openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml
@@ -250,7 +250,7 @@ values:
     value: 1867.02
 metadata:
   short_label: Smic brut mensuel
-  last_value_still_valid_on: "2026-01-12"
+  last_value_still_valid_on: "2026-06-01"
   label_en: Minimum wage - Smic
   ipp_csv_id: smic_m
   unit: currency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "175.0.40"
+version = "175.0.41"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/06/2026.
* Zones impactées : 
- `openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_horaire.yaml`
- `openfisca_france/parameters/marche_travail/salaire_minimum/smic/smic_b_mensuel.yaml`
* Détails :
  - Revalorisation du SMIC au 1er juin 2026

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.