### PR TITLE
[APL] Arrondit la CRDS au centime inferieur

### DIFF
--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -5,7 +5,7 @@ import logging
 import importlib
 import sys
 
-from numpy import ceil, datetime64, fromiter, int16, logical_or as or_, logical_and as and_, logical_not as not_
+from numpy import ceil, datetime64, floor, fromiter, int16, logical_or as or_, logical_and as and_, logical_not as not_
 
 from openfisca_core.periods import Instant, Period
 
@@ -1451,7 +1451,9 @@ class crds_logement(Variable):
     def formula(famille, period, parameters):
         aide_logement_montant_brut = famille('aide_logement_montant_brut_crds', period)
         crds = parameters(period).prelevements_sociaux.contributions_sociales.crds
-        return -aide_logement_montant_brut * crds
+        # Arrondi au centime d'euro inferieur (plancher)
+        crds_arrondie = floor((aide_logement_montant_brut * crds) * 100) / 100
+        return -crds_arrondie
 
 
 class TypesZoneApl(Enum):


### PR DESCRIPTION
## Description

Cette PR corrige l'arrondi de la CRDS prelevee sur les aides au logement en appliquant un arrondi au centime inferieur.

Avant cette correction, OpenFisca calculait la CRDS sans ce plancher explicite, ce qui produisait de petits ecarts residuels sur le brut CRDS puis sur le montant net verse. La formule est modifiee pour tronquer le montant au centime inferieur avant de le retourner avec son signe.

## Sources juridiques

- Brochure CAF - section 4 Règles d’arrondis page 59 : https://web.archive.org/web/20260514102320/https://www.ecologie.gouv.fr/sites/default/files/documents/Brochure-bareme-2024-APL.pdf

## Changelog propose

Evolution du systeme socio-fiscal

Zones impactees : `prestations/aides_logement`

Details :

- arrondi de la CRDS au centime d'euro inferieur ;
- reduction des ecarts de quelques centimes entre l'implementation et le bareme attendu ;
- impact sur le montant net final des aides au logement.

Ces changements :

- corrigent ou ameliorent un calcul deja existant.