### PR TITLE
[APL] Applique les baremes logement outre-mer a Saint-Barthelemy et Saint-Martin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 167.0.2 [#2777](https://github.com/openfisca/openfisca-france/pull/2777)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2019.
+* Zones impactées :
+    - `openfisca_france/prestations/aides_logement`
+    - `tests/formulas/aides_logement`
+* Détails :
+    - ajout de Saint-Barthelemy et Saint-Martin dans le champ du barème outre-mer des aides au logement
+    - la variable dédiée est `residence_aides_logement_outre_mer`
+    - correction des composantes TF, R0 et des montants dérivés pour les ménages concernés
+
 ### 167.0.1 [#2776](https://github.com/openfisca/openfisca-france/pull/2776)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1316,9 +1316,9 @@ class aide_logement_R0(Variable):
         couple = famille('al_couple', period)
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
 
-        residence_dom = famille.demandeur.menage('residence_dom', period)
+        residence_outre_mer = famille.demandeur.menage('residence_aides_logement_outre_mer', period)
         nb_pac_supp = max_(al_nb_pac - 6, 0)
-        nb_pac_supp = where(residence_dom, 0, nb_pac_supp)
+        nb_pac_supp = where(residence_outre_mer, 0, nb_pac_supp)
 
         return (
             al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
@@ -1338,9 +1338,9 @@ class aide_logement_R0(Variable):
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
         residence_mayotte = famille.demandeur.menage('residence_mayotte', period)
 
-        residence_dom = famille.demandeur.menage('residence_dom', period)
+        residence_outre_mer = famille.demandeur.menage('residence_aides_logement_outre_mer', period)
         nb_pac_supp = max_(al_nb_pac - 6, 0)
-        nb_pac_supp = where(residence_dom, 0, nb_pac_supp)
+        nb_pac_supp = where(residence_outre_mer, 0, nb_pac_supp)
 
         R0_cas_general = (
             al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
@@ -1366,7 +1366,7 @@ class aide_logement_R0(Variable):
             )
 
         return select(
-            (residence_mayotte, residence_dom * (al_nb_pac == 1)),
+            (residence_mayotte, residence_outre_mer * (al_nb_pac == 1)),
             (R0_mayotte, al_r0.outre_mer.taux1pac),
             default=R0_cas_general,
             )
@@ -1376,10 +1376,10 @@ class aide_logement_R0(Variable):
         couple = famille('al_couple', period)
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
 
-        residence_dom = famille.demandeur.menage('residence_dom', period)
+        residence_outre_mer = famille.demandeur.menage('residence_aides_logement_outre_mer', period)
         nb_pac_supp = max_(al_nb_pac - 6, 0)
         if period.start.date < date(2023, 1, 1):
-            nb_pac_supp = where(residence_dom, 0, nb_pac_supp)
+            nb_pac_supp = where(residence_outre_mer, 0, nb_pac_supp)
 
         R0_cas_general = (
             al_r0.cas_general.taux_seul * not_(couple) * (al_nb_pac == 0)
@@ -1394,7 +1394,7 @@ class aide_logement_R0(Variable):
             )
 
         return where(
-            residence_dom * (al_nb_pac == 1),
+            residence_outre_mer * (al_nb_pac == 1),
             al_r0.outre_mer.taux1pac,
             R0_cas_general,
             )

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -242,6 +242,22 @@ class logement_conventionne(Variable):
         return menage('statut_occupation_logement', period) == TypesStatutOccupationLogement.locataire_hlm
 
 
+class residence_aides_logement_outre_mer(Variable):
+    value_type = bool
+    entity = Menage
+    label = 'Le logement relève du barème outre-mer des aides au logement'
+    reference = 'https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329'
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+
+    def formula(menage, period):
+        return (
+            menage('residence_dom', period)
+            + menage('residence_saint_bartelemy', period)
+            + menage('residence_saint_martin', period)
+            )
+
+
 class TypeEtatLogement(Enum):
     order__ = ' non_renseigne construction_acquisition_logement_neuf travaux_amelioration_residence_principale agrandissement_amenagement acquisition_amelioration acquisition_sans_amelioration_logement_existant amelioration'  # Needed to preserve the enum order in Python 2
     non_renseigne = 'Non renseigné'
@@ -1395,7 +1411,7 @@ class aide_logement_taux_famille(Variable):
         al_tf = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.tp_taux.tf_taille_famille
         couple = famille('al_couple', period)
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
-        residence_dom = famille.demandeur.menage('residence_dom', period)
+        residence_outre_mer = famille.demandeur.menage('residence_aides_logement_outre_mer', period)
 
         TF_metropole = (
             al_tf.metropole.personnes_isolees * (not_(couple)) * (al_nb_pac == 0)
@@ -1418,14 +1434,14 @@ class aide_logement_taux_famille(Variable):
             + al_tf.dom.avec_6_enfants * (al_nb_pac >= 6)
             )
 
-        return where(residence_dom, TF_dom, TF_metropole)
+        return where(residence_outre_mer, TF_dom, TF_metropole)
 
     def formula_2023_01_01(famille, period, parameters):
         al_tf = parameters(period).prestations_sociales.aides_logement.allocations_logement.locatif.formule.pp_particip_perso.tp_taux.tf_taille_famille
 
         couple = famille('al_couple', period)
         al_nb_pac = famille('al_nb_personnes_a_charge', period)
-        residence_dom = famille.demandeur.menage('residence_dom', period)
+        residence_outre_mer = famille.demandeur.menage('residence_aides_logement_outre_mer', period)
 
         TF_metropole = (
             al_tf.metropole.personnes_isolees * (not_(couple)) * (al_nb_pac == 0)
@@ -1452,7 +1468,7 @@ class aide_logement_taux_famille(Variable):
             + al_tf.dom.maj_par_enf_supp * (al_nb_pac > 7) * (al_nb_pac - 7)
             )
 
-        return where(residence_dom, TF_dom, TF_metropole)
+        return where(residence_outre_mer, TF_dom, TF_metropole)
 
 
 class aide_logement_loyer_reference(Variable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "176.0.1"
+version = "176.0.2"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/formulas/aides_logement.yaml
+++ b/tests/formulas/aides_logement.yaml
@@ -215,6 +215,25 @@
   output:
     al_nb_personnes_a_charge: 9
 
+- name: Aides logements - Saint-Barthélemy relève du barème outre-mer
+  period: 2023-10
+  relative_error_margin: 0.001
+  input:
+    famille:
+      parents: [parent1]
+      al_nb_personnes_a_charge: 8
+    foyer_fiscal:
+      declarants: [parent1]
+    menage:
+      personne_de_reference: parent1
+      depcom: "97701"
+    individus:
+      parent1:
+        age: 40
+  output:
+    residence_aides_logement_outre_mer: true
+    aide_logement_taux_famille: 0.0161
+
 - name: Aides logements - les enfants de plus de 21 ans handicapés (>80%) sont considérés à charge
   description: Nombre de personnes à charge pour les AL
   period: 2015-01


### PR DESCRIPTION
## Description

Cette PR etend explicitement le champ du bareme outre-mer des aides au logement a Saint-Barthelemy et Saint-Martin.

Avant cette correction, OpenFisca disposait de variables de residence distinctes pour ces collectivites, mais elles n'etaient pas integrees dans la logique utilisee pour selectionner les baremes outre-mer. En pratique, certains menages etaient donc calcules avec des composantes metropolitaines au lieu du bareme applicable en outre-mer.

La PR introduit une variable de residence dediee aux aides au logement outre-mer et l'utilise dans les formules concernees.

## Sources juridiques

* Arrete du 27 septembre 2019, article 46 : https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000041489188/2020-01-01
* Article D823-17 du code de la construction et de l'habitation : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255

## Changelog propose

Evolution du systeme socio-fiscal

Periodes concernees : a partir du 01/10/2019.

Zones impactees : `prestations/aides_logement`

Details :

* ajout de Saint-Barthelemy et Saint-Martin dans le champ du bareme outre-mer des aides au logement ;
* introduction d'une variable de residence dediee a ce champ d'application ;
* correction des composantes `TF`, `R0` et des montants derives pour les menages concernes.

Ces changements :

* corrigent ou ameliorent un calcul deja existant.