### PR TITLE
[APL] Calcule le montant locatif des aides au logement a Mayotte

### DIFF
--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -203,7 +203,7 @@ class aide_logement_montant_brut_avant_degressivite(Variable):
         seuil_versement = al.locatif.seuils_minimum_versement[type_aide]
         minimum_atteint = montant >= seuil_versement
 
-        return minimum_atteint * montant * not_(residence_mayotte)
+        return minimum_atteint * montant
 
 
 class TypeEtatLogementFoyer(Enum):


### PR DESCRIPTION
## Description

Cette PR supprime une exclusion technique qui annulait le montant locatif des aides au logement a Mayotte.

OpenFisca disposait deja de baremes specifiques pour Mayotte, mais la formule du montant brut avant degressivite multipliait encore le resultat par `not_(residence_mayotte)`, ce qui ramenait le montant a zero meme lorsque le menage relevait bien du calcul locatif.

La correction consiste a laisser s'appliquer la formule generale une fois que les baremes et les conditions specifiques a Mayotte ont ete determines.

## Sources juridiques

* Article D823-16 du code de la construction et de l'habitation : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000038878905
* Article D823-17 du code de la construction et de l'habitation : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
* Arrete du 27 septembre 2019, article 47 : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041489186/2020-01-01/

## Changelog propose

Evolution du systeme socio-fiscal

Periodes concernees : a partir du 01/10/2019.

Zones impactees : `prestations/aides_logement`

Details :

* suppression de l'annulation du montant locatif a Mayotte ;
* application effective du calcul locatif lorsque le menage releve du bareme mahorais ;
* correction du montant brut avant degressivite et du montant final verse.

Ces changements :

* corrigent ou ameliorent un calcul deja existant.