### PR TITLE
Changement de dépendances

### DIFF
--- a/.github/is-version-number-acceptable.sh
+++ b/.github/is-version-number-acceptable.sh
@@ -36,7 +36,7 @@ then
     exit 2
 fi
 
-if ! $(dirname "$BASH_SOURCE")/has-functional-changes.sh | grep --quiet CHANGELOG.md
+if ! git diff-index `git describe --tags --abbrev=0 --first-parent` | grep --quiet CHANGELOG.md
 then
     echo "CHANGELOG.md has not been modified, while functional changes were made."
     echo "Explain what you changed before merging this branch into master."

--- a/.github/pyproject_version.py
+++ b/.github/pyproject_version.py
@@ -28,7 +28,7 @@ def get_versions():
     version = re.search(r'"openfisca-core\[web-api\]\s*(>=\s*[\d.]+,\s*<\s*[\d.]+)"', content, re.MULTILINE)
     if version:
         openfisca_core_api = version.group(1)
-    version = re.search(r'numpy\s*(>=\s*[\d\.]*,\s*<\d*)"', content, re.MULTILINE)
+    version = re.search(r'numpy\s*(>=\s*[\d\.]*,\s*<[\d.]*)"', content, re.MULTILINE)
     if version:
         numpy = version.group(1)
     if not openfisca_core_api or not numpy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Zones impactées : `pyproject.toml`.
 * Détails :
   - Restriction de la version de numpy pour permettre les tests en python 3.13.
+  - Reprend également [#2765](https://github.com/openfisca/openfisca-france/pull/2765) pour faire passer la CI : [#2760](https://github.com/openfisca/openfisca-france/pull/2760) a permis de considérer le CHANGELOG comme un fichier non-fonctionnel pour en permettre l'édition sans publication d'une nouvelle version, mais la détection de l'édition du CHANGELOG se reposait sur le fait qu'il soit un fichier fonctionnel, ce qui a eu pour conséquence d'empêcher toute détection de l'édition du CHANGELOG.
 
 ### 175.0.45 [#2756](https://github.com/openfisca/openfisca-france/pull/2756)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 175.1.0 [#2782](https://github.com/openfisca/openfisca-france/pull/2782)
+
+* Modifications des dépendances.
+* Périodes concernées : toutes.
+* Zones impactées : `pyproject.toml`.
+* Détails :
+  - Restriction de la version de numpy pour permettre les tests en python 3.13.
+
 ### 175.0.45 [#2756](https://github.com/openfisca/openfisca-france/pull/2756)
 
 * Évolution du système socio-fiscal.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "175.0.45"
+version = "175.0.46"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">= 3.9"
 dependencies = [
-    "numpy >=1.24.3, <3",
+    "numpy >=1.24.3, <2.4",
     "openfisca-core[web-api] >=43, <45",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "175.0.46"
+version = "175.1.0"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]


### PR DESCRIPTION

* Correction d'un crash.
* Périodes concernées : toutes.
* Zones impactées : `pyproject.toml`, CI.
* Détails :
  - Restriction de la version de numpy pour permettre aux tests en Python 3.13 de passer
  - Reprend également https://github.com/openfisca/openfisca-france/pull/2765 pour faire passer la CI : https://github.com/openfisca/openfisca-france/pull/2760 a permis de considérer le CHANGELOG comme un fichier non-fonctionnel pour en permettre l'édition sans publication d'une nouvelle version, mais la détection de l'édition du CHANGELOG se reposait sur le fait qu'il soit un fichier fonctionnel, ce qui a eu pour conséquence d'empêcher toute détection de l'édition du CHANGELOG.

- - - -

Ces changements :

- Modifient des éléments non fonctionnels de ce dépôt (par exemple modification du README).

- - - -

Quelques conseils à prendre en compte :

- [ ] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [ ] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [ ] Documentez votre contribution avec des références législatives.
- [ ] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [ ] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [ ] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [ ] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
