### PR TITLE
[APL] Corrige le plafonnement a six PAC dans les DOM jusqu'en 2022 et sa fin a partir de 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 175.1.9 [#2773](https://github.com/openfisca/openfisca-france/pull/2773)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : Jusqu'au 31/12/2022 pour le plafonnement ; à partir du 01/01/2023 pour sa suppression.
+* Zones impactées :
+    - `openfisca_france/model/prestations/aides_logement`
+    - `tests/formulas/aides_logement`
+* Détails :
+    - Plafonnement du `R0` DOM à six personnes à charge jusqu'en 2022
+    - Correction de la fin du plafonnement du loyer de référence DOM
+    - Suppression du plafonnement à partir de 2023 lorsque le barème ne le prévoit plus
+
 ### 175.1.8 [#2772](https://github.com/openfisca/openfisca-france/pull/2772)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -417,8 +417,8 @@ class al_nb_personnes_a_charge(Variable):
             return famille.sum(adulte_handicape, role = Famille.ENFANT)
 
         nb_pac = al_nb_enfants() + al_nb_adultes_handicapes()
-        nb_pac = where(residence_dom, min_(nb_pac, 6), nb_pac)
-        # Dans les DOMs, le barème est fixe à partir de 6 enfants.
+        limitation_six_pac_dom = residence_dom * (period.start.year < 2023)
+        nb_pac = where(limitation_six_pac_dom, min_(nb_pac, 6), nb_pac)
 
         return nb_pac
 

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1288,6 +1288,10 @@ class aide_logement_R0(Variable):
         al_r0 = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.r0_abattement
         couple = famille('al_couple', period)
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
+        residence_dom = famille.demandeur.menage('residence_dom', period)
+        nb_pac_supp = max_(al_nb_pac - 6, 0)
+        if period.start.date < date(2023, 1, 1):
+            nb_pac_supp = where(residence_dom, 0, nb_pac_supp)
 
         R0 = (
             al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
@@ -1298,7 +1302,7 @@ class aide_logement_R0(Variable):
             + al_r0.cas_general.taux4pac * (al_nb_pac == 4)
             + al_r0.cas_general.taux5pac * (al_nb_pac == 5)
             + al_r0.cas_general.taux6pac * (al_nb_pac >= 6)  # la dernière valeur est un montant additionnel à rajouter pour chaque pac au-delà de 6.
-            + al_r0.cas_general.taux_pac_supp * (al_nb_pac > 6) * (al_nb_pac - 6)
+            + al_r0.cas_general.taux_pac_supp * nb_pac_supp
             )
 
         return R0

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1374,7 +1374,6 @@ class aide_logement_taux_famille(Variable):
 
         return where(residence_dom, TF_dom, TF_metropole)
 
-
 class aide_logement_taux_loyer(Variable):
     value_type = float
     entity = Famille
@@ -1393,12 +1392,19 @@ class aide_logement_taux_loyer(Variable):
         L = famille('aide_logement_loyer_retenu', period)
         couple = famille('al_couple', period)
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
+        residence_dom = famille.demandeur.menage('residence_dom', period)
+        limitation_six_pac_dom = residence_dom * (period.start.year < 2023)
+        al_nb_pac_reference = where(
+            limitation_six_pac_dom,
+            min_(al_nb_pac, 6),
+            al_nb_pac,
+            )
 
         loyer_reference = (
             al_plafonds_z2.personnes_seules * (not_(couple)) * (al_nb_pac == 0)
             + al_plafonds_z2.couples * (couple) * (al_nb_pac == 0)
             + al_plafonds_z2.un_enfant * (al_nb_pac >= 1)
-            + al_plafonds_z2.majoration_par_enf_supp * (al_nb_pac > 1) * (al_nb_pac - 1)
+            + al_plafonds_z2.majoration_par_enf_supp * (al_nb_pac_reference > 1) * (al_nb_pac_reference - 1)
             )
 
         RL = L / loyer_reference

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1378,6 +1378,7 @@ class aide_logement_taux_famille(Variable):
 
         return where(residence_dom, TF_dom, TF_metropole)
 
+
 class aide_logement_taux_loyer(Variable):
     value_type = float
     entity = Famille

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "175.1.8"
+version = "175.1.9"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/formulas/aides_logement.yaml
+++ b/tests/formulas/aides_logement.yaml
@@ -56,6 +56,80 @@
   output:
     al_nb_personnes_a_charge: 0
 
+- name: Aides logements - la limite de six personnes à charge dans les DOM s'applique en 2022
+  period: 2022-12
+  input:
+    famille:
+      parents: [parent1]
+      enfants: [enfant1, enfant2, enfant3, enfant4, enfant5, enfant6, enfant7, enfant8, enfant9]
+    foyer_fiscal:
+      declarants: [parent1]
+      personnes_a_charge: [enfant1, enfant2, enfant3, enfant4, enfant5, enfant6, enfant7, enfant8, enfant9]
+    menage:
+      personne_de_reference: parent1
+      enfants: [enfant1, enfant2, enfant3, enfant4, enfant5, enfant6, enfant7, enfant8, enfant9]
+      depcom: "97100"
+    individus:
+      parent1:
+        age: 40
+      enfant1:
+        age: 10
+      enfant2:
+        age: 10
+      enfant3:
+        age: 10
+      enfant4:
+        age: 10
+      enfant5:
+        age: 10
+      enfant6:
+        age: 10
+      enfant7:
+        age: 10
+      enfant8:
+        age: 10
+      enfant9:
+        age: 10
+  output:
+    al_nb_personnes_a_charge: 6
+
+- name: Aides logements - la limite de six personnes à charge dans les DOM est supprimée en 2023
+  period: 2023-01
+  input:
+    famille:
+      parents: [parent1]
+      enfants: [enfant1, enfant2, enfant3, enfant4, enfant5, enfant6, enfant7, enfant8, enfant9]
+    foyer_fiscal:
+      declarants: [parent1]
+      personnes_a_charge: [enfant1, enfant2, enfant3, enfant4, enfant5, enfant6, enfant7, enfant8, enfant9]
+    menage:
+      personne_de_reference: parent1
+      enfants: [enfant1, enfant2, enfant3, enfant4, enfant5, enfant6, enfant7, enfant8, enfant9]
+      depcom: "97100"
+    individus:
+      parent1:
+        age: 40
+      enfant1:
+        age: 10
+      enfant2:
+        age: 10
+      enfant3:
+        age: 10
+      enfant4:
+        age: 10
+      enfant5:
+        age: 10
+      enfant6:
+        age: 10
+      enfant7:
+        age: 10
+      enfant8:
+        age: 10
+      enfant9:
+        age: 10
+  output:
+    al_nb_personnes_a_charge: 9
+
 - name: Aides logements - les enfants de plus de 21 ans handicapés (>80%) sont considérés à charge
   description: Nombre de personnes à charge pour les AL
   period: 2015-01


### PR DESCRIPTION
## Description

Cette PR regroupe trois corrections liees au plafonnement a six personnes a charge dans les DOM :

* suppression du plafonnement a partir de 2023 ;
* correction de la fin du plafonnement sur le loyer de reference ;
* plafonnement du `R0` DOM jusqu'en 2022.

L'article 46 de l'arrete du 27 septembre 2019 limite la majoration pour personne a charge a 6 personnes dans les territoires concernes, mais cette logique ne s'applique pas de la meme facon sur toute la periode. OpenFisca prolongeait ou interrompait ce plafonnement selon les composantes du calcul.

La PR introduit :

* plafonnement maintenu jusqu'au 31/12/2022 la ou il est prevu ;
* fin du plafonnement a partir du 01/01/2023 ;
* alignement de `R0` et du loyer de reference sur cette chronologie.

## Sources juridiques

* Arrete du 27 septembre 2019, article 46 : https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000041489188/2020-01-01
* Arrete du 20 decembre 2021, article 1 : https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
* Arrete du 26 decembre 2022, article 1 : https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046834757
* Article D823-17 du code de la construction et de l'habitation : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255

## Changelog propose

Evolution du systeme socio-fiscal

Periodes concernees : jusqu'au 31/12/2022 pour le plafonnement ; a partir du 01/01/2023 pour sa suppression.

Zones impactees : `prestations/aides_logement`

Details :

* plafonnement du `R0` DOM a six personnes a charge jusqu'en 2022 ;
* correction de la fin du plafonnement du loyer de reference DOM ;
* suppression du plafonnement a partir de 2023 lorsque le bareme ne le prevoit plus.

Ces changements :

* corrigent ou ameliorent un calcul deja existant.