### PR TITLE
Application des règles arrondi cacul aides au logement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 176.0.9 [#2799](https://github.com/openfisca/openfisca-france/pull/2799)
+
+* Changement mineur.
+* Périodes concernées : toutes.
+* Zones impactées :
+  - `openfisca_france/model/prestations/aides_logement.py`
+* Détails :
+  - Applique les règles d'arrondi de Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement (NOR : LOGL1925404A) Article 14: RL est exprimé en pourcentage et arrondi à la deuxième décimale / TL est exprimé en pourcentage et arrondi à la troisième décimale
+
 ### 176.0.8 [#2796](https://github.com/openfisca/openfisca-france/pull/2796)
 
 * Évolution du système socio-fiscal.
@@ -41,7 +50,7 @@
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/01/2023.
-* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py` et `tests/calculateur_impots/yaml/credit_invest_forestier.yaml` 
+* Zones impactées : `openfisca_france/model/prelevements_obligatoires/impot_revenu/credits_impot.py` et `tests/calculateur_impots/yaml/credit_invest_forestier.yaml`
 * Détails :
   - Mise à jour de la formule pour 2025 corrections sur 2024 et 2023
   - ajout et correction des tests sur la période

--- a/openfisca_france/model/prestations/aides_logement.py
+++ b/openfisca_france/model/prestations/aides_logement.py
@@ -1615,7 +1615,7 @@ class aide_logement_taux_loyer(Variable):
             + al_plafonds_z2.majoration_par_enf_supp * (al_nb_pac_reference > 1) * (al_nb_pac_reference - 1)
             )
 
-        RL = L / loyer_reference
+        RL = round_(L / loyer_reference * 100, 2) / 100
 
         TL = where(RL >= al_tl_seuils.seuil_2,
             al_tl_taux.tl_taux_3 * (RL - al_tl_seuils.seuil_2)
@@ -1623,7 +1623,7 @@ class aide_logement_taux_loyer(Variable):
             max_(0, al_tl_taux.tl_taux_2 * (RL - al_tl_seuils.seuil_1))
             )
 
-        return TL
+        return round_(TL, 5)
 
 
 class aide_logement_ressources_apres_abattement(Variable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-France"
-version = "176.0.8"
+version = "176.0.9"
 description = "OpenFisca Rules as Code model for France."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "france"]

--- a/tests/formulas/aides_logement.yaml
+++ b/tests/formulas/aides_logement.yaml
@@ -542,6 +542,35 @@
     aide_logement_participation_personnelle: 34.73 + (0.0283 + 0.00405) * 7438  # 275.35
     aide_logement_montant_brut: 292.85 + 53.27 - 275.35 # 70.77 brut CRDS
 
+- name: Personne isolée 2026-08
+  period: 2026-08
+  absolute_error_margin: 0.00001
+  input:
+    famille:
+      parents: [parent1]
+      aide_logement_base_ressources: 9900
+      reduction_loyer_solidarite: 35.99
+    menage:
+      personne_de_reference: parent1
+      zone_apl: zone_1
+      loyer: 200
+      statut_occupation_logement: locataire_hlm
+    individus:
+      parent1:
+        age: 36
+    foyer_fiscal:
+      declarants: [parent1]
+  output:
+    # Loyer de Reference: 290.34
+    # R_L: 0.6888
+    aide_logement_taux_loyer: round(0.0045 * (0.6888 - 0.45), 5) # 0.00107; sans arrondi: 0.001074814
+    # taux de participation T_p : 0.02937
+    aide_logement_taux_participation_personnelle: 0.0283 + 0.00107
+    aide_logement_participation_personnelle: 39.56 + (0.0283 + 0.00107) * 4665
+    aide_logement_montant_brut: round(200 + 60.59 - 176.57105, 2) - 5 # 79.02; sans arrondi: 79.00
+    aide_logement_montant_brut_crds: round(200 + 60.59 - 176.57105, 2) - 5 - 35.99 * 0.98 # 43.7498; sans arrondi: 43.7298
+    aide_logement_montant: round(43.7498 * (1 - 0.005), 2) # 43.53; sans arrondi: 43.51
+
 - name: Personne isolée, avant degressivité
   period: 2016-06
   relative_error_margin: 0.01


### PR DESCRIPTION
AI Usage Disclosure: ⭐ AI-assisted

* Changement mineur.
* Périodes concernées : toutes
* Zones impactées : `openfisca_france/model/prestations/aides_logement.py`.
* Détails :
  - Applique les règles d'arrondi de Arrêté du 27 septembre 2019 relatif au calcul des aides personnelles au logement et de la prime de déménagement (NOR : LOGL1925404A) Article 14: RL est exprimé en pourcentage et arrondi à la deuxième décimale / TL est exprimé en pourcentage et arrondi à la troisième décimale
  
- - - -

Ces changements (effacez les lignes ne correspondant pas à votre cas) :

- Corrigent ou améliorent un calcul déjà existant.

- - - -

Quelques conseils à prendre en compte :

- [x] Jetez un coup d'œil au [guide de contribution](https://github.com/openfisca/openfisca-france/blob/master/CONTRIBUTING.md).
- [x] Regardez s'il n'y a pas une [proposition introduisant ces mêmes changements](https://github.com/openfisca/openfisca-france/pulls).
- [x] Documentez votre contribution avec des références législatives.
- [x] Mettez à jour ou ajoutez des tests correspondant à votre contribution.
- [x] Augmentez le [numéro de version](https://speakerdeck.com/mattisg/git-session-2-strategies?slide=81) dans [`pyproject.toml`](https://github.com/openfisca/openfisca-france/blob/master/pyproject.toml).
- [x] Mettez à jour le [`CHANGELOG.md`](https://github.com/openfisca/openfisca-france/blob/master/CHANGELOG.md).
- [x] Assurez-vous de bien décrire votre contribution, comme indiqué ci-dessus

Et surtout, n'hésitez pas à demander de l'aide ! :)
