### PR TITLE
[APL] Ajoute le bareme R0 de Saint-Pierre-et-Miquelon et applique la montee en charge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 167.0.3 [#2778](https://github.com/openfisca/openfisca-france/pull/2778)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/07/2022
+* Zones impactées :
+    - `openfisca_france/prestations/aides_logement`
+    - `openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/*`
+    - `tests/formulas/aides_logement`
+* Détails :
+    - ajout du barème R0 applicable a Saint-Pierre-et-Miquelon
+    - application de la montée en charge specifique au territoire
+
 ### 167.0.2 [#2777](https://github.com/openfisca/openfisca-france/pull/2777)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -96,9 +96,22 @@ class aide_logement_montant(Variable):
     def formula(famille, period):
         aide_logement_montant_brut = famille('aide_logement_montant_brut_crds', period)
         crds_logement = famille('crds_logement', period)
-        montant = round_(aide_logement_montant_brut + crds_logement, 2)
 
-        return montant
+        # De 2022 à 2025, l'AL à Saint-Pierre-et-Miquelon s'aligne progressivement sur les montants en vigueur en métropole
+        # Décret n° 2021-1750 du 21 décembre 2021, art. 7
+        # https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000044608297/2021-12-24
+        residence_saint_pierre_et_miquelon = famille.demandeur.menage('residence_saint_pierre_et_miquelon', period)
+        annee = period.start.year
+        coefficient_saint_pierre_et_miquelon = 1 - (2026 - annee) / 8
+        coefficient = where(
+            residence_saint_pierre_et_miquelon * (annee >= 2022) * (annee <= 2025),
+            coefficient_saint_pierre_et_miquelon,
+            1,
+            )
+
+        montant = aide_logement_montant_brut * coefficient
+
+        return round_(montant + crds_logement, 2)
 
 
 class aide_logement_montant_brut_crds(Variable):

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1406,11 +1406,29 @@ class aide_logement_R0(Variable):
             + al_r0.cas_general.taux_pac_supp * nb_pac_supp
             )
 
-        return where(
+        R0_hors_saint_pierre_et_miquelon = where(
             residence_outre_mer * (al_nb_pac == 1),
             al_r0.outre_mer.taux1pac,
             R0_cas_general,
             )
+
+        if period.start.date < date(2022, 7, 1):
+            return R0_hors_saint_pierre_et_miquelon
+
+        residence_saint_pierre_et_miquelon = famille.demandeur.menage('residence_saint_pierre_et_miquelon', period)
+        R0_saint_pierre_et_miquelon = (
+            al_r0.saint_pierre_et_miquelon.taux_seul * not_(couple) * (al_nb_pac == 0)
+            + al_r0.saint_pierre_et_miquelon.taux_couple * couple * (al_nb_pac == 0)
+            + al_r0.saint_pierre_et_miquelon.taux1pac * (al_nb_pac == 1)
+            + al_r0.saint_pierre_et_miquelon.taux2pac * (al_nb_pac == 2)
+            + al_r0.saint_pierre_et_miquelon.taux3pac * (al_nb_pac == 3)
+            + al_r0.saint_pierre_et_miquelon.taux4pac * (al_nb_pac == 4)
+            + al_r0.saint_pierre_et_miquelon.taux5pac * (al_nb_pac == 5)
+            + al_r0.saint_pierre_et_miquelon.taux6pac * (al_nb_pac >= 6)
+            + al_r0.saint_pierre_et_miquelon.taux_pac_supp * nb_pac_supp
+            )
+
+        return where(residence_saint_pierre_et_miquelon, R0_saint_pierre_et_miquelon, R0_hors_saint_pierre_et_miquelon)
 
 
 class aide_logement_taux_famille(Variable):

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/index.yaml
@@ -6,4 +6,5 @@ metadata:
   - cas_general
   - outre_mer
   - mayotte
+  - saint_pierre_et_miquelon
   - avant_2015

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/index.yaml
@@ -1,0 +1,14 @@
+description: Abattement forfaitaire « R0 » applicable à Saint-Pierre-et-Miquelon
+metadata:
+  short_label: Saint-Pierre-et-Miquelon
+  order:
+  - taux_seul
+  - taux_couple
+  - taux1pac
+  - taux2pac
+  - taux3pac
+  - taux4pac
+  - taux5pac
+  - taux6pac
+  - taux_pac_supp
+documentation: Mentionné à l'article 47 de l'arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux1pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux1pac.yaml
@@ -1,0 +1,26 @@
+description: Abattement forfaitaire « R0 » à Saint-Pierre-et-Miquelon avec une personne à charge
+values:
+  2022-07-01:
+    value: 8322
+  2023-01-01:
+    value: 9008
+  2024-01-01:
+    value: 9116
+  2025-01-01:
+    value: 9410
+metadata:
+  short_label: Une personne à charge
+  unit: currency
+  reference:
+    2022-07-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046126968/2022-08-01"
+    2023-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2023-06-17"
+    2024-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-01-01"
+    2025-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2025-01-01"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux2pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux2pac.yaml
@@ -1,0 +1,26 @@
+description: Abattement forfaitaire « R0 » à Saint-Pierre-et-Miquelon avec deux personnes à charge
+values:
+  2022-07-01:
+    value: 8509
+  2023-01-01:
+    value: 9211
+  2024-01-01:
+    value: 9322
+  2025-01-01:
+    value: 9623
+metadata:
+  short_label: Deux personnes à charge
+  unit: currency
+  reference:
+    2022-07-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046126968/2022-08-01"
+    2023-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2023-06-17"
+    2024-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-01-01"
+    2025-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2025-01-01"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux3pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux3pac.yaml
@@ -1,0 +1,26 @@
+description: Abattement forfaitaire « R0 » à Saint-Pierre-et-Miquelon avec trois personnes à charge
+values:
+  2022-07-01:
+    value: 8834
+  2023-01-01:
+    value: 9563
+  2024-01-01:
+    value: 9678
+  2025-01-01:
+    value: 9990
+metadata:
+  short_label: Trois personnes à charge
+  unit: currency
+  reference:
+    2022-07-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046126968/2022-08-01"
+    2023-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2023-06-17"
+    2024-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-01-01"
+    2025-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2025-01-01"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux4pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux4pac.yaml
@@ -1,0 +1,26 @@
+description: Abattement forfaitaire « R0 » à Saint-Pierre-et-Miquelon avec quatre personnes à charge
+values:
+  2022-07-01:
+    value: 9163
+  2023-01-01:
+    value: 9919
+  2024-01-01:
+    value: 10039
+  2025-01-01:
+    value: 10363
+metadata:
+  short_label: Quatre personnes à charge
+  unit: currency
+  reference:
+    2022-07-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046126968/2022-08-01"
+    2023-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2023-06-17"
+    2024-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-01-01"
+    2025-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2025-01-01"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux5pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux5pac.yaml
@@ -1,0 +1,26 @@
+description: Abattement forfaitaire « R0 » à Saint-Pierre-et-Miquelon avec cinq personnes à charge
+values:
+  2022-07-01:
+    value: 9488
+  2023-01-01:
+    value: 10271
+  2024-01-01:
+    value: 10395
+  2025-01-01:
+    value: 10730
+metadata:
+  short_label: Cinq personnes à charge
+  unit: currency
+  reference:
+    2022-07-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046126968/2022-08-01"
+    2023-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2023-06-17"
+    2024-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-01-01"
+    2025-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2025-01-01"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux6pac.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux6pac.yaml
@@ -1,0 +1,26 @@
+description: Abattement forfaitaire « R0 » à Saint-Pierre-et-Miquelon avec six personnes à charge
+values:
+  2022-07-01:
+    value: 9816
+  2023-01-01:
+    value: 10626
+  2024-01-01:
+    value: 10754
+  2025-01-01:
+    value: 11101
+metadata:
+  short_label: Six personnes à charge
+  unit: currency
+  reference:
+    2022-07-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046126968/2022-08-01"
+    2023-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2023-06-17"
+    2024-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-01-01"
+    2025-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2025-01-01"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux_couple.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux_couple.yaml
@@ -1,0 +1,26 @@
+description: Abattement forfaitaire « R0 » à Saint-Pierre-et-Miquelon pour un couple sans personne à charge
+values:
+  2022-07-01:
+    value: 6977
+  2023-01-01:
+    value: 7552
+  2024-01-01:
+    value: 7643
+  2025-01-01:
+    value: 7889
+metadata:
+  short_label: Couple sans personne à charge
+  unit: currency
+  reference:
+    2022-07-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046126968/2022-08-01"
+    2023-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2023-06-17"
+    2024-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-01-01"
+    2025-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2025-01-01"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux_pac_supp.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux_pac_supp.yaml
@@ -1,0 +1,26 @@
+description: Majoration de l'abattement forfaitaire « R0 » à Saint-Pierre-et-Miquelon par personne à charge au-delà de six
+values:
+  2022-07-01:
+    value: 323
+  2023-01-01:
+    value: 350
+  2024-01-01:
+    value: 354
+  2025-01-01:
+    value: 365
+metadata:
+  short_label: Majoration par personne à charge supplémentaire
+  unit: currency
+  reference:
+    2022-07-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046126968/2022-08-01"
+    2023-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2023-06-17"
+    2024-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-01-01"
+    2025-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2025-01-01"

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux_seul.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/allocations_logement/locatif/formule/pp_particip_perso/r0_abattement/saint_pierre_et_miquelon/taux_seul.yaml
@@ -1,0 +1,26 @@
+description: Abattement forfaitaire « R0 » à Saint-Pierre-et-Miquelon pour une personne seule sans personne à charge
+values:
+  2022-07-01:
+    value: 4870
+  2023-01-01:
+    value: 5272
+  2024-01-01:
+    value: 5335
+  2025-01-01:
+    value: 5507
+metadata:
+  short_label: Personne seule sans personne à charge
+  unit: currency
+  reference:
+    2022-07-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046126968/2022-08-01"
+    2023-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2023-06-17"
+    2024-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2024-01-01"
+    2025-01-01:
+      title: "Arrêté du 27 septembre 2019, article 47"
+      href: "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2025-01-01"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "176.0.2"
+version = "176.0.3"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/formulas/aides_logement.yaml
+++ b/tests/formulas/aides_logement.yaml
@@ -234,6 +234,40 @@
     residence_aides_logement_outre_mer: true
     aide_logement_taux_famille: 0.0161
 
+- name: Aides logements - R0 Saint-Pierre-et-Miquelon en juillet 2022
+  period: 2022-07
+  input:
+    famille:
+      parents: [parent1]
+      al_nb_personnes_a_charge: 1
+    foyer_fiscal:
+      declarants: [parent1]
+    menage:
+      personne_de_reference: parent1
+      depcom: "97500"
+    individus:
+      parent1:
+        age: 40
+  output:
+    aide_logement_R0: 8322
+
+- name: Aides logements - R0 Saint-Pierre-et-Miquelon en 2023
+  period: 2023-01
+  input:
+    famille:
+      parents: [parent1]
+      al_nb_personnes_a_charge: 1
+    foyer_fiscal:
+      declarants: [parent1]
+    menage:
+      personne_de_reference: parent1
+      depcom: "97500"
+    individus:
+      parent1:
+        age: 40
+  output:
+    aide_logement_R0: 9008
+
 - name: Aides logements - les enfants de plus de 21 ans handicapés (>80%) sont considérés à charge
   description: Nombre de personnes à charge pour les AL
   period: 2015-01


### PR DESCRIPTION
## Description

Cette PR regroupe deux corrections liees a Saint-Pierre-et-Miquelon :

* l'ajout du bareme `R0` propre a ce territoire ;
* l'application de la montee en charge du montant locatif.

Avant cette correction, OpenFisca ne disposait pas du bareme `R0` local et n'appliquait pas la montee en charge progressive prevue pour Saint-Pierre-et-Miquelon. Cela produisait des ecarts a la fois sur la participation personnelle et sur le montant final verse.

La PR ajoute les parametres de `R0` par composition familiale, branche la formule sur ces parametres, et applique le coefficient de montee en charge selon l'annee de calcul.

## Sources juridiques

* Arrete du 27 septembre 2019, article 47 : https://www.legifrance.gouv.fr/loda/id/LEGIARTI000046126968/2022-08-01
* Arrete du 27 septembre 2019, article 47, version consolidee : https://www.legifrance.gouv.fr/loda/id/JORFTEXT000039160329/2023-06-17
* Article D823-17 du code de la construction et de l'habitation : https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041419255

## Changelog propose

Evolution du systeme socio-fiscal

Periodes concernees : a partir du 01/07/2022 pour la montee en charge et a partir du 01/07/2022 pour le bareme `R0` local.

Zones impactees : `prestations/aides_logement`

Details :

* ajout du bareme `R0` applicable a Saint-Pierre-et-Miquelon ;
* application de la montee en charge specifique au territoire ;
* correction de la participation personnelle et du montant final des aides au logement.

Ces changements :

* corrigent ou ameliorent un calcul deja existant.