### PR TITLE
[APL] Applique le coefficient meuble en APL sur les logements meubles

### DIFF
--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1135,14 +1135,13 @@ class aide_logement_loyer_reel(Variable):
         statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
         loyer = famille.demandeur.menage('loyer', period)
         categorie_apl = famille.demandeur.menage('logement_conventionne', period)
-        logement_chambre = famille.demandeur.menage('logement_chambre', period)
         locataire_meuble = statut_occupation_logement == TypesStatutOccupationLogement.locataire_meuble
 
-        # Coeff de 2/3 pour les logements meublés pour l'AL
+        # Coeff de 2/3 pour les logements meublés
         coeff_meuble_al = where(locataire_meuble, 2 / 3, 1)
-        # Coeff de 2/3 pour les seules chambres meublées pour l'APL
-        coeff_meuble_apl = where(locataire_meuble * logement_chambre, 2 / 3, 1)
-        return where(categorie_apl, round_(loyer * coeff_meuble_apl), round_(loyer * coeff_meuble_al))
+        # Coeff de 2/3 applique egalement en APL pour les logements meublés
+        coeff_meuble_apl = where(locataire_meuble, 2 / 3, 1)
+        return where(categorie_apl, loyer * coeff_meuble_apl, round_(loyer * coeff_meuble_al))
 
 
 class aide_logement_loyer_retenu(Variable):


### PR DESCRIPTION
## Description

Cette PR applique en APL le coefficient de reduction des logements meubles dans le calcul du loyer reel retenu.

Avant cette correction, OpenFisca appliquait bien le coefficient `2/3` pour les AL, mais limitait en pratique son application en APL a un sous-ensemble de cas. La formule est simplifiee pour appliquer le coefficient aux logements meubles de facon coherente.

Cette correction modifie le loyer reel, puis le loyer retenu, la participation personnelle et enfin le montant final de l'aide.

## Sources juridiques

- Article D823-18 du code de la construction et de l'habitation : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041477261
- Article L842-2 du code de la construction et de l'habitation : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038814849

## Changelog propose

Evolution du systeme socio-fiscal

Periodes concernees : a partir du 01/01/2002.

Zones impactees : `prestations/aides_logement`

Details :

- application du coefficient de reduction des logements meubles dans le calcul du loyer reel en APL ;
- harmonisation du traitement des logements meubles entre les differentes aides au logement ;
- correction des montants retenus dans le secteur locatif.

Ces changements :

- corrigent ou ameliorent un calcul deja existant.