### PR TITLE
[APL] ajoute les valeurs R0 applicables au 1er juillet 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 175.1.5 [#2766](https://github.com/openfisca/openfisca-france/pull/2766)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : du 01/07/2022 au 31/12/2022.
+* Zones impactées : `parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/*`.
+* Détails :
+  - Ajout des valeurs du forfait `R0` applicables au 1er juillet 2022.
+  - Mise à jour des valeurs pour les personnes seules, les couples et les ménages avec une à six personnes à charge.
+  - Ajout de la majoration applicable par personne à charge au-delà de six.
+  - Valeurs fixées par l'article 1 de l'arrêté du 29 juillet 2022 (https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046114998).
+
 ### 175.1.4 [#2781](https://github.com/openfisca/openfisca-france/pull/2781)
 
 * Évolution du système socio-fiscal

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux1pac.yaml
@@ -10,6 +10,8 @@ values:
     value: 7839
   2022-01-01:
     value: 8002.0
+  2022-07-01:
+    value: 8322
   2023-01-01:
     value: 8456
   2024-01-01:
@@ -38,6 +40,9 @@ metadata:
     2022-01-01:
       title: Arrêté du 20/12/2021, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
+    2022-08-01:
+    - title: Arrêté du 29/07/2022, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046114998
     2023-01-01:
     - title: Arrêté du 26/12/2022, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
@@ -61,6 +66,7 @@ metadata:
     2016-01-01: "2016-01-22"
     2019-01-01: "2018-12-29"
     2020-01-01: "2020-01-04"
+    2022-08-01: "2022-07-30"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
     2025-01-01: "2024-12-31"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux2pac.yaml
@@ -10,6 +10,8 @@ values:
     value: 8015
   2022-01-01:
     value: 8182.0
+  2022-07-01:
+    value: 8509
   2023-01-01:
     value: 8646
   2024-01-01:
@@ -38,6 +40,9 @@ metadata:
     2022-01-01:
       title: Arrêté du 20/12/2021, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
+    2022-08-01:
+    - title: Arrêté du 29/07/2022, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046114998
     2023-01-01:
     - title: Arrêté du 26/12/2022, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
@@ -61,6 +66,7 @@ metadata:
     2016-01-01: "2016-01-22"
     2019-01-01: "2018-12-29"
     2020-01-01: "2020-01-04"
+    2022-08-01: "2022-07-30"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
     2025-01-01: "2024-12-31"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux3pac.yaml
@@ -10,6 +10,8 @@ values:
     value: 8322
   2022-01-01:
     value: 8495.0
+  2022-07-01:
+    value: 8834
   2023-01-01:
     value: 8977
   2024-01-01:
@@ -38,6 +40,9 @@ metadata:
     2022-01-01:
       title: Arrêté du 20/12/2021, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
+    2022-08-01:
+    - title: Arrêté du 29/07/2022, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046114998
     2023-01-01:
     - title: Arrêté du 26/12/2022, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
@@ -61,6 +66,7 @@ metadata:
     2016-01-01: "2016-01-22"
     2019-01-01: "2018-12-29"
     2020-01-01: "2020-01-04"
+    2022-08-01: "2022-07-30"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
     2025-01-01: "2024-12-31"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux4pac.yaml
@@ -10,6 +10,8 @@ values:
     value: 8631
   2022-01-01:
     value: 8811.0
+  2022-07-01:
+    value: 9163
   2023-01-01:
     value: 9311
   2024-01-01:
@@ -38,6 +40,9 @@ metadata:
     2022-01-01:
       title: Arrêté du 20/12/2021, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
+    2022-08-01:
+    - title: Arrêté du 29/07/2022, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046114998
     2023-01-01:
     - title: Arrêté du 26/12/2022, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
@@ -61,6 +66,7 @@ metadata:
     2016-01-01: "2016-01-22"
     2019-01-01: "2018-12-29"
     2020-01-01: "2020-01-04"
+    2022-08-01: "2022-07-30"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
     2025-01-01: "2024-12-31"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux5pac.yaml
@@ -10,6 +10,8 @@ values:
     value: 8938
   2022-01-01:
     value: 9124.0
+  2022-07-01:
+    value: 9488
   2023-01-01:
     value: 9642
   2024-01-01:
@@ -38,6 +40,9 @@ metadata:
     2022-01-01:
       title: Arrêté du 20/12/2021, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
+    2022-08-01:
+    - title: Arrêté du 29/07/2022, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046114998
     2023-01-01:
     - title: Arrêté du 26/12/2022, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
@@ -61,6 +66,7 @@ metadata:
     2016-01-01: "2016-01-22"
     2019-01-01: "2018-12-29"
     2020-01-01: "2020-01-04"
+    2022-08-01: "2022-07-30"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
     2025-01-01: "2024-12-31"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux6pac.yaml
@@ -10,6 +10,8 @@ values:
     value: 9246
   2022-01-01:
     value: 9439.0
+  2022-07-01:
+    value: 9816
   2023-01-01:
     value: 9975
   2024-01-01:
@@ -38,6 +40,9 @@ metadata:
     2022-01-01:
       title: Arrêté du 20/12/2021, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
+    2022-08-01:
+    - title: Arrêté du 29/07/2022, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046114998
     2023-01-01:
     - title: Arrêté du 26/12/2022, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
@@ -61,6 +66,7 @@ metadata:
     2016-01-01: "2016-01-22"
     2019-01-01: "2018-12-29"
     2020-01-01: "2020-01-04"
+    2022-08-01: "2022-07-30"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
     2025-01-01: "2024-12-31"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux_couple.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux_couple.yaml
@@ -10,6 +10,8 @@ values:
     value: 6572
   2022-01-01:
     value: 6709.0
+  2022-07-01:
+    value: 6977
   2023-01-01:
     value: 7090
   2024-01-01:
@@ -38,6 +40,9 @@ metadata:
     2022-01-01:
       title: Arrêté du 20/12/2021, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
+    2022-08-01:
+    - title: Arrêté du 29/07/2022, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046114998
     2023-01-01:
     - title: Arrêté du 26/12/2022, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
@@ -61,6 +66,7 @@ metadata:
     2016-01-01: "2016-01-22"
     2019-01-01: "2018-12-29"
     2020-01-01: "2020-01-04"
+    2022-08-01: "2022-07-30"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
     2025-01-01: "2024-12-31"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux_pac_supp.yaml
@@ -10,6 +10,8 @@ values:
     value: 305
   2022-01-01:
     value: 311.0
+  2022-07-01:
+    value: 323
   2023-01-01:
     value: 328
   2024-01-01:
@@ -38,6 +40,9 @@ metadata:
     2022-01-01:
       title: Arrêté du 20/12/2021, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
+    2022-08-01:
+    - title: Arrêté du 29/07/2022, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046114998
     2023-01-01:
     - title: Arrêté du 26/12/2022, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
@@ -61,6 +66,7 @@ metadata:
     2016-01-01: "2016-01-22"
     2019-01-01: "2018-12-29"
     2020-01-01: "2020-01-04"
+    2022-08-01: "2022-07-30"
     2023-01-01: "2022-12-29"
     2024-01-01: "2023-12-21"
     2025-01-01: "2024-12-31"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux_seul.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general/taux_seul.yaml
@@ -10,6 +10,8 @@ values:
     value: 4588
   2022-01-01:
     value: 4683
+  2022-07-01:
+    value: 4870
   2023-01-01:
     value: 4949
   2024-01-01:
@@ -36,6 +38,9 @@ metadata:
     2022-01-01:
     - title: Arrêté du 20/12/2021, art. 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
+    2022-08-01:
+    - title: Arrêté du 29/07/2022, art. 1
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046114998
     2023-01-01:
     - title: Arrêté du 26/12/2022, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046829580
@@ -59,6 +64,7 @@ metadata:
     2016-01-01: "2016-01-22"
     2019-01-01: "2018-12-29"
     2020-01-01: "2020-01-04"
+    2022-08-01: "2022-07-30"
     2024-01-01: "2023-12-21"
     2025-01-01: "2024-12-31"
 documentation: |-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "175.1.4"
+version = "175.1.5"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
# Description

Cette PR ajoute les valeurs manquantes du forfait `R0` applicables à partir du 1er juillet 2022 pour le calcul des aides au logement.

En l'absence de ce palier, OpenFisca continuait à utiliser les valeurs du 1er janvier 2022 jusqu'à la revalorisation de 2023. Le montant des ressources pris en compte pouvait alors être trop élevé, ce qui pouvait sous-estimer l'aide au logement.

La correction concerne les personnes seules, les couples, les ménages ayant une à six personnes à charge et la majoration par personne supplémentaire.

Ces valeurs sont prévues par l'article 1 de l'arrêté du 29 juillet 2022 :

https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046114998

## Changelog

### Évolution du système socio-fiscal

- Périodes concernées : du 01/07/2022 au 31/12/2022.
- Zones impactées : `prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/cas_general`
- Détails :
  - Ajout des valeurs du forfait `R0` applicables au 1er juillet 2022.
  - Mise à jour des valeurs pour les personnes seules, les couples et les ménages avec personnes à charge.
  - Ajout de la majoration applicable par personne à charge au-delà de six.

Ces changements :

- Corrigent ou améliorent un calcul déjà existant.