### PR TITLE
Corrige la détection de l'édition du CHANGELOG

### DIFF
--- a/.github/is-version-number-acceptable.sh
+++ b/.github/is-version-number-acceptable.sh
@@ -36,7 +36,7 @@ then
     exit 2
 fi
 
-if ! $(dirname "$BASH_SOURCE")/has-functional-changes.sh | grep --quiet CHANGELOG.md
+if ! git diff-index `git describe --tags --abbrev=0 --first-parent` | grep --quiet CHANGELOG.md
 then
     echo "CHANGELOG.md has not been modified, while functional changes were made."
     echo "Explain what you changed before merging this branch into master."


### PR DESCRIPTION
#2760 a permis de considérer le CHANGELOG comme un fichier non-fonctionnel pour en permettre l'édition sans publication d'une nouvelle version, mais la détection de l'édition du CHANGELOG se reposait sur le fait qu'il soit un fichier fonctionnel, ce qui a eu pour conséquence d'empêcher toute détection de l'édition du CHANGELOG.

Ce changement restaure la détection des modifications du CHANGELOG, indépendamment de son statut de fichier « fonctionnel » ou non.

* Amélioration technique.
* Zones impactées : CI.

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).