### PR TITLE
Visale zonage 2026

### DIFF
--- a/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
+++ b/openfisca_france/model/caracteristiques_socio_demographiques/logement.py
@@ -1,6 +1,7 @@
 from numpy import char
 
 from openfisca_france.model.base import *
+from openfisca_france.model.prestations.aides_logement import TypesZoneApl
 
 
 class coloc(Variable):
@@ -138,6 +139,43 @@ class residence_ile_de_france(Variable):
     def formula(menage, period, parameters):
         depcom = menage('depcom', period).astype(str)
         return sum([char.startswith(depcom, departement_idf) for departement_idf in parameters(period).geopolitique.regions.ile_de_france.departements])
+
+
+class residence_corse(Variable):
+    label = 'Le logement est situé dans la région Corse'
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+
+    def formula(menage, period, parameters):
+        depcom = menage('depcom', period).astype(str)
+        return sum([char.startswith(depcom, departement_corse) for departement_corse in parameters(period).geopolitique.regions.corse.departements])
+
+
+class residence_agglomeration_plus_100000_habitants(Variable):
+    label = 'Le logement est situé dans une agglomération de plus de 100 000 habitants'
+    value_type = bool
+    entity = Menage
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+
+    def formula(menage, period):
+        '''
+        OpenFisca-France n'embarque pas la table des unités urbaines de l'INSEE : la taille de
+        l'agglomération n'est donc pas déductible du seul `depcom`. Le zonage APL est retenu comme
+        approximation, faute de mieux, car sa zone II est définie comme « les agglomérations de plus
+        de 100 000 habitants » (la zone I étant l'agglomération parisienne). L'approximation est
+        imparfaite : le zonage APL classe en réalité les communes selon la tension du marché locatif,
+        de sorte que des communes de zone II n'atteignent pas 100 000 habitants et qu'inversement
+        certaines communes plus peuplées peuvent être en zone III.
+        Attention également : `zone_apl` vaut `zone_2` par défaut pour un `depcom` absent de la table
+        ou non renseigné, ce qui classe par défaut le ménage en grande agglomération.
+        La variable est renseignable en entrée pour permettre un classement exact quand il est connu.
+        '''
+        zone_apl = menage('zone_apl', period)
+
+        return (zone_apl == TypesZoneApl.zone_1) + (zone_apl == TypesZoneApl.zone_2)
 
 
 class residence_dom(Variable):

--- a/openfisca_france/model/prestations/visale.py
+++ b/openfisca_france/model/prestations/visale.py
@@ -1,5 +1,4 @@
 from openfisca_france.model.base import *
-from openfisca_france.model.prestations.aides_logement import TypesZoneApl
 from numpy import datetime64
 
 
@@ -84,6 +83,7 @@ class visale_montant_max(Variable):
     set_input = set_input_divide_by_period
     reference = 'https://www.visale.fr/vos-questions/faq-locataires/locataire-de-30-ans-ou-moins-suis-je-eligible/#13'
 
+    # Jusqu'au 18/06/2018, le plafond de loyer garanti sans justification de ressources aux étudiants est unique sur tout le territoire. Le lancement du 19/06/2018 introduit la différenciation Île-de-France / hors Île-de-France, et le 06/01/2026 scinde le hors Île-de-France en deux zones.
     def formula_2016_01_01(menage, period, parameters):
         '''
         Attention, un montant non nul pour cette variable ne signifie pas nécessairement que l'entité est éligible à Visale : d'autres conditions peuvent ne pas être remplies. Pour déterminer l'éligibilité à la caution Visale au loyer actuellement renseigné pour le ménage, il faut utiliser la variable `visale_eligibilite`.
@@ -91,19 +91,40 @@ class visale_montant_max(Variable):
         Cette modélisation est impossible à réaliser telle quelle dans OpenFisca, car cela correspondrait à une variable de Ménage pour 1 à 2 personnes, et une variable d'Individu à partir de 3 personnes en colocation, mais pour laquelle le montant du loyer serait différent (ou en tous cas, serait la quote-part du loyer total du logement loué).
         Par conséquent, le calcul de cette variable fait l'hypothèse d'une déclaration des Ménages avec un Ménage par personne inscrite sur le bail pour 3 personnes ou plus, et avec un seul Ménage pour une colocation (ou un bail solidaire) de 2 personnes.
         '''
+        plafond_loyer_parameters = parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer
+
+        etudiant = menage.personne_de_reference('etudiant', period)
+        minimum_etudiant = plafond_loyer_parameters.etudiant.toutes_communes
+
+        plafond_loyer = where(  # le cas général n'est paramétré qu'à partir du 19/06/2018 : cette branche lève une `ParameterNotFoundError` avant cette date, faute de source sur le plafond applicable aux non-étudiants entre 2016 et 2018
+            menage('residence_ile_de_france', period),
+            plafond_loyer_parameters.cas_general.ile_de_france,
+            plafond_loyer_parameters.cas_general.hors_ile_de_france,
+            )
+
+        moitie_des_ressources = menage('visale_base_ressources', period) / 2
+
+        return max_(etudiant * minimum_etudiant, min_(moitie_des_ressources, plafond_loyer))
+
+    def formula_2018_06_19(menage, period, parameters):
+        '''
+        Le lancement du 19/06/2018 ouvre Visale à tous les étudiants et introduit la différenciation entre l'Île-de-France et le reste du territoire.
+        '''
+        plafond_loyer_parameters = parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer
+
         residence_ile_de_france = menage('residence_ile_de_france', period)
 
         etudiant = menage.personne_de_reference('etudiant', period)
         minimum_etudiant = where(
             residence_ile_de_france,
-            parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer.etudiant.ile_de_france,
-            parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer.etudiant.hors_ile_de_france,
+            plafond_loyer_parameters.etudiant.ile_de_france,
+            plafond_loyer_parameters.etudiant.hors_ile_de_france,
             )
 
         plafond_loyer = where(
             residence_ile_de_france,
-            parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer.cas_general.ile_de_france,
-            parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer.cas_general.hors_ile_de_france,
+            plafond_loyer_parameters.cas_general.ile_de_france,
+            plafond_loyer_parameters.cas_general.hors_ile_de_france,
             )
 
         moitie_des_ressources = menage('visale_base_ressources', period) / 2
@@ -112,51 +133,34 @@ class visale_montant_max(Variable):
 
     def formula_2026_01_06(menage, period, parameters):
         '''
-        À compter du 6 janvier 2026, les plafonds de loyers garantis par Visale évoluent.
-        Les montants maximums de loyers garantis tiennent désormais compte des spécificités des grandes agglomérations de plus de 100 000 habitants.
+        À compter du 6 janvier 2026, les plafonds de loyers garantis par Visale évoluent et le hors Île-de-France est scindé en deux.
         Le zonage distingue désormais trois catégories :
         - Île-de-France
-        - Grandes agglomérations (> 100 000 habitants, DROM, Corse, Saint-Martin)
-        - Reste du territoire
+        - Agglomérations de plus de 100 000 habitants, Corse, DROM et Saint-Martin
+        - Autres communes
+        Le critère est alternatif : la Corse, les DROM et Saint-Martin relèvent de la deuxième catégorie dans leur intégralité, indépendamment de la taille de leur agglomération.
         '''
-        residence_ile_de_france = menage('residence_ile_de_france', period)
-        zone_apl = menage('zone_apl', period)
+        plafond_loyer_parameters = parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer
 
-        # TODO: Ce zonage APL sert ici de contournement pour approcher le zonage Visale 2026.
-        # Il ne recouvre pas exactement les grandes agglomérations > 100 000 habitants,
-        # les DROM, la Corse et Saint-Martin dans tous les cas.
-        grandes_agglomerations = (zone_apl == TypesZoneApl.zone_1) + (zone_apl == TypesZoneApl.zone_2)
-        residence_grande_agglomeration = grandes_agglomerations * not_(residence_ile_de_france)
+        residence_ile_de_france = menage('residence_ile_de_france', period)
+        residence_grande_agglomeration = (
+            menage('residence_agglomeration_plus_100000_habitants', period)
+            + menage('residence_corse', period)
+            + menage('residence_dom', period)
+            + menage('residence_saint_martin', period)
+            ) > 0
+
+        def plafond_par_zone(plafonds):
+            return select(
+                [residence_ile_de_france, residence_grande_agglomeration],  # l'Île-de-France prime : ses communes appartiennent aussi à une agglomération de plus de 100 000 habitants
+                [plafonds.ile_de_france, plafonds.grandes_agglomerations_DROM_Corse_SaintMartin],
+                default = plafonds.autres_communes,
+                )
 
         etudiant = menage.personne_de_reference('etudiant', period)
+        minimum_etudiant = plafond_par_zone(plafond_loyer_parameters.etudiant)
 
-        minimum_etudiant_idf = parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer.etudiant.ile_de_france
-        minimum_etudiant_agglomeration = parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer.etudiant.grandes_agglomerations_DROM_Corse_SaintMartin
-        minimum_etudiant_reste = parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer.etudiant.hors_ile_de_france
-
-        minimum_etudiant = where(
-            etudiant * residence_ile_de_france,
-            minimum_etudiant_idf,
-            where(
-                etudiant * residence_grande_agglomeration,
-                minimum_etudiant_agglomeration,
-                minimum_etudiant_reste,
-                ),
-            )
-
-        plafond_loyer_idf = parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer.cas_general.ile_de_france
-        plafond_loyer_agglomeration = parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer.cas_general.grandes_agglomerations_DROM_Corse_SaintMartin
-        plafond_loyer_reste = parameters(period).prestations_sociales.aides_logement.action_logement.visale.plafond_loyer.cas_general.hors_ile_de_france
-
-        plafond_loyer = where(
-            residence_ile_de_france,
-            plafond_loyer_idf,
-            where(
-                residence_grande_agglomeration,
-                plafond_loyer_agglomeration,
-                plafond_loyer_reste,
-                ),
-            )
+        plafond_loyer = plafond_par_zone(plafond_loyer_parameters.cas_general)
 
         moitie_des_ressources = menage('visale_base_ressources', period) / 2
 

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/cas_general/autres_communes.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/cas_general/autres_communes.yaml
@@ -1,0 +1,14 @@
+description: Montant maximum du loyer éligible à la caution Visale dans le cas général pour les personnes logeant hors Île-de-France, hors agglomération de plus de 100 000 habitants, hors Corse, hors DROM et hors Saint-Martin
+values:
+  2026-01-06:
+    value: 1365
+metadata:
+  last_value_still_valid_on: "2026-04-01"
+  short_label: Autres communes
+  unit: currency
+  reference:
+    2026-01-06:
+    - title: Visale.fr
+      href: https://www.visale.fr/evolution_visale_2026/
+documentation: |-
+  À compter du 6 janvier 2026, les plafonds de loyers garantis par Visale évoluent, une nouvelle catégorie de ville est introduite en plus du cas général et du cas Ile-de-France.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/cas_general/hors_ile_de_france.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/cas_general/hors_ile_de_france.yaml
@@ -19,7 +19,7 @@ metadata:
       href: https://www.visale.fr/evolution_visale_2026/
   notes:
     2026-01-06:
-    - title: Catégorie supprimée au 06/01/2026 et scindée en « grandes agglomérations, DROM, Corse et Saint-Martin » (1 575 €) et « autres communes » (1 365 €).
+    - title: Catégorie supprimée au 06/01/2026 et scindée en « agglomération de plus de 100 000 habitants, Corse, DROM et Saint-Martin » (1 575 €) et « autres communes » (1 365 €).
 documentation: |-
   https://www.senat.fr/questions/base/2018/qSEQ180504798.html
   https://www.visale.fr/vos-questions/faq-locataires/locataire-de-30-ans-ou-moins-suis-je-eligible/#13

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/cas_general/hors_ile_de_france.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/cas_general/hors_ile_de_france.yaml
@@ -1,12 +1,11 @@
-description: Montant maximum du loyer éligible à la caution Visale dans le cas général pour les personnes logeant hors Île-de-France, agglomération > 100 000 habitants, départements outre-mer, Corse, ou Saint-Martin
+description: Montant maximum du loyer éligible à la caution Visale dans le cas général pour les personnes logeant hors Île-de-France
 values:
   2018-06-19:
     value: 1300
   2026-01-06:
-    value: 1365
+    value: null
 metadata:
-  last_value_still_valid_on: "2026-03-31"
-  short_label: Communes hors cas particuliers
+  short_label: Hors Île-de-France
   unit: currency
   reference:
     2018-06-19:
@@ -18,5 +17,9 @@ metadata:
     2026-01-06:
     - title: Visale.fr
       href: https://www.visale.fr/evolution_visale_2026/
+  notes:
+    2026-01-06:
+    - title: Catégorie supprimée au 06/01/2026 et scindée en « grandes agglomérations, DROM, Corse et Saint-Martin » (1 575 €) et « autres communes » (1 365 €).
 documentation: |-
-  À compter du 6 janvier 2026, les plafonds de loyers garantis par Visale évoluent à la hausse, une nouvelle catégorie de ville est introduite en plus du cas général et du cas Ile-de-France.
+  https://www.senat.fr/questions/base/2018/qSEQ180504798.html
+  https://www.visale.fr/vos-questions/faq-locataires/locataire-de-30-ans-ou-moins-suis-je-eligible/#13

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/cas_general/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/cas_general/index.yaml
@@ -2,6 +2,7 @@ description: Montant maximum du loyer éligible à la caution Visale dans le cas
 metadata:
   short_label: Cas Général
   order:
-  - hors_ile_de_france
   - ile_de_france
+  - hors_ile_de_france
   - grandes_agglomerations_DROM_Corse_SaintMartin
+  - autres_communes

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/etudiant/autres_communes.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/etudiant/autres_communes.yaml
@@ -1,0 +1,14 @@
+description: Montant maximum du loyer pour l'éligibilité automatique à Visale pour les personnes disposant d'un statut étudiant et logeant hors Île-de-France, hors agglomération de plus de 100 000 habitants, hors Corse, hors DROM et hors Saint-Martin
+values:
+  2026-01-06:
+    value: 680
+metadata:
+  last_value_still_valid_on: "2026-04-01"
+  short_label: Autres communes
+  unit: currency
+  reference:
+    2026-01-06:
+    - title: Visale.fr
+      href: https://www.visale.fr/evolution_visale_2026/
+documentation: |-
+  À compter du 6 janvier 2026, les plafonds de loyers garantis par Visale évoluent, une nouvelle catégorie de ville est introduite en plus du cas général et du cas Ile-de-France.

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/etudiant/hors_ile_de_france.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/etudiant/hors_ile_de_france.yaml
@@ -18,7 +18,7 @@ metadata:
       href: https://www.visale.fr/evolution_visale_2026/
   notes:
     2026-01-06:
-    - title: Catégorie supprimée au 06/01/2026 et scindée en « grandes agglomérations, DROM, Corse et Saint-Martin » (840 €) et « autres communes » (680 €).
+    - title: Catégorie supprimée au 06/01/2026 et scindée en « agglomération de plus de 100 000 habitants, Corse, DROM et Saint-Martin » (840 €) et « autres communes » (680 €).
 documentation: |-
   https://www.visale.fr/vos-questions/faq-locataires/locataire-de-30-ans-ou-moins-suis-je-eligible/#13
   https://www.lemonde.fr/campus/article/2018/06/11/logement-le-systeme-de-caution-visale-etendu-a-tous-les-etudiants_5312871_4401467.html

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/etudiant/hors_ile_de_france.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/etudiant/hors_ile_de_france.yaml
@@ -1,30 +1,26 @@
-description: Montant maximum du loyer pour l'éligibilité automatique à Visale pour les personnes disposant d'un statut étudiant et logeant hors Île-de-France, agglomération > 100 000 habitants, départements outre-mer, Corse, ou Saint-Martin
+description: Montant maximum du loyer pour l'éligibilité automatique à Visale pour les personnes disposant d'un statut étudiant et logeant hors Île-de-France
 values:
-  2016-01-01:
-    value: 425
   2018-06-19:
     value: 600
   2026-01-06:
-    value: 680
+    value: null
 metadata:
-  last_value_still_valid_on: "2026-03-31"
-  short_label: Communes hors cas particuliers
+  short_label: Hors Île-de-France
   unit: currency
   reference:
-    2016-01-01:
+    2018-06-19:
     - title: Convention quinquennale 7.4.1. 2018-2022 du 16/01/2018
       href: https://www.legifrance.gouv.fr/jorf/id/JORFSCTA000036580381
-    - title: Décret 2016-1769 du 19/12/2016
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000033652118#JORFARTI000033652118
-      note: Décret de création de l'Action Logement, il ne mentionne pas les montants.
+    - title: Réponse à la question écrite n° 04798 du 19/07/2018 (Sénat)
+      href: https://www.senat.fr/questions/base/2018/qSEQ180504798.html
     2026-01-06:
     - title: Visale.fr
       href: https://www.visale.fr/evolution_visale_2026/
+  notes:
+    2026-01-06:
+    - title: Catégorie supprimée au 06/01/2026 et scindée en « grandes agglomérations, DROM, Corse et Saint-Martin » (840 €) et « autres communes » (680 €).
 documentation: |-
-  À compter du 6 janvier 2026, les plafonds de loyers garantis par Visale évoluent à la hausse, une nouvelle catégorie de ville est introduite en plus du cas général et du cas Ile-de-France.
-
-  https://www.senat.fr/questions/base/2018/qSEQ180504798.html
+  https://www.visale.fr/vos-questions/faq-locataires/locataire-de-30-ans-ou-moins-suis-je-eligible/#13
   https://www.lemonde.fr/campus/article/2018/06/11/logement-le-systeme-de-caution-visale-etendu-a-tous-les-etudiants_5312871_4401467.html
-  Hors_ile_de_france (Etudiant) https://www.fage.org/idees/idees-social/idees-social-crous-aide-logement/idees-social-garantie-locative-visale.htm
   Pour la date (Etudiant) https://www.crous-paris.fr/logement/les-aides-au-logement/visale-caution-locative
-  Pour le montant (pas encore actualisé à la date d'écriture) (Etudiant) https://www.senat.fr/questions/base/2018/qSEQ180504798.html
+  https://www.fage.org/idees/idees-social/idees-social-crous-aide-logement/idees-social-garantie-locative-visale.htm

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/etudiant/ile_de_france.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/etudiant/ile_de_france.yaml
@@ -1,31 +1,24 @@
 description: Montant maximum du loyer pour l'éligibilité automatique à Visale pour les personnes disposant d'un statut étudiant et logeant en Île-de-France
 values:
-  2016-01-01:
-    value: 425
   2018-06-19:
     value: 800
   2026-01-06:
     value: 1000
 metadata:
-  last_value_still_valid_on: "2026-03-31"
+  last_value_still_valid_on: "2026-04-01"
   short_label: En Île-de-France
   unit: currency
   reference:
-    2016-01-01:
+    2018-06-19:
     - title: Convention quinquennale 7.4.1. 2018-2022 du 16/01/2018
       href: https://www.legifrance.gouv.fr/jorf/id/JORFSCTA000036580381
-    - title: Décret 2016-1769 du 19/12/2016
-      href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000033652118#JORFARTI000033652118
-      note: Décret de création de l'Action Logement, il ne mentionne pas les montants.
+    - title: Réponse à la question écrite n° 04798 du 19/07/2018 (Sénat)
+      href: https://www.senat.fr/questions/base/2018/qSEQ180504798.html
     2026-01-06:
     - title: Visale.fr
       href: https://www.visale.fr/evolution_visale_2026/
 documentation: |-
-  À compter du 6 janvier 2026, les plafonds de loyers garantis par Visale évoluent à la hausse, une nouvelle catégorie de ville est introduite en plus du cas général et du cas Ile-de-France.
-
-  Autres références https://www.visale.fr/vos-questions/faq-locataires/locataire-de-30-ans-ou-moins-suis-je-eligible/#13"
-  https://www.senat.fr/questions/base/2018/qSEQ180504798.html
+  https://www.visale.fr/vos-questions/faq-locataires/locataire-de-30-ans-ou-moins-suis-je-eligible/#13
   https://www.lemonde.fr/campus/article/2018/06/11/logement-le-systeme-de-caution-visale-etendu-a-tous-les-etudiants_5312871_4401467.html
-  Hors_ile_de_france (Etudiant) https://www.fage.org/idees/idees-social/idees-social-crous-aide-logement/idees-social-garantie-locative-visale.htm
   Pour la date (Etudiant) https://www.crous-paris.fr/logement/les-aides-au-logement/visale-caution-locative
-  Pour le montant (pas encore actualisé à la date d'écriture) (Etudiant) https://www.senat.fr/questions/base/2018/qSEQ180504798.html
+  https://www.fage.org/idees/idees-social/idees-social-crous-aide-logement/idees-social-garantie-locative-visale.htm

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/etudiant/index.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/etudiant/index.yaml
@@ -2,6 +2,8 @@ description: Montant maximum du loyer éligible à la caution Visale pour les pe
 metadata:
   short_label: Étudiants
   order:
-  - hors_ile_de_france
+  - toutes_communes
   - ile_de_france
+  - hors_ile_de_france
   - grandes_agglomerations_DROM_Corse_SaintMartin
+  - autres_communes

--- a/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/etudiant/toutes_communes.yaml
+++ b/openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/etudiant/toutes_communes.yaml
@@ -1,0 +1,26 @@
+description: Montant maximum du loyer pour l'éligibilité automatique à Visale pour les personnes disposant d'un statut étudiant, avant la différenciation géographique du 19/06/2018
+values:
+  2016-01-01:
+    value: 425
+  2018-06-19:
+    value: null
+metadata:
+  short_label: Toutes communes
+  unit: currency
+  reference:
+    2016-01-01:
+    - title: Décret 2016-1769 du 19/12/2016
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFARTI000033652118#JORFARTI000033652118
+      note: Décret de création de l'Action Logement, il ne mentionne pas les montants.
+    2018-06-19:
+    - title: Convention quinquennale 7.4.1. 2018-2022 du 16/01/2018
+      href: https://www.legifrance.gouv.fr/jorf/id/JORFSCTA000036580381
+    - title: Réponse à la question écrite n° 04798 du 19/07/2018 (Sénat)
+      href: https://www.senat.fr/questions/base/2018/qSEQ180504798.html
+  notes:
+    2016-01-01:
+    - title: Jusqu'au 18/06/2018 le plafond de loyer garanti sans justification de ressources est unique sur tout le territoire.
+    2018-06-19:
+    - title: "Le lancement du 19/06/2018 ouvre Visale à tous les étudiants et introduit la différenciation géographique : 800 € en Île-de-France, 600 € sur le reste du territoire."
+documentation: |-
+  https://www.visale.fr/vos-questions/faq-locataires/locataire-de-30-ans-ou-moins-suis-je-eligible/#13

--- a/tests/formulas/visale.yaml
+++ b/tests/formulas/visale.yaml
@@ -412,3 +412,52 @@
     loyer: [ 600 ]
   output:
     visale_eligibilite: [ false ]
+
+- name: Le zonage Visale 2026 est un critère alternatif
+  description: >-
+    La Corse, les DROM et Saint-Martin relèvent de la catégorie intermédiaire dans leur intégralité,
+    indépendamment de la taille de leur agglomération. Ce test fige cette lecture, que le zonage APL
+    utilisé par défaut pour approcher le critère « plus de 100 000 habitants » ne garantit pas à lui seul.
+  period: 2026-02
+  input:
+    age: [ 18, 18, 18, 18 ]
+    date_entree_logement: [2026-03-01, 2026-03-01, 2026-03-01, 2026-03-01]
+    etudiant: [ true, true, true, true ]
+    depcom: [ "2B002", "97101", "97801", "23001" ]  # petite commune de Haute-Corse ; Guadeloupe ; Saint-Martin (~35 000 habitants) ; commune rurale de la Creuse
+    salaire_net:
+      2026-01: [ 0, 0, 0, 0 ]
+  output:
+    residence_corse: [ true, false, false, false ]
+    residence_dom: [ false, true, false, false ]
+    residence_saint_martin: [ false, false, true, false ]
+    visale_montant_max: [ 840, 840, 840, 680 ]
+
+- name: Le zonage Visale 2026 est corrigible sans altérer le zonage APL
+  description: >-
+    `residence_agglomeration_plus_100000_habitants` est déduite du zonage APL faute de table des unités
+    urbaines, mais reste renseignable en entrée. La renseigner corrige le classement Visale sans modifier
+    la zone APL du ménage, dont dépendent les allocations logement.
+  period: 2026-02
+  input:
+    age: [ 18, 18 ]
+    date_entree_logement: [2026-03-01, 2026-03-01]
+    etudiant: [ true, true ]
+    depcom: [ "23001", "23001" ]
+    residence_agglomeration_plus_100000_habitants: [ false, true ]
+    salaire_net:
+      2026-01: [ 0, 0 ]
+  output:
+    zone_apl: [ zone_3, zone_3 ]
+    visale_montant_max: [ 680, 840 ]
+
+- name: Le zonage Visale à trois catégories ne s'applique pas avant le 06/01/2026
+  period: 2025-12
+  input:
+    age: [ 18, 18, 18 ]
+    date_entree_logement: [2026-01-01, 2026-01-01, 2026-01-01]
+    etudiant: [ true, true, true ]
+    depcom: [ "75112", "06088", "23001" ]
+    salaire_net:
+      2025-11: [ 0, 0, 0 ]
+  output:
+    visale_montant_max: [ 800, 600, 600 ]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/01/2016.
* Zones impactées :
    - `openfisca_france/parameters/prestations_sociales/aides_logement/action_logement/visale/plafond_loyer/*`
    - `openfisca_france/model/prestations/visale.py`
    - `openfisca_france/model/caracteristiques_socio_demographiques/logement.py`
* Détails :
  - Répond à la question laissée ouverte sur #2739 : comment mesurer la taille d'une agglomération pour le critère « plus de 100 000 habitants ».
  - Modélise chaque tranche de plafond de loyer à partir de sa date d'entrée en vigueur, plutôt que de réutiliser `hors_ile_de_france` comme catégorie « autres communes ».

Cette PR se branche sur `param/visale` et vient donc **s'ajouter** à #2739, dont elle conserve l'intégralité du travail — en particulier l'extension aux salariés de plus de 30 ans et le paramètre `plafond_ressources_salaries_plus_30_ans`. Les 22 tests de #2739 passent sans modification.

- - - -

### 1. Le zonage Visale 2026 est un critère **alternatif**

Le texte dit « agglomération de plus de 100 000 habitants, **Corse, DROM et Saint-Martin** ». La Corse, les DROM et Saint-Martin relèvent donc de cette catégorie **en totalité**, quelle que soit la taille de leur agglomération.

Cela lève deux des trois réserves formulées en commentaire de #2739 : Saint-Martin et ses ~35 000 habitants, comme les petites communes corses, sont bien dans cette catégorie — ce ne sont pas des faux positifs du zonage APL, mais le résultat correct. Ces trois cas sont désormais déduits exactement du `depcom`, via `residence_corse` (nouvelle), `residence_dom` et `residence_saint_martin`.

Reste la seule réserve qui tienne : le critère « plus de 100 000 habitants » en métropole, qu'OpenFisca-France ne peut pas trancher exactement faute d'embarquer la table des unités urbaines de l'INSEE.

### 2. Une variable dédiée plutôt qu'une lecture directe de `zone_apl`

`residence_agglomeration_plus_100000_habitants` **conserve le zonage APL comme valeur par défaut** — c'est la meilleure approximation disponible, et le comportement est inchangé — mais l'expose comme une variable nommée d'après le critère légal et renseignable en entrée. Deux bénéfices concrets :

- **On peut corriger le classement Visale d'un ménage sans surcharger sa `zone_apl`.** Avec une lecture directe, le seul moyen de corriger le zonage Visale est de forcer `zone_apl`, ce qui modifie du même coup ses allocations logement. Un test fige cette indépendance.
- **La table de zonage APL date de 2011** (`20110914_zonage.csv`). Le classement de la Corse et des DROM ne dépend plus du fait qu'elle les place aujourd'hui tous en zone II.

À noter, indépendamment de cette PR : `zone_apl` vaut `zone_2` par défaut pour un `depcom` absent ou non renseigné. Un ménage sans commune renseignée est donc classé en grande agglomération (1 575 € / 840 €) alors que la zone III couvre 33 794 des 37 417 communes de la table. Le comportement est documenté dans la docstring de la nouvelle variable ; le corriger relèverait plutôt d'une PR sur `zone_apl`.

### 3. Chaque tranche est modélisée à partir de sa date d'entrée en vigueur

- `etudiant/toutes_communes` porte les 425 € en vigueur sur tout le territoire jusqu'au 18/06/2018, jusqu'ici dupliqués sur `ile_de_france` et `hors_ile_de_france` ;
- `hors_ile_de_france` est clos au 06/01/2026 ;
- `autres_communes` s'ouvre à cette date.

`hors_ile_de_france` retrouve ainsi une `description` et un `short_label` qui décrivent la période qu'il couvre réellement : dans #2739, l'historique 2018-2026 se retrouvait étiqueté « Communes hors cas particuliers », c'est-à-dire avec son sens post-2026. `visale_montant_max` suit les trois régimes successifs avec une formule chacun.

C'est aussi la convention retenue côté [barèmes IPP](https://gitlab.com/ipp/partage-public-ipp/baremes-ipp/baremes-ipp-yaml), où la même réforme est modélisée. Le nom de nœud `grandes_agglomerations_DROM_Corse_SaintMartin` retenu ici est celui de #2739 ; il vient d'être répercuté côté barèmes IPP pour que les deux dépôts restent alignés.

### Tests

25 tests sur `tests/formulas/visale.yaml`, dont les 22 de #2739 inchangés. Les trois ajoutés couvrent le caractère alternatif du critère (Corse, DROM, Saint-Martin), l'indépendance vis-à-vis de `zone_apl`, et la frontière de régime au 06/01/2026.

- - - -

Ces changements :

- Ajoutent une fonctionnalité (par exemple ajout d'une variable).
- Corrigent ou améliorent un calcul déjà existant.

