### PR TITLE
[APL] Applique le R0 outre-mer avec une PAC en 2020, 2021 et 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 167.0.1 [#2776](https://github.com/openfisca/openfisca-france/pull/2776)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2020.
+* Zones impactées :
+    - `openfisca_france/prestations/aides_logement`
+    - `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/outre_mer/*`
+    - `tests/formulas/aides_logement`
+* Détails :
+    - ajout du barème `R0` outre-mer pour les ménages avec une personne à charge
+    - ajout de la valeur 2022 et correction des périodes 2020-2021
+
 # 176.0.0 [#2775](https://github.com/openfisca/openfisca-france/pull/2775)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1348,7 +1348,12 @@ class aide_logement_R0(Variable):
             + al_r0.mayotte.taux5pac * (al_nb_pac == 5)
             + al_r0.mayotte.taux6pac * (al_nb_pac >= 6)
             )
-        return where(residence_mayotte, R0_mayotte, R0_cas_general)
+
+        return select(
+            (residence_mayotte, residence_dom * (al_nb_pac == 1)),
+            (R0_mayotte, al_r0.outre_mer.taux1pac),
+            default=R0_cas_general,
+            )
 
     def formula_2022_01_01(famille, period, parameters):
         al_r0 = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.r0_abattement
@@ -1360,7 +1365,7 @@ class aide_logement_R0(Variable):
         if period.start.date < date(2023, 1, 1):
             nb_pac_supp = where(residence_dom, 0, nb_pac_supp)
 
-        return (
+        R0_cas_general = (
             al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
             + al_r0.cas_general.taux_couple * couple * (al_nb_pac == 0)
             + al_r0.cas_general.taux1pac * (al_nb_pac == 1)
@@ -1372,29 +1377,12 @@ class aide_logement_R0(Variable):
             + al_r0.cas_general.taux_pac_supp * nb_pac_supp
             )
 
-    def formula_2020_01_01(famille, period, parameters):
-        al_r0 = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.r0_abattement
-        couple = famille('al_couple', period)
-        al_nb_pac = famille('al_nb_personnes_a_charge', period)
-        residence_dom = famille.demandeur.menage('residence_dom', period)
-
-        R0_cas_general = (
-            al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
-            + al_r0.cas_general.taux_couple * couple * (al_nb_pac == 0)
-            + al_r0.cas_general.taux1pac * (al_nb_pac == 1)
-            + al_r0.cas_general.taux2pac * (al_nb_pac == 2)
-            + al_r0.cas_general.taux3pac * (al_nb_pac == 3)
-            + al_r0.cas_general.taux4pac * (al_nb_pac == 4)
-            + al_r0.cas_general.taux5pac * (al_nb_pac == 5)
-            + al_r0.cas_general.taux6pac * (al_nb_pac >= 6)
-            + al_r0.cas_general.taux_pac_supp * (al_nb_pac > 6) * (al_nb_pac - 6)
-            )
-
         return where(
             residence_dom * (al_nb_pac == 1),
             al_r0.outre_mer.taux1pac,
             R0_cas_general,
             )
+
 
 class aide_logement_taux_famille(Variable):
     value_type = float

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1396,7 +1396,6 @@ class aide_logement_R0(Variable):
             R0_cas_general,
             )
 
-
 class aide_logement_taux_famille(Variable):
     value_type = float
     entity = Famille

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1372,6 +1372,30 @@ class aide_logement_R0(Variable):
             + al_r0.cas_general.taux_pac_supp * nb_pac_supp
             )
 
+    def formula_2020_01_01(famille, period, parameters):
+        al_r0 = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.r0_abattement
+        couple = famille('al_couple', period)
+        al_nb_pac = famille('al_nb_personnes_a_charge', period)
+        residence_dom = famille.demandeur.menage('residence_dom', period)
+
+        R0_cas_general = (
+            al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
+            + al_r0.cas_general.taux_couple * couple * (al_nb_pac == 0)
+            + al_r0.cas_general.taux1pac * (al_nb_pac == 1)
+            + al_r0.cas_general.taux2pac * (al_nb_pac == 2)
+            + al_r0.cas_general.taux3pac * (al_nb_pac == 3)
+            + al_r0.cas_general.taux4pac * (al_nb_pac == 4)
+            + al_r0.cas_general.taux5pac * (al_nb_pac == 5)
+            + al_r0.cas_general.taux6pac * (al_nb_pac >= 6)
+            + al_r0.cas_general.taux_pac_supp * (al_nb_pac > 6) * (al_nb_pac - 6)
+            )
+
+        return where(
+            residence_dom * (al_nb_pac == 1),
+            al_r0.outre_mer.taux1pac,
+            R0_cas_general,
+            )
+
 
 class aide_logement_taux_famille(Variable):
     value_type = float

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/index.yaml
@@ -4,5 +4,6 @@ metadata:
   label_en: Parameters for R0 (the amount deducted from revenues) - rental sector (after the 2001 reform)
   order:
   - cas_general
+  - outre_mer
   - mayotte
   - avant_2015

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/outre_mer/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/outre_mer/index.yaml
@@ -1,0 +1,6 @@
+description: Abattement forfaitaire « R0 » spécifique à l'outre-mer appliqué aux ressources du ménage en fonction de sa composition familiale
+metadata:
+  short_label: Outre-mer
+  order:
+  - taux1pac
+documentation: Mentionné à l'article 46 de l'arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/outre_mer/taux1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/outre_mer/taux1pac.yaml
@@ -3,7 +3,11 @@ values:
   2020-01-01:
     value: 7584
   2022-01-01:
-    value: null
+    value: 7742
+  2022-07-01:
+    value: 8051
+  2023-01-01:
+    value: 8181
 metadata:
   short_label: Personne seule ou couple ayant une personne à charge
   unit: currency
@@ -14,3 +18,9 @@ metadata:
     2022-01-01:
       title: Arrêté du 20 décembre 2021 relatif au calcul des aides personnelles au logement pour l'année 2022, article 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
+    2022-07-01:
+      title: Arrêté du 16 août 2022 relatif au calcul des aides personnelles au logement, article 1
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046206184
+    2023-01-01:
+      title: Arrêté du 26 décembre 2022 relatif au calcul des aides personnelles au logement pour l'année 2023, article 1
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046834757

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/outre_mer/taux1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/outre_mer/taux1pac.yaml
@@ -1,0 +1,16 @@
+description: Abattement forfaitaire « R0 » en outre-mer pour une personne seule ou un couple ayant une personne à charge
+values:
+  2020-01-01:
+    value: 7584
+  2022-01-01:
+    value: null
+metadata:
+  short_label: Personne seule ou couple ayant une personne à charge
+  unit: currency
+  reference:
+    2020-01-01:
+      title: Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement, article 46
+      href: https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000041489188/2020-01-01
+    2022-01-01:
+      title: Arrêté du 20 décembre 2021 relatif au calcul des aides personnelles au logement pour l'année 2022, article 1
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/outre_mer/taux1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/outre_mer/taux1pac.yaml
@@ -19,8 +19,8 @@ metadata:
       title: Arrêté du 20 décembre 2021 relatif au calcul des aides personnelles au logement pour l'année 2022, article 1
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
     2022-07-01:
-      title: Arrêté du 16 août 2022 relatif au calcul des aides personnelles au logement, article 1
-      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046206184
+      title: Arrêté du 29 juillet 2022 relatif au calcul des aides personnelles au logement, article 1
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046114992/#JORFARTI000046115002
     2023-01-01:
       title: Arrêté du 26 décembre 2022 relatif au calcul des aides personnelles au logement pour l'année 2023, article 1
-      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046834757
+      href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046829583

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "176.0.0"
+version = "176.0.1"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/formulas/aides_logement.yaml
+++ b/tests/formulas/aides_logement.yaml
@@ -90,6 +90,57 @@
   output:
     aide_logement_R0: 7584
 
+- name: Aides logements - R0 outre-mer avec une personne à charge en janvier 2022
+  period: 2022-01
+  input:
+    famille:
+      parents: [parent1]
+      al_nb_personnes_a_charge: 1
+    foyer_fiscal:
+      declarants: [parent1]
+    menage:
+      personne_de_reference: parent1
+      depcom: "97300"
+    individus:
+      parent1:
+        age: 40
+  output:
+    aide_logement_R0: 7742
+
+- name: Aides logements - R0 outre-mer avec une personne à charge en juillet 2022
+  period: 2022-07
+  input:
+    famille:
+      parents: [parent1]
+      al_nb_personnes_a_charge: 1
+    foyer_fiscal:
+      declarants: [parent1]
+    menage:
+      personne_de_reference: parent1
+      depcom: "97300"
+    individus:
+      parent1:
+        age: 40
+  output:
+    aide_logement_R0: 8051
+
+- name: Aides logements - R0 outre-mer avec une personne à charge en 2023
+  period: 2023-01
+  input:
+    famille:
+      parents: [parent1]
+      al_nb_personnes_a_charge: 1
+    foyer_fiscal:
+      declarants: [parent1]
+    menage:
+      personne_de_reference: parent1
+      depcom: "97300"
+    individus:
+      parent1:
+        age: 40
+  output:
+    aide_logement_R0: 8181
+
 - name: Aides logements - la limite de six personnes à charge dans les DOM s'applique en 2022
   period: 2022-12
   input:

--- a/tests/formulas/aides_logement.yaml
+++ b/tests/formulas/aides_logement.yaml
@@ -56,6 +56,40 @@
   output:
     al_nb_personnes_a_charge: 0
 
+- name: Aides logements - R0 outre-mer avec une personne à charge en 2020
+  period: 2020-01
+  input:
+    famille:
+      parents: [parent1]
+      al_nb_personnes_a_charge: 1
+    foyer_fiscal:
+      declarants: [parent1]
+    menage:
+      personne_de_reference: parent1
+      depcom: "97100"
+    individus:
+      parent1:
+        age: 40
+  output:
+    aide_logement_R0: 7584
+
+- name: Aides logements - R0 outre-mer avec une personne à charge en 2021
+  period: 2021-01
+  input:
+    famille:
+      parents: [parent1]
+      al_nb_personnes_a_charge: 1
+    foyer_fiscal:
+      declarants: [parent1]
+    menage:
+      personne_de_reference: parent1
+      depcom: "97100"
+    individus:
+      parent1:
+        age: 40
+  output:
+    aide_logement_R0: 7584
+
 - name: Aides logements - la limite de six personnes à charge dans les DOM s'applique en 2022
   period: 2022-12
   input:


### PR DESCRIPTION
## Description

Cette PR corrige la valeur de `R0` applicable en outre-mer pour les menages ayant exactement une personne a charge.

OpenFisca reutilisait la logique du cas general alors qu'un bareme specifique outre-mer existe pour ce cas. La PR :

* ajoute le parametre `outre_mer.taux1pac` ;
* l'utilise dans la formule de `aide_logement_R0` ;
* complete la valeur pour 2022, en plus des periodes 2020 et 2021.

Cette correction reduit les ecarts sur la participation personnelle puis sur le montant final des aides.

## Sources juridiques

* Arrete du 27 septembre 2019, article 46 : https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000041489188/2020-01-01
* Arrete du 20 decembre 2021, article 1 : https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000044572819
* Arrete du 16 aout 2022, article 1 : https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046206184
* Arrete du 26 decembre 2022, article 1 : https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000046834757
* Article D823-17 du code de la construction et de l'habitation : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255

## Changelog propose

Evolution du systeme socio-fiscal

Periodes concernees : a partir du 01/01/2020, avec ajout explicite de la valeur 2022.

Zones impactees : `prestations/aides_logement`

Details :

* ajout du bareme `R0` outre-mer pour les menages avec une personne a charge ;
* application de ce bareme dans la formule de calcul ;
* ajout de la valeur 2022 et correction des periodes 2020-2021.

Ces changements :

* corrigent ou ameliorent un calcul deja existant.