### PR TITLE
Réintègre les heures supplémentaires exonérées au RFR depuis 2019

### DIFF
--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/ir.py
@@ -2546,6 +2546,58 @@ class rfr(Variable):
 
         # TO CHECK : f3vb after 2015 (abattements sur moins-values = interdits)
 
+    def formula_2019_01_01(foyer_fiscal, period, parameters):
+        '''
+        Comme la formule de base, plus la réintégration des heures
+        supplémentaires et complémentaires exonérées (loi n° 2018-1213)
+        dans la limite du plafond annuel par déclarant (article 81 quater
+        du CGI, plafond relevé par l'article 4 de la LFR 2022).
+        '''
+        abattements_plus_values = foyer_fiscal('abattements_plus_values', period)
+        f2dm = foyer_fiscal('f2dm', period)
+        microentreprise = foyer_fiscal('microentreprise', period)
+        rfr_rev_capitaux_mobiliers = foyer_fiscal('rfr_rvcm_abattements_a_reintegrer', period)
+        revenus_capitaux_prelevement_liberatoire = foyer_fiscal('revenus_capitaux_prelevement_liberatoire', period, options = [ADD])
+        revenus_capitaux_prelevement_forfaitaire_unique_ir = foyer_fiscal('revenus_capitaux_prelevement_forfaitaire_unique_ir', period, options = [ADD])
+        rfr_charges_deductibles = foyer_fiscal('rfr_cd', period)
+        rfr_plus_values_hors_rni = foyer_fiscal('rfr_plus_values_hors_rni', period)
+        rni = foyer_fiscal('rni', period)
+        imposition_au_bareme = foyer_fiscal('f2op', period)
+        f3sb = foyer_fiscal('f3sb', period)
+        rpns_exon_i = foyer_fiscal.members('rpns_exon', period)
+        rpns_info_i = foyer_fiscal.members('rpns_info', period)
+
+        rpns_info = foyer_fiscal.sum(rpns_info_i)
+        rpns_exon = foyer_fiscal.sum(rpns_exon_i)
+
+        prime_partage_valeur_exoneree_exceptionnelle_i = foyer_fiscal.members('prime_partage_valeur_exoneree_exceptionnelle', period)
+        prime_partage_valeur_exoneree_exceptionnelle = (foyer_fiscal.sum(prime_partage_valeur_exoneree_exceptionnelle_i) * 0.9)
+
+        # Réintégration des heures supplémentaires exonérées au RFR,
+        # plafonnée individuellement par déclarant et après application
+        # de l'abattement forfaitaire de 10 % pour frais professionnels
+        # (cohérent avec le traitement de la PPV exonérée ci-dessus, et
+        # avec ce qui figure sur l'avis : ligne "Nets" = 0,9 × ligne
+        # "Déclarés"). TODO : tenir compte des frais réels le cas
+        # échéant, comme pour la PPV.
+        plafond = parameters(period).impot_revenu.calcul_revenus_imposables.heures_supplementaires_exonerees.plafond_annuel
+        heures_supplementaires_exonerees_i = foyer_fiscal.members('heures_supplementaires_exonerees', period)
+        heures_supplementaires_exonerees_rfr = foyer_fiscal.sum(
+            min_(heures_supplementaires_exonerees_i, plafond) * 0.9
+            )
+
+        f3sb = where(imposition_au_bareme, f3sb, 0)
+
+        return (
+            max_(0, rni - f3sb)
+            + rfr_charges_deductibles + rfr_plus_values_hors_rni + rfr_rev_capitaux_mobiliers + revenus_capitaux_prelevement_liberatoire + revenus_capitaux_prelevement_forfaitaire_unique_ir
+            + rpns_exon + rpns_info
+            + abattements_plus_values
+            + f2dm + microentreprise
+            + prime_partage_valeur_exoneree_exceptionnelle
+            + heures_supplementaires_exonerees_rfr
+            )
+
 
 class glo_taxation_ir_forfaitaire_taux2(Variable):
     value_type = float

--- a/openfisca_france/model/revenus/activite/salarie.py
+++ b/openfisca_france/model/revenus/activite/salarie.py
@@ -61,6 +61,24 @@ class frais_reels(Variable):
 
 
 class hsup(Variable):
+    '''
+    Heures supplémentaires exonérées d'IR au titre du dispositif TEPA
+    (article 1er de la loi n° 2007-1223 du 21 août 2007 en faveur du
+    travail, de l'emploi et du pouvoir d'achat), supprimé fin 2012 par
+    l'article 3 de la loi n° 2012-958 du 16 août 2012 et clôturé ici
+    le 13/12/2013 sur les déclarations 2013.
+
+    Cette variable reste référencée par les modules de cotisations
+    sociales, d'aides au logement et de prestations familiales qui en
+    consomment l'historique via `period.n_2`. Pour le dispositif
+    post-2019 rétabli par l'article 7 de la loi n° 2018-1213, voir la
+    variable `heures_supplementaires_exonerees` (cases 1GH/1HH/1IH/1JH
+    de la 2042) qui alimente la nouvelle formule du `rfr`.
+
+    Refs #1893 : la clarification complète du périmètre de `hsup` reste
+    à mener, mais la séparation entre les deux dispositifs élimine au
+    moins l'ambiguïté côté IR.
+    '''
     cerfa_field = {
         0: '1AU',
         1: '1BU',
@@ -70,12 +88,35 @@ class hsup(Variable):
     value_type = int
     unit = 'currency'
     entity = Individu
-    label = 'Heures supplémentaires : revenus exonérés connus'
+    label = 'Heures supplémentaires : revenus exonérés connus (dispositif TEPA, 2007-2012)'
     # start_date = date(2007, 1, 1)
     end = '2013-12-13'
     definition_period = MONTH
     set_input = set_input_divide_by_period
     calculate_output = calculate_output_add
+
+
+class heures_supplementaires_exonerees(Variable):
+    '''
+    Heures supplémentaires et complémentaires exonérées d'impôt sur le
+    revenu depuis la loi n° 2018-1213 (article 7), à hauteur d'un
+    plafond annuel. Le montant déclaré sur les cases 1GH/1HH/1IH/1JH
+    de la 2042 alimente directement le revenu fiscal de référence via
+    la formule `rfr`, sans entrer dans le revenu net imposable.
+    '''
+    cerfa_field = {
+        0: '1GH',
+        1: '1HH',
+        2: '1IH',
+        3: '1JH',
+        }
+    value_type = float
+    unit = 'currency'
+    entity = Individu
+    label = "Heures supplémentaires et complémentaires exonérées d'impôt sur le revenu"
+    reference = 'https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038589734'
+    definition_period = YEAR
+    end = None
 
 
 class ppe_du_sa(Variable):

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/heures_supplementaires_exonerees/index.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/heures_supplementaires_exonerees/index.yaml
@@ -1,0 +1,10 @@
+description: Heures supplémentaires et complémentaires exonérées d'impôt sur le revenu (article 81 quater du CGI)
+documentation: |
+  L'article 7 de la loi n° 2018-1213 du 24 décembre 2018 portant mesures
+  d'urgence économiques et sociales a rétabli l'exonération d'impôt sur
+  le revenu des heures supplémentaires et complémentaires à partir du
+  1er janvier 2019, à hauteur d'un plafond annuel.
+
+  Le plafond a été relevé par l'article 4 de la loi n° 2022-1157 du 16
+  août 2022 de finances rectificative pour 2022 pour l'ensemble de
+  l'année 2022 et les années suivantes.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/heures_supplementaires_exonerees/plafond_annuel.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/heures_supplementaires_exonerees/plafond_annuel.yaml
@@ -1,0 +1,22 @@
+description: Plafond annuel d'exonération des heures supplémentaires et complémentaires
+values:
+  2019-01-01:
+    value: 5000
+  2022-01-01:
+    value: 7500
+metadata:
+  short_label: Plafond d'exonération
+  last_value_still_valid_on: "2025-03-28"
+  unit: currency
+  reference:
+    2019-01-01:
+      title: LOI n° 2018-1213 du 24 décembre 2018 portant mesures d'urgence économiques et sociales, article 7
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000037851197/
+    2022-01-01:
+      title: LOI n° 2022-1157 du 16 août 2022 de finances rectificative pour 2022, article 4
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046190472/
+documentation: |
+  Le plafond est appliqué à l'ensemble des heures supplémentaires et complémentaires
+  exonérées perçues par chaque membre du foyer fiscal. Au-delà du plafond, la
+  rémunération est ajoutée au revenu net imposable et soumise au barème
+  progressif de l'impôt sur le revenu.

--- a/tests/formulas/heures_supplementaires_exonerees.yaml
+++ b/tests/formulas/heures_supplementaires_exonerees.yaml
@@ -1,0 +1,110 @@
+- name: Heures supplémentaires exonérées sous plafond entrent dans le RFR
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    salaire_imposable:
+      2024: 30000
+    heures_supplementaires_exonerees:
+      2024: 3000
+  output:
+    rfr:
+      2024: 29700
+
+# Salaire net imposable : 30 000 × 0,9 = 27 000.
+# Heures supplémentaires (3 000 € ≤ plafond 7 500 €) écrêtées au
+# plafond puis réduites par l'abattement forfaitaire de 10 % :
+# 3 000 × 0,9 = 2 700, ajoutées au RFR.
+# RFR attendu : 27 000 + 2 700 = 29 700 €.
+
+
+- name: Heures supplémentaires exonérées au-dessus du plafond sont écrêtées
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    salaire_imposable:
+      2024: 30000
+    heures_supplementaires_exonerees:
+      2024: 10000
+  output:
+    rfr:
+      2024: 33750
+
+# Plafond 2024 : 7 500 €. Sur 10 000 € déclarés, seuls 7 500 €
+# entrent dans le calcul ; après abattement 10 % : 6 750 € au RFR.
+# RFR attendu : 27 000 + 6 750 = 33 750 €.
+
+
+- name: Heures supplémentaires inactives avant 2019 - aucun effet RFR
+  period: 2018
+  absolute_error_margin: 1
+  input:
+    salaire_imposable:
+      2018: 30000
+    heures_supplementaires_exonerees:
+      2018: 3000
+  output:
+    rfr:
+      2018: 27000
+
+# L'exonération a été rétablie par la loi du 24 décembre 2018 à effet
+# du 1er janvier 2019 ; la formule rfr d'avant cette date ignore les
+# heures supplémentaires exonérées.
+
+
+- name: Couple - plafond appliqué individuellement à chaque déclarant
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    individus:
+      decl1:
+        salaire_imposable:
+          2024: 30000
+        heures_supplementaires_exonerees:
+          2024: 8000
+      decl2:
+        salaire_imposable:
+          2024: 20000
+        heures_supplementaires_exonerees:
+          2024: 6000
+    familles:
+      famille_0:
+        parents:
+        - decl1
+        - decl2
+    foyers_fiscaux:
+      foyer_0:
+        declarants:
+        - decl1
+        - decl2
+    menages:
+      menage_0:
+        personne_de_reference:
+        - decl1
+        conjoint:
+        - decl2
+  output:
+    rfr:
+      2024: 57150
+
+# Salaire imposable couple : (30 000 + 20 000) × 0,9 = 45 000.
+# Plafond par déclarant 7 500 € : decl1 écrêté à 7 500, decl2 conserve
+# 6 000. Après abattement 10 % : 7 500 × 0,9 + 6 000 × 0,9 =
+# 6 750 + 5 400 = 12 150 ajoutés au RFR.
+# RFR attendu : 45 000 + 12 150 = 57 150 €.
+
+
+- name: Cas combiné - salaire et heures supplémentaires sous plafond
+  period: 2024
+  absolute_error_margin: 1
+  input:
+    salaire_imposable:
+      2024: 50000
+    heures_supplementaires_exonerees:
+      2024: 4000
+  output:
+    rfr:
+      2024: 48600
+
+# Salaire net imposable : 50 000 × 0,9 = 45 000.
+# Heures supplémentaires nets : 4 000 × 0,9 = 3 600.
+# RFR attendu : 45 000 + 3 600 = 48 600 €.


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2019.
* Zones impactées :
  - `model/revenus/activite/salarie` (ajout de `heures_supplementaires_exonerees`, docstring sur
`hsup`)
  - `model/prelevements_obligatoires/impot_revenu/ir` (nouvelle `formula_2019_01_01` sur `rfr`)
  - `parameters/impot_revenu/calcul_revenus_imposables/heures_supplementaires_exonerees`
* Détails :
  - Ajout de la variable `heures_supplementaires_exonerees` (cerfa 1GH/1HH/1IH/1JH) représentant les
heures supplémentaires et complémentaires exonérées d'IR depuis le rétablissement du dispositif par
l'article 7 de la loi n° 2018-1213 du 24 décembre 2018 (article 81 quater CGI).
  - Création du paramètre `plafond_annuel` : 5 000 € depuis le 01/01/2019, 7 500 € depuis le
01/01/2022 (article 4 de la LFR 2022).
  - Réintégration des montants au RFR via une nouvelle `formula_2019_01_01`, plafonnée par déclarant
puis abattue de 10 % pour frais professionnels — alignée sur le traitement de la PPV exonérée déjà
présent dans la même formule et sur la ligne « Nets » de l'avis (= 0,9 × ligne « Déclarés »).
  - Documentation par docstring sur la variable historique `hsup` pour la rattacher au dispositif TEPA
 et la relier au nouveau dispositif post-2019.
  - 5 cas de test couvrent : sous plafond, au-dessus du plafond, période antérieure à 2019, couple
avec plafond par déclarant, et un cas combiné salaire + heures sup.

- - - -

Ces changements **ajoutent une fonctionnalité** (nouvelle variable + nouveau paramètre + nouvelle
branche de formule), sans modifier l'API publique existante ni les comportements pré-2019.

Refs #1893 — cette PR n'épuise pas l'audit demandé (la variable `hsup` reste référencée par les
modules `cotisations_sociales`, `aides_logement` et `prestations_familiales` ; clarifier ces usages
dépasse le périmètre de cette PR), mais elle élimine au moins l'ambiguïté côté IR en séparant
explicitement les deux dispositifs.

Points ouverts pour la revue :
- La docstring ajoutée à `hsup` modifie son `label` pour y inclure « (dispositif TEPA, 2007-2012) ».
Facile à retirer si vous préférez ne toucher à aucun label existant dans cette PR.
- Pas de `set_input` explicite sur la nouvelle variable (YEAR pur input). Je peux ajouter
`set_input_divide_by_period` par cohérence avec `prime_partage_valeur_exoneree_exceptionnelle` si vous
 préférez.