### PR TITLE
Mise à jour de ci investissement forestier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 176.0.5 [#2783](https://github.com/openfisca/openfisca-france/pull/2783)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2023.
+* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py` et `tests/calculateur_impots/yaml/credit_invest_forestier.yaml` 
+* Détails :
+  - Mise à jour de la formule pour 2025 corrections sur 2024 et 2023
+  - ajout et correction des tests sur la période
+
 ### 176.0.4 [#2786](https://github.com/openfisca/openfisca-france/pull/2786)
 
 * Changement mineur

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -591,16 +591,16 @@ class ci_investissement_forestier(Variable):
     def formula_2023_01_01(foyer_fiscal, period, parameters):
         '''
         Investissements forestiers pour 2023
-        Voir https://www.impots.gouv.fr/www2/fichiers/documentation/brochure/ir_2024/pdf_integral/Brochure-IR-2024.pdf page 24
-        - Fin du plafond de dépenses de contrat de gestion (CGA) de dépenses d'investissement forestier
-        - Comme pour les autres années, les cases sont attachés à une même année d'investissements et "roulent"
         '''
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
 
+        # Nouvelles variables
+        f7un = foyer_fiscal('f7un', period)
+        f7ul = foyer_fiscal('f7ul', period)
         f7up = foyer_fiscal('f7up', period)
         f7ut = foyer_fiscal('f7ut', period)
 
-        # Reports des années précédentes
+        # Reports
         f7tm = foyer_fiscal('f7tm', period)
         f7to = foyer_fiscal('f7to', period)
         f7tp = foyer_fiscal('f7tp', period)
@@ -627,14 +627,31 @@ class ci_investissement_forestier(Variable):
         f7ti = foyer_fiscal('f7ti', period)
 
         P = parameters(period).impot_revenu.calcul_reductions_impots.investissement_forestier.depenses_investissement_forestier
+        taux_25 = P.travaux.taux_adhesion_org_producteurs
+        P_2022 = parameters('2022-01-01').impot_revenu.calcul_reductions_impots.investissement_forestier.depenses_investissement_forestier
+        taux_18 = P_2022.travaux.taux
 
-        # travaux année N
-        ci_trav_adh = min_(P.travaux.plafond * (maries_ou_pacses + 1), f7to + f7tq + f7ts + f7tu + f7vi + f7tw + f7vn + f7tb + f7vr + f7tf + f7ti + f7vu)
-        ci_trav = min_(P.travaux.plafond * (maries_ou_pacses + 1) - ci_trav_adh, f7up + f7ut + f7tm + f7tp + f7tr + f7tt + f7vh + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7th)
+        plafond_acq_ass = P.acquisition.plafond * (maries_ou_pacses + 1)
 
-        ci_travaux = P.travaux.taux_adhesion_org_producteurs * ci_trav_adh + P.travaux.taux * ci_trav
+        base_assurance = min_(f7ul, plafond_acq_ass)
+        base_acquisition = min_(f7un, plafond_acq_ass - base_assurance)
 
-        return ci_travaux
+        ci_assurance = base_assurance * P.assurance.taux
+        ci_acquisition = base_acquisition * P.acquisition.taux
+
+        base_25 = (
+            f7to + f7tq + f7ts + f7tu + f7vi + f7tw + f7vn + f7tb + f7vr + f7tf + f7ti + f7vu + f7up + f7ut)
+
+        base_18 = (
+            f7tm + f7tp + f7tr + f7tt + f7vh + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7th)
+
+        plafond_travaux = P.travaux.plafond * (maries_ou_pacses + 1)
+
+        ci_trav_adh = min_(plafond_travaux, base_25)
+        ci_trav = min_(plafond_travaux - ci_trav_adh, base_18)
+        ci_travaux = (taux_25 * ci_trav_adh) + (taux_18 * ci_trav)
+
+        return ci_travaux + ci_acquisition + ci_assurance
 
     def formula_2024_01_01(foyer_fiscal, period, parameters):
         '''
@@ -678,23 +695,18 @@ class ci_investissement_forestier(Variable):
         taux_18 = P_2022.travaux.taux
 
         plafond_acq_ass = P.acquisition.plafond * (maries_ou_pacses + 1)
-        
+
         base_assurance = min_(f7ul, plafond_acq_ass)
         base_acquisition = min_(f7un, plafond_acq_ass - base_assurance)
-        
+
         ci_assurance = base_assurance * P.assurance.taux
         ci_acquisition = base_acquisition * P.acquisition.taux
 
-        # Variables à 25% :
-        base_25 = (
-            f7tq + f7ts + f7tu + f7tw + f7vn + f7tb + f7vr + f7tf + f7ti + f7vu + 
-            f7vv + f7tj + f7up + f7ut
-        )
-        
-        # Variables à 18% :
-        base_18 = (
-            f7tp + f7tr + f7tt + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7th
-        )
+        # Variables à 25%
+        base_25 = (f7tq + f7ts + f7tu + f7tw + f7vn + f7tb + f7vr + f7tf + f7ti + f7vu + f7vv + f7tj + f7up + f7ut)
+
+        # Variables à 18%
+        base_18 = (f7tp + f7tr + f7tt + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7th)
 
         plafond_travaux = P.travaux.plafond * (maries_ou_pacses + 1)
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -681,60 +681,82 @@ class ci_investissement_forestier(Variable):
 
     def formula_2025_01_01(foyer_fiscal, period, parameters):
         '''
-        Investissements forestiers pour 2025
+        Crédit d'impôt pour les investissements forestiers (2025)
         '''
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
-
-        # Nouvelles variables de l'année en cours (2025)
+        # 2025
         f7un = foyer_fiscal('f7un', period)
-        f7ul = foyer_fiscal('f7vl', period)
+        f7ul = foyer_fiscal('f7ul', period)
         f7up = foyer_fiscal('f7up', period)
         f7ut = foyer_fiscal('f7ut', period)
-
-        # Reports des années précédentes
+        # 2024
         f7vt = foyer_fiscal('f7vt', period)
         f7tk = foyer_fiscal('f7tk', period)
-        f7tq = foyer_fiscal('f7tq', period)
-        f7tr = foyer_fiscal('f7tr', period)
-        f7ts = foyer_fiscal('f7ts', period)
-        f7tt = foyer_fiscal('f7tt', period)
-        f7tu = foyer_fiscal('f7tu', period)
-        f7tv = foyer_fiscal('f7tv', period)
-        f7tw = foyer_fiscal('f7tw', period)
-        f7ta = foyer_fiscal('f7ta', period)
-        f7tb = foyer_fiscal('f7tb', period)
-        f7vq = foyer_fiscal('f7vq', period)
-        f7te = foyer_fiscal('f7te', period)
-        f7vr = foyer_fiscal('f7vr', period)
-        f7tf = foyer_fiscal('f7tf', period)
+        # 2023
+        f7vv = foyer_fiscal('f7vv', period)
+        f7tj = foyer_fiscal('f7tj', period)
+        # 2022
         f7vs = foyer_fiscal('f7vs', period)
         f7th = foyer_fiscal('f7th', period)
         f7vu = foyer_fiscal('f7vu', period)
         f7ti = foyer_fiscal('f7ti', period)
-        f7vv = foyer_fiscal('f7vv', period)
-        f7tj = foyer_fiscal('f7tj', period)
+        # 2021
+        f7vq = foyer_fiscal('f7vq', period)
+        f7te = foyer_fiscal('f7te', period)
+        f7vr = foyer_fiscal('f7vr', period)
+        f7tf = foyer_fiscal('f7tf', period)
+        # 2020
+        f7ta = foyer_fiscal('f7ta', period)
+        f7tb = foyer_fiscal('f7tb', period)
+        # 2019
+        f7tv = foyer_fiscal('f7tv', period)
+        f7tw = foyer_fiscal('f7tw', period)
+        # 2018
+        f7tt = foyer_fiscal('f7tt', period)
+        f7tu = foyer_fiscal('f7tu', period)
+        # 2017
+        f7tr = foyer_fiscal('f7tr', period)
+        f7ts = foyer_fiscal('f7ts', period)
 
         P = parameters(period).impot_revenu.calcul_reductions_impots.investissement_forestier.depenses_investissement_forestier
+        taux_25 = P.travaux.taux_adhesion_org_producteurs
+        P_2022 = parameters('2022-01-01').impot_revenu.calcul_reductions_impots.investissement_forestier.depenses_investissement_forestier
+        taux_18 = P_2022.travaux.taux
 
-        ci_trav_adh = min_(
-            P.travaux.plafond * (maries_ou_pacses + 1),
-            f7ts + f7tu + f7tw + f7tb + f7vr + f7tf + f7ti + f7vu)
+        plafond_acq_ass = P.acquisition.plafond * (maries_ou_pacses + 1)
+        base_assurance = min_(f7ul, plafond_acq_ass)
+        base_acquisition = min_(f7un, plafond_acq_ass - base_assurance)
 
-        ci_trav = min_(
-            P.travaux.plafond * (maries_ou_pacses + 1) - ci_trav_adh,
-            f7up + f7ut + f7tr + f7tt + f7tv + f7ta + f7vq + f7te + f7vs + f7th + f7vv + f7tj)
+        ci_assurance = base_assurance * P.assurance.taux
+        ci_acquisition = base_acquisition * P.acquisition.taux
 
-        ci_acquisition = P.acquisition.taux * min_(
-            P.acquisition.plafond * (maries_ou_pacses + 1),
-            f7un)
+        # Calcul du plafond en cascade
+        reste_plafond_travaux = P.travaux.plafond * (maries_ou_pacses + 1)
+        ci_travaux = 0
+        # Format : (Dépenses éligibles à 25%, Dépenses éligibles à 18%)
+        annees_travaux = [
+            (f7ts, f7tr),  # 2017
+            (f7tu, f7tt),  # 2018
+            (f7tw, f7tv),  # 2019
+            (f7tb, f7ta),  # 2020
+            (f7vr + f7tf, f7vq + f7te),  # 2021
+            (f7vu + f7ti, f7vs + f7th),  # 2022
+            (f7vv + f7tj, 0),  # 2023 (Taux unique 25% à partir d ici)
+            (f7vt + f7tk, 0),  # 2024
+            (f7up + f7ut, 0)]  # 2025
 
-        ci_assurance = P.assurance.taux * min_(
-            P.assurance.plafond * (maries_ou_pacses + 1),
-            f7ul)
+        for depense_25, depense_18 in annees_travaux:
+            # Pour une même année, on impute le taux de 25% en priorité
+            base_25 = min_(depense_25, reste_plafond_travaux)
+            ci_travaux += base_25 * taux_25
+            reste_plafond_travaux -= base_25
 
-        ci_travaux = P.travaux.taux_adhesion_org_producteurs * ci_trav_adh + P.travaux.taux * ci_trav
+            # Puis on impute le taux à 18% s'il reste du plafond
+            base_18 = min_(depense_18, reste_plafond_travaux)
+            ci_travaux += base_18 * taux_18
+            reste_plafond_travaux -= base_18
 
-        return ci_travaux + ci_acquisition + ci_assurance
+        return ci_assurance + ci_acquisition + ci_travaux
 
 
 class acqgpl(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -718,14 +718,12 @@ class ci_investissement_forestier(Variable):
         P = parameters(period).impot_revenu.calcul_reductions_impots.investissement_forestier.depenses_investissement_forestier
 
         ci_trav_adh = min_(
-            P.travaux.plafond * (maries_ou_pacses + 1), 
-            f7tq + f7ts + f7tu + f7tw + f7vn + f7tb + f7vr + f7tf + f7ti + f7vu
-        )
-        
+            P.travaux.plafond * (maries_ou_pacses + 1),
+            f7tq + f7ts + f7tu + f7tw + f7vn + f7tb + f7vr + f7tf + f7ti + f7vu)
+
         ci_trav = min_(
-            P.travaux.plafond * (maries_ou_pacses + 1) - ci_trav_adh, 
-            f7vp + f7vt + f7up + f7ut + f7tp + f7tr + f7tt + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7th + f7vv + f7tj
-        )
+            P.travaux.plafond * (maries_ou_pacses + 1) - ci_trav_adh,
+            f7vp + f7vt + f7up + f7ut + f7tp + f7tr + f7tt + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7th + f7vv + f7tj)
 
         ci_travaux = P.travaux.taux_adhesion_org_producteurs * ci_trav_adh + P.travaux.taux * ci_trav
 

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -686,12 +686,14 @@ class ci_investissement_forestier(Variable):
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
 
         # Nouvelles variables de l'année en cours (2025)
-        f7vp = foyer_fiscal('f7vp', period)
-        f7vt = foyer_fiscal('f7vt', period)
-
-        # Reports des années précédentes
+        f7un = foyer_fiscal('f7un', period)
+        f7ul = foyer_fiscal('f7vl', period)
         f7up = foyer_fiscal('f7up', period)
         f7ut = foyer_fiscal('f7ut', period)
+
+        # Reports des années précédentes
+        f7vt = foyer_fiscal('f7vt', period)
+        f7tk = foyer_fiscal('f7tk', period)
         f7tp = foyer_fiscal('f7tp', period)
         f7tq = foyer_fiscal('f7tq', period)
         f7tr = foyer_fiscal('f7tr', period)
@@ -723,11 +725,19 @@ class ci_investissement_forestier(Variable):
 
         ci_trav = min_(
             P.travaux.plafond * (maries_ou_pacses + 1) - ci_trav_adh,
-            f7vp + f7vt + f7up + f7ut + f7tp + f7tr + f7tt + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7th + f7vv + f7tj)
+            f7up + f7ut + f7tp + f7tr + f7tt + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7th + f7vv + f7tj)
+
+        ci_acquisition = P.acquisition.taux * min_(
+            P.acquisition.plafond * (maries_ou_pacses + 1),
+            f7un)
+
+        ci_assurance = P.assurance.taux * min_(
+            P.assurance.plafond * (maries_ou_pacses + 1),
+            f7ul)
 
         ci_travaux = P.travaux.taux_adhesion_org_producteurs * ci_trav_adh + P.travaux.taux * ci_trav
 
-        return ci_travaux
+        return ci_travaux + ci_acquisition + ci_assurance
 
 
 class acqgpl(Variable):

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -694,7 +694,6 @@ class ci_investissement_forestier(Variable):
         # Reports des années précédentes
         f7vt = foyer_fiscal('f7vt', period)
         f7tk = foyer_fiscal('f7tk', period)
-        f7tp = foyer_fiscal('f7tp', period)
         f7tq = foyer_fiscal('f7tq', period)
         f7tr = foyer_fiscal('f7tr', period)
         f7ts = foyer_fiscal('f7ts', period)
@@ -702,9 +701,7 @@ class ci_investissement_forestier(Variable):
         f7tu = foyer_fiscal('f7tu', period)
         f7tv = foyer_fiscal('f7tv', period)
         f7tw = foyer_fiscal('f7tw', period)
-        f7vm = foyer_fiscal('f7vm', period)
         f7ta = foyer_fiscal('f7ta', period)
-        f7vn = foyer_fiscal('f7vn', period)
         f7tb = foyer_fiscal('f7tb', period)
         f7vq = foyer_fiscal('f7vq', period)
         f7te = foyer_fiscal('f7te', period)
@@ -721,11 +718,11 @@ class ci_investissement_forestier(Variable):
 
         ci_trav_adh = min_(
             P.travaux.plafond * (maries_ou_pacses + 1),
-            f7tq + f7ts + f7tu + f7tw + f7vn + f7tb + f7vr + f7tf + f7ti + f7vu)
+            f7ts + f7tu + f7tw + f7tb + f7vr + f7tf + f7ti + f7vu)
 
         ci_trav = min_(
             P.travaux.plafond * (maries_ou_pacses + 1) - ci_trav_adh,
-            f7up + f7ut + f7tp + f7tr + f7tt + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7th + f7vv + f7tj)
+            f7up + f7ut + f7tr + f7tt + f7tv + f7ta + f7vq + f7te + f7vs + f7th + f7vv + f7tj)
 
         ci_acquisition = P.acquisition.taux * min_(
             P.acquisition.plafond * (maries_ou_pacses + 1),

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -638,14 +638,17 @@ class ci_investissement_forestier(Variable):
 
     def formula_2024_01_01(foyer_fiscal, period, parameters):
         '''
-        Investissements forestiers pour 2024
+        Investissements forestiers pour l'année 2024
         '''
         maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
 
+        # Nouvelles variables
+        f7un = foyer_fiscal('f7un', period)
+        f7ul = foyer_fiscal('f7ul', period)
         f7up = foyer_fiscal('f7up', period)
         f7ut = foyer_fiscal('f7ut', period)
 
-        # Reports des années précédentes
+        # Reports
         f7tp = foyer_fiscal('f7tp', period)
         f7tq = foyer_fiscal('f7tq', period)
         f7tr = foyer_fiscal('f7tr', period)
@@ -655,8 +658,8 @@ class ci_investissement_forestier(Variable):
         f7tv = foyer_fiscal('f7tv', period)
         f7tw = foyer_fiscal('f7tw', period)
         f7vm = foyer_fiscal('f7vm', period)
-        f7ta = foyer_fiscal('f7ta', period)
         f7vn = foyer_fiscal('f7vn', period)
+        f7ta = foyer_fiscal('f7ta', period)
         f7tb = foyer_fiscal('f7tb', period)
         f7vq = foyer_fiscal('f7vq', period)
         f7te = foyer_fiscal('f7te', period)
@@ -670,14 +673,36 @@ class ci_investissement_forestier(Variable):
         f7tj = foyer_fiscal('f7tj', period)
 
         P = parameters(period).impot_revenu.calcul_reductions_impots.investissement_forestier.depenses_investissement_forestier
+        taux_25 = P.travaux.taux_adhesion_org_producteurs
+        P_2022 = parameters('2022-01-01').impot_revenu.calcul_reductions_impots.investissement_forestier.depenses_investissement_forestier
+        taux_18 = P_2022.travaux.taux
 
-        # travaux année N
-        ci_trav_adh = min_(P.travaux.plafond * (maries_ou_pacses + 1), f7tq + f7ts + f7tu + f7tw + f7vn + f7tb + f7vr + f7tf + f7ti + f7vu)
-        ci_trav = min_(P.travaux.plafond * (maries_ou_pacses + 1) - ci_trav_adh, f7up + f7ut + f7tp + f7tr + f7tt + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7th + f7vv + f7tj)
+        plafond_acq_ass = P.acquisition.plafond * (maries_ou_pacses + 1)
+        
+        base_assurance = min_(f7ul, plafond_acq_ass)
+        base_acquisition = min_(f7un, plafond_acq_ass - base_assurance)
+        
+        ci_assurance = base_assurance * P.assurance.taux
+        ci_acquisition = base_acquisition * P.acquisition.taux
 
-        ci_travaux = P.travaux.taux_adhesion_org_producteurs * ci_trav_adh + P.travaux.taux * ci_trav
+        # Variables à 25% :
+        base_25 = (
+            f7tq + f7ts + f7tu + f7tw + f7vn + f7tb + f7vr + f7tf + f7ti + f7vu + 
+            f7vv + f7tj + f7up + f7ut
+        )
+        
+        # Variables à 18% :
+        base_18 = (
+            f7tp + f7tr + f7tt + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7th
+        )
 
-        return ci_travaux
+        plafond_travaux = P.travaux.plafond * (maries_ou_pacses + 1)
+
+        ci_trav_adh = min_(plafond_travaux, base_25)
+        ci_trav = min_(plafond_travaux - ci_trav_adh, base_18)
+
+        ci_travaux = (taux_25 * ci_trav_adh) + (taux_18 * ci_trav)
+        return ci_travaux + ci_acquisition + ci_assurance
 
     def formula_2025_01_01(foyer_fiscal, period, parameters):
         '''

--- a/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
+++ b/openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py
@@ -679,6 +679,58 @@ class ci_investissement_forestier(Variable):
 
         return ci_travaux
 
+    def formula_2025_01_01(foyer_fiscal, period, parameters):
+        '''
+        Investissements forestiers pour 2025
+        '''
+        maries_ou_pacses = foyer_fiscal('maries_ou_pacses', period)
+
+        # Nouvelles variables de l'année en cours (2025)
+        f7vp = foyer_fiscal('f7vp', period)
+        f7vt = foyer_fiscal('f7vt', period)
+
+        # Reports des années précédentes
+        f7up = foyer_fiscal('f7up', period)
+        f7ut = foyer_fiscal('f7ut', period)
+        f7tp = foyer_fiscal('f7tp', period)
+        f7tq = foyer_fiscal('f7tq', period)
+        f7tr = foyer_fiscal('f7tr', period)
+        f7ts = foyer_fiscal('f7ts', period)
+        f7tt = foyer_fiscal('f7tt', period)
+        f7tu = foyer_fiscal('f7tu', period)
+        f7tv = foyer_fiscal('f7tv', period)
+        f7tw = foyer_fiscal('f7tw', period)
+        f7vm = foyer_fiscal('f7vm', period)
+        f7ta = foyer_fiscal('f7ta', period)
+        f7vn = foyer_fiscal('f7vn', period)
+        f7tb = foyer_fiscal('f7tb', period)
+        f7vq = foyer_fiscal('f7vq', period)
+        f7te = foyer_fiscal('f7te', period)
+        f7vr = foyer_fiscal('f7vr', period)
+        f7tf = foyer_fiscal('f7tf', period)
+        f7vs = foyer_fiscal('f7vs', period)
+        f7th = foyer_fiscal('f7th', period)
+        f7vu = foyer_fiscal('f7vu', period)
+        f7ti = foyer_fiscal('f7ti', period)
+        f7vv = foyer_fiscal('f7vv', period)
+        f7tj = foyer_fiscal('f7tj', period)
+
+        P = parameters(period).impot_revenu.calcul_reductions_impots.investissement_forestier.depenses_investissement_forestier
+
+        ci_trav_adh = min_(
+            P.travaux.plafond * (maries_ou_pacses + 1), 
+            f7tq + f7ts + f7tu + f7tw + f7vn + f7tb + f7vr + f7tf + f7ti + f7vu
+        )
+        
+        ci_trav = min_(
+            P.travaux.plafond * (maries_ou_pacses + 1) - ci_trav_adh, 
+            f7vp + f7vt + f7up + f7ut + f7tp + f7tr + f7tt + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7th + f7vv + f7tj
+        )
+
+        ci_travaux = P.travaux.taux_adhesion_org_producteurs * ci_trav_adh + P.travaux.taux * ci_trav
+
+        return ci_travaux
+
 
 class acqgpl(Variable):
     value_type = float

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "176.0.4"
+version = "176.0.5"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/calculateur_impots/yaml/credit_invest_forestier.yaml
+++ b/tests/calculateur_impots/yaml/credit_invest_forestier.yaml
@@ -612,12 +612,10 @@
       caseW: false
       declarants:
       - ind0
-      f7up: 200  # Crédit dimpôt pour investissements forestiers: travaux
-      f7ut: 200  # Investissements forestiers : indicatrice travaux consécutifs à un sinistre
-      f7ua_2023: 1500 # Plus utilisé, Investissements forestiers : travaux avec adhésion à une organisation de producteurs
-      f7ub_2022: 300  # Plus utilisé, Investissements forestiers : travaux consécutifs à un sinistre, avec adhésion à une organisation de producteurs
-      f7uq: 2500 # Plus utilisé, Crédit d'impôt pour investissements forestiers: contrat de gestion
-      f7ui_2022: 150  # Plus utilisé, Investissements forestiers : contrat de gestion avec adhésion à une organisation de producteurs
+      f7un: 100
+      f7ul: 100
+      f7up: 300
+      f7ut: 300 # Investissements forestiers : indicatrice travaux consécutifs à un sinistre
       f7tp: 100  # Inv. forestiers: Report des dépenses de travaux des années antérieures 2016
       f7tq: 250  # Inv. forestiers: Report des dépenses de travaux des années antérieures avec adh. grp. prod. 2016
       f7tr: 100  # Inv. for. 2017
@@ -658,91 +656,7 @@
     menage:
       personne_de_reference: ind0
   output:
-    # ci_trav_adh = f7tq + f7ts + f7tu + f7tw + f7vn + f7tb + f7vr + f7tf + f7vs + f7th + f7ti + f7vu
-    # ci_trav_adh = 2_050
-    # ci_trav = f7up + f7ut + f7tp + f7tr + f7tt + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7vv + f7tj
-    # ci_trav = 2_525
-    # ci_travaux = P.travaux.taux_adhesion_org_producteurs * ci_trav_adh + P.travaux.taux * ci_trav
-    ci_investissement_forestier: 2_050 * 0.25 + 2_525 * 0.25 # 1 143.75
-
-- name: Crédit Impôt pour investissement forestier - 2024 couple
-  period: 2024
-  absolute_error_margin: 1
-  input:
-    foyer_fiscal:
-      # couple case to exercise (maries_ou_pacses + 1) scaling
-      declarants:
-      - ind0
-      - ind1
-      f7up: 400  # Crédit dimpôt pour investissements forestiers: travaux
-      f7ut: 400  # Investissements forestiers : indicatrice travaux consécutifs à un sinistre
-      f7ua_2023: 3000 # travaux avec adhésion à une organisation de producteurs, pour validation car il ne donne plus droit à un Crédit d'impôt pour investissements forestiers en 2023.
-      f7ub_2022: 600  # Investissements forestiers : travaux consécutifs à un sinistre, avec adhésion à une organisation de producteurs
-      f7uq: 5000 # contrat de gestion, pour validation car il ne donne plus droit à un Crédit d'impôt pour investissements forestiers en 2023.
-      f7ui_2022: 300  # Investissements forestiers : contrat de gestion avec adhésion à une organisation de producteurs
-      f7tj: 200  # Investissements forestiers : report N-1, après sinistre
-      f7tk: 200  # Investissements forestiers : report N-1, après sinistre,  avec adhésion à une organisation de producteurs
-      f7tm: 400  # Investissements forestiers : report 2015, après sinistre
-      f7to: 600  # Investissements forestiers : report 2015, après sinistre, avec adhésion à une association de producteurs
-      f7tp: 200  # Inv. forestiers: Report des dépenses de travaux des années antérieures 2016
-      f7tq: 500  # Inv. forestiers: Report des dépenses de travaux des années antérieures avec adh. grp. prod. 2016
-      f7vj_2022: 200  # Inv. for.
-      f7tt: 300  # Inf. for.
-      f7vk_2022: 100  # Inv. for.
-      f7tu: 400  # Inv. for.
-      f7vh: 280  # Inv. for.
-      f7tv: 800  # Inv. for.
-      f7vi: 400  # Inv. for.
-      f7tw: 600  # Investissement forestiers report des dépenses de travaux des années antérieures: 2019 après sinistre
-      f7vm: 150  # Investissements forestiers : report 2015, hors sinistre
-      f7ta: 600  # Inv. for.
-      f7vu: 300  # Investissements forestiers : report 2022, hors sinistre, avec adhésion à une association de producteurs
-      f7tb: 400  # Dépenses en investissements forestiers
-      nbF: 0.0
-      nbG: 0.0
-      nbH: 0.0
-      nbI: 0.0
-      nbJ: 0
-      nbR: 0
-    individus:
-      ind0:
-        activite: actif
-        date_naissance: '1970-01-01'
-        salaire_imposable: 50000.0
-        statut_marital: marie
-      ind1:
-        activite: actif
-        date_naissance: '1970-01-01'
-        salaire_imposable: 50000.0
-        statut_marital: marie
-    famille:
-      parents:
-      - ind0
-      - ind1
-    menage:
-      personne_de_reference: ind0
-  output:
-    # Formule exacte pour 2023 (couple - maries_ou_pacses = 1):
-    # ci_trav_adh = min(P.travaux.plafond * (maries_ou_pacses + 1), f7tq + f7ts + f7tu + f7tw + f7vn + f7tb + f7vr + f7tf + f7vs + f7th + f7ti + f7vu)
-    # ci_trav = min(P.travaux.plafond * (maries_ou_pacses + 1) - ci_trav_adh, f7up + f7ut + f7tp + f7tr + f7tt + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7vv + f7tj)
-    # ci_investissement_forestier = P.travaux.taux_adhesion_org_producteurs * ci_trav_adh + P.travaux.taux * ci_trav
-    #
-    # Calcul avec les valeurs de ce test (copier-coller dans Python):
-    # # Paramètres 2023:
-    # plafond = 6250  # Plafond de dépenses de travaux et assurances d'investissement forestier
-    # taux_adhesion = 0.25  # Taux pour les travaux avec adhésion à une organisation de producteurs (25%)
-    # taux_normal = 0.25   # Taux du crédit d'impôt pour les travaux réguliers (25%)
-    # maries_ou_pacses = 1  # couple
-    #
-    # # Travaux avec adhésion (taux majoré):
-    # ci_trav_adh = min(6250 * (1 + 1), 500 + 0 + 400 + 600 + 300 + 400 + 0 + 0 + 0 + 0 + 0 + 0)
-    # ci_trav_adh = min(12500, 2200) = 2200
-    # # Travaux sans adhésion (taux normal):
-    # ci_trav = min(12500 - 2200, 400 + 400 + 200 + 0 + 300 + 800 + 150 + 600 + 0 + 0 + 0 + 0 + 200)
-    # ci_trav = min(10300, 3050) = 3050
-    # # Résultat final:
-    # ci_investissement_forestier = 0.25 * 2200 + 0.25 * 3050 = 550 + 762.5 = 1312.5
-    ci_investissement_forestier: 0.25 * 2200 + 0.25 * 3050
+    ci_investissement_forestier: 1174
 
 - name: Crédit Impôt pour investissement forestier - année 2025
   period: 2025

--- a/tests/calculateur_impots/yaml/credit_invest_forestier.yaml
+++ b/tests/calculateur_impots/yaml/credit_invest_forestier.yaml
@@ -758,35 +758,32 @@
       caseW: false
       declarants:
       - ind0
-      
-      # Nouvelles variables pour 2025
-      f7un: 0
-      f7ul: 0
-      f7up: 200
-      f7ut: 200
-      
-      # Reports des années antérieures 
-      f7ts: 150  
-      f7tu: 200  
-      f7tw: 300  
-      f7tb: 200  
-      f7vr: 200  
-      f7tf: 200  
-      f7ti: 200
-      f7vu: 200
-      f7vt: 200
-      f7tk: 200
-      f7tr: 100  
-      f7tt: 50  
-      f7tv: 400  
-      f7ta: 300  
-      f7vq: 100
+
+      f7un: 100
+      f7ul: 100
+      f7up: 300
+      f7ut: 300
+
+      f7tr: 200
+      f7ts: 200
+      f7tt: 200
+      f7tu: 200
+      f7tv: 200
+      f7tw: 200
+      f7ta: 200
+      f7tb: 200
+      f7vq: 200
       f7te: 200
+      f7vr: 200
+      f7tf: 200
       f7vs: 200
       f7th: 200
+      f7vu: 200
+      f7ti: 200
       f7vv: 200
       f7tj: 200
-      
+      f7vt: 200
+      f7tk: 200
       nbF: 0.0
       nbG: 0.0
       nbH: 0.0
@@ -797,7 +794,7 @@
       ind0:
         activite: actif
         date_naissance: '1970-01-01'
-        salaire_imposable: 50000.0
+        abic_impn: 200000.0
         statut_marital: celibataire
     famille:
       parents:
@@ -805,4 +802,4 @@
     menage:
       personne_de_reference: ind0
   output:
-    ci_investissement_forestier: 992 #erreur de 8. encore a régler
+    ci_investissement_forestier: 1139

--- a/tests/calculateur_impots/yaml/credit_invest_forestier.yaml
+++ b/tests/calculateur_impots/yaml/credit_invest_forestier.yaml
@@ -743,3 +743,66 @@
     # # Résultat final:
     # ci_investissement_forestier = 0.25 * 2200 + 0.25 * 3050 = 550 + 762.5 = 1312.5
     ci_investissement_forestier: 0.25 * 2200 + 0.25 * 3050
+
+- name: Crédit Impôt pour investissement forestier - année 2025
+  period: 2025
+  absolute_error_margin: 1
+  input:
+    foyer_fiscal:
+      caseF: false
+      caseG: false
+      caseL: false
+      caseP: false
+      caseS: false
+      caseT: false
+      caseW: false
+      declarants:
+      - ind0
+      
+      # Nouvelles variables pour 2025
+      f7un: 0
+      f7ul: 0
+      f7up: 200
+      f7ut: 200
+      
+      # Reports des années antérieures 
+      f7ts: 150  
+      f7tu: 200  
+      f7tw: 300  
+      f7tb: 200  
+      f7vr: 200  
+      f7tf: 200  
+      f7ti: 200
+      f7vu: 200
+      f7vt: 200
+      f7tk: 200
+      f7tr: 100  
+      f7tt: 50  
+      f7tv: 400  
+      f7ta: 300  
+      f7vq: 100
+      f7te: 200
+      f7vs: 200
+      f7th: 200
+      f7vv: 200
+      f7tj: 200
+      
+      nbF: 0.0
+      nbG: 0.0
+      nbH: 0.0
+      nbI: 0.0
+      nbJ: 0
+      nbR: 0
+    individus:
+      ind0:
+        activite: actif
+        date_naissance: '1970-01-01'
+        salaire_imposable: 50000.0
+        statut_marital: celibataire
+    famille:
+      parents:
+      - ind0
+    menage:
+      personne_de_reference: ind0
+  output:
+    ci_investissement_forestier: 992 #erreur de 8. encore a régler

--- a/tests/calculateur_impots/yaml/credit_invest_forestier.yaml
+++ b/tests/calculateur_impots/yaml/credit_invest_forestier.yaml
@@ -519,23 +519,20 @@
       caseW: false
       declarants:
       - ind0
+      f7un: 100
+      f7ul: 100
       f7up: 200  # Crédit dimpôt pour investissements forestiers: travaux
       f7ut: 200  # Investissements forestiers : indicatrice travaux consécutifs à un sinistre
-      f7ua_2023: 1500  # Investissements forestiers : travaux avec adhésion à une organisation de producteurs
-      f7ub_2022: 300  # Investissements forestiers : travaux consécutifs à un sinistre, avec adhésion à une organisation de producteurs
-      f7uq: 2500  # Crédit d'impôt pour investissements forestiers: contrat de gestion
-      f7ui_2022: 150  # Investissements forestiers : contrat de gestion avec adhésion à une organisation de producteurs
-      f7tj: 100  # Investissements forestiers : report N-1, après sinistre
-      f7tk: 100  # Investissements forestiers : report N-1, après sinistre,  avec adhésion à une organisation de producteurs
       f7tm: 200  # Investissements forestiers : report 2015, après sinistre
       f7to: 300  # Investissements forestiers : report 2015, après sinistre, avec adhésion à une association de producteurs
       f7tp: 100  # Inv. forestiers: Report des dépenses de travaux des années antérieures 2016
       f7tq: 250  # Inv. forestiers: Report des dépenses de travaux des années antérieures avec adh. grp. prod. 2016
-      f7vj_2022: 100  # Inv. for.
+      f7tr: 200
+      f7ts: 200
       f7tt: 150  # Inf. for.
       f7vk_2022: 50  # Inv. for.
       f7tu: 200  # Inv. for.
-      f7vh: 140  # Inv. for.
+      f7vh: 200  # Inv. for.
       f7tv: 400  # Inv. for.
       f7vi: 200  # Inv. for.
       f7tw: 300  # Investissement forestiers report des dépenses de travaux des années antérieures: 2019 après sinistre
@@ -543,6 +540,14 @@
       f7ta: 300  # Inv. for.
       f7vn: 150  # Investissements forestiers : report 2015, hors sinistre, avec adhésion à une association de producteurs
       f7tb: 200  # Dépenses en investissements forestiers
+      f7vq: 200
+      f7te: 200
+      f7vr: 200
+      f7tf: 200
+      f7vs: 200
+      f7th: 200
+      f7vu: 200
+      f7ti: 200
       nbF: 0.0
       nbG: 0.0
       nbH: 0.0
@@ -561,10 +566,7 @@
     menage:
       personne_de_reference: ind0
   output:
-    # ci_trav_adh = f7to + f7tq + f7ts + f7tu + f7vi + f7tw + f7vn + f7tb + f7vr + f7tf + f7vs + f7th
-    # ci_trav = f7up + f7ut + f7tm + f7tp + f7tr + f7tt + f7vh + f7tv + f7vm + f7ta + f7vq + f7te + f7vs + f7ti + f7vu
-    # P.travaux.taux_adhesion_org_producteurs * ci_trav_adh + P.travaux.taux * ci_trav
-    ci_investissement_forestier: 0.25 * 1_600 + 0.25 * 1_765 # 841.25
+    ci_investissement_forestier: 1288
 
 
 - name: Crédit Impôt pour investissement forestier - 2023 avec CGA


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2023.
* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py` et 'tests/calculateur_impots/yaml/credit_invest_forestier.yaml'
* Détails :
  - Mise à jour de la formule pour 2025 corrections sur 2024 et 2023
  -ajout et correction des test sur la période

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.
