### PR TITLE
[APL] Arrondit la CRDS au centime inferieur && 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### 176.0.5 [#2779](https://github.com/openfisca/openfisca-france/pull/2779)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2019
+* Zones impactées :
+    - `openfisca_france/prestations/aides_logement`
+    - `tests/formulas/aides_logement`
+* Détails :
+    - arrondi de la CRDS au centime d'euro inférieur
+    - arrondi de l'AL à l'euro inférieur
+    - annulation de la CRDS à Saint-Pierre-et-Miquelon
+
 ### 176.0.4 [#2786](https://github.com/openfisca/openfisca-france/pull/2786)
 
 * Changement mineur

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -18,6 +18,12 @@ from openfisca_france.model.prestations.prestations_familiales.base_ressource im
 log = logging.getLogger(__name__)
 
 
+def _centimes_stables(montant):
+    # Stabilise les flottants quand le montant est deja cense etre au centime,
+    # afin d'eviter qu'un 317.579987 soit replancher a 317.57.
+    return floor(montant * 100 + 0.5)
+
+
 class aide_logement(Variable):
     value_type = float
     entity = Famille
@@ -95,15 +101,17 @@ class aide_logement_montant(Variable):
 
     def formula(famille, period):
         aide_logement_montant_brut = famille('aide_logement_montant_brut_crds', period)
+        aide_logement_montant_brut_centimes = _centimes_stables(aide_logement_montant_brut)
         crds_logement = famille('crds_logement', period)
 
         # Arrondi à l'euro inférieur du montant net de CRDS
-        aide_logement_montant_net_arrondi = floor(aide_logement_montant_brut + crds_logement)
+        aide_logement_montant_net_arrondi = floor(aide_logement_montant_brut_centimes / 100 + crds_logement)
 
         # De 2022 à 2025, l'AL à Saint-Pierre-et-Miquelon s'aligne progressivement sur les montants en vigueur en métropole
         # Décret n° 2021-1750 du 21 décembre 2021, art. 7
         # https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000044608297/2021-12-24
         residence_saint_pierre_et_miquelon = famille.demandeur.menage('residence_saint_pierre_et_miquelon', period)
+
         annee = period.start.year
         coefficient_saint_pierre_et_miquelon = 1 - (2026 - annee) / 8
         coefficient = where(
@@ -1738,8 +1746,17 @@ class crds_logement(Variable):
 
     def formula(famille, period, parameters):
         aide_logement_montant_brut = famille('aide_logement_montant_brut_crds', period)
+        aide_logement_montant_brut_centimes = _centimes_stables(aide_logement_montant_brut)
         crds = parameters(period).prelevements_sociaux.contributions_sociales.crds
-        return -aide_logement_montant_brut * crds
+
+        # La CRDS est arrondie au centime d'euro inférieur
+        # https://www.ecologie.gouv.fr/sites/default/files/documents/Brochure-bareme-2024-APL.pdf (p59)
+        crds_arrondie = floor(aide_logement_montant_brut_centimes * crds) / 100
+
+        # La CRDS n'est pas applicable à Saint-Pierre-et-Miquelon
+        # https://www.services-fiscaux975.fr/fr/38.html
+        residence_saint_pierre_et_miquelon = famille.demandeur.menage('residence_saint_pierre_et_miquelon', period)
+        return where(residence_saint_pierre_et_miquelon, 0, -crds_arrondie)
 
 
 class TypesZoneApl(Enum):

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -5,7 +5,7 @@ import logging
 import importlib
 import sys
 
-from numpy import ceil, datetime64, fromiter, int16, logical_or as or_, logical_and as and_, logical_not as not_
+from numpy import ceil, floor, datetime64, fromiter, int16, logical_or as or_, logical_and as and_, logical_not as not_
 
 from openfisca_core.periods import Instant, Period
 
@@ -97,6 +97,9 @@ class aide_logement_montant(Variable):
         aide_logement_montant_brut = famille('aide_logement_montant_brut_crds', period)
         crds_logement = famille('crds_logement', period)
 
+        # Arrondi à l'euro inférieur du montant net de CRDS
+        aide_logement_montant_net_arrondi = floor(aide_logement_montant_brut + crds_logement)
+
         # De 2022 à 2025, l'AL à Saint-Pierre-et-Miquelon s'aligne progressivement sur les montants en vigueur en métropole
         # Décret n° 2021-1750 du 21 décembre 2021, art. 7
         # https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000044608297/2021-12-24
@@ -109,9 +112,9 @@ class aide_logement_montant(Variable):
             1,
             )
 
-        montant = aide_logement_montant_brut * coefficient
+        montant = aide_logement_montant_net_arrondi * coefficient
 
-        return round_(montant + crds_logement, 2)
+        return floor(montant)
 
 
 class aide_logement_montant_brut_crds(Variable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "176.0.4"
+version = "176.0.5"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/formulas/aides_logement.yaml
+++ b/tests/formulas/aides_logement.yaml
@@ -268,6 +268,23 @@
   output:
     aide_logement_R0: 9008
 
+- name: Aides logements - absence de CRDS à Saint-Pierre-et-Miquelon
+  period: 2023-01
+  input:
+    famille:
+      parents: [parent1]
+      aide_logement_montant_brut_crds: 389.24
+    foyer_fiscal:
+      declarants: [parent1]
+    menage:
+      personne_de_reference: parent1
+      depcom: "97500"
+    individus:
+      parent1:
+        age: 40
+  output:
+    crds_logement: 0
+
 - name: Aides logements - les enfants de plus de 21 ans handicapés (>80%) sont considérés à charge
   description: Nombre de personnes à charge pour les AL
   period: 2015-01

--- a/tests/formulas/aides_logement.yaml
+++ b/tests/formulas/aides_logement.yaml
@@ -792,7 +792,7 @@
       - parent1
   output:
     aide_logement_montant_brut: 47.08
-    aide_logement_montant: 46.84
+    aide_logement_montant: 46
 
 - name: Le patrimoine composé uniquement d'épargne générant des revenus imposables n'augmente pas la base ressources des ALs
   period: 2017-10


### PR DESCRIPTION
## Description

Cette PR corrige l'arrondi de la CRDS prelevee sur les aides au logement en appliquant un arrondi au centime inferieur.

Avant cette correction, OpenFisca calculait la CRDS sans ce plancher explicite, ce qui produisait de petits ecarts residuels sur le brut CRDS puis sur le montant net verse. La formule est modifiee pour tronquer le montant au centime inferieur avant de le retourner avec son signe.

## Sources juridiques

- Article L136-1-3 du code de la securite sociale : https://web.archive.org/web/20260514102320/https://www.ecologie.gouv.fr/sites/default/files/documents/Brochure-bareme-2024-APL.pdf

Details :

- arrondi de la CRDS au centime d'euro inferieur ;
- reduction des ecarts de quelques centimes entre l'implementation et le bareme attendu ;
- impact sur le montant net final des aides au logement.
- stabilise le montant brut au centime avant calcul final ;
- stabilise la CRDS sur cette base.


Ces changements :

- corrigent ou ameliorent un calcul deja existant.