### PR TITLE
[APL] Prend en compte le bareme R0 specifique a Mayotte jusqu'en 2021 puis le borne a sa periode d'application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+# 176.0.0 [#2775](https://github.com/openfisca/openfisca-france/pull/2775)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : du 01/01/2020 au 31/12/2021 pour le barème specifique, puis articulation avec le bareme outre-mer a partir du 01/01/2022.
+* Zones impactées :
+    - `openfisca_france/prestations/aides_logement`
+    - `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/*`
+* Détails :
+    - correction des valeurs du `R0` spécifique à Mayotte en 2020 et 2021
+    - prise en compte du barème mahorais dans la formule de calcul
+    - borne de ce barème a sa période légale d'application
+    - utilisation du bareme outre-mer à partir de 2022
+    - suppression de l'annulation du montant locatif à Mayotte
+
 ### 175.1.10 [#2785](https://github.com/openfisca/openfisca-france/pull/2785)
 
 * Évolution du système socio-fiscal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@
     - borne de ce barème a sa période légale d'application
     - utilisation du bareme outre-mer à partir de 2022
     - suppression de l'annulation du montant locatif à Mayotte
+    - `aide_logement_montant_brut_avant_degressivite` est découpé en `aide_logement_montant_selectionne_avant_seuil` puis `aide_logement_montant_brut_avant_degressivite`.
+    - `aide_logement_participation_personnelle` est découpé en :
+        + `aide_logement_ressources_apres_abattement` (`Rp`),
+        + `aide_logement_taux_participation_personnelle` (`Tp`),
+        + `aide_logement_participation_ressources` (`Rp*Tp`),
+        + `aide_logement_participation_minimale` (`P0`),
+        + `aide_logement_participation_personnelle` (`aide_logement_participation_personnelle`).
 
 ### 175.1.10 [#2785](https://github.com/openfisca/openfisca-france/pull/2785)
 

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1342,37 +1342,6 @@ class aide_logement_R0(Variable):
             )
         return where(residence_mayotte, R0_mayotte, R0_cas_general)
 
-    def formula_2021_01_01(famille, period, parameters):
-        al_r0 = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.r0_abattement
-        couple = famille('al_couple', period)
-        al_nb_pac = famille('al_nb_personnes_a_charge', period)
-
-        residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
-
-        R0_cas_general = (
-            al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
-            + al_r0.cas_general.taux_couple * couple * (al_nb_pac == 0)
-            + al_r0.cas_general.taux1pac * (al_nb_pac == 1)
-            + al_r0.cas_general.taux2pac * (al_nb_pac == 2)
-            + al_r0.cas_general.taux3pac * (al_nb_pac == 3)
-            + al_r0.cas_general.taux4pac * (al_nb_pac == 4)
-            + al_r0.cas_general.taux5pac * (al_nb_pac == 5)
-            + al_r0.cas_general.taux6pac * (al_nb_pac >= 6)
-            + al_r0.cas_general.taux_pac_supp * (al_nb_pac > 6) * (al_nb_pac - 6)
-            )
-
-        R0_mayotte = (
-            al_r0.mayotte.taux_seul * not_(couple) * (al_nb_pac == 0)
-            + al_r0.mayotte.taux_couple * couple * (al_nb_pac == 0)
-            + al_r0.mayotte.taux1pac * (al_nb_pac == 1)
-            + al_r0.mayotte.taux2pac * (al_nb_pac == 2)
-            + al_r0.mayotte.taux3pac * (al_nb_pac == 3)
-            + al_r0.mayotte.taux4pac * (al_nb_pac == 4)
-            + al_r0.mayotte.taux5pac * (al_nb_pac == 5)
-            + al_r0.mayotte.taux6pac * (al_nb_pac >= 6)
-            )
-        return where(residence_mayotte, R0_mayotte, R0_cas_general)
-
     def formula_2022_01_01(famille, period, parameters):
         al_r0 = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.r0_abattement
         couple = famille('al_couple', period)

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1288,12 +1288,15 @@ class aide_logement_R0(Variable):
         al_r0 = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.r0_abattement
         couple = famille('al_couple', period)
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
+
         residence_dom = famille.demandeur.menage('residence_dom', period)
         nb_pac_supp = max_(al_nb_pac - 6, 0)
         if period.start.date < date(2023, 1, 1):
             nb_pac_supp = where(residence_dom, 0, nb_pac_supp)
 
-        R0 = (
+        residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
+
+        R0_cas_general = (
             al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
             + al_r0.cas_general.taux_couple * couple * (al_nb_pac == 0)
             + al_r0.cas_general.taux1pac * (al_nb_pac == 1)
@@ -1305,7 +1308,17 @@ class aide_logement_R0(Variable):
             + al_r0.cas_general.taux_pac_supp * nb_pac_supp
             )
 
-        return R0
+        R0_mayotte = (
+            al_r0.mayotte.taux_seul * not_(couple) * (al_nb_pac == 0)
+            + al_r0.mayotte.taux_couple * couple * (al_nb_pac == 0)
+            + al_r0.mayotte.taux1pac * (al_nb_pac == 1)
+            + al_r0.mayotte.taux2pac * (al_nb_pac == 2)
+            + al_r0.mayotte.taux3pac * (al_nb_pac == 3)
+            + al_r0.mayotte.taux4pac * (al_nb_pac == 4)
+            + al_r0.mayotte.taux5pac * (al_nb_pac == 5)
+            + al_r0.mayotte.taux6pac * (al_nb_pac >= 6)
+            )
+        return where(residence_mayotte, R0_mayotte, R0_cas_general)
 
 
 class aide_logement_taux_famille(Variable):

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -165,19 +165,14 @@ class aide_logement_montant_brut(Variable):
         return famille('aide_logement_montant_brut_avant_degressivite', period)
 
 
-class aide_logement_montant_brut_avant_degressivite(Variable):
+class aide_logement_montant_selectionne_avant_seuil(Variable):
     value_type = float
-    label = 'Montant des aides aux logements en secteur locatif avant degressivité et brut de CRDS'
-    reference = 'https://www.legifrance.gouv.fr/eli/arrete/2018/2/27/TERL1801552A/jo/article_1'
+    label = 'Montant des aides aux logements avant minimum de versement et exclusions'
     entity = Famille
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
-    def formula(famille, period, parameters):
-        al = parameters(period).prestations_sociales.aides_logement.allocations_logement
-
-        residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
-
+    def formula(famille, period):
         statut_occupation_logement = famille.demandeur.menage('statut_occupation_logement', period)
         locataire = ((statut_occupation_logement == TypesStatutOccupationLogement.locataire_hlm)
                 + (statut_occupation_logement == TypesStatutOccupationLogement.locataire_vide)
@@ -195,8 +190,24 @@ class aide_logement_montant_brut_avant_degressivite(Variable):
         montant_accedant_et_foyer = famille('aides_logement_accedant_et_foyer', period)
         montant_locataire = max_(0, loyer_retenu + charges_retenues - participation_personnelle)
 
-        montant = select([locataire, accedant + locataire_logement_foyer + logement_crous],
-                         [montant_locataire, montant_accedant_et_foyer])
+        return select([locataire, accedant + locataire_logement_foyer + logement_crous],
+                      [montant_locataire, montant_accedant_et_foyer])
+
+
+class aide_logement_montant_brut_avant_degressivite(Variable):
+    value_type = float
+    label = 'Montant des aides aux logements en secteur locatif avant degressivité et brut de CRDS'
+    reference = 'https://www.legifrance.gouv.fr/eli/arrete/2018/2/27/TERL1801552A/jo/article_1'
+    entity = Famille
+    definition_period = MONTH
+    set_input = set_input_divide_by_period
+
+    def formula(famille, period, parameters):
+        al = parameters(period).prestations_sociales.aides_logement.allocations_logement
+
+        residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
+
+        montant = famille('aide_logement_montant_selectionne_avant_seuil', period)
 
         logement_conventionne = famille.demandeur.menage('logement_conventionne', period)
         type_aide = where(logement_conventionne, 'apl', 'non_apl', )
@@ -1101,6 +1112,7 @@ class aide_logement_loyer_plafond(Variable):
         couple = famille('al_couple', period)
         coloc = famille.demandeur.menage('coloc', period)
         chambre = famille.demandeur.menage('logement_chambre', period)
+        residence_dom = famille.demandeur.menage('residence_dom', period)
         personne_agee_handicapee = famille.demandeur.menage(
             'personne_agee_handicapee', period
             )
@@ -1112,7 +1124,8 @@ class aide_logement_loyer_plafond(Variable):
 
         plafond_personne_seule = plafonds_loyers_par_zone.personnes_seules
         plafond_couple = plafonds_loyers_par_zone.couples
-        plafond_famille = plafonds_loyers_par_zone.un_enfant + (al_nb_pac > 1) * (al_nb_pac - 1) * plafonds_loyers_par_zone.majoration_par_enf_supp
+        al_nb_pac_plafond = where(residence_dom, min_(al_nb_pac, 6), al_nb_pac)
+        plafond_famille = plafonds_loyers_par_zone.un_enfant + (al_nb_pac_plafond > 1) * (al_nb_pac_plafond - 1) * plafonds_loyers_par_zone.majoration_par_enf_supp
 
         plafond = select(
             [not_(couple) * (al_nb_pac == 0) + chambre, al_nb_pac > 0],
@@ -1301,6 +1314,36 @@ class aide_logement_R0(Variable):
             + al_r0.cas_general.taux_pac_supp * (al_nb_pac > 6) * (al_nb_pac - 6)
             )
 
+    def formula_2020_01_01(famille, period, parameters):
+        al_r0 = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.r0_abattement
+        couple = famille('al_couple', period)
+        al_nb_pac = famille('al_nb_personnes_a_charge', period)
+        residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
+
+        R0_cas_general = (
+            al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
+            + al_r0.cas_general.taux_couple * couple * (al_nb_pac == 0)
+            + al_r0.cas_general.taux1pac * (al_nb_pac == 1)
+            + al_r0.cas_general.taux2pac * (al_nb_pac == 2)
+            + al_r0.cas_general.taux3pac * (al_nb_pac == 3)
+            + al_r0.cas_general.taux4pac * (al_nb_pac == 4)
+            + al_r0.cas_general.taux5pac * (al_nb_pac == 5)
+            + al_r0.cas_general.taux6pac * (al_nb_pac >= 6)
+            + al_r0.cas_general.taux_pac_supp * (al_nb_pac > 6) * (al_nb_pac - 6)
+            )
+
+        R0_mayotte = (
+            al_r0.mayotte.taux_seul * not_(couple) * (al_nb_pac == 0)
+            + al_r0.mayotte.taux_couple * couple * (al_nb_pac == 0)
+            + al_r0.mayotte.taux1pac * (al_nb_pac == 1)
+            + al_r0.mayotte.taux2pac * (al_nb_pac == 2)
+            + al_r0.mayotte.taux3pac * (al_nb_pac == 3)
+            + al_r0.mayotte.taux4pac * (al_nb_pac == 4)
+            + al_r0.mayotte.taux5pac * (al_nb_pac == 5)
+            + al_r0.mayotte.taux6pac * (al_nb_pac >= 6)
+            )
+        return where(residence_mayotte, R0_mayotte, R0_cas_general)
+
     def formula_2021_01_01(famille, period, parameters):
         al_r0 = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.r0_abattement
         couple = famille('al_couple', period)
@@ -1426,6 +1469,86 @@ class aide_logement_taux_famille(Variable):
         return where(residence_dom, TF_dom, TF_metropole)
 
 
+class aide_logement_loyer_reference(Variable):
+    value_type = float
+    entity = Famille
+    label = 'Loyer de référence dans le calcul du taux de participation personnelle'
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+
+    def formula(famille, period, parameters):
+        al_locatif = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif
+        al_plafonds_z2 = al_locatif.formule.l_plafonds_loyers.par_zone.zone_2
+
+        couple = famille('al_couple', period)
+        al_nb_pac = famille('al_nb_personnes_a_charge', period)
+        residence_dom = famille.demandeur.menage('residence_dom', period)
+        al_nb_pac_reference = where(residence_dom, min_(al_nb_pac, 6), al_nb_pac)
+
+        return (
+            al_plafonds_z2.personnes_seules * (not_(couple)) * (al_nb_pac == 0)
+            + al_plafonds_z2.couples * (couple) * (al_nb_pac == 0)
+            + al_plafonds_z2.un_enfant * (al_nb_pac >= 1)
+            + al_plafonds_z2.majoration_par_enf_supp * (al_nb_pac_reference > 1) * (al_nb_pac_reference - 1)
+            )
+
+
+class aide_logement_rapport_loyers(Variable):
+    value_type = float
+    entity = Famille
+    label = 'Rapport entre le loyer retenu et le loyer de référence'
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+
+    def formula(famille, period):
+        loyer_retenu = famille('aide_logement_loyer_retenu', period)
+        loyer_reference = famille('aide_logement_loyer_reference', period)
+
+        return loyer_retenu / loyer_reference
+
+
+class aide_logement_rapport_loyers_arrondi_pourcent(Variable):
+    value_type = float
+    entity = Famille
+    label = 'Rapport entre le loyer retenu et le loyer de référence, arrondi en pourcentage'
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+
+    def formula(famille, period):
+        rapport_loyers = famille('aide_logement_rapport_loyers', period)
+
+        # RL and TL rounding follow regulatory wording:
+        # - RL is rounded to 2 decimals in percent
+        # - TL is rounded to 3 decimals in percent
+        # In decimal representation, rounding TL at 3 decimals in percent
+        # is equivalent to rounding at 5 decimals.
+        return round_(rapport_loyers * 100, 2)
+
+
+class aide_logement_taux_loyer_formule(Variable):
+    value_type = float
+    entity = Famille
+    label = 'Taux de loyer avant arrondi final'
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+
+    def formula(famille, period, parameters):
+        al_locatif = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif
+
+        al_tl_seuils = al_locatif.formule.pp_particip_perso.tp_taux.tl_loyer.seuils
+        al_tl_taux = al_locatif.formule.pp_particip_perso.tp_taux.tl_loyer.taux
+
+        RL_pct = famille('aide_logement_rapport_loyers_arrondi_pourcent', period)
+
+        TL_pct = where(RL_pct >= al_tl_seuils.seuil_2 * 100,
+            al_tl_taux.tl_taux_3 * (RL_pct - al_tl_seuils.seuil_2 * 100)
+            + al_tl_taux.tl_taux_2 * ((al_tl_seuils.seuil_2 - al_tl_seuils.seuil_1) * 100),
+            max_(0, al_tl_taux.tl_taux_2 * (RL_pct - al_tl_seuils.seuil_1 * 100))
+            )
+
+        return TL_pct / 100
+
+
 class aide_logement_taux_loyer(Variable):
     value_type = float
     entity = Famille
@@ -1470,6 +1593,65 @@ class aide_logement_taux_loyer(Variable):
         return TL
 
 
+class aide_logement_ressources_apres_abattement(Variable):
+    value_type = float
+    entity = Famille
+    label = 'Ressources prises en compte après abattement forfaitaire'
+    definition_period = MONTH
+    set_input = set_input_divide_by_period
+
+    def formula(famille, period):
+        ressources = famille('aide_logement_base_ressources', period)
+        abattement = famille('aide_logement_R0', period)
+
+        return max_(0, ressources - abattement)
+
+
+class aide_logement_taux_participation_personnelle(Variable):
+    value_type = float
+    entity = Famille
+    label = 'Taux de participation personnelle'
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+
+    def formula(famille, period):
+        taux_famille = famille('aide_logement_taux_famille', period)
+        taux_loyer = famille('aide_logement_taux_loyer', period)
+
+        return taux_famille + taux_loyer
+
+
+class aide_logement_participation_minimale(Variable):
+    value_type = float
+    entity = Famille
+    label = 'Participation personnelle minimale'
+    definition_period = MONTH
+    set_input = set_input_divide_by_period
+
+    def formula(famille, period, parameters):
+        al_participation_minimale = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.p0_particip_min
+
+        loyer_retenu = famille('aide_logement_loyer_retenu', period)
+        charges_retenues = famille('aide_logement_charges', period)
+        E = loyer_retenu + charges_retenues
+
+        return max_(al_participation_minimale.p0_taux * E, al_participation_minimale.p0_forfait)
+
+
+class aide_logement_participation_ressources(Variable):
+    value_type = float
+    entity = Famille
+    label = 'Participation personnelle liée aux ressources'
+    definition_period = MONTH
+    set_input = set_input_divide_by_period
+
+    def formula(famille, period):
+        ressources_apres_abattement = famille('aide_logement_ressources_apres_abattement', period)
+        taux_participation = famille('aide_logement_taux_participation_personnelle', period)
+
+        return taux_participation * ressources_apres_abattement
+
+
 class aide_logement_participation_personnelle(Variable):
     value_type = float
     entity = Famille
@@ -1477,23 +1659,11 @@ class aide_logement_participation_personnelle(Variable):
     definition_period = MONTH
     set_input = set_input_divide_by_period
 
-    def formula(famille, period, parameters):
-        al_participation_minimale = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.p0_particip_min
+    def formula(famille, period):
+        participation_minimale = famille('aide_logement_participation_minimale', period)
+        participation_ressources = famille('aide_logement_participation_ressources', period)
 
-        R = famille('aide_logement_base_ressources', period)
-        R0 = famille('aide_logement_R0', period)
-        Rp = max_(0, R - R0)
-
-        loyer_retenu = famille('aide_logement_loyer_retenu', period)
-        charges_retenues = famille('aide_logement_charges', period)
-        E = loyer_retenu + charges_retenues
-        P0 = max_(al_participation_minimale.p0_taux * E, al_participation_minimale.p0_forfait)  # Participation personnelle minimale
-
-        Tf = famille('aide_logement_taux_famille', period)
-        Tl = famille('aide_logement_taux_loyer', period)
-        Tp = Tf + Tl  # Taux de participation
-
-        return P0 + Tp * Rp
+        return participation_minimale + participation_ressources
 
 
 class TypesAideLogementNonCalculable(Enum):

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1289,10 +1289,22 @@ class aide_logement_R0(Variable):
         couple = famille('al_couple', period)
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
 
-        residence_dom = famille.demandeur.menage('residence_dom', period)
-        nb_pac_supp = max_(al_nb_pac - 6, 0)
-        if period.start.date < date(2023, 1, 1):
-            nb_pac_supp = where(residence_dom, 0, nb_pac_supp)
+        return (
+            al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
+            + al_r0.cas_general.taux_couple * couple * (al_nb_pac == 0)
+            + al_r0.cas_general.taux1pac * (al_nb_pac == 1)
+            + al_r0.cas_general.taux2pac * (al_nb_pac == 2)
+            + al_r0.cas_general.taux3pac * (al_nb_pac == 3)
+            + al_r0.cas_general.taux4pac * (al_nb_pac == 4)
+            + al_r0.cas_general.taux5pac * (al_nb_pac == 5)
+            + al_r0.cas_general.taux6pac * (al_nb_pac >= 6)  # la dernière valeur est un montant additionnel à rajouter pour chaque pac au-delà de 6.
+            + al_r0.cas_general.taux_pac_supp * (al_nb_pac > 6) * (al_nb_pac - 6)
+            )
+
+    def formula_2021_01_01(famille, period, parameters):
+        al_r0 = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.r0_abattement
+        couple = famille('al_couple', period)
+        al_nb_pac = famille('al_nb_personnes_a_charge', period)
 
         residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
 
@@ -1304,8 +1316,8 @@ class aide_logement_R0(Variable):
             + al_r0.cas_general.taux3pac * (al_nb_pac == 3)
             + al_r0.cas_general.taux4pac * (al_nb_pac == 4)
             + al_r0.cas_general.taux5pac * (al_nb_pac == 5)
-            + al_r0.cas_general.taux6pac * (al_nb_pac >= 6)  # la dernière valeur est un montant additionnel à rajouter pour chaque pac au-delà de 6.
-            + al_r0.cas_general.taux_pac_supp * nb_pac_supp
+            + al_r0.cas_general.taux6pac * (al_nb_pac >= 6)
+            + al_r0.cas_general.taux_pac_supp * (al_nb_pac > 6) * (al_nb_pac - 6)
             )
 
         R0_mayotte = (
@@ -1319,6 +1331,28 @@ class aide_logement_R0(Variable):
             + al_r0.mayotte.taux6pac * (al_nb_pac >= 6)
             )
         return where(residence_mayotte, R0_mayotte, R0_cas_general)
+
+    def formula_2022_01_01(famille, period, parameters):
+        al_r0 = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.r0_abattement
+        couple = famille('al_couple', period)
+        al_nb_pac = famille('al_nb_personnes_a_charge', period)
+
+        residence_dom = famille.demandeur.menage('residence_dom', period)
+        nb_pac_supp = max_(al_nb_pac - 6, 0)
+        if period.start.date < date(2023, 1, 1):
+            nb_pac_supp = where(residence_dom, 0, nb_pac_supp)
+
+        return (
+            al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
+            + al_r0.cas_general.taux_couple * couple * (al_nb_pac == 0)
+            + al_r0.cas_general.taux1pac * (al_nb_pac == 1)
+            + al_r0.cas_general.taux2pac * (al_nb_pac == 2)
+            + al_r0.cas_general.taux3pac * (al_nb_pac == 3)
+            + al_r0.cas_general.taux4pac * (al_nb_pac == 4)
+            + al_r0.cas_general.taux5pac * (al_nb_pac == 5)
+            + al_r0.cas_general.taux6pac * (al_nb_pac >= 6)
+            + al_r0.cas_general.taux_pac_supp * nb_pac_supp
+            )
 
 
 class aide_logement_taux_famille(Variable):

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1300,6 +1300,10 @@ class aide_logement_R0(Variable):
         couple = famille('al_couple', period)
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
 
+        residence_dom = famille.demandeur.menage('residence_dom', period)
+        nb_pac_supp = max_(al_nb_pac - 6, 0)
+        nb_pac_supp = where(residence_dom, 0, nb_pac_supp)
+
         return (
             al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
             + al_r0.cas_general.taux_couple * couple * (al_nb_pac == 0)
@@ -1309,7 +1313,7 @@ class aide_logement_R0(Variable):
             + al_r0.cas_general.taux4pac * (al_nb_pac == 4)
             + al_r0.cas_general.taux5pac * (al_nb_pac == 5)
             + al_r0.cas_general.taux6pac * (al_nb_pac >= 6)  # la dernière valeur est un montant additionnel à rajouter pour chaque pac au-delà de 6.
-            + al_r0.cas_general.taux_pac_supp * (al_nb_pac > 6) * (al_nb_pac - 6)
+            + al_r0.cas_general.taux_pac_supp * nb_pac_supp
             )
 
     def formula_2020_01_01(famille, period, parameters):
@@ -1317,6 +1321,10 @@ class aide_logement_R0(Variable):
         couple = famille('al_couple', period)
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
         residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
+
+        residence_dom = famille.demandeur.menage('residence_dom', period)
+        nb_pac_supp = max_(al_nb_pac - 6, 0)
+        nb_pac_supp = where(residence_dom, 0, nb_pac_supp)
 
         R0_cas_general = (
             al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
@@ -1327,7 +1335,7 @@ class aide_logement_R0(Variable):
             + al_r0.cas_general.taux4pac * (al_nb_pac == 4)
             + al_r0.cas_general.taux5pac * (al_nb_pac == 5)
             + al_r0.cas_general.taux6pac * (al_nb_pac >= 6)
-            + al_r0.cas_general.taux_pac_supp * (al_nb_pac > 6) * (al_nb_pac - 6)
+            + al_r0.cas_general.taux_pac_supp * nb_pac_supp
             )
 
         R0_mayotte = (

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -205,8 +205,6 @@ class aide_logement_montant_brut_avant_degressivite(Variable):
     def formula(famille, period, parameters):
         al = parameters(period).prestations_sociales.aides_logement.allocations_logement
 
-        residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
-
         montant = famille('aide_logement_montant_selectionne_avant_seuil', period)
 
         logement_conventionne = famille.demandeur.menage('logement_conventionne', period)
@@ -214,7 +212,7 @@ class aide_logement_montant_brut_avant_degressivite(Variable):
         seuil_versement = al.locatif.seuils_minimum_versement[type_aide]
         minimum_atteint = montant >= seuil_versement
 
-        return minimum_atteint * montant * not_(residence_mayotte)
+        return minimum_atteint * montant
 
 
 class TypeEtatLogementFoyer(Enum):

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux2pac.yaml
@@ -2,6 +2,8 @@ description: Abattement forfaitaire « R0 » à Mayotte pour pour une personne s
 values:
   2019-10-01:
     value: 6247
+  2020-01-01:
+    value: 6849
   2021-01-01:
     value: 7432
   2022-01-01:
@@ -15,6 +17,9 @@ metadata:
     2019-10-01:
       title: Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement - Art. 47
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000039160717/2019-10-01/
+    2020-01-01:
+      title: Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement - Art. 47
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041489186/2020-01-01/
     2021-01-01:
     - title: Arrêté du 31/12/2020, article 1, 3°,3°
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043041786/2021-01-02/

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux2pac.yaml
@@ -19,7 +19,7 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000039160717/2019-10-01/
     2020-01-01:
       title: Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement - Art. 47
-      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041489186/2020-01-01/
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000041489186/2020-01-05
     2021-01-01:
     - title: Arrêté du 31/12/2020, article 1, 3°,3°
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043041786/2021-01-02/

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux3pac.yaml
@@ -1,5 +1,7 @@
 description: Abattement forfaitaire « R0 » à Mayotte pour pour une personne seule ou couple ayant trois personnes à charge, intervenant sur la participation personnelle du ménage « Pp » prise en compte dans le calcul de l'aide mensuelle au logement
 values:
+  2020-01-01:
+    value: 7386
   2021-01-01:
     value: 7854
   2022-01-01:
@@ -9,6 +11,9 @@ metadata:
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   unit: currency
   reference:
+    2020-01-01:
+      title: Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement - Art. 47
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041489186/2020-01-01/
     2021-01-01:
     - title: Arrêté du 31/12/2020, article 1, 3°, 3°
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043041786/2021-01-02/

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux4pac.yaml
@@ -1,5 +1,7 @@
 description: Abattement forfaitaire « R0 » à Mayotte pour pour une personne seule ou couple ayant quatre personnes à charge, intervenant sur la participation personnelle du ménage « Pp » prise en compte dans le calcul de l'aide mensuelle au logement
 values:
+  2020-01-01:
+    value: 7935
   2021-01-01:
     value: 8283
   2022-01-01:
@@ -10,6 +12,9 @@ metadata:
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   unit: currency
   reference:
+    2020-01-01:
+      title: Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement - Art. 47
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041489186/2020-01-01/
     2021-01-01:
     - title: Arrêté du 31/12/2020, article 1, 3°, 3°
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043041786/2021-01-02/

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux5pac.yaml
@@ -1,5 +1,7 @@
 description: Abattement forfaitaire « R0 » à Mayotte pour pour une personne seule ou couple ayant cinq personnes à charge, intervenant sur la participation personnelle du ménage « Pp » prise en compte dans le calcul de l'aide mensuelle au logement
 values:
+  2020-01-01:
+    value: 8484
   2021-01-01:
     value: 8711
   2022-01-01:
@@ -9,6 +11,9 @@ metadata:
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   unit: currency
   reference:
+    2020-01-01:
+      title: Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement - Art. 47
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041489186/2020-01-01/
     2021-01-01:
     - title: Arrêté du 31/12/2020, article 1, 3°,3°
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043041786/2021-01-02/

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux6pac.yaml
@@ -1,5 +1,7 @@
 description: Abattement forfaitaire « R0 » à Mayotte pour une personne seule ou couple ayant une six personnes à charge ou plus, intervenant sur la participation personnelle du ménage « Pp » prise en compte dans le calcul de l'aide mensuelle au logement
 values:
+  2020-01-01:
+    value: 9032
   2021-01-01:
     value: 9139
   2022-01-01:
@@ -9,6 +11,9 @@ metadata:
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   unit: currency
   reference:
+    2020-01-01:
+      title: Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement - Art. 47
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041489186/2020-01-01/
     2021-01-01:
     - title: Arrêté du 31/12/2020, article 1, 3°, 3°
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043041786/2021-01-02/

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux_couple.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux_couple.yaml
@@ -2,6 +2,8 @@ description: Abattement forfaitaire « R0 » à Mayotte pour un couple sans pers
 values:
   2019-10-01:
     value: 5208
+  2020-01-01:
+    value: 5673
   2021-01-01:
     value: 6122
   2022-01-01:
@@ -15,6 +17,9 @@ metadata:
     2019-10-01:
       title: Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement - Art. 47
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000039160717/2019-10-01/
+    2020-01-01:
+      title: Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement - Art. 47
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041489186/2020-01-01/
     2021-01-01:
     - title: Arrêté du 31/12/2020, article 1, 3°,3°
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043041786/2021-01-02/

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux_seul.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/mayotte/taux_seul.yaml
@@ -2,6 +2,8 @@ description: Abattement forfaitaire « R0 » à Mayotte pour une personne seule 
 values:
   2019-10-01:
     value: 3636
+  2020-01-01:
+    value: 3960
   2021-01-01:
     value: 4274
   2022-01-01:
@@ -15,6 +17,9 @@ metadata:
     2019-10-01:
       title: Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement - Art. 47
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000039160717/2019-10-01/
+    2020-01-01:
+      title: Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement - Art. 47
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041489186/2020-01-01/
     2021-01-01:
     - title: Arrêté du 31/12/2020, article 1, 3°,3°
       href: https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043041786/2021-01-02/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "175.1.10"
+version = "176.0.0"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION
## Description

Cette PR regroupe les corrections necessaires pour le `R0` specifique a Mayotte :

* prise en compte du bareme mahorais dans la formule ;
* correction des valeurs 2020 et 2021 par composition familiale ;
* borne temporelle de ce bareme a sa periode d'application.

A compter du 1er janvier 2022, le forfait `R0` applicable a Mayotte devient identique a celui de l'outre-mer. Avant cette correction, OpenFisca utilisait encore des valeurs ou une logique métropole selon les periodes, ce qui produisait des ecarts importants sur la participation personnelle.

## Sources juridiques

* Article D823-17 du code de la construction et de l'habitation : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255
* Arrete du 27 septembre 2019, article 47 : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041489186/2020-01-01/
* Arrete du 31 decembre 2020, article 1 : https://www.legifrance.gouv.fr/loda/id/LEGIARTI000043041786/2021-01-02/
* Arrete du 20 decembre 2021, article 1 : https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
* Note de periode dans les parametres OpenFisca : a compter du 1er janvier 2022, Mayotte suit le bareme outre-mer, cf. https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000048656243

## Changelog propose

Evolution du systeme socio-fiscal

Periodes concernees : du 01/01/2020 au 31/12/2021 pour le bareme specifique, puis articulation avec le bareme outre-mer a partir du 01/01/2022.

Zones impactees : `prestations/aides_logement`

Details :

* correction des valeurs du `R0` specifique a Mayotte en 2020 et 2021 ;
* prise en compte du bareme mahorais dans la formule de calcul ;
* borne de ce bareme a sa periode legale d'application ;
* utilisation du bareme outre-mer a partir de 2022.

Ces changements :

* corrigent ou ameliorent un calcul deja existant.