### PR TITLE
[APL] corrige le taux TF des ménages avec 6 enfants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+### 175.1.2 [#2761](https://github.com/openfisca/openfisca-france/pull/2761)
+
+* Évolution du système socio-fiscal
+* Périodes concernées : À partir du 01/01/2007.
+* Zones impactées : `parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/tp_taux/tf_taille_famille/metropole/avec_6_enfants`
+* Détails :
+  - Correction de la valeur du paramètre TF pour les ménages avec 6 enfants dans les aides au logement.
 
 ### 175.1.1 [#2654](https://github.com/openfisca/openfisca-france/pull/2654)
 

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/tp_taux/tf_taille_famille/metropole/avec_6_enfants.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/tp_taux/tf_taille_famille/metropole/avec_6_enfants.yaml
@@ -1,7 +1,7 @@
 description: Taux « TF » des personnes seules ou couple ayant six personnes à charge, pris en compte dans le taux de participation personnel du ménage « Tp » pour le calcul des allocations logement
 values:
   2007-07-01:
-    value: 0.0179
+    value: 0.0173
 metadata:
   short_label: Personnes seules ou couple ayant six personnes à charge
   last_value_still_valid_on: "2025-03-11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "175.1.1"
+version = "175.1.2"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
Cette pull request est issue d'un projet de recherche qui vise à comparer et améliorer des implémentations d'aide au logement via des méthodes formelles. Ce projet est financé par l'action AVoCat de l'Inria.

## Description

Cette PR corrige la valeur du paramètre `avec_6_enfants` utilisé dans le calcul du taux de famille `TF` pour les aides au logement en métropole.

La valeur était fixée à `0.0179` et est remplacée par `0.0173`, conformément à la valeur prévue par l’article 14 de l’arrêté du 27 septembre 2019 : https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000046206208/2022-07-01/
## Changelog

### Évolution du système socio-fiscal

- Périodes concernées : À partir du 01/01/2007.
- Zones impactées : `prestations/aides_logement`

* Détails :
  - Correction de la valeur du paramètre `avec_6_enfants` lors du calcul du taux de famille `TF`.
  - Cette modification affecte les ménages métropolitains comptant six personnes à charge dans le calcul des aides au logement.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :
- Corrigent ou améliorent un calcul déjà existant.
