### PR TITLE
Mises à jour paramètres décret 2026-562

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 175.1.10 [#2785](https://github.com/openfisca/openfisca-france/pull/2785)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/01/2025.
+* Zones impactées :
+  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables`
+  - `openfisca_france/parameters/prelevements_sociaux`
+  - `openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire`
+* Détails :
+  - Mise à jours de paramètres d'impôt et de prélèvements sociaux
+
 ### 175.1.9 [#2773](https://github.com/openfisca/openfisca-france/pull/2773)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/contribuable_age_invalide.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/abat_rni/contribuable_age_invalide.yaml
@@ -93,7 +93,9 @@ brackets:
     2023-01-01:
       value: 2746
     2024-01-01:
-      value: 2795
+      value: 2796
+    2025-01-01:
+      value: 2822
 - threshold:
     1977-01-01:
       value: 21000
@@ -187,6 +189,8 @@ brackets:
       value: 17200
     2024-01-01:
       value: 17510
+    2025-01-01:
+      value: 17670
   amount:
     1977-01-01:
       value: 1700
@@ -278,6 +282,8 @@ brackets:
       value: 1373
     2024-01-01:
       value: 1398
+    2025-01-01:
+      value: 1411
 - threshold:
     1977-01-01:
       value: 34000
@@ -371,12 +377,14 @@ brackets:
       value: 27670
     2024-01-01:
       value: 28170
+    2025-01-01:
+      value: 28430
   amount:
     1977-01-01:
       value: 0
 metadata:
   short_label: Abattement pour contribuable de plus de 65 ans ou invalide
-  last_value_still_valid_on: "2025-03-07"
+  last_value_still_valid_on: "2026-07-15"
   type: single_amount
   amount_unit: currency_next_year
   threshold_unit: currency_next_year
@@ -485,6 +493,9 @@ metadata:
     2024-01-01:
     - title: Article 157 bis du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622555/2025-06-02/
+    2025-01-01:
+    - title: Article 157 bis du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622555/2026-07-15
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"
@@ -524,6 +535,7 @@ metadata:
     2021-01-01: 2021-12-31; 2021-06-11
     2022-01-01: "2023-06-02"
     2023-01-01: "2024-06-01"
+    2025-01-01: "2026-06-30"
   notes:
     2001-01-01:
     - title: Voir aussi Loi 2001-1276 du 28/12/2001 - art. 51 (LFR pour 2001)

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/accueil_personne_agee/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/charges_deductibles/accueil_personne_agee/plafond.yaml
@@ -78,9 +78,12 @@ values:
     value: 3968
   2024-01-01:
     value: 4039
+  2025-01-01:
+    value: 4075
+
 metadata:
   short_label: Plafond de la déduction par personne âgée
-  last_value_still_valid_on: "2025-02-25"
+  last_value_still_valid_on: "2026-07-15"
   ipp_csv_id: plaf_frais
   unit: currency_next_year
   reference:
@@ -215,6 +218,11 @@ metadata:
     2024-01-01:
     - title: Article 156, II-2° ter, du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622626
+    2025-01-01:
+    - title: Article 156, II-2° ter, du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622626
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
   official_journal_date:
     1984-01-01: "1984-12-30"
     1985-01-01: "1985-12-31"
@@ -253,6 +261,7 @@ metadata:
     2021-01-01: "2021-05-06"
     2022-01-01: "2023-06-02"
     2023-01-01: "2024-06-01"
+    2025-01-01: "2026-06-30"
 documentation: |-
   Plafond frais personnes de plus de 75 ans : art. 156-II-2° ter du CGI
   https://www.ipp.eu/baremes-ipp/impot-sur-le-revenu/calcul_revenus_imposables/charg_deduc/

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/max.yaml
@@ -94,9 +94,11 @@ values:
     value: 4321
   2024-01-01:
     value: 4399
+  2025-01-01:
+    value: 4439
 metadata:
   short_label: Montant maximum de l'abattement, pour le foyer fiscal
-  last_value_still_valid_on: "2025-02-25"
+  last_value_still_valid_on: "2026-07-15"
   ipp_csv_id: max_abtpen
   unit: currency_next_year
   reference:
@@ -224,6 +226,11 @@ metadata:
     2024-01-01:
     - title: Article 158, 5.a. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042909707/
+    2025-01-01:
+    - title: Article 158, 5.a. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042909707/
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
   official_journal_date:
     1977-01-01: "1977-12-31"
     1978-01-01: "1978-12-30"
@@ -269,6 +276,7 @@ metadata:
     2020-01-01: "2020-12-30"
     2022-01-01: "2023-06-02"
     2023-01-01: "2024-06-01"
+    2025-01-01: "2026-06-30"
   notes:
     1978-01-01:
     - title: Le maximum sur les pensions est pris en compte par foyer fiscal pour l'imposition des revenus de 1977 et 1978.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpen/min.yaml
@@ -60,9 +60,11 @@ values:
     value: 442
   2024-01-01:
     value: 450
+  2025-01-01:
+    value: 454
 metadata:
   short_label: Montant minimum de l'abattement, par pensionné
-  last_value_still_valid_on: "2025-02-25"
+  last_value_still_valid_on: "2026-07-15"
   ipp_csv_id: min_abtpen
   unit: currency_next_year
   reference:
@@ -153,6 +155,11 @@ metadata:
     2024-01-01:
     - title: Article 158, 5.a. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042909707/
+    2025-01-01:
+    - title: Article 158, 5.a. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042909707/
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
   official_journal_date:
     1978-01-01: "1978-12-30"
     1992-01-01: "1992-12-31"
@@ -181,6 +188,7 @@ metadata:
     2020-01-01: "2020-12-30"
     2022-01-01: "2023-06-02"
     2023-01-01: "2024-06-01"
+    2025-01-01: "2026-06-30"
   notes:
     1978-01-01:
     - title: Le maximum sur les pensions est pris en compte par foyer fiscal pour l'imposition des revenus de 1977 et 1978.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/max.yaml
@@ -96,9 +96,11 @@ values:
     value: 14171
   2024-01-01:
     value: 14426
+  2025-01-01:
+    value: 14555
 metadata:
   short_label: Montant maximum de la déduction
-  last_value_still_valid_on: "2025-02-25"
+  last_value_still_valid_on: "2026-07-15"
   ipp_csv_id: max_abtsal
   unit: currency_next_year
   reference:
@@ -217,6 +219,11 @@ metadata:
     2024-01-01:
     - title: Article 83, 3. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000032701943
+    2025-01-01:
+    - title: Article 83, 3. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000032701943
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
   official_journal_date:
     1979-01-01: "1980-01-19"
     1980-01-01: "1980-12-31"
@@ -259,6 +266,7 @@ metadata:
     2020-01-01: "2020-12-30"
     2022-01-01: "2023-06-02"
     2023-01-01: "2024-06-01"
+    2025-01-01: "20226-06-30"
   notes:
     1952-01-01:
     - title: Au titre de l'imposition des revenus des années 1943-1952, les salariés avaient également droit à une déduction forfaitaire pour frais professionnels de 5% au-delà du plafond.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/deductions/abatpro/min.yaml
@@ -68,9 +68,11 @@ values:
     value: 495
   2024-01-01:
     value: 504
+  2025-01-01:
+    value: 509
 metadata:
   short_label: Montant minimum de la déduction
-  last_value_still_valid_on: "2025-02-25"
+  last_value_still_valid_on: "2026-07-15"
   ipp_csv_id: min_abtsal
   unit: currency_next_year
   reference:
@@ -166,6 +168,11 @@ metadata:
     2024-01-01:
     - title: Article 83, 3. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000032701943
+    2025-01-01:
+    - title: Article 83, 3. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000032701943
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
   official_journal_date:
     1977-01-01: "1977-12-31"
     1978-01-01: "1978-12-30"
@@ -198,6 +205,7 @@ metadata:
     2020-01-01: "2020-12-30"
     2022-01-01: "2023-06-02"
     2023-01-01: "2024-06-01"
+    2025-01-01: "2026-06-30"
   notes:
     1978-01-01:
     - title: Le maximum sur les pensions est pris en compte par foyer fiscal pour l'imposition des revenus de 1977 et 1978.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/plafond_recettes.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_ba/plafond_recettes.yaml
@@ -10,8 +10,10 @@ values:
     value: 91900
   2024-01-01:
     value: 120000
+  2025-01-01:
+    value: 129200
 metadata:
-  last_value_still_valid_on: "2025-08-22"
+  last_value_still_valid_on: "2026-07-15"
   ipp_csv_id: plaf_micro_ba
   unit: currency_next_year
   reference:
@@ -34,12 +36,18 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000048727447
     - title: Article 69, I. du Code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000028447731
+    2025-01-01:
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+    - title: Article 69, I. du Code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000028447731
   official_journal_date:
     2016-01-01: "2015-12-30"
     2017-01-01: "2017-05-04"
     2020-01-01: "2020-07-24"
     2023-01-01: "2023-06-02"
     2024-01-01: "2023-12-30"
+    2025-01-01: "2026-06-30"
 documentation: |-
   Ref : Article 69 I du CGI.
   Les seuils sont actualisés tous les trois ans dans la même proportion que l'évolution triennale de la limite supérieure de la première tranche du barème de l'impôt sur le revenu et sont arrondis, respectivement, à la centaine d'euros la plus proche et au millier d'euros le plus proche.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bic/marchandises/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bic/marchandises/plafond.yaml
@@ -24,9 +24,11 @@ values:
     value: 176200
   2023-01-01:
     value: 188700
+  2025-01-01:
+    value: 203100
 metadata:
   short_label: Plafond
-  last_value_still_valid_on: "2025-11-14"
+  last_value_still_valid_on: "2026-07-15"
   ipp_csv_id: limit_micro
   unit: currency_next_year
   reference:
@@ -68,6 +70,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048844097/2023-12-31/
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    2025-01-01:
+    - title: Article 50-0 du CGI
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048844097/2023-12-31/
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
   official_journal_date:
     1991-01-01: "1991-12-31"
     1996-01-01: "1996-12-31"
@@ -81,6 +88,7 @@ metadata:
     2017-01-01: "2017-12-31"
     2020-01-01: "2020-07-24"
     2023-01-01: "2023-06-02"
+    2026-01-01: "2026-06-30"
   notes:
     1999-01-01:
     - title: Jusqu'à l'imposition des revenus de 1998, les régimes spéciaux (appelé micro et micro_service ici) concernent les locations meublés non professionnelles, les BIC non professionnelles (depuis 98 seulement) et les autres activités industrielles et commerciales

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bic/services/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bic/services/plafond.yaml
@@ -24,9 +24,11 @@ values:
     value: 72600
   2023-01-01:
     value: 77700
+  2025-01-01:
+    value: 83600
 metadata:
   short_label: Plafond
-  last_value_still_valid_on: "2025-11-14"
+  last_value_still_valid_on: "2026-07-15"
   ipp_csv_id: limit_micro_service
   unit: currency_next_year
   reference:
@@ -68,6 +70,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048844097/2023-12-31/
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    2025-01-01:
+    - title: Article 50-0 du CGI
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048844097/2023-12-31/
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
   official_journal_date:
     1979-01-01: "1980-01-19"
     1991-01-01: "1991-12-31"
@@ -82,6 +89,7 @@ metadata:
     2017-01-01: "2017-12-31"
     2020-01-01: "2020-07-24"
     2023-01-01: "2023-06-02"
+    2025-01-01: "2026-07-15"
   notes:
     1999-01-01:
     - title: Jusqu'à l'imposition des revenus de 1998, les régimes spéciaux(appelé micro et micro_service ici) concernent les locations meublés non professionnelles, les BIC non professionnelles (depuis 98 seulement) et les autres activités industrielles et commerciales

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/plafond.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/microentreprise/regime_micro_bnc/plafond.yaml
@@ -24,9 +24,11 @@ values:
     value: 72600
   2023-01-01:
     value: 77700
+  2025-01-01:
+    value: 83600
 metadata:
   short_label: Plafond
-  last_value_still_valid_on: "2025-08-22"
+  last_value_still_valid_on: "2026-07-15"
   ipp_csv_id: limit_micro_service
   unit: currency_next_year
   reference:
@@ -68,6 +70,11 @@ metadata:
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048844097/2023-12-31/
     - title: Décret n° 2023-422 du 31/05/2023, art. 1
       href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000047618675
+    2025-01-01:
+    - title: Article 50-0 du CGI
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048844097/2023-12-31/
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
   official_journal_date:
     1991-01-01: "1991-12-31"
     1996-01-01: "1996-12-31"
@@ -81,6 +88,7 @@ metadata:
     2017-01-01: "2017-12-31"
     2020-01-01: "2020-07-24"
     2023-01-01: "2023-06-02"
+    2025-01-01: "2026-07-15"
 documentation: |-
   Réf : Article 201 ter du CGI https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622381/2023-06-03/
   Les seuils sont actualisés tous les trois ans dans la même proportion que l'évolution triennale de la première tranche du barème de l'impôt sur le revenu et arrondis à la centaine d'euros la plus proche.

--- a/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/plafond_imputation_deficits_agricoles_sur_revenu_global.yaml
+++ b/openfisca_france/parameters/impot_revenu/calcul_revenus_imposables/rpns/micro/plafond_imputation_deficits_agricoles_sur_revenu_global.yaml
@@ -52,9 +52,11 @@ values:
     value: 125419
   2025-01-01:
     value: 127677
+  2026-01-01:
+    value: 128826
 metadata:
   short_label: Plafond (déficits agricoles)
-  last_value_still_valid_on: "2026-03-27"
+  last_value_still_valid_on: "2026-07-15"
   ipp_csv_id: plaf_defba
   unit: currency_next_year
   reference:
@@ -150,6 +152,11 @@ metadata:
     - title: Décret n° 2025-547 du 17 juin 2025, art. 2
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051754167
       note: "au premier alinéa du 1° du I, le montant : « 125 419 € » est remplacé par le montant : « 127 677 € »"
+    2026-01-01:
+    - title: Art. 156 du Code général des impôts, premier alinéa du 1° du I
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051765216/2026-07-15
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
   official_journal_date:
     1979-01-01: "1980-01-19"
     1988-01-01: "1988-12-28"
@@ -176,6 +183,7 @@ metadata:
     2022-01-01: "2023-06-02"
     2023-01-01: "2024-06-01"
     2025-01-01: "2025-06-18"
+    2026-01-01: "2026-07-15"
   notes:
     1994-01-01:
     - title: Cf. article 156 du Code Général des Impôt pour le plafonnement du déficit foncier global

--- a/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/taxsal/abattement_special.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/taxsal/abattement_special.yaml
@@ -36,9 +36,11 @@ values:
     value: 23616
   2025-01-01:
     value: 24041
+  2026-01-01:
+    value: 24256
 metadata:
   short_label: Abattement spécial
-  last_value_still_valid_on: "2026-03-27"
+  last_value_still_valid_on: "2026-07-15"
   unit: currency
   reference:
     2018-01-01:
@@ -69,3 +71,8 @@ metadata:
       href: https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000051754167
     - title: Article 1679-A du CGI
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764500/2025-06-19
+    2026-01-01:
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+    - title: Article 1679-A du CGI
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764500/2026-07-15

--- a/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/taxsal/taux_maj.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/autres_taxes_participations_assises_salaires/taxsal/taux_maj.yaml
@@ -81,6 +81,8 @@ brackets:
       value: 8985
     2025-01-01:
       value: 9147
+    2026-01-01:
+      value: 9229
   rate:
     1968-11-01:
       value: 0.0425
@@ -159,6 +161,8 @@ brackets:
       value: 17936
     2025-01-01:
       value: 18259
+    2026-01-01:
+      value: 18423
   rate:
     1968-11-01:
       value: 0.0935
@@ -291,6 +295,11 @@ metadata:
     - title: Article 231 du CGI
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622885
       note: "8.50% - 4.25% = 0.0425 ; 13.60% - 4.25% = 0.0935"
+    2026-01-01:
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+    - title: Article 231 du CGI
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000047622885
   official_journal_date:
     1968-11-01: 1968-10-10
     1979-01-01: 1978-12-30
@@ -308,12 +317,13 @@ metadata:
     2022-01-01: 2022-05-06
     2023-01-01: 2023-06-02
     2024-01-01: 2024-06-01
+    2026-01-01: 2026-06-30
   notes:
     2021-01-01:
     - title: BOFIP non mis à jour
   rate_unit: /1
   threshold_unit: currency
-  last_value_still_valid_on: "2026-03-27"
+  last_value_still_valid_on: "2026-07-15"
 documentation: |-
   Notes :
   Le taux applicable entre le plafond 1 et le plafond 2 (resp. entre les plafonds 2 et 3 et au dessus du plafond 3) est égal au (taux 1 + majoration 1) (resp. au (taux 1 + majoration2) et (taux1 + majoration3)), soit 8,50% (resp. 13,60% et 20%).

--- a/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/assiette/cantines_titres_restaurants/seuil_prix_titre.yaml
+++ b/openfisca_france/parameters/prelevements_sociaux/cotisations_securite_sociale_regime_general/assiette/cantines_titres_restaurants/seuil_prix_titre.yaml
@@ -12,9 +12,11 @@ values:
     value: 7.18
   2025-01-01:
     value: 7.26
+  2026-01-01:
+    value: 7.32
 metadata:
   short_label: Seuil
-  last_value_still_valid_on: "2025-11-20"
+  last_value_still_valid_on: "2026-07-15"
   unit: currency
   reference:
     2022-01-01:
@@ -29,6 +31,11 @@ metadata:
     2025-01-01:
       title: Code général des impôts, art. 81 (19°)
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048600731/2026-01-01
+    2026-01-01:
+    - title: Code général des impôts, art. 81 (19°)
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000048600731/2026-07-15
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
 documentation: |-
   La limite d'exonération est relevée chaque année dans la même proportion que la variation de
   l'indice des prix à la consommation hors tabac entre le 1er octobre de l'avant-dernière année et le 1er octobre

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/guadeloupe/demi_part_supplementaire.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/guadeloupe/demi_part_supplementaire.yaml
@@ -16,6 +16,8 @@ values:
     value: 3326
   2025-06-19:
     value: 3386
+  2026-07-01:
+    value: 3416
 metadata:
   short_label: Demi-part supplémentaire
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/guadeloupe/premiere_demi_part.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/guadeloupe/premiere_demi_part.yaml
@@ -16,6 +16,8 @@ values:
     value: 3520
   2025-06-19:
     value: 3583
+  2026-07-01:
+    value: 3615
 metadata:
   short_label: Première demi-part
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/guadeloupe/valeur_de_base.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/guadeloupe/valeur_de_base.yaml
@@ -16,6 +16,8 @@ values:
     value: 14739
   2025-06-19:
     value: 15004
+  2026-07-01:
+    value: 15139
 metadata:
   short_label: Valeur de base
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/guyane/demi_part_supplementaire.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/guyane/demi_part_supplementaire.yaml
@@ -16,6 +16,8 @@ values:
     value: 3326
   2025-06-19:
     value: 3386
+  2026-07-01:
+    value: 3416
 metadata:
   short_label: Demi-part supplémentaire
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/guyane/premiere_demi_part.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/guyane/premiere_demi_part.yaml
@@ -16,6 +16,8 @@ values:
     value: 4241
   2025-06-19:
     value: 4317
+  2026-07-01:
+    value: 4356
 metadata:
   short_label: Première demi-part
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/guyane/valeur_de_base.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/guyane/valeur_de_base.yaml
@@ -16,6 +16,8 @@ values:
     value: 15409
   2025-06-19:
     value: 15686
+  2026-07-01:
+    value: 15827
 metadata:
   short_label: Valeur de base
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/la_reunion/demi_part_supplementaire.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/la_reunion/demi_part_supplementaire.yaml
@@ -16,6 +16,8 @@ values:
     value: 3326
   2025-06-19:
     value: 3386
+  2026-07-01:
+    value: 3416
 metadata:
   short_label: Demi-part supplémentaire
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/la_reunion/premiere_demi_part.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/la_reunion/premiere_demi_part.yaml
@@ -37,4 +37,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/la_reunion/premiere_demi_part.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/la_reunion/premiere_demi_part.yaml
@@ -16,6 +16,10 @@ values:
     value: 3520
   2025-06-19:
     value: 3583
+2025-06-19:
+  value: 3583
+2026-07-01:
+  value: 3615
 metadata:
   short_label: Première demi-part
   reference:

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/la_reunion/premiere_demi_part.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/la_reunion/premiere_demi_part.yaml
@@ -16,10 +16,8 @@ values:
     value: 3520
   2025-06-19:
     value: 3583
-2025-06-19:
-  value: 3583
-2026-07-01:
-  value: 3615
+  2026-07-01:
+    value: 3615
 metadata:
   short_label: Première demi-part
   reference:

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/la_reunion/valeur_de_base.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/la_reunion/valeur_de_base.yaml
@@ -16,6 +16,8 @@ values:
     value: 14739
   2025-06-19:
     value: 15004
+  2026-07-01:
+    value: 15139
 metadata:
   short_label: Valeur de base
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/martinique/demi_part_supplementaire.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/martinique/demi_part_supplementaire.yaml
@@ -16,6 +16,8 @@ values:
     value: 3326
   2025-06-19:
     value: 3386
+  2026-07-01:
+    value: 3416
 metadata:
   short_label: Demi-part supplémentaire
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/martinique/premiere_demi_part.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/martinique/premiere_demi_part.yaml
@@ -16,6 +16,8 @@ values:
     value: 3520
   2025-06-19:
     value: 3583
+  2026-07-01:
+    value: 3615
 metadata:
   short_label: Première demi-part
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/martinique/valeur_de_base.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/martinique/valeur_de_base.yaml
@@ -16,6 +16,8 @@ values:
     value: 14739
   2025-06-19:
     value: 15004
+  2026-07-01:
+    value: 15139
 metadata:
   short_label: Valeur de base
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/martinique_guadeloupe_la_reunion/demi_part_supplementaire.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/martinique_guadeloupe_la_reunion/demi_part_supplementaire.yaml
@@ -16,6 +16,8 @@ values:
     value: 3326
   2025-06-19:
     value: 3386
+  2026-07-01:
+    value: 3416
 metadata:
   short_label: Demi-part supplémentaire
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/martinique_guadeloupe_la_reunion/premiere_demi_part.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/martinique_guadeloupe_la_reunion/premiere_demi_part.yaml
@@ -16,6 +16,8 @@ values:
     value: 3520
   2025-06-19:
     value: 3583
+  2026-07-01:
+    value: 3615
 metadata:
   short_label: Première demi-part
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/martinique_guadeloupe_la_reunion/valeur_de_base.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/martinique_guadeloupe_la_reunion/valeur_de_base.yaml
@@ -16,6 +16,8 @@ values:
     value: 14739
   2025-06-19:
     value: 15004
+  2026-07-01:
+    value: 15139
 metadata:
   short_label: Valeur de base
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/mayotte/demi_part_supplementaire.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/mayotte/demi_part_supplementaire.yaml
@@ -16,6 +16,8 @@ values:
     value: 3326
   2025-06-19:
     value: 3386
+  2026-07-01:
+    value: 3416
 metadata:
   short_label: Demi-part supplémentaire
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/mayotte/premiere_demi_part.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/mayotte/premiere_demi_part.yaml
@@ -16,6 +16,8 @@ values:
     value: 4241
   2025-06-19:
     value: 4317
+  2026-07-01:
+    value: 4356
 metadata:
   short_label: Première demi-part
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/mayotte/valeur_de_base.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/mayotte/valeur_de_base.yaml
@@ -16,6 +16,8 @@ values:
     value: 15409
   2025-06-19:
     value: 15686
+  2026-07-01:
+    value: 15827
 metadata:
   short_label: Valeur de base
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/metropole/demi_part_supplementaire.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/metropole/demi_part_supplementaire.yaml
@@ -16,6 +16,8 @@ values:
     value: 3326
   2025-06-19:
     value: 3386
+  2026-07-01:
+    value: 3416
 metadata:
   short_label: Demi-part supplémentaire
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/metropole/premiere_demi_part.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/metropole/premiere_demi_part.yaml
@@ -16,6 +16,8 @@ values:
     value: 3326
   2025-06-19:
     value: 3386
+  2026-07-01:
+    value: 3416
 metadata:
   short_label: Première demi-part
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/metropole/valeur_de_base.yaml
+++ b/openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire/baremes/metropole/valeur_de_base.yaml
@@ -16,6 +16,8 @@ values:
     value: 12455
   2025-06-19:
     value: 12679
+  2026-07-01:
+    value: 12793
 metadata:
   short_label: Valeur de base
   reference:
@@ -37,4 +39,9 @@ metadata:
     2025-06-19:
       title: I de l'article 1417 du code général des impôts
       href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2025-06-19
-  last_value_still_valid_on: "2026-04-03"
+    2026-07-01:
+    - title: I de l'article 1417 du code général des impôts
+      href: https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000051764856/2026-07-01
+    - title: Décret n° 2026-562 du 29/06/2026, art. 2
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000054341109
+  last_value_still_valid_on: "2026-07-15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "175.1.9"
+version = "175.1.10"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/leximpact/2024/aspa_02_couple_retraites_1pension_moyenne_1_sans_pension.yml
+++ b/tests/leximpact/2024/aspa_02_couple_retraites_1pension_moyenne_1_sans_pension.yml
@@ -217,9 +217,9 @@ output:
       nbptr:
         2024: 2
       rfr:
-        2024: 14069.96
+        2024: 14068.96
       rni:
-        2024: 14069.96
+        2024: 14068.96
   menages:
     logement_principal_n_1:
       niveau_de_vie:

--- a/uv.lock
+++ b/uv.lock
@@ -178,7 +178,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
@@ -195,7 +195,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
@@ -234,7 +234,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -400,7 +400,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -576,7 +576,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/67/c7415cf04ebe418193cfd6595ae03e3a64d76dac7b9c010098b39cc7992e/numexpr-2.10.2.tar.gz", hash = "sha256:b0aff6b48ebc99d2f54f27b5f73a58cb92fde650aeff1b397c71c8788b4fff1a", size = 106787, upload-time = "2024-11-23T13:34:23.127Z" }
 wheels = [
@@ -627,7 +627,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/2f/fdba158c9dbe5caca9c3eca3eaffffb251f2fb8674bf8e2d0aed5f38d319/numexpr-2.14.1.tar.gz", hash = "sha256:4be00b1086c7b7a5c32e31558122b7b80243fe098579b170967da83f3152b48b", size = 119400, upload-time = "2025-10-13T16:17:27.351Z" }
 wheels = [
@@ -740,16 +740,16 @@ resolution-markers = [
     "python_full_version >= '3.13'",
 ]
 dependencies = [
-    { name = "dpath" },
-    { name = "numexpr", version = "2.14.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy" },
-    { name = "pendulum" },
-    { name = "psutil" },
-    { name = "pytest" },
-    { name = "pyyaml" },
-    { name = "sortedcontainers" },
-    { name = "strenum" },
-    { name = "typing-extensions" },
+    { name = "dpath", marker = "python_full_version >= '3.13'" },
+    { name = "numexpr", version = "2.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "numpy", marker = "python_full_version >= '3.13'" },
+    { name = "pendulum", marker = "python_full_version >= '3.13'" },
+    { name = "psutil", marker = "python_full_version >= '3.13'" },
+    { name = "pytest", marker = "python_full_version >= '3.13'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.13'" },
+    { name = "sortedcontainers", marker = "python_full_version >= '3.13'" },
+    { name = "strenum", marker = "python_full_version >= '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/6e/e5aab6806467e676e87efd7257e03b13b70a1ae3a2e3eb363b500bd660f6/openfisca_core-43.5.0.tar.gz", hash = "sha256:85e871638850dad086629ed59a60073352dae17c8188de023ece131b618db7c6", size = 200638, upload-time = "2025-12-03T17:33:13.037Z" }
 wheels = [
@@ -758,10 +758,10 @@ wheels = [
 
 [package.optional-dependencies]
 web-api = [
-    { name = "flask" },
-    { name = "flask-cors" },
-    { name = "gunicorn" },
-    { name = "werkzeug" },
+    { name = "flask", marker = "python_full_version >= '3.13'" },
+    { name = "flask-cors", marker = "python_full_version >= '3.13'" },
+    { name = "gunicorn", marker = "python_full_version >= '3.13'" },
+    { name = "werkzeug", marker = "python_full_version >= '3.13'" },
 ]
 
 [[package]]
@@ -774,17 +774,17 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "dpath" },
-    { name = "numexpr", version = "2.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or python_full_version >= '3.13'" },
+    { name = "dpath", marker = "python_full_version < '3.13'" },
+    { name = "numexpr", version = "2.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "numexpr", version = "2.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
-    { name = "numpy" },
-    { name = "pendulum" },
-    { name = "psutil" },
-    { name = "pytest" },
-    { name = "pyyaml" },
-    { name = "sortedcontainers" },
-    { name = "strenum" },
-    { name = "typing-extensions" },
+    { name = "numpy", marker = "python_full_version < '3.13'" },
+    { name = "pendulum", marker = "python_full_version < '3.13'" },
+    { name = "psutil", marker = "python_full_version < '3.13'" },
+    { name = "pytest", marker = "python_full_version < '3.13'" },
+    { name = "pyyaml", marker = "python_full_version < '3.13'" },
+    { name = "sortedcontainers", marker = "python_full_version < '3.13'" },
+    { name = "strenum", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1b/16/8929a985f2d16d5db4e6ebbd596bd48dfca0da5cfde527d3d2cc4008ae54/openfisca_core-44.0.4.tar.gz", hash = "sha256:9307ee8d05bfc1133a1e750734afb35d0927f1eda26a77d94371207c54afb54b", size = 206473, upload-time = "2025-12-30T17:17:33.149Z" }
 wheels = [
@@ -793,15 +793,15 @@ wheels = [
 
 [package.optional-dependencies]
 web-api = [
-    { name = "flask" },
-    { name = "flask-cors" },
-    { name = "gunicorn" },
-    { name = "werkzeug" },
+    { name = "flask", marker = "python_full_version < '3.13'" },
+    { name = "flask-cors", marker = "python_full_version < '3.13'" },
+    { name = "gunicorn", marker = "python_full_version < '3.13'" },
+    { name = "werkzeug", marker = "python_full_version < '3.13'" },
 ]
 
 [[package]]
 name = "openfisca-france"
-version = "175.1.0"
+version = "175.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -1170,7 +1170,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/00/48c2f661e2816ccf2ecd77982f6605b2950afe60f60a52b4cbbc2504aa8f/scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c", size = 57210720, upload-time = "2024-05-23T03:29:26.079Z" }
 wheels = [
@@ -1208,7 +1208,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -1268,7 +1268,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
 wheels = [


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2025.
* Zones impactées : 
  - `openfisca_france/parameters/impot_revenu/calcul_revenus_imposables`
  - `openfisca_france/parameters/prelevements_sociaux`
  - `openfisca_france/parameters/taxation_capital/epargne/livret_epargne_populaire`
* Détails :
  - Mise à jours de paramètres d'impôt et de prélèvements sociaux

- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.
